### PR TITLE
Added --subfolder to source-packages command

### DIFF
--- a/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
@@ -39,17 +39,37 @@ final class SourcePackagesCommand extends AbstractSymplifyCommand
             InputOption::VALUE_NONE,
             'Include all packages, including several not-yet-migrated to PSR-4 ones.'
         );
+        $this->addOption(
+            Option::SUBFOLDER,
+            null,
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'Add paths to a subfolder from the package.',
+            []
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $asJSON = (bool) $input->getOption(Option::JSON);
         $includeAll = (bool) $input->getOption(Option::INCLUDE_ALL);
+        $subfolders = $input->getOption(Option::SUBFOLDER);
 
         $sourcePackages = $this->sourcePackagesProvider->provideSourcePackages($includeAll);
 
+        // Point to some subfolder?
+        if ($subfolders !== []) {
+            $sourcePackagePaths = [];
+            foreach ($sourcePackages as $sourcePackage) {
+                foreach ($subfolders as $subfolder) {
+                    $sourcePackagePaths[] = $sourcePackage . DIRECTORY_SEPARATOR . $subfolder;
+                }
+            }
+        } else {
+            $sourcePackagePaths = $sourcePackages;
+        }
+
         // JSON: must be without spaces, otherwise it breaks GitHub Actions json
-        $response = $asJSON ? Json::encode($sourcePackages) : implode(' ', $sourcePackages);
+        $response = $asJSON ? Json::encode($sourcePackagePaths) : implode(' ', $sourcePackagePaths);
         $this->symfonyStyle->writeln($response);
 
         return ShellCode::SUCCESS;

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
@@ -52,6 +52,7 @@ final class SourcePackagesCommand extends AbstractSymplifyCommand
     {
         $asJSON = (bool) $input->getOption(Option::JSON);
         $includeAll = (bool) $input->getOption(Option::INCLUDE_ALL);
+        /** @var string[] $subfolders */
         $subfolders = $input->getOption(Option::SUBFOLDER);
 
         $sourcePackages = $this->sourcePackagesProvider->provideSourcePackages($includeAll);

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
@@ -18,4 +18,8 @@ final class Option
      * @var string
      */
     public const INCLUDE_ALL = 'include-all';
+    /**
+     * @var string
+     */
+    public const SUBFOLDER = 'subfolder';
 }


### PR DESCRIPTION
The `"source-packages"` command brings the list of paths for packages with `src/` and `tests/` folders:


```bash
vendor/bin/monorepo-builder source-packages
```

which produces:

```
layers/API/packages/api-clients layers/API/packages/api-endpoints ...
```

This PR enables to execute this command with `--subfolder` option:

```bash
vendor/bin/monorepo-builder source-packages --subfolder=src --subfolder=tests
```

which produces:

```
layers/API/packages/api-clients/src layers/API/packages/api-clients/tests layers/API/packages/api-endpoints/src layers/API/packages/api-endpoints/tests ...
```