### PR TITLE
Small improvements

### DIFF
--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -52,7 +52,7 @@ jobs:
                 run: vendor/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} --config=rector-downgrade-code.php --ansi
 
             -   name: Dependencies - Downgrade PHP code via Rector
-                run: layers/Engine/packages/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+                run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
             # Executing `composer config platform-check false` throws error:
             # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR

--- a/layers/API/packages/api-clients/.github/workflows/coding_standards.yml
+++ b/layers/API/packages/api-clients/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/API/packages/api-clients/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-clients/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/API/packages/api-clients/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-clients/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/API/packages/api-clients/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-clients/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/API/packages/api-clients/.github/workflows/unit_tests.yml
+++ b/layers/API/packages/api-clients/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/API/packages/api-endpoints-for-wp/.github/workflows/coding_standards.yml
+++ b/layers/API/packages/api-endpoints-for-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/API/packages/api-endpoints-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-endpoints-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/API/packages/api-endpoints-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-endpoints-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/API/packages/api-endpoints-for-wp/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-endpoints-for-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/API/packages/api-endpoints-for-wp/.github/workflows/unit_tests.yml
+++ b/layers/API/packages/api-endpoints-for-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/API/packages/api-endpoints-for-wp/rector-downgrade-code.php
+++ b/layers/API/packages/api-endpoints-for-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
 

