### PR TITLE
Lando: revert to PHP 7.4 instead of 8.0 (because of bug)

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,7 +2,7 @@ name: graphql-api-dev
 recipe: wordpress
 config:
   webroot: wordpress
-  php: '8.0'
+  php: '7.4'
   ssl: true
   database: mariadb
   xdebug: false

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.lando.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.lando.yml
@@ -2,7 +2,7 @@ name: graphql-api-dev
 recipe: wordpress
 config:
   webroot: wordpress
-  php: '8.0'
+  php: '7.4'
   ssl: true
   database: mariadb
   xdebug: false


### PR DESCRIPTION
There is a bug in Lando that makes Composer fail when using PHP 8.0: https://github.com/lando/lando/issues/2795

This PR sets Lando to use PHP 7.4, until the bug is fixed.