### PR TITLE
Bumped composer/semver to ^3.2 to enable latest version of Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "ext-mbstring": "*",
         "brain/cortex": "~1.0.0",
         "composer/installers": "~1.0",
-        "composer/semver": "^1.5",
+        "composer/semver": "^3.2",
         "erusev/parsedown": "^1.7",
         "guzzlehttp/guzzle": "~6.3",
         "jrfnl/php-cast-to-type": "^2.0",

--- a/layers/Engine/packages/component-model/composer.json
+++ b/layers/Engine/packages/component-model/composer.json
@@ -16,7 +16,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4|^8.0",
-        "composer/semver": "^1.5",
+        "composer/semver": "^3.2",
         "getpop/definitions": "^0.7.6",
         "getpop/field-query": "^0.7.6",
         "getpop/migrate-component-model": "^0.7.6",


### PR DESCRIPTION
Rector `0.9.3` upwards requires `^3.2` for `composer/semver`, so bumped this dependency elsewhere to avoid conflicts and be able to use Rector's latest version.