--- a/layers/API/packages/api-endpoints-for-wp/rector-downgrade-code.php
+++ b/layers/API/packages/api-endpoints-for-wp/rector-downgrade-code.php
@@ -16,7 +16,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/API/packages/api-endpoints/.github/workflows/coding_standards.yml
+++ b/layers/API/packages/api-endpoints/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/API/packages/api-endpoints/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-endpoints/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/API/packages/api-endpoints/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-endpoints/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/API/packages/api-endpoints/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-endpoints/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/API/packages/api-endpoints/.github/workflows/unit_tests.yml
+++ b/layers/API/packages/api-endpoints/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/API/packages/api-graphql/.github/workflows/coding_standards.yml
+++ b/layers/API/packages/api-graphql/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/API/packages/api-graphql/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-graphql/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/API/packages/api-graphql/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-graphql/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/API/packages/api-graphql/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-graphql/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/API/packages/api-graphql/.github/workflows/unit_tests.yml
+++ b/layers/API/packages/api-graphql/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/API/packages/api-mirrorquery/.github/workflows/coding_standards.yml
+++ b/layers/API/packages/api-mirrorquery/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/API/packages/api-mirrorquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-mirrorquery/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/API/packages/api-mirrorquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-mirrorquery/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/API/packages/api-mirrorquery/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-mirrorquery/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/API/packages/api-mirrorquery/.github/workflows/unit_tests.yml
+++ b/layers/API/packages/api-mirrorquery/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/API/packages/api-rest/.github/workflows/coding_standards.yml
+++ b/layers/API/packages/api-rest/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/API/packages/api-rest/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-rest/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/API/packages/api-rest/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api-rest/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/API/packages/api-rest/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-rest/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/API/packages/api-rest/.github/workflows/unit_tests.yml
+++ b/layers/API/packages/api-rest/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/API/packages/api/.github/workflows/coding_standards.yml
+++ b/layers/API/packages/api/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/API/packages/api/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/API/packages/api/.github/workflows/downgrade_php_tests.yml
+++ b/layers/API/packages/api/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/API/packages/api/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/API/packages/api/.github/workflows/unit_tests.yml
+++ b/layers/API/packages/api/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/access-control/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/access-control/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/access-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/access-control/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/access-control/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/access-control/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/access-control/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/access-control/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/cache-control/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/cache-control/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/cache-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/cache-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/cache-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/cache-control/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/cache-control/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/cache-control/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/cache-control/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/cache-control/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/component-model/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/component-model/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/component-model/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/component-model/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/component-model/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/component-model/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/component-model/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/component-model/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/component-model/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/component-model/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/configurable-schema-feedback/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/configurable-schema-feedback/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/configurable-schema-feedback/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/configurable-schema-feedback/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/configurable-schema-feedback/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/configurable-schema-feedback/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/configurable-schema-feedback/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/configurable-schema-feedback/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/configurable-schema-feedback/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/configurable-schema-feedback/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/definitions/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/definitions/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/definitions/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/definitions/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/definitions/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/definitions/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/definitions/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/definitions/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/definitions/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/definitions/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/engine-wp-bootloader/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/engine-wp-bootloader/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/engine-wp-bootloader/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine-wp-bootloader/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/engine-wp-bootloader/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine-wp-bootloader/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/engine-wp-bootloader/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/engine-wp-bootloader/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/engine-wp-bootloader/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/engine-wp-bootloader/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/engine-wp/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/engine-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/engine-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/engine-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/engine-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/engine-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/engine-wp/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/engine-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/engine-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/engine-wp/rector-downgrade-code.php
@@ -13,10 +13,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
-
 
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [

--- a/layers/Engine/packages/engine/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/engine/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/engine/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/engine/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/engine/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/engine/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/engine/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/engine/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/engine/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/field-query/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/field-query/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/field-query/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/field-query/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/field-query/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/field-query/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/field-query/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/field-query/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/field-query/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/field-query/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/filestore/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/filestore/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/filestore/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/filestore/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/filestore/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/filestore/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/filestore/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/filestore/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/filestore/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/filestore/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/function-fields/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/function-fields/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/function-fields/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/function-fields/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/function-fields/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/function-fields/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/function-fields/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/function-fields/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/function-fields/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/function-fields/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/guzzle-helpers/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/guzzle-helpers/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/guzzle-helpers/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/guzzle-helpers/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/guzzle-helpers/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/guzzle-helpers/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/guzzle-helpers/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/guzzle-helpers/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/guzzle-helpers/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/guzzle-helpers/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/hooks-wp/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/hooks-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/hooks-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/hooks-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/hooks-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/hooks-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/hooks-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/hooks-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/hooks-wp/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/hooks-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/hooks-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/hooks-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
 

--- a/layers/Engine/packages/hooks-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/hooks-wp/rector-downgrade-code.php
@@ -16,7 +16,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/hooks/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/hooks/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/hooks/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/hooks/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/hooks/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/hooks/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/hooks/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/hooks/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/hooks/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/hooks/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/loosecontracts/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/loosecontracts/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/loosecontracts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/loosecontracts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/loosecontracts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/loosecontracts/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/loosecontracts/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/loosecontracts/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/loosecontracts/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/loosecontracts/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/modulerouting/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/modulerouting/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/modulerouting/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/modulerouting/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/modulerouting/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/modulerouting/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/modulerouting/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/modulerouting/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/modulerouting/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/modulerouting/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/query-parsing/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/query-parsing/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/query-parsing/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/query-parsing/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/query-parsing/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/query-parsing/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/query-parsing/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/query-parsing/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/query-parsing/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/query-parsing/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/root/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/root/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/root/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/root/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/root/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/root/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/root/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/root/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/root/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/root/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/routing-wp/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/routing-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/routing-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/routing-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/routing-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/routing-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/routing-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/routing-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/routing-wp/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/routing-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/routing-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/routing-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
 

--- a/layers/Engine/packages/routing-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/routing-wp/rector-downgrade-code.php
@@ -16,7 +16,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/routing/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/routing/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/routing/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/routing/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/routing/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/routing/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/routing/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/routing/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/routing/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/routing/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/trace-tools/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/trace-tools/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/trace-tools/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/trace-tools/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/trace-tools/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/trace-tools/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/trace-tools/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/trace-tools/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/trace-tools/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/trace-tools/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/translation-wp/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/translation-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/translation-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/translation-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/translation-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/translation-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/translation-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/translation-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/translation-wp/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/translation-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Engine/packages/translation-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/translation-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
 

--- a/layers/Engine/packages/translation-wp/rector-downgrade-code.php
+++ b/layers/Engine/packages/translation-wp/rector-downgrade-code.php
@@ -16,7 +16,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/Engine/packages/translation/.github/workflows/coding_standards.yml
+++ b/layers/Engine/packages/translation/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Engine/packages/translation/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/translation/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Engine/packages/translation/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Engine/packages/translation/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Engine/packages/translation/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/translation/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Engine/packages/translation/.github/workflows/unit_tests.yml
+++ b/layers/Engine/packages/translation/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/phpstan.yml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/rector-downgrade-code.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/rector-downgrade-code.php
@@ -25,8 +25,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/bin/rector process src --config=rector-downgrade-code.php

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/generate_plugin.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/generate_plugin.yml
@@ -47,7 +47,7 @@ jobs:
           composer install
 
       - name: Downgrade code for production (to PHP 7.1)
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       - name: Replace PHP version in plugin main file
         run: |

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/phpstan.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/rector-downgrade-code.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/rector-downgrade-code.php
@@ -25,8 +25,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // files to skip downgrading

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/phpstan.yml
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/rector-downgrade-code.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/rector-downgrade-code.php
@@ -25,8 +25,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     /**

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/rector-downgrade-code.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/coding_standards.yml
+++ b/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/downgrade_php_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/unit_tests.yml
+++ b/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Misc/packages/examples-for-pop/.github/workflows/coding_standards.yml
+++ b/layers/Misc/packages/examples-for-pop/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Misc/packages/examples-for-pop/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Misc/packages/examples-for-pop/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Misc/packages/examples-for-pop/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Misc/packages/examples-for-pop/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Misc/packages/examples-for-pop/.github/workflows/phpstan.yml
+++ b/layers/Misc/packages/examples-for-pop/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Misc/packages/examples-for-pop/.github/workflows/unit_tests.yml
+++ b/layers/Misc/packages/examples-for-pop/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/basic-directives/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/basic-directives/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/basic-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/basic-directives/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/basic-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/basic-directives/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/basic-directives/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/basic-directives/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/basic-directives/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/basic-directives/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/block-metadata-for-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/block-metadata-for-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/block-metadata-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/block-metadata-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/block-metadata-for-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/block-metadata-for-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/block-metadata-for-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/block-metadata-for-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/block-metadata-for-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/block-metadata-for-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/block-metadata-for-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/block-metadata-for-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/categories-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/categories-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/categories-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/categories-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/categories-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/categories-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/categories-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/categories-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/categories-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/categories-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/categories-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/categories-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/categories/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/categories/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/categories/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/categories/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/categories/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/categories/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/categories/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/categories/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/categories/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/categories/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/cdn-directive/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/cdn-directive/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/cdn-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/cdn-directive/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/cdn-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/cdn-directive/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/cdn-directive/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/cdn-directive/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/cdn-directive/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/cdn-directive/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/comment-mutations-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/comment-mutations-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/comment-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comment-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/comment-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comment-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/comment-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comment-mutations-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/comment-mutations-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/comment-mutations-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/comment-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/comment-mutations-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/comment-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/comment-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/comment-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comment-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/comment-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/comment-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/commentmeta-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/commentmeta-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/commentmeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/commentmeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/commentmeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/commentmeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/commentmeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/commentmeta-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/commentmeta-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/commentmeta-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/commentmeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/commentmeta-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/commentmeta/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/commentmeta/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/commentmeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/commentmeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/commentmeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/commentmeta/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/commentmeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/commentmeta/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/commentmeta/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/commentmeta/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/comments-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/comments-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/comments-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comments-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/comments-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comments-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/comments-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comments-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/comments-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/comments-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/comments-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/comments-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/comments/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/comments/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/comments/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comments/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/comments/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/comments/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/comments/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comments/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/comments/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/comments/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/convert-case-directives/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/convert-case-directives/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/convert-case-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/convert-case-directives/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/convert-case-directives/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/convert-case-directives/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/convert-case-directives/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/convert-case-directives/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/convert-case-directives/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/convert-case-directives/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompost-mutations-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompost-mutations-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompost-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompost-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompost-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompost-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompost-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompost-mutations-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompost-mutations-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompost-mutations-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompost-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompost-mutations-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/custompost-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompost-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompost-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompost-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompost-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompost-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompostmedia-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/custompostmedia-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompostmedia-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompostmedia-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompostmedia-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompostmedia-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompostmedia-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompostmedia-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompostmedia-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompostmedia-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompostmedia-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompostmedia-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompostmedia-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompostmedia-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompostmedia-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompostmedia-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmedia-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/custompostmedia/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompostmedia/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompostmedia/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompostmedia/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmedia/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompostmedia/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompostmedia/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompostmedia/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompostmeta-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompostmeta-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompostmeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompostmeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompostmeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmeta-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompostmeta-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompostmeta-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/custompostmeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/custompostmeta-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/custompostmeta/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/custompostmeta/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/custompostmeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/custompostmeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/custompostmeta/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/custompostmeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmeta/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/custompostmeta/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/custompostmeta/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/customposts-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/customposts-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/customposts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/customposts-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/customposts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/customposts-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/customposts-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/customposts-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/customposts-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/customposts-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/customposts-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/customposts-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/customposts/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/customposts/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/customposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/customposts/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/customposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/customposts/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/customposts/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/customposts/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/event-mutations-wp-em/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/event-mutations-wp-em/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/event-mutations-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/event-mutations-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/event-mutations-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/event-mutations-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/event-mutations-wp-em/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/event-mutations-wp-em/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/event-mutations-wp-em/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/event-mutations-wp-em/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/event-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/event-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/event-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/event-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/event-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/event-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/events-wp-em/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/events-wp-em/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/events-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/events-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/events-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/events-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/events-wp-em/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/events-wp-em/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/events-wp-em/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/events-wp-em/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/events/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/events/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/events/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/events/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/events/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/events/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/events/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/events/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/events/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/events/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/everythingelse-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/everythingelse-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/everythingelse-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/everythingelse-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/everythingelse-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/everythingelse-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/everythingelse-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/everythingelse-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/everythingelse-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/everythingelse-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/everythingelse-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/everythingelse-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/everythingelse/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/everythingelse/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/everythingelse/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/everythingelse/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/everythingelse/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/everythingelse/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/everythingelse/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/everythingelse/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/everythingelse/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/everythingelse/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/generic-customposts/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/generic-customposts/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/generic-customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/generic-customposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/generic-customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/generic-customposts/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/generic-customposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/generic-customposts/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/generic-customposts/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/generic-customposts/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/google-translate-directive/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/google-translate-directive/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/google-translate-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/google-translate-directive/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/google-translate-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/google-translate-directive/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/google-translate-directive/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/google-translate-directive/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/google-translate-directive/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/google-translate-directive/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/highlights-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/highlights-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/highlights-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/highlights-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/highlights-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/highlights-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/highlights-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/highlights-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/highlights-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/highlights-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/highlights-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/highlights-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/highlights/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/highlights/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/highlights/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/highlights/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/highlights/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/highlights/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/highlights/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/highlights/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/highlights/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/highlights/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/locationposts-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/locationposts-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/locationposts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locationposts-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/locationposts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locationposts-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/locationposts-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locationposts-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/locationposts-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/locationposts-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/locationposts-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/locationposts-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/locationposts/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/locationposts/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/locationposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locationposts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/locationposts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locationposts/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/locationposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locationposts/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/locationposts/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/locationposts/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/locations-wp-em/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/locations-wp-em/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/locations-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locations-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/locations-wp-em/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locations-wp-em/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/locations-wp-em/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locations-wp-em/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/locations-wp-em/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/locations-wp-em/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/locations/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/locations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/locations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/locations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/locations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/locations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/locations/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/locations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/media-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/media-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/media-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/media-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/media-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/media-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/media-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/media-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/media-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/media-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/media-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/media-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/media/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/media/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/media/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/media/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/media/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/media/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/media/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/media/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/media/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/media/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/menus-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/menus-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/menus-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/menus-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/menus-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/menus-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/menus-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/menus-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/menus-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/menus-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/menus-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/menus-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/menus/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/menus/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/menus/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/menus/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/menus/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/menus/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/menus/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/menus/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/menus/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/menus/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/meta/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/meta/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/meta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/meta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/meta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/meta/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/meta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/meta/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/meta/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/meta/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/metaquery-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/metaquery-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/metaquery-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/metaquery-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/metaquery-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/metaquery-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/metaquery-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/metaquery-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/metaquery-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/metaquery-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/metaquery-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/metaquery-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/metaquery/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/metaquery/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/metaquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/metaquery/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/metaquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/metaquery/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/metaquery/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/metaquery/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/metaquery/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/metaquery/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/notifications-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/notifications-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/notifications-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/notifications-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/notifications-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/notifications-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/notifications-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/notifications-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/notifications-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/notifications-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/notifications-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/notifications-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/notifications/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/notifications/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/notifications/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/notifications/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/notifications/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/notifications/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/notifications/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/notifications/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/notifications/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/notifications/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/pages-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/pages-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/pages-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/pages-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/pages-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/pages-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/pages-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/pages-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/pages-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/pages-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/pages-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/pages-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/pages/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/pages/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/pages/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/pages/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/pages/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/pages/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/pages/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/pages/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/pages/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/pages/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/post-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/post-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/post-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/post-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/post-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/post-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/post-tags-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/post-tags-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/post-tags-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-tags-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/post-tags-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-tags-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/post-tags-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/post-tags-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/post-tags-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/post-tags-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/post-tags-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/post-tags-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/post-tags/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/post-tags/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/post-tags/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-tags/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/post-tags/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/post-tags/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/post-tags/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/post-tags/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/post-tags/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/post-tags/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/posts-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/posts-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/posts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/posts-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/posts-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/posts-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/posts-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/posts-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/posts-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/posts-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/posts-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/posts-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/posts/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/posts/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/posts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/posts/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/posts/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/posts/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/posts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/posts/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/posts/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/posts/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/queriedobject-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/queriedobject-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/queriedobject-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/queriedobject-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/queriedobject-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/queriedobject-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/queriedobject-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/queriedobject-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/queriedobject-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/queriedobject-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/queriedobject-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/queriedobject-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/queriedobject/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/queriedobject/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/queriedobject/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/queriedobject/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/queriedobject/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/queriedobject/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/queriedobject/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/queriedobject/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/queriedobject/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/queriedobject/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/schema-commons/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/schema-commons/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/schema-commons/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/schema-commons/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/schema-commons/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/schema-commons/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/schema-commons/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/schema-commons/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/schema-commons/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/schema-commons/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/stances-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/stances-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/stances-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/stances-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/stances-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/stances-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/stances-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/stances-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/stances-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/stances-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/stances-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/stances-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/stances/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/stances/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/stances/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/stances/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/stances/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/stances/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/stances/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/stances/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/stances/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/stances/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/tags-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/tags-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/tags-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/tags-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/tags-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/tags-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/tags-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/tags-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/tags-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/tags-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/tags-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/tags-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/tags/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/tags/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/tags/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/tags/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/tags/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/tags/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/tags/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/tags/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/tags/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/tags/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/taxonomies-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/taxonomies-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/taxonomies-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomies-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/taxonomies-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomies-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/taxonomies-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomies-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/taxonomies-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/taxonomies-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/taxonomies-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomies-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/taxonomies/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/taxonomies/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/taxonomies/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomies/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/taxonomies/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomies/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/taxonomies/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomies/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/taxonomies/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/taxonomies/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/taxonomymeta-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/taxonomymeta-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/taxonomymeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomymeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/taxonomymeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomymeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/taxonomymeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomymeta-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/taxonomymeta-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/taxonomymeta-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/taxonomymeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomymeta-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/taxonomymeta/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/taxonomymeta/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/taxonomymeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomymeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/taxonomymeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomymeta/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/taxonomymeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomymeta/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/taxonomymeta/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/taxonomymeta/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/taxonomyquery-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/taxonomyquery-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/taxonomyquery-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomyquery-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/taxonomyquery-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomyquery-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/taxonomyquery-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomyquery-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/taxonomyquery-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/taxonomyquery-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/taxonomyquery-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/taxonomyquery-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/taxonomyquery/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/taxonomyquery/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/taxonomyquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomyquery/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/taxonomyquery/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/taxonomyquery/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/taxonomyquery/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomyquery/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/taxonomyquery/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/taxonomyquery/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/translate-directive-acl/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/translate-directive-acl/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/translate-directive-acl/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/translate-directive-acl/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/translate-directive-acl/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/translate-directive-acl/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/translate-directive-acl/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/translate-directive-acl/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/translate-directive-acl/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/translate-directive-acl/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/translate-directive/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/translate-directive/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/translate-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/translate-directive/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/translate-directive/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/translate-directive/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/translate-directive/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/translate-directive/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/translate-directive/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/translate-directive/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-roles-access-control/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-roles-access-control/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-roles-access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-access-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-roles-access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-access-control/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-roles-access-control/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles-access-control/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-roles-access-control/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-roles-access-control/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-roles-acl/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-roles-acl/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-roles-acl/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-acl/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-roles-acl/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-acl/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-roles-acl/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles-acl/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-roles-acl/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-roles-acl/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-roles-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-roles-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-roles-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-roles-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-roles-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-roles-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-roles-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-roles-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-roles-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/user-roles/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-roles/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-roles/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-roles/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-roles/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-roles/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-roles/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-roles/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-state-access-control/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-state-access-control/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-state-access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-access-control/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-state-access-control/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-access-control/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-state-access-control/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-access-control/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-state-access-control/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-state-access-control/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-state-mutations-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-state-mutations-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-state-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-state-mutations-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-mutations-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-state-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-mutations-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-state-mutations-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-state-mutations-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-state-mutations-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-state-mutations-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/user-state-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-state-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-state-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-state-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-state-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-state-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-state-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-state-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-state-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-state-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-state-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-state-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/user-state-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/user-state-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/user-state/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/user-state/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/user-state/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/user-state/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/user-state/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/user-state/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/user-state/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/user-state/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/usermeta-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/usermeta-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/usermeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/usermeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/usermeta-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/usermeta-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/usermeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/usermeta-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/usermeta-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/usermeta-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/usermeta-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/usermeta-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/usermeta/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/usermeta/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/usermeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/usermeta/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/usermeta/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/usermeta/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/usermeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/usermeta/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/usermeta/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/usermeta/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/users-wp/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/users-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/users-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/users-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/users-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/users-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/users-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/users-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/users-wp/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/users-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Schema/packages/users-wp/rector-downgrade-code.php
+++ b/layers/Schema/packages/users-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
     // here we can define, what sets of rules will be applied

--- a/layers/Schema/packages/users/.github/workflows/coding_standards.yml
+++ b/layers/Schema/packages/users/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Schema/packages/users/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/users/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Schema/packages/users/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Schema/packages/users/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Schema/packages/users/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/users/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Schema/packages/users/.github/workflows/unit_tests.yml
+++ b/layers/Schema/packages/users/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/application-wp/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/application-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/application-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/application-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/application-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/application-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/application-wp/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/application-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/application-wp/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/application-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/application-wp/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/application-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
 

--- a/layers/SiteBuilder/packages/application-wp/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/application-wp/rector-downgrade-code.php
@@ -16,7 +16,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/application/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/application/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/application/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/application/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/application/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/application/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/application/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/application/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/application/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/application/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/definitions-base36/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/definitions-base36/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/definitions-base36/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-base36/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/definitions-base36/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-base36/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/definitions-base36/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/definitions-base36/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/definitions-base36/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-base36/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/multisite/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/multisite/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/multisite/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/multisite/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/multisite/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/multisite/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/multisite/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/multisite/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/multisite/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/multisite/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/resourceloader/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/resourceloader/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/resourceloader/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/resourceloader/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/resourceloader/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/resourceloader/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/resourceloader/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/resourceloader/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/resourceloader/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/resourceloader/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/resources/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/resources/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/resources/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/resources/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/resources/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/resources/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/resources/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/resources/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/resources/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/resources/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/site-wp/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/site-wp/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/site-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/site-wp/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/site-wp/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/site-wp/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/site-wp/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/site-wp/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/site-wp/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/site-wp/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/site-wp/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/site-wp/rector-downgrade-code.php
@@ -13,8 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        // full directory
-        __DIR__ . '/vendor/wordpress/wordpress',
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
 

--- a/layers/SiteBuilder/packages/site-wp/rector-downgrade-code.php
+++ b/layers/SiteBuilder/packages/site-wp/rector-downgrade-code.php
@@ -16,7 +16,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 
-
     // here we can define, what sets of rules will be applied
     $parameters->set(Option::SETS, [
         // @todo Uncomment when PHP 8.0 released

--- a/layers/SiteBuilder/packages/site/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/site/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/site/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/site/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/site/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/site/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/site/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/site/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/site/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/site/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/spa/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/spa/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/spa/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/spa/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/spa/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/spa/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/spa/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/spa/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/spa/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/spa/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/SiteBuilder/packages/static-site-generator/.github/workflows/coding_standards.yml
+++ b/layers/SiteBuilder/packages/static-site-generator/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/SiteBuilder/packages/static-site-generator/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/static-site-generator/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/SiteBuilder/packages/static-site-generator/.github/workflows/downgrade_php_tests.yml
+++ b/layers/SiteBuilder/packages/static-site-generator/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/SiteBuilder/packages/static-site-generator/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/static-site-generator/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/SiteBuilder/packages/static-site-generator/.github/workflows/unit_tests.yml
+++ b/layers/SiteBuilder/packages/static-site-generator/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/comment-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/comment-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/comment-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/comment-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/comment-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/comment-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/comment-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/contactus-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/contactus-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/contactus-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/contactus-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/contactus-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/contactus-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/contactus-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/contactus-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/contactus-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/contactus-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/contactuser-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/contactuser-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/contactuser-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/contactuser-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/contactuser-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/contactuser-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/contactuser-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/contactuser-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/contactuser-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/contactuser-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/custompost-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/custompost-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/custompost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/custompost-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/custompost-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/custompost-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/custompost-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/custompostlink-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/custompostlink-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/custompostlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/custompostlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/custompostlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/custompostlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/custompostlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/custompostlink-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/custompostlink-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/custompostlink-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/event-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/event-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/event-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/event-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/event-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/event-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/event-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/eventlink-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/eventlink-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/eventlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/eventlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/eventlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/eventlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/eventlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/eventlink-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/eventlink-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/eventlink-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/everythingelse-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/everythingelse-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/everythingelse-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/everythingelse-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/everythingelse-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/everythingelse-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/everythingelse-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/everythingelse-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/everythingelse-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/everythingelse-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/flag-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/flag-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/flag-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/flag-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/flag-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/flag-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/flag-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/flag-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/flag-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/flag-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/form-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/form-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/form-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/form-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/form-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/form-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/form-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/form-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/form-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/form-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/gravityforms-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/gravityforms-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/gravityforms-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/gravityforms-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/gravityforms-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/gravityforms-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/gravityforms-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/gravityforms-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/gravityforms-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/gravityforms-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/highlight-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/highlight-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/highlight-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/highlight-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/highlight-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/highlight-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/highlight-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/highlight-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/highlight-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/highlight-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/location-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/location-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/location-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/location-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/location-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/location-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/location-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/location-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/location-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/location-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/locationpost-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/locationpost-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/locationpost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/locationpost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/locationpost-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/locationpost-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/locationpost-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/locationpost-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/locationpost-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/locationpost-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/newsletter-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/newsletter-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/newsletter-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/newsletter-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/newsletter-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/newsletter-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/newsletter-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/newsletter-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/newsletter-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/newsletter-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/notification-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/notification-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/notification-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/notification-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/notification-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/notification-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/notification-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/notification-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/notification-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/notification-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/post-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/post-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/post-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/post-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/post-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/post-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/post-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/postlink-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/postlink-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/postlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/postlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/postlink-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/postlink-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/postlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/postlink-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/postlink-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/postlink-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/share-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/share-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/share-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/share-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/share-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/share-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/share-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/share-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/share-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/share-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/stance-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/stance-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/stance-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/stance-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/stance-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/stance-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/stance-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/stance-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/stance-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/stance-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/system-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/system-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/system-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/system-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/system-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/system-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/system-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/system-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/system-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/system-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/user-state-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/user-state-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/user-state-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/user-state-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/user-state-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/user-state-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/user-state-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/volunteer-mutations/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/volunteer-mutations/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/volunteer-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/volunteer-mutations/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/volunteer-mutations/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/volunteer-mutations/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/volunteer-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/volunteer-mutations/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/volunteer-mutations/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/volunteer-mutations/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit

--- a/layers/Wassup/packages/wassup/.github/workflows/coding_standards.yml
+++ b/layers/Wassup/packages/wassup/.github/workflows/coding_standards.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs -n src/

--- a/layers/Wassup/packages/wassup/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/wassup/.github/workflows/downgrade_php_tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
-        run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"
+        run: vendor/getpop/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
       # dumpautoload will remove vendor/composer/platform_check.php, otherwise executing phpstan on 7.1 fails
       - name: Avoid Composer v2 platform checks

--- a/layers/Wassup/packages/wassup/.github/workflows/downgrade_php_tests.yml
+++ b/layers/Wassup/packages/wassup/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Downgrade PHP code via Rector
         run: vendor/getpop/root/ci/downgrade_code.sh "7.1" "rector-downgrade-code.php"

--- a/layers/Wassup/packages/wassup/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/wassup/.github/workflows/phpstan.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/layers/Wassup/packages/wassup/.github/workflows/unit_tests.yml
+++ b/layers/Wassup/packages/wassup/.github/workflows/unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --ansi
+        uses: "ramsey/composer-install@v1"
 
       - name: Run tests
         run: vendor/bin/phpunit


### PR DESCRIPTION
Several small improvements:

- Autoload WordPress stubs (instead of the WP dir) in Rector: `__DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php'`
- Use `ramsey/composer-install@v1` instead of doing `composer install --no-progress --ansi`
- Remove quotes from: `downgrade_code.sh "7.1" "rector-downgrade-code.php"`