### PR TITLE
Set empty matrix if git diff involves no packages

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -42,7 +42,7 @@ jobs:
             # 2. Extract 4 first layers only (for package path) and get unique entries
             # 3. Add --filter= in between entries
             -   id: output_data
-                name: Calculate matrix
+                name: Calculate matrix for packages
                 run: |
                     quote=\'
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
@@ -50,7 +50,12 @@ jobs:
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
                     filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
                     echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                if: env.GIT_DIFF
+                if: env.GIT_DIFF != ""
+            -   id: output_data
+                name: Set empty matrix
+                run: |
+                    echo "::set-output name=matrix::[]"
+                if: env.GIT_DIFF == ""
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -39,7 +39,7 @@ jobs:
             # 2. Extract 4 first layers only (for package path) and get unique entries
             # 3. Add --filter= in between entries
             -   id: output_data
-                name: Calculate matrix
+                name: Calculate matrix for packages
                 run: |
                     quote=\'
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
@@ -47,7 +47,12 @@ jobs:
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
                     filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
                     echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                if: env.GIT_DIFF
+                if: env.GIT_DIFF != ""
+            -   id: output_data
+                name: Set empty matrix
+                run: |
+                    echo "::set-output name=matrix::[]"
+                if: env.GIT_DIFF == ""
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -48,7 +48,7 @@ jobs:
             # 2. Extract 4 first layers only (for package path) and get unique entries
             # 3. Add --filter= in between entries
             -   id: output_data
-                name: Calculate matrix
+                name: Calculate matrix for packages
                 run: |
                     quote=\'
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
@@ -56,7 +56,12 @@ jobs:
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
                     filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
                     echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                if: env.GIT_DIFF
+                if: env.GIT_DIFF != ""
+            -   id: output_data
+                name: Set empty matrix
+                run: |
+                    echo "::set-output name=matrix::[]"
+                if: env.GIT_DIFF == ""
 
         outputs:
             matrix: ${{ steps.output_data.outputs.matrix }}


### PR DESCRIPTION
Make sure that `${{ steps.output_data.outputs.matrix }}` always has a value, otherwise the [CI shows an error](https://github.com/leoloso/PoP/actions/runs/473711282):

```
Error when evaluating 'strategy' for job 'split_monorepo'. (Line: 66, Col: 26): Error reading JToken from JsonReader. Path '', line 0, position 0.,(Line: 66, Col: 26): Unexpected value '' 
```