### PR TITLE
Removed conditionals, and || true, in bash

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -44,9 +44,8 @@ jobs:
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')" || true
-                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))" || true
-                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]" || true
+                    filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -54,9 +54,8 @@ jobs:
                     clean_diff="$(echo "${{ env.GIT_DIFF }}" | sed -e s/$quote//g)"
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
-                    [ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')" || true
-                    [ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))" || true
-                    [ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]" || true
+                    filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
 
         outputs:
             matrix: ${{ steps.output_data.outputs.matrix }}


### PR DESCRIPTION
In order to calculate the packages for the matrix, in `split_monorepo` we are doing:

```sh
[ -n "$GIT_DIFF" ] && filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')" |
[ -n "$GIT_DIFF" ] && echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))" || true
[ -z "$GIT_DIFF" ] && echo "::set-output name=matrix::[]" || true
```

The `|| true` at the end was needed to have the 2 conditionals always be successful at the end, to avoid the workflow from showing it failed.

But this produces a side effect: if the call `vendor/bin/monorepo-builder package-entries-json` fails, it is also ignored! Yet, that one must be shown.

Indeed, it happened exactly that: Symplify Monorepo Builder [introduced breaking changes](https://github.com/symplify/symplify/commit/c41ca16c867d0bb1e7be59099c138f8435d01bfa#r45809512) that broke that command, yet the error did not bubble in the CI. That's not good.

So this PR replaces it with this code, which achieves the same:

```sh
filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
```

The key is that the first `--filter` is added always, so when `packages_in_diff` is empty, the command will be `monorepo-builder package-entries-json --filter=` which produces an array with an empty string, so the filtering is performed against that, producing no matching packages. So it works as intended.