### PR TITLE
Validate monorepo in CI

### DIFF
--- a/.github/workflows/monorepo_validation.yml
+++ b/.github/workflows/monorepo_validation.yml
@@ -1,0 +1,29 @@
+name: Monorepo validation
+on:
+    push:
+        branches:
+            - master
+    pull_request: null
+
+jobs:
+    main:
+        name: Validate monorepo
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+
+            -   name: Set-up PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.4
+                    coverage: none
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            -   name: Install Composer dependencies
+                uses: "ramsey/composer-install@v1"
+
+            -   name: Run validation
+                run: vendor/bin/monorepo-builder validate --ansi
+


### PR DESCRIPTION
Execute `monorepo-builder validate` to make sure that all versions in `composer.json` from all packages are the same.