### PR TITLE
[Monorepo Builder] Restore Package from v9.0.25

### DIFF
--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -9,7 +9,9 @@ use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command\SymlinkLocalPackageComma
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\CustomDependencyUpdater;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PackageEntriesJsonProvider;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\SourcePackagesProvider;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Package\CustomPackageProvider;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Utils\PackageUtils;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\CustomPackage;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option as CustomOption;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
@@ -77,6 +79,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     /** Commands */
     $services
+        ->set(CustomPackageProvider::class)
+        ->set(CustomPackage::class)
         ->set(CustomDependencyUpdater::class)
         ->set(CustomBumpInterdependencyCommand::class)
         ->set(PackageUtils::class)

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PackageEntriesJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PackageEntriesJsonProvider.php
@@ -6,13 +6,13 @@ namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json;
 
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Utils\PackageUtils;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
-use Symplify\MonorepoBuilder\Package\PackageProvider;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Package\CustomPackageProvider;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class PackageEntriesJsonProvider
 {
-    private PackageProvider $packageProvider;
+    private CustomPackageProvider $customPackageProvider;
     private PackageUtils $packageUtils;
 
     /**
@@ -21,11 +21,11 @@ final class PackageEntriesJsonProvider
     private array $packageOrganizations = [];
 
     public function __construct(
-        PackageProvider $packageProvider,
+        CustomPackageProvider $customPackageProvider,
         ParameterProvider $parameterProvider,
         PackageUtils $packageUtils
     ) {
-        $this->packageProvider = $packageProvider;
+        $this->customPackageProvider = $customPackageProvider;
         $this->packageOrganizations = $parameterProvider->provideArrayParameter(Option::PACKAGE_ORGANIZATIONS);
         $this->packageUtils = $packageUtils;
     }
@@ -37,7 +37,7 @@ final class PackageEntriesJsonProvider
     public function providePackageEntries(array $fileListFilter = []): array
     {
         $packageEntries = [];
-        $packages = $this->packageProvider->provide();
+        $packages = $this->customPackageProvider->provide();
         foreach ($packages as $package) {
             $packageRelativePath = $package->getRelativePath();
             // If provided, filter the packages to the ones containing the list of files.

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json;
 
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Utils\PackageUtils;
-use Symplify\MonorepoBuilder\Package\PackageProvider;
-use Symplify\MonorepoBuilder\ValueObject\Package;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Package\CustomPackageProvider;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\CustomPackage;
 
 final class SourcePackagesProvider
 {
-    private PackageProvider $packageProvider;
+    private CustomPackageProvider $customPackageProvider;
     private PackageUtils $packageUtils;
 
     public function __construct(
-        PackageProvider $packageProvider,
+        CustomPackageProvider $customPackageProvider,
         PackageUtils $packageUtils
     ) {
-        $this->packageProvider = $packageProvider;
+        $this->customPackageProvider = $customPackageProvider;
         $this->packageUtils = $packageUtils;
     }
 
@@ -31,18 +31,18 @@ final class SourcePackagesProvider
         bool $skipUnmigrated = false,
         array $fileListFilter = []
     ): array {
-        $packages = $this->packageProvider->provide();
+        $packages = $this->customPackageProvider->provide();
         if ($psr4Only) {
             $packages = array_values(array_filter(
                 $packages,
-                function (Package $package): bool {
+                function (CustomPackage $package): bool {
                     return $package->hasTests();
                 }
             ));
         }
         // Operate with package paths from now on
         $packages = array_map(
-            function (Package $package): string {
+            function (CustomPackage $package): string {
                 return $package->getRelativePath();
             },
             $packages

--- a/src/Extensions/Symplify/MonorepoBuilder/Package/CustomPackageProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Package/CustomPackageProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Package;
+
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\CustomPackage;
+use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
+use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
+
+final class CustomPackageProvider
+{
+    /**
+     * @var ComposerJsonProvider
+     */
+    private $composerJsonProvider;
+
+    /**
+     * @var JsonFileManager
+     */
+    private $jsonFileManager;
+
+    public function __construct(ComposerJsonProvider $composerJsonProvider, JsonFileManager $jsonFileManager)
+    {
+        $this->composerJsonProvider = $composerJsonProvider;
+        $this->jsonFileManager = $jsonFileManager;
+    }
+
+    /**
+     * @return CustomPackage[]
+     */
+    public function provideWithTests(): array
+    {
+        return array_filter($this->provide(), function (CustomPackage $package): bool {
+            return $package->hasTests();
+        });
+    }
+
+    /**
+     * @return CustomPackage[]
+     */
+    public function provide(): array
+    {
+        $packages = [];
+        foreach ($this->composerJsonProvider->getPackagesComposerFileInfos() as $packagesComposerFileInfo) {
+            $packageName = $this->detectNameFromFileInfo($packagesComposerFileInfo);
+            $packages[] = new CustomPackage($packageName, $packagesComposerFileInfo);
+        }
+
+        usort($packages, function (CustomPackage $firstPackage, CustomPackage $secondPackage): int {
+            return $firstPackage->getShortName() <=> $secondPackage->getShortName();
+        });
+
+        return $packages;
+    }
+
+    private function detectNameFromFileInfo(SmartFileInfo $smartFileInfo): string
+    {
+        $json = $this->jsonFileManager->loadFromFileInfo($smartFileInfo);
+
+        if (! isset($json['name'])) {
+            throw new ShouldNotHappenException();
+        }
+
+        return (string) $json['name'];
+    }
+}

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/CustomPackage.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/CustomPackage.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject;
+
+use Nette\Utils\Strings;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class CustomPackage
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var SmartFileInfo
+     */
+    private $rootDirectoryFileInfo;
+
+    /**
+     * @var string
+     */
+    private $shortName;
+
+    /**
+     * @var string
+     */
+    private $shortDirectory;
+
+    public function __construct(string $name, SmartFileInfo $composerJsonFileInfo)
+    {
+        $this->name = $name;
+
+        $this->shortName = (string) Strings::after($name, '/', -1);
+
+        $this->rootDirectoryFileInfo = new SmartFileInfo($composerJsonFileInfo->getPath());
+
+        $this->shortDirectory = (string) Strings::after($composerJsonFileInfo->getPath(), '/', -1);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function hasTests(): bool
+    {
+        $expectedTestsDirectory = $this->rootDirectoryFileInfo->getRealPath() . DIRECTORY_SEPARATOR . 'tests';
+        return file_exists($expectedTestsDirectory);
+    }
+
+    public function getShortName(): string
+    {
+        return $this->shortName;
+    }
+
+    public function getShortDirectory(): string
+    {
+        return $this->shortDirectory;
+    }
+
+    public function getRelativePath(): string
+    {
+        return $this->rootDirectoryFileInfo->getRelativeFilePathFromCwd();
+    }
+}


### PR DESCRIPTION
Monorepo Builder `v9.0.26` [introduced a breaking change](https://github.com/symplify/symplify/commit/c41ca16c867d0bb1e7be59099c138f8435d01bfa#r45809512) which broke the CI for this project.

So this PR recreates the modified classes `Package` and `PackageProvider` as "custom", with the code from `v9.0.25`