### PR TITLE
Added "if" to spawn matrix

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -58,7 +58,7 @@ jobs:
 
     split_monorepo:
         needs: provide_packages_json
-
+        if: needs.provide_packages_json.outputs.matrix
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -55,7 +55,7 @@ jobs:
 
     split_monorepo_tagged:
         needs: provide_packages_json_tagged
-
+        if: needs.provide_packages_json_tagged.outputs.matrix
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -63,9 +63,8 @@ jobs:
 
     split_tests:
         needs: provide_packages_json
-
+        if: needs.provide_packages_json.outputs.matrix
         runs-on: ubuntu-latest
-
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
When there are no packages, the matrix [returns an error](https://github.com/leoloso/PoP/actions/runs/473764701):

```
Error when evaluating 'strategy' for job 'split_monorepo'. (Line: 66, Col: 26): Matrix vector 'package' does not contain any values 
```

So added an `if` to check that the variable has values.