### PR TITLE
Define empty matrix in same step

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -48,14 +48,9 @@ jobs:
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
-                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                if: env.GIT_DIFF != ""
-            -   id: output_data
-                name: Set empty matrix
-                run: |
-                    echo "::set-output name=matrix::[]"
-                if: env.GIT_DIFF == ""
+                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
+                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
+                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]"
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -45,14 +45,9 @@ jobs:
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
-                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                if: env.GIT_DIFF != ""
-            -   id: output_data
-                name: Set empty matrix
-                run: |
-                    echo "::set-output name=matrix::[]"
-                if: env.GIT_DIFF == ""
+                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
+                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
+                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]"
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -54,14 +54,9 @@ jobs:
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
-                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                if: env.GIT_DIFF != ""
-            -   id: output_data
-                name: Set empty matrix
-                run: |
-                    echo "::set-output name=matrix::[]"
-                if: env.GIT_DIFF == ""
+                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
+                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
+                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]"
 
         outputs:
             matrix: ${{ steps.output_data.outputs.matrix }}


### PR DESCRIPTION
PR #313 didn't work, it [gives error message](https://github.com/leoloso/PoP/actions/runs/473750902):

```
The workflow is not valid. .github/workflows/split_monorepo.yaml (Line: 54, Col: 21): The identifier 'output_data' may not be used more than once within the same scope. 
```

So set the value for the matrix, or define it as empty, within the same step:

```sh
[ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
[ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
[ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]"
```