### PR TITLE
Added " || true" on bash

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -44,9 +44,9 @@ jobs:
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
-                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]"
+                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')" || true
+                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))" || true
+                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]" || true
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -54,9 +54,9 @@ jobs:
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
-                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
-                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]"
+                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')" || true
+                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))" || true
+                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]" || true
 
         outputs:
             matrix: ${{ steps.output_data.outputs.matrix }}


### PR DESCRIPTION
After adding the conditional `[ -z "$GIT_DIFF" ]` on bash, the command would exit with `1`, [producing an error](https://github.com/leoloso/PoP/runs/1673110836?check_suite_focus=true).

To avoid that happening, whenever doing a conditional, append at the end ` || true`

