### PR TITLE
On tagging, split all packages

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -5,10 +5,6 @@ on:
         branches:
             - master
 
-        # see https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/10?u=tomasvotruba
-        tags:
-            - '*'
-
 jobs:
     provide_packages_json:
         name: Provide data

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -27,27 +27,11 @@ jobs:
 
             -   uses: "ramsey/composer-install@v1"
 
-            # git diff to generate matrix with modified packages only
-            -   uses: technote-space/get-diff-action@v4
-                with:
-                    PATTERNS: layers/*/*/*/**
-
-            # get package json list - if filter is empty, don't launch any split
-            # Enhancement: produce the packages already, avoid potentially sending thousands of CLI args
-            # Steps to process string:
-            # 1. remove single quotes
-            # 2. Extract 4 first layers only (for package path) and get unique entries
-            # 3. Add --filter= in between entries
+            # get package json list
             -   id: output_data
                 name: Calculate matrix for packages
                 run: |
-                    quote=\'
-                    clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
-                    packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
-                    echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
-                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json)"
 
         # this step is needed, so the output gets to the next defined job
         outputs:
@@ -55,7 +39,6 @@ jobs:
 
     split_monorepo_tagged:
         needs: provide_packages_json_tagged
-        if: needs.provide_packages_json_tagged.outputs.matrix != '[]'
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false


### PR DESCRIPTION
When tagging the monorepo, all packages must be tagged also, even if they have no changes. Hence, ignore `git diff` and split everything.

Also, no need to trigger `split_monorepo` on tagging, since the `tagged_split_monorepo` already takes care of it