### PR TITLE
Execute monorepo-builder under root vendor/

### DIFF
--- a/.github/workflows/split_code_analysis.yaml
+++ b/.github/workflows/split_code_analysis.yaml
@@ -25,13 +25,12 @@ jobs:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             -   uses: "ramsey/composer-install@v1"
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
 
             # get package json list
             -
                 id: output_data
                 run: |
-                    echo "::set-output name=matrix::$(monorepo-builder/vendor/bin/monorepo-builder package-entries-json)"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json)"
 
         outputs:
             matrix: ${{ steps.output_data.outputs.matrix }}
@@ -58,9 +57,8 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   uses: "ramsey/composer-install@v1"
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
 
-            -   run: monorepo-builder/vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.package.path }}/composer.json --ansi
+            -   run: vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.package.path }}/composer.json --ansi
 
             -   run: composer update --no-progress --ansi --working-dir ${{ matrix.package.path }}
 

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -28,13 +28,12 @@ jobs:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             -   uses: "ramsey/composer-install@v1"
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
 
             # get package json list
             -
                 id: output_data
                 run: |
-                    echo "::set-output name=matrix::$(monorepo-builder/vendor/bin/monorepo-builder package-entries-json)"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json)"
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -25,13 +25,12 @@ jobs:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             -   uses: "ramsey/composer-install@v1"
-            -   run: cd monorepo-builder && composer install --no-progress --ansi
 
             # get package json list
             -
                 id: output_data
                 run: |
-                    echo "::set-output name=matrix::$(monorepo-builder/vendor/bin/monorepo-builder package-entries-json)"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json)"
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/var-dumper": "^5.1",
+        "symplify/monorepo-builder": "^9.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2"
     },
     "autoload": {
@@ -182,6 +183,7 @@
             "PoP\\MandatoryDirectivesByConfiguration\\": "layers/Engine/packages/mandatory-directives-by-configuration/src",
             "PoP\\ModuleRouting\\": "layers/Engine/packages/modulerouting/src",
             "PoP\\Multisite\\": "layers/SiteBuilder/packages/multisite/src",
+            "PoP\\PoP\\Symplify\\MonorepoBuilder\\": "monorepo-builder/src",
             "PoP\\QueryParsing\\": "layers/Engine/packages/query-parsing/src",
             "PoP\\RESTAPI\\": "layers/API/packages/api-rest/src",
             "PoP\\ResourceLoader\\": "layers/SiteBuilder/packages/resourceloader/src",
@@ -630,19 +632,19 @@
         "install-monorepo-builder": "cd monorepo-builder && composer install --no-progress --ansi",
         "merge-monorepo": [
             "@install-monorepo-builder",
-            "monorepo-builder/vendor/bin/monorepo-builder merge --ansi"
+            "vendor/bin/monorepo-builder merge --ansi"
         ],
         "propagate-monorepo": [
             "@install-monorepo-builder",
-            "monorepo-builder/vendor/bin/monorepo-builder propagate --ansi"
+            "vendor/bin/monorepo-builder propagate --ansi"
         ],
         "validate-monorepo": [
             "@install-monorepo-builder",
-            "monorepo-builder/vendor/bin/monorepo-builder validate --ansi"
+            "vendor/bin/monorepo-builder validate --ansi"
         ],
         "release": [
             "@install-monorepo-builder",
-            "monorepo-builder/vendor/bin/monorepo-builder release patch --ansi"
+            "vendor/bin/monorepo-builder release patch --ansi"
         ]
     },
     "minimum-stability": "dev",

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-require_once 'monorepo-builder/vendor/autoload.php';
-
 use PoP\PoP\Symplify\MonorepoBuilder\Command\PackageEntriesJsonCommand;
 use PoP\PoP\Symplify\MonorepoBuilder\Command\SymlinkLocalPackageCommand;
 use PoP\PoP\Symplify\MonorepoBuilder\Json\PackageEntriesJsonProvider;
@@ -56,29 +54,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // 'prefer-stable' => true,
     ]);
 
-    // // how skip packages in loaded direectories?
-    // $parameters->set(Option::PACKAGE_DIRECTORIES_EXCLUDES, [__DIR__ . '/packages/secret-package']);
-
-    // // "merge" command related
-
-    // // what extra parts to add after merge?
-    // $parameters->set(Option::DATA_TO_APPEND, [
-    //     'autoload-dev' => [
-    //         'psr-4' => [
-    //             'Symplify\Tests\\' => 'tests',
-    //         ],
-    //     ],
-    //     'require-dev' => [
-    //         'phpstan/phpstan' => '^0.12',
-    //     ],
-    // ]);
-
-    // $parameters->set(Option::DATA_TO_REMOVE, [
-    //     'require' => [
-    //         // the line is removed by key, so version is irrelevant, thus *
-    //         'phpunit/phpunit' => '*',
-    //     ],
-    // ]);
+    // Install also the monorepo-builder! So it can be used in CI
+    $parameters->set(Option::DATA_TO_APPEND, [
+        'require-dev' => [
+            'symplify/monorepo-builder' => '^9.0',
+        ],
+        'autoload' => [
+            'psr-4' => [
+                'PoP\\PoP\\Symplify\\MonorepoBuilder\\'=> 'monorepo-builder/src',
+            ],
+        ],
+    ]);
 
     $services = $containerConfigurator->services();
     $services->defaults()


### PR DESCRIPTION
Instead of installing the monorepo-builder under folder `monorepo-builder`, we can append extra data to the root `composer.json` to add the mapping for the custom classes.

Then, this makes it faster to run CI, since there's no need to do `composer install` under the `monorepo-builder/` folder