### PR TITLE
Convert string to object in if

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -58,7 +58,7 @@ jobs:
 
     split_monorepo:
         needs: provide_packages_json
-        if: needs.provide_packages_json.outputs.matrix
+        if: fromJson(needs.provide_packages_json.outputs.matrix)
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -55,7 +55,7 @@ jobs:
 
     split_monorepo_tagged:
         needs: provide_packages_json_tagged
-        if: needs.provide_packages_json_tagged.outputs.matrix
+        if: fromJson(needs.provide_packages_json_tagged.outputs.matrix)
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -63,12 +63,12 @@ jobs:
 
     split_tests:
         needs: provide_packages_json
-        if: needs.provide_packages_json.outputs.matrix
+        if: fromJson(needs.provide_packages_json.outputs.matrix)
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                package: ${{ fromJson(needs.provide_packages_json.outputs.matrix )}}
+                package: ${{ fromJson(needs.provide_packages_json.outputs.matrix)}}
 
         name: Split Tests of ${{ matrix.package.name }} (${{ matrix.package.path }})
 


### PR DESCRIPTION
The `if` condition was always `true`, since it received the string `[]`, so it still [throws an error](https://github.com/leoloso/PoP/actions/runs/473773581). This PR converts it with `fromJson` before evaluation.