### PR TITLE
Use the downgrade_code.sh from getpop/root, and Rector instead of PHPStan in all downgrade tests

### DIFF
--- a/layers/API/packages/api-clients/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-clients/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/API/packages/api-clients/rector-downgrade-code.php
+++ b/layers/API/packages/api-clients/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/API/packages/api-endpoints-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-endpoints-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/API/packages/api-endpoints-for-wp/rector-downgrade-code.php
+++ b/layers/API/packages/api-endpoints-for-wp/rector-downgrade-code.php
@@ -17,16 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/API/packages/api-endpoints/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-endpoints/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/API/packages/api-endpoints/rector-downgrade-code.php
+++ b/layers/API/packages/api-endpoints/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/API/packages/api-graphql/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-graphql/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/API/packages/api-graphql/rector-downgrade-code.php
+++ b/layers/API/packages/api-graphql/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/API/packages/api-mirrorquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-mirrorquery/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/API/packages/api-mirrorquery/rector-downgrade-code.php
+++ b/layers/API/packages/api-mirrorquery/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/API/packages/api-rest/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-rest/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/API/packages/api-rest/rector-downgrade-code.php
+++ b/layers/API/packages/api-rest/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/API/packages/api/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/API/packages/api/rector-downgrade-code.php
+++ b/layers/API/packages/api/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/access-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/access-control/rector-downgrade-code.php
+++ b/layers/Engine/packages/access-control/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/cache-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/cache-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/cache-control/rector-downgrade-code.php
+++ b/layers/Engine/packages/cache-control/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/component-model/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/component-model/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/component-model/rector-downgrade-code.php
+++ b/layers/Engine/packages/component-model/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/configurable-schema-feedback/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/configurable-schema-feedback/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/configurable-schema-feedback/rector-downgrade-code.php
+++ b/layers/Engine/packages/configurable-schema-feedback/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/definitions/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/definitions/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/definitions/rector-downgrade-code.php
+++ b/layers/Engine/packages/definitions/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/engine-wp-bootloader/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine-wp-bootloader/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/engine-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/engine-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/engine-wp/rector-downgrade-code.php
@@ -17,16 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/Engine/packages/engine/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/engine/rector-downgrade-code.php
+++ b/layers/Engine/packages/engine/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/field-query/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/field-query/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/field-query/rector-downgrade-code.php
+++ b/layers/Engine/packages/field-query/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/filestore/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/filestore/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/filestore/rector-downgrade-code.php
+++ b/layers/Engine/packages/filestore/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/function-fields/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/function-fields/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/function-fields/rector-downgrade-code.php
+++ b/layers/Engine/packages/function-fields/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/guzzle-helpers/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/guzzle-helpers/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/guzzle-helpers/rector-downgrade-code.php
+++ b/layers/Engine/packages/guzzle-helpers/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/hooks-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/hooks-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/hooks-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/hooks-wp/rector-downgrade-code.php
@@ -17,16 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/Engine/packages/hooks/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/hooks/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/hooks/rector-downgrade-code.php
+++ b/layers/Engine/packages/hooks/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/loosecontracts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/loosecontracts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/loosecontracts/rector-downgrade-code.php
+++ b/layers/Engine/packages/loosecontracts/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/mandatory-directives-by-configuration/rector-downgrade-code.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/modulerouting/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/modulerouting/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/modulerouting/rector-downgrade-code.php
+++ b/layers/Engine/packages/modulerouting/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/query-parsing/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/query-parsing/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/query-parsing/rector-downgrade-code.php
+++ b/layers/Engine/packages/query-parsing/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/root/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/root/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available. Check https://github.com/rectorphp/rector/pull/4447"
+      #   run: vendor/bin/rector-php71 process build/downgraded-code --ansi --dry-run
 

--- a/layers/Engine/packages/root/rector-downgrade-code.php
+++ b/layers/Engine/packages/root/rector-downgrade-code.php
@@ -11,16 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/routing-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/routing-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/routing-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/routing-wp/rector-downgrade-code.php
@@ -17,16 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/Engine/packages/routing/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/routing/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/routing/rector-downgrade-code.php
+++ b/layers/Engine/packages/routing/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/trace-tools/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/trace-tools/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/trace-tools/rector-downgrade-code.php
+++ b/layers/Engine/packages/trace-tools/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/translation-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/translation-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/translation-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/translation-wp/rector-downgrade-code.php
@@ -17,16 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/Engine/packages/translation/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/translation/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Engine/packages/translation/rector-downgrade-code.php
+++ b/layers/Engine/packages/translation/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/rector-downgrade-code.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/graphql-parser/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/generate_plugin.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/generate_plugin.yml
@@ -110,15 +110,10 @@ jobs:
         with:
           composer-options: "--ignore-platform-reqs"
 
