### PR TITLE
Make includes in PHPStan config relative to working directory

### DIFF
--- a/layers/API/packages/api-endpoints-for-wp/phpstan.neon.dist
+++ b/layers/API/packages/api-endpoints-for-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Engine/packages/engine-wp/phpstan.neon.dist
+++ b/layers/Engine/packages/engine-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Engine/packages/hooks-wp/phpstan.neon.dist
+++ b/layers/Engine/packages/hooks-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Engine/packages/routing-wp/phpstan.neon.dist
+++ b/layers/Engine/packages/routing-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Engine/packages/translation-wp/phpstan.neon.dist
+++ b/layers/Engine/packages/translation-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpstan.neon.dist
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
     # Errors in production (downgraded via Rector) may not show up in development. So avoid throwing errors
     reportUnmatchedIgnoredErrors: false

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/phpstan.neon copy.dist
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/phpstan.neon copy.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 5
 	paths:

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/phpstan.neon.dist
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/block-metadata-for-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/block-metadata-for-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/categories-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/categories-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/comment-mutations-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/comment-mutations-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/commentmeta-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/commentmeta-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/comments-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/comments-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/custompost-mutations-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/custompost-mutations-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/custompostmedia-mutations-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/custompostmedia-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/custompostmedia-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/custompostmeta-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/custompostmeta-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/customposts-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/customposts-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/everythingelse-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/everythingelse-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/highlights-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/highlights-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/locationposts-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/locationposts-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/media-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/media-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/menus-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/menus-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/metaquery-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/metaquery-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/notifications-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/notifications-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/pages-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/pages-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/post-tags-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/post-tags-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/posts-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/posts-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/queriedobject-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/queriedobject-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/stances-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/stances-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/tags-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/tags-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/taxonomies-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/taxonomies-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/taxonomymeta-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/taxonomymeta-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/taxonomyquery-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/taxonomyquery-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/user-roles-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/user-roles-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/user-state-mutations-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/user-state-mutations-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/user-state-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/user-state-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/usermeta-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/usermeta-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/Schema/packages/users-wp/phpstan.neon.dist
+++ b/layers/Schema/packages/users-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/SiteBuilder/packages/application-wp/phpstan.neon.dist
+++ b/layers/SiteBuilder/packages/application-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:

--- a/layers/SiteBuilder/packages/site-wp/phpstan.neon.dist
+++ b/layers/SiteBuilder/packages/site-wp/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
 	level: 8
 	paths:


### PR DESCRIPTION
When running script `phpstan` in `composer.json`, we would get many errors of this kind:

```
File '.../PoP/layers/Schema/packages/users-wp/vendor/szepeviktor/phpstan-wordpress/extension.neon' is missing or is not readable.
```

The reason is that the monorepo installs a unique `vendor/` folder at the root, and not for each of the packages. Hence, when in the `phpstan.neon.dist` for all WordPress packages we had this configuration:

```yaml
includes:
    - vendor/szepeviktor/phpstan-wordpress/extension.neon
```

it couldn't find that file.

This PR fixes it, by [adding `%currentWorkingDirectory%`](https://phpstan.org/config-reference#expanding-paths), making the path relative to where `vendor/bin/phpstan` is executed at the monorepo root, and not at the package root:

```yaml
includes:
    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
```