### PR TITLE
Use ramsey/composer-install in GitHub actions

### DIFF
--- a/.github/workflows/split_code_analysis.yaml
+++ b/.github/workflows/split_code_analysis.yaml
@@ -24,8 +24,10 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            -   run: composer install --no-progress --ansi
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
+            -   uses: "ramsey/composer-install@v1"
+            -   
+                uses: "ramsey/composer-install@v1"
+                working-directory: monorepo-builder
 
             # get package json list
             -
@@ -57,9 +59,11 @@ jobs:
                     coverage: none
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            -   uses: "ramsey/composer-install@v1"
+            -   
+                uses: "ramsey/composer-install@v1"
+                working-directory: monorepo-builder
 
-            -   run: composer install --no-progress --ansi
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
 
             -   run: monorepo-builder/vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.package.path }}/composer.json --ansi
 

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -27,8 +27,10 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            -   run: composer install --no-progress --ansi
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
+            -   uses: "ramsey/composer-install@v1"
+            -   
+                uses: "ramsey/composer-install@v1"
+                working-directory: monorepo-builder
 
             # get package json list
             -

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -24,8 +24,10 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            -   run: composer install --no-progress --ansi
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
+            -   uses: "ramsey/composer-install@v1"
+            -   
+                uses: "ramsey/composer-install@v1"
+                working-directory: monorepo-builder
 
             # get package json list
             -

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit


### PR DESCRIPTION
Use the [ramsey/composer-install](https://github.com/ramsey/composer-install) action, which installs your Composer dependencies and caches them for improved build times.

Hence, now we do:

```yaml
-   uses: "ramsey/composer-install@v1"
-   
    uses: "ramsey/composer-install@v1"
    working-directory: monorepo-builder
```

instead of:

```yaml
-   run: composer install --no-progress --ansi
-   run: cd monorepo-builder && composer install --no-progress --ansi
```