### PR TITLE
Bumped GraphQL API to version 0.7.6

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -10,6 +10,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Composable directives
 
+## 0.7.5 to 0.7.6 - 2021-01-09
+
+### Fixed
+
+- Compatibility with PHP 8.0
+
 ## 0.7.1 to 0.7.4 - 2020-12-17
 
 ### Fixed

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
@@ -63,7 +63,7 @@ Add the following configuration to your `composer.json`:
 ```json
 {
     "require": {
-        "graphql-api/graphql-api-for-wp": "^0.7.4"
+        "graphql-api/graphql-api-for-wp": "^0.7.6"
     },
     "minimum-stability": "dev",
     "repositories": [
@@ -72,7 +72,7 @@ Add the following configuration to your `composer.json`:
             "package": {
                 "name": "graphql-api/graphql-api-for-wp",
                 "type": "wordpress-plugin",
-                "version": "0.7.4",
+                "version": "0.7.6",
                 "dist": {
                     "url": "https://github.com/GraphQLAPI/graphql-api-for-wp/releases/latest/download/graphql-api.zip",
                     "type": "zip"

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
@@ -3,7 +3,7 @@
 Plugin Name: GraphQL API for WordPress
 Plugin URI: https://graphql-api.com
 Description: Transform your WordPress site into a GraphQL server.
-Version: 0.7.4
+Version: 0.7.6
 Requires at least: 5.4
 Requires PHP: 7.4
 Author: Leonardo Losoviz
@@ -36,13 +36,13 @@ if (defined('GRAPHQL_API_VERSION')) {
             sprintf(
                 __('Plugin <strong>GraphQL API for WordPress</strong> is already installed with version <code>%s</code>, so version <code>%s</code> has not been loaded. Please deactivate all versions, remove the older version, and activate again the latest version of the plugin.', 'graphql-api'),
                 \GRAPHQL_API_VERSION,
-                '0.7.4'
+                '0.7.6'
             )
         ));
     });
     return;
 }
-define('GRAPHQL_API_VERSION', '0.7.4');
+define('GRAPHQL_API_VERSION', '0.7.6');
 define('GRAPHQL_API_PLUGIN_FILE', __FILE__);
 define('GRAPHQL_API_DIR', dirname(__FILE__));
 define('GRAPHQL_API_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
Tag `0.7.5` is already used in the repo, then skip to version `0.7.6`