-      # Running PHPStan doesn't work, because dependencies do not pass it!
-      # - name: Run PHPStan on PHP 7.1
-      #   run: vendor/bin/phpstan analyse build/downgraded-code --level 0
-      # Can run Rector on the downgraded code instead.
-      # However, Rector for PHP 7.1 is not ready yet
-      # @see: https://github.com/rectorphp/rector/pull/4447
-      # Uncomment these lines when available
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
       - name: Run Rector on PHP 7.1
-        run: echo "Running Rector on PHP 7.1 must be enabled, once available. Check https://github.com/rectorphp/rector/pull/4447"
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
       #   run: vendor/bin/rector-php71 process build/downgraded-code --ansi --dry-run
 
   upload_and_deploy:

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/rector-downgrade-code.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/graphql-parser/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/rector-downgrade-code.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/rector-downgrade-code.php
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLByPoP/packages/graphql-parser/rector-downgrade-code.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLByPoP/packages/graphql-query/rector-downgrade-code.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLByPoP/packages/graphql-request/rector-downgrade-code.php
+++ b/layers/GraphQLByPoP/packages/graphql-request/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/GraphQLByPoP/packages/graphql-server/rector-downgrade-code.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Misc/packages/examples-for-pop/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Misc/packages/examples-for-pop/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Misc/packages/examples-for-pop/rector-downgrade-code.php
+++ b/layers/Misc/packages/examples-for-pop/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/graphql-by-pop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/graphql-by-pop/graphql-parser/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/basic-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/basic-directives/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/basic-directives/rector-downgrade-code.php
+++ b/layers/Schema/packages/basic-directives/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/block-metadata-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/block-metadata-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/block-metadata-for-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/block-metadata-for-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/categories-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/categories-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/categories-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/categories-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/categories/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/categories/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/categories/rector-downgrade-code.php
+++ b/layers/Schema/packages/categories/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/cdn-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/cdn-directive/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/cdn-directive/rector-downgrade-code.php
+++ b/layers/Schema/packages/cdn-directive/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/comment-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comment-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/comment-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/comment-mutations-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/comment-mutations/rector-downgrade-code.php
+++ b/layers/Schema/packages/comment-mutations/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/commentmeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/commentmeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/commentmeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/commentmeta-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/commentmeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/commentmeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/commentmeta/rector-downgrade-code.php
+++ b/layers/Schema/packages/commentmeta/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/comments-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comments-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/comments-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/comments-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/comments/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comments/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/comments/rector-downgrade-code.php
+++ b/layers/Schema/packages/comments/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/convert-case-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/convert-case-directives/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/convert-case-directives/rector-downgrade-code.php
+++ b/layers/Schema/packages/convert-case-directives/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompost-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompost-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompost-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompost-mutations-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompost-mutations/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompost-mutations/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompostmedia-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompostmedia-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompostmedia-mutations/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmedia-mutations/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompostmedia-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompostmedia-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmedia-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompostmedia/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompostmedia/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmedia/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompostmeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompostmeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmeta-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/custompostmeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/custompostmeta/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmeta/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/customposts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/customposts-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/customposts-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/customposts-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/customposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/customposts/rector-downgrade-code.php
+++ b/layers/Schema/packages/customposts/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/event-mutations-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/event-mutations-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/event-mutations-wp-em/rector-downgrade-code.php
+++ b/layers/Schema/packages/event-mutations-wp-em/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/event-mutations/rector-downgrade-code.php
+++ b/layers/Schema/packages/event-mutations/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/events-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/events-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/events-wp-em/rector-downgrade-code.php
+++ b/layers/Schema/packages/events-wp-em/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/events/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/events/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/events/rector-downgrade-code.php
+++ b/layers/Schema/packages/events/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/everythingelse-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/everythingelse-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/everythingelse-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/everythingelse-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/everythingelse/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/everythingelse/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/everythingelse/rector-downgrade-code.php
+++ b/layers/Schema/packages/everythingelse/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/generic-customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/generic-customposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/generic-customposts/rector-downgrade-code.php
+++ b/layers/Schema/packages/generic-customposts/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/google-translate-directive-for-customposts/rector-downgrade-code.php
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/google-translate-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/google-translate-directive/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/google-translate-directive/rector-downgrade-code.php
+++ b/layers/Schema/packages/google-translate-directive/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/highlights-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/highlights-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/highlights-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/highlights-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/highlights/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/highlights/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/highlights/rector-downgrade-code.php
+++ b/layers/Schema/packages/highlights/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/locationposts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locationposts-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/locationposts-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/locationposts-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/locationposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locationposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/locationposts/rector-downgrade-code.php
+++ b/layers/Schema/packages/locationposts/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/locations-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locations-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/locations-wp-em/rector-downgrade-code.php
+++ b/layers/Schema/packages/locations-wp-em/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/locations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/locations/rector-downgrade-code.php
+++ b/layers/Schema/packages/locations/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/media-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/media-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/media-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/media-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/media/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/media/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/media/rector-downgrade-code.php
+++ b/layers/Schema/packages/media/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/menus-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/menus-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/menus-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/menus-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/menus/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/menus/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/menus/rector-downgrade-code.php
+++ b/layers/Schema/packages/menus/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/meta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/meta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/meta/rector-downgrade-code.php
+++ b/layers/Schema/packages/meta/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/metaquery-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/metaquery-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/metaquery-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/metaquery-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/metaquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/metaquery/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/metaquery/rector-downgrade-code.php
+++ b/layers/Schema/packages/metaquery/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/notifications-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/notifications-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/notifications-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/notifications-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/notifications/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/notifications/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/notifications/rector-downgrade-code.php
+++ b/layers/Schema/packages/notifications/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/pages-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/pages-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/pages-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/pages-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/pages/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/pages/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/pages/rector-downgrade-code.php
+++ b/layers/Schema/packages/pages/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/post-mutations/rector-downgrade-code.php
+++ b/layers/Schema/packages/post-mutations/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/post-tags-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-tags-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/post-tags-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/post-tags-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/post-tags/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-tags/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/post-tags/rector-downgrade-code.php
+++ b/layers/Schema/packages/post-tags/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/posts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/posts-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/posts-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/posts-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/posts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/posts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/posts/rector-downgrade-code.php
+++ b/layers/Schema/packages/posts/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/queriedobject-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/queriedobject-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/queriedobject-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/queriedobject-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/queriedobject/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/queriedobject/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/queriedobject/rector-downgrade-code.php
+++ b/layers/Schema/packages/queriedobject/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/schema-commons/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/schema-commons/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/schema-commons/rector-downgrade-code.php
+++ b/layers/Schema/packages/schema-commons/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/stances-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/stances-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/stances-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/stances-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/stances/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/stances/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/stances/rector-downgrade-code.php
+++ b/layers/Schema/packages/stances/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/tags-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/tags-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/tags-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/tags-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/tags/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/tags/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/tags/rector-downgrade-code.php
+++ b/layers/Schema/packages/tags/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/taxonomies-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomies-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/taxonomies-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomies-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/taxonomies/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomies/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/taxonomies/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomies/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/taxonomymeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomymeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/taxonomymeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomymeta-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/taxonomymeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomymeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/taxonomymeta/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomymeta/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/taxonomyquery-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomyquery-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/taxonomyquery-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomyquery-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/taxonomyquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomyquery/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/taxonomyquery/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomyquery/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/translate-directive-acl/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/translate-directive-acl/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/translate-directive-acl/rector-downgrade-code.php
+++ b/layers/Schema/packages/translate-directive-acl/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/translate-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/translate-directive/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/translate-directive/rector-downgrade-code.php
+++ b/layers/Schema/packages/translate-directive/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-roles-access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-access-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-roles-access-control/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-roles-access-control/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-roles-acl/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-acl/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-roles-acl/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-roles-acl/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-roles-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-roles-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-roles-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-roles/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-roles/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-roles/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-state-access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-access-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-state-access-control/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-state-access-control/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-state-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-state-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-state-mutations-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-state-mutations/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-state-mutations/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-state-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-state-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-state-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/user-state/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/user-state/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-state/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/usermeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/usermeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/usermeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/usermeta-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/usermeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/usermeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/usermeta/rector-downgrade-code.php
+++ b/layers/Schema/packages/usermeta/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/users-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/users-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/users-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/users-wp/rector-downgrade-code.php
@@ -17,19 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Schema/packages/users/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/users/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Schema/packages/users/rector-downgrade-code.php
+++ b/layers/Schema/packages/users/rector-downgrade-code.php
@@ -11,19 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/application-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/application-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/application-wp/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/application-wp/rector-downgrade-code.php
@@ -17,16 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/SiteBuilder/packages/application/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/application/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/application/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/application/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/component-model-configuration/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/component-model-configuration/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/definitionpersistence/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/definitions-base36/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-base36/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/definitions-base36/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/definitions-base36/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/definitions-emoji/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/definitions-emoji/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/multisite/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/multisite/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/multisite/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/multisite/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/resourceloader/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/resourceloader/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/resourceloader/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/resourceloader/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/resources/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/resources/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/resources/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/resources/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/site-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/site-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/site-wp/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/site-wp/rector-downgrade-code.php
@@ -17,16 +17,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/wordpress/wordpress',
     ]);
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/SiteBuilder/packages/site/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/site/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/site/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/site/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/spa/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/spa/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/spa/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/spa/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/static-site-generator/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/static-site-generator/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/SiteBuilder/packages/static-site-generator/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/static-site-generator/rector-downgrade-code.php
@@ -11,17 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/comment-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/comment-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/contactus-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/contactus-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/contactus-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/contactus-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/contactuser-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/contactuser-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/contactuser-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/contactuser-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/custompost-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/custompost-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        // __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        // __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/custompostlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/custompostlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/custompostlink-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/custompostlink-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        // __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        // __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/event-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/event-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/eventlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/eventlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/eventlink-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/eventlink-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/everythingelse-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/everythingelse-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/everythingelse-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/everythingelse-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/flag-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/flag-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/flag-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/flag-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/form-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/form-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/form-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/form-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/gravityforms-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/gravityforms-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/gravityforms-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/gravityforms-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/highlight-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/highlight-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/highlight-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/highlight-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/location-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/location-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/location-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/location-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/locationpost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/locationpost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/locationpost-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/locationpost-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/locationpostlink-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/locationpostlink-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/newsletter-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/newsletter-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/newsletter-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/newsletter-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/notification-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/notification-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/notification-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/notification-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/post-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/post-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/postlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/postlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/postlink-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/postlink-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/share-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/share-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/share-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/share-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/socialnetwork-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/stance-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/stance-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/stance-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/stance-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/system-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/system-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/system-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/system-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/user-state-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/user-state-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/volunteer-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/volunteer-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/volunteer-mutations/rector-downgrade-code.php
+++ b/layers/Wassup/packages/volunteer-mutations/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Wassup/packages/wassup/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/wassup/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --ansi
 
       - name: Downgrade PHP code via Rector
