### PR TITLE
Print the "Source Packages" command as JSON or string

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -24,7 +24,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=packages::$(vendor/bin/monorepo-builder source-packages --json)"
+                    echo "::set-output name=packages::$(vendor/bin/monorepo-builder source-packages)"
 
         outputs:
             packages: ${{ steps.output_data.outputs.packages }}
@@ -34,7 +34,7 @@ jobs:
         name: Execute PHPStan
         runs-on: ubuntu-latest
         env:
-            PHPSTAN_PACKAGES: ${{ join(fromJson(needs.provide_data.outputs.packages), ' ') }}
+            PHPSTAN_PACKAGES: ${{ needs.provide_data.outputs.packages }}
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -24,7 +24,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=packages::$(vendor/bin/monorepo-builder source-packages-json)"
+                    echo "::set-output name=packages::$(vendor/bin/monorepo-builder source-packages)"
 
         outputs:
             packages: ${{ steps.output_data.outputs.packages }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -24,7 +24,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=packages::$(vendor/bin/monorepo-builder source-packages)"
+                    echo "::set-output name=packages::$(vendor/bin/monorepo-builder source-packages --json)"
 
         outputs:
             packages: ${{ steps.output_data.outputs.packages }}

--- a/composer.json
+++ b/composer.json
@@ -632,7 +632,8 @@
         "merge-monorepo": "vendor/bin/monorepo-builder merge --ansi",
         "propagate-monorepo": "vendor/bin/monorepo-builder propagate --ansi",
         "validate-monorepo": "vendor/bin/monorepo-builder validate --ansi",
-        "release": "vendor/bin/monorepo-builder release patch --ansi"
+        "release": "vendor/bin/monorepo-builder release patch --ansi",
+        "phpstan": "./.github/workflows/scripts/phpstan.sh \"$(vendor/bin/monorepo-builder source-packages)\""
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\PackageCodePathsJsonCommand;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\PackageEntriesJsonCommand;
-use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\SourcePackagesJsonCommand;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\SourcePackagesCommand;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\SymlinkLocalPackageCommand;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PackageCodePathsJsonProvider;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PackageEntriesJsonProvider;
-use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\SourcePackagesJsonProvider;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\SourcePackagesProvider;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option as CustomOption;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
@@ -81,8 +81,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set(PackageEntriesJsonCommand::class)
         ->set(PackageCodePathsJsonProvider::class)
         ->set(PackageCodePathsJsonCommand::class)
-        ->set(SourcePackagesJsonProvider::class)
-        ->set(SourcePackagesJsonCommand::class)
+        ->set(SourcePackagesProvider::class)
+        ->set(SourcePackagesCommand::class)
         ->set(SymlinkLocalPackageCommand::class);
 
     /** release workers - in order to execute */

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
@@ -5,22 +5,22 @@ declare(strict_types=1);
 namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
 
 use Nette\Utils\Json;
-use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\SourcePackagesJsonProvider;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\SourcePackagesProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\PackageBuilder\Console\ShellCode;
 
-final class SourcePackagesJsonCommand extends AbstractSymplifyCommand
+final class SourcePackagesCommand extends AbstractSymplifyCommand
 {
     /**
-     * @var SourcePackagesJsonProvider
+     * @var SourcePackagesProvider
      */
-    private $sourcePackagesJsonProvider;
+    private $sourcePackagesProvider;
 
-    public function __construct(SourcePackagesJsonProvider $sourcePackagesJsonProvider)
+    public function __construct(SourcePackagesProvider $sourcePackagesProvider)
     {
-        $this->sourcePackagesJsonProvider = $sourcePackagesJsonProvider;
+        $this->sourcePackagesProvider = $sourcePackagesProvider;
 
         parent::__construct();
     }
@@ -32,7 +32,7 @@ final class SourcePackagesJsonCommand extends AbstractSymplifyCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $sourcePackageEntries = $this->sourcePackagesJsonProvider->provideSourcePackages();
+        $sourcePackageEntries = $this->sourcePackagesProvider->provideSourcePackages();
 
         // must be without spaces, otherwise it breaks GitHub Actions json
         $json = Json::encode($sourcePackageEntries);

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
@@ -6,7 +6,9 @@ namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
 
 use Nette\Utils\Json;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\SourcePackagesProvider;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\PackageBuilder\Console\ShellCode;
@@ -28,15 +30,23 @@ final class SourcePackagesCommand extends AbstractSymplifyCommand
     protected function configure(): void
     {
         $this->setDescription('Provides source packages (i.e. packages with code under src/ and tests/), in json format. Useful for GitHub Actions Workflow');
+        $this->addOption(
+            Option::JSON,
+            null,
+            InputOption::VALUE_NONE,
+            'Print with encoded JSON format.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $sourcePackageEntries = $this->sourcePackagesProvider->provideSourcePackages();
+        $sourcePackages = $this->sourcePackagesProvider->provideSourcePackages();
 
-        // must be without spaces, otherwise it breaks GitHub Actions json
-        $json = Json::encode($sourcePackageEntries);
-        $this->symfonyStyle->writeln($json);
+        $asJSON = (bool) $input->getOption(Option::JSON);
+
+        // JSON: must be without spaces, otherwise it breaks GitHub Actions json
+        $response = $asJSON ? Json::encode($sourcePackages) : implode(' ', $sourcePackages);
+        $this->symfonyStyle->writeln($response);
 
         return ShellCode::SUCCESS;
     }

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
@@ -7,7 +7,7 @@ namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json;
 use Symplify\MonorepoBuilder\Package\PackageProvider;
 use Symplify\MonorepoBuilder\ValueObject\Package;
 
-final class SourcePackagesJsonProvider
+final class SourcePackagesProvider
 {
     /**
      * @var PackageProvider

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
@@ -10,4 +10,8 @@ final class Option
      * @var string
      */
     public const PACKAGE_ORGANIZATIONS = 'package_organizations';
+    /**
+     * @var string
+     */
+    public const JSON = 'json';
 }


### PR DESCRIPTION
By printing it as a string, it can be directly incorporated as a script in `composer.json`, for local execution