### PR TITLE
Check phpcs for monorepo in CI

### DIFF
--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -1,0 +1,52 @@
+name: PHP Coding Standards
+on:
+    push:
+        branches:
+            - master
+    pull_request: null
+
+jobs:
+    provide_data:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                uses: actions/checkout@v2
+
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.4
+                    coverage: none
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            -   uses: "ramsey/composer-install@v1"
+
+            -   id: output_data
+                run: |
+                    echo "::set-output name=code_paths::$(vendor/bin/monorepo-builder package-code-paths-json)"
+
+        outputs:
+            code_paths: ${{ steps.output_data.outputs.code_paths }}
+
+    main:
+        needs: provide_data
+        name: Execute PHP Code Sniffer
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+
+            -   name: Set-up PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.4
+                    coverage: none
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            -   name: Install Composer dependencies
+                uses: "ramsey/composer-install@v1"
+
+            -   name: Run PHP Code Sniffer
+                run: vendor/bin/phpcs -n ${{ join(fromJson(needs.provide_data.outputs.code_paths), " ") }}
+

--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -48,5 +48,5 @@ jobs:
                 uses: "ramsey/composer-install@v1"
 
             -   name: Run PHP Code Sniffer
-                run: vendor/bin/phpcs -n ${{ join(fromJson(needs.provide_data.outputs.code_paths), " ") }}
+                run: vendor/bin/phpcs -n ${{ join(fromJson(needs.provide_data.outputs.code_paths), ' ') }}
 

--- a/.github/workflows/split_code_analysis.yaml.disabled
+++ b/.github/workflows/split_code_analysis.yaml.disabled
@@ -80,8 +80,3 @@ jobs:
                 name: PHPStan
                 working-directory: ${{ matrix.package.path }}
                 run: vendor/bin/phpstan analyse -c phpstan.neon.dist
-
-            -
-                name: PHP Code Sniffer
-                working-directory: ${{ matrix.package.path }}
-                run: vendor/bin/phpcs -n src/

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,25 +6,24 @@ on:
     pull_request: null
 
 jobs:
-  main:
-    name: Execute PHPUnit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+    main:
+        name: Execute PHPUnit tests
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
 
-        # see https://github.com/shivammathur/setup-php
-      - name: Set-up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          coverage: none
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Set-up PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.4
+                    coverage: none
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+            -   name: Install Composer dependencies
+                uses: "ramsey/composer-install@v1"
 
-      - name: Run tests
-        run: vendor/bin/phpunit
+            -   name: Run tests
+                run: vendor/bin/phpunit
 

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\PackageEntriesJsonCommand;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\PackageCodePathsJsonCommand;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\SymlinkLocalPackageCommand;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PackageCodePathsJsonProvider;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PackageEntriesJsonProvider;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option as CustomOption;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
@@ -75,6 +77,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services
         ->set(PackageEntriesJsonProvider::class)
         ->set(PackageEntriesJsonCommand::class)
+        ->set(PackageCodePathsJsonProvider::class)
+        ->set(PackageCodePathsJsonCommand::class)
         ->set(SymlinkLocalPackageCommand::class);
 
     /** release workers - in order to execute */

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/PackageCodePathsJsonCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/PackageCodePathsJsonCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
+
+use Nette\Utils\Json;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PackageCodePathsJsonProvider;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
+use Symplify\PackageBuilder\Console\ShellCode;
+
+final class PackageCodePathsJsonCommand extends AbstractSymplifyCommand
+{
+    /**
+     * @var PackageCodePathsJsonProvider
+     */
+    private $packageCodePathsJsonProvider;
+
+    public function __construct(PackageCodePathsJsonProvider $packageCodePathsJsonProvider)
+    {
+        $this->packageCodePathsJsonProvider = $packageCodePathsJsonProvider;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Provides package code paths in json format. Useful for GitHub Actions Workflow');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $packageCodePaths = $this->packageCodePathsJsonProvider->providePackageCodePaths();
+
+        // must be without spaces, otherwise it breaks GitHub Actions json
+        $json = Json::encode($packageCodePaths);
+        $this->symfonyStyle->writeln($json);
+
+        return ShellCode::SUCCESS;
+    }
+}

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PackageCodePathsJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PackageCodePathsJsonProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json;
+
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
+use Symplify\MonorepoBuilder\Package\PackageProvider;
+use Symplify\MonorepoBuilder\ValueObject\Package;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
+
+final class PackageCodePathsJsonProvider
+{
+    /**
+     * @var PackageProvider
+     */
+    private $packageProvider;
+
+    /**
+     * @var array<string, mixed[]>
+     */
+    private $packageOrganizations = [];
+
+    public function __construct(
+        PackageProvider $packageProvider,
+        ParameterProvider $parameterProvider
+    ) {
+        $this->packageProvider = $packageProvider;
+        $this->packageOrganizations = $parameterProvider->provideArrayParameter(Option::PACKAGE_ORGANIZATIONS);
+    }
+
+    /**
+     * Code paths are src/ and tests/ folders.
+     * But not all packages have them, so check if these folders exist.
+     * Since a Package already has function `hasTests`, and since every
+     * package that has tests/ also has src/, then using this function
+     * already does the job.
+     * @return array<string[]>
+     */
+    public function providePackageCodePaths(): array
+    {
+        $packageCodePaths = [];
+        $packagesWithTests = array_filter(
+            $this->packageProvider->provide(),
+            function (Package $package): bool {
+                return $package->hasTests();
+            }
+        );
+        foreach ($packagesWithTests as $package) {
+            $packageRelativePath = $package->getRelativePath();
+            $packageCodePaths[] = $packageRelativePath . DIRECTORY_SEPARATOR . 'src';
+            $packageCodePaths[] = $packageRelativePath . DIRECTORY_SEPARATOR . 'tests';
+        }
+
+        return $packageCodePaths;
+    }
+}


### PR DESCRIPTION
Obtain the list of all the `src/` and `tests/` folders in all the packages, and execute `vendor/bin/phpcs -n` on them, in a single execution.