-        run: vendor/bin/rector process --config=rector-downgrade-code.php
+        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks
@@ -42,6 +42,9 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run static analysis via PHPStan on PHP 7.1
-        run: vendor/bin/phpstan analyse src/ --level 0
+      # @todo Fix this code
+      # @see https://github.com/leoloso/PoP/issues/299
+      - name: Run Rector on PHP 7.1
+        run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
+      #   run: vendor/bin/rector-php71 process src vendor --ansi --dry-run
 

--- a/layers/Wassup/packages/wassup/rector-downgrade-code.php
+++ b/layers/Wassup/packages/wassup/rector-downgrade-code.php
@@ -11,21 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
 
-    // paths to refactor; solid alternative to CLI arguments
-    $parameters->set(Option::PATHS, [
-        __DIR__ . '/src',
-        __DIR__ . '/vendor/getpop/*/src',
-        __DIR__ . '/vendor/pop-schema/*/src',
-        __DIR__ . '/vendor/pop-sites-wassup/*/src',
-    ]);
-
-    // is there a file you need to skip?
-    $parameters->set(Option::SKIP, [
-        __DIR__ . '/vendor/getpop/migrate-*/*',
-        __DIR__ . '/vendor/pop-schema/migrate-*/*',
-        __DIR__ . '/vendor/pop-sites-wassup/migrate-*/*',
-    ]);
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released


### PR DESCRIPTION
Two tasks:

1. Use the single `downgrade_code.sh` script placed on `getpop/root`
2. Replace PHPStan with Rector to test the downgrade on PHP 7.1

The last task is added as disabled, because Rector on PHP 7.1 is still unavailable. Check #299.