### PR TITLE
Use branch instead of dev-master for composer plugin wp-muplugin-loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "guzzlehttp/guzzle": "~6.3",
         "jrfnl/php-cast-to-type": "^2.0",
         "league/pipeline": "^1.0",
-        "lkwdwrd/wp-muplugin-loader": "dev-master",
+        "lkwdwrd/wp-muplugin-loader": "dev-feature-composer-v2",
         "obsidian/polyfill-hrtime": "^0.1",
         "psr/cache": "^1.0",
         "symfony/cache": "^5.1",

--- a/layers/Engine/packages/engine-wp-bootloader/composer.json
+++ b/layers/Engine/packages/engine-wp-bootloader/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.4|^8.0",
         "composer/installers": "~1.0",
         "getpop/routing-wp": "dev-master",
-        "lkwdwrd/wp-muplugin-loader": "dev-master"
+        "lkwdwrd/wp-muplugin-loader": "dev-feature-composer-v2"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0"


### PR DESCRIPTION
To avoid the [canonical error from installing Composer dependencies](https://github.com/leoloso/PoP/pull/297/checks?check_run_id=1666932282#step:4:17):

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires lkwdwrd/wp-muplugin-loader dev-master, it is satisfiable by lkwdwrd/wp-muplugin-loader[dev-master] from composer repo (https://repo.packagist.org) but lkwdwrd/wp-muplugin-loader[1.0.0, ..., 1.0.5] from vcs repo (github https://github.com/leoloso/wp-muplugin-loader.git) has higher repository priority. The packages with higher priority do not match your constraint and are therefore not installable. See https://getcomposer.org/repoprio for details and assistance.

Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires lkwdwrd/wp-muplugin-loader dev-master, it is satisfiable by lkwdwrd/wp-muplugin-loader[dev-master] from composer repo (https://repo.packagist.org) but lkwdwrd/wp-muplugin-loader[1.0.0, ..., 1.0.5] from vcs repo (github https://github.com/leoloso/wp-muplugin-loader.git) has higher repository priority. The packages with higher priority do not match your constraint and are therefore not installable. See https://getcomposer.org/repoprio for details and assistance.

```