### PR TITLE
Removed "-c phpstan.neon.dist" when doing phpstan analyse

### DIFF
--- a/layers/API/packages/api-clients/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-clients/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/API/packages/api-endpoints-for-wp/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-endpoints-for-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/API/packages/api-endpoints-for-wp/composer.json
+++ b/layers/API/packages/api-endpoints-for-wp/composer.json
@@ -45,7 +45,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/API/packages/api-endpoints/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-endpoints/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/API/packages/api-graphql/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-graphql/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/API/packages/api-graphql/composer.json
+++ b/layers/API/packages/api-graphql/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/API/packages/api-mirrorquery/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-mirrorquery/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/API/packages/api-mirrorquery/composer.json
+++ b/layers/API/packages/api-mirrorquery/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/API/packages/api-rest/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api-rest/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/API/packages/api-rest/composer.json
+++ b/layers/API/packages/api-rest/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/API/packages/api/.github/workflows/phpstan.yml
+++ b/layers/API/packages/api/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/API/packages/api/composer.json
+++ b/layers/API/packages/api/composer.json
@@ -43,7 +43,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/access-control/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/access-control/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/access-control/composer.json
+++ b/layers/Engine/packages/access-control/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/cache-control/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/cache-control/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/cache-control/composer.json
+++ b/layers/Engine/packages/cache-control/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/component-model/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/component-model/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/component-model/composer.json
+++ b/layers/Engine/packages/component-model/composer.json
@@ -44,7 +44,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/configurable-schema-feedback/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/configurable-schema-feedback/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/configurable-schema-feedback/composer.json
+++ b/layers/Engine/packages/configurable-schema-feedback/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/definitions/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/definitions/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/definitions/composer.json
+++ b/layers/Engine/packages/definitions/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/engine-wp-bootloader/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/engine-wp-bootloader/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/engine-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/engine-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/engine-wp/composer.json
+++ b/layers/Engine/packages/engine-wp/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/engine/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/engine/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/engine/composer.json
+++ b/layers/Engine/packages/engine/composer.json
@@ -45,7 +45,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/field-query/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/field-query/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/field-query/composer.json
+++ b/layers/Engine/packages/field-query/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/filestore/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/filestore/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/filestore/composer.json
+++ b/layers/Engine/packages/filestore/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/function-fields/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/function-fields/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/function-fields/composer.json
+++ b/layers/Engine/packages/function-fields/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/guzzle-helpers/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/guzzle-helpers/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/guzzle-helpers/composer.json
+++ b/layers/Engine/packages/guzzle-helpers/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/hooks-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/hooks-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/hooks-wp/composer.json
+++ b/layers/Engine/packages/hooks-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/hooks/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/hooks/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/hooks/composer.json
+++ b/layers/Engine/packages/hooks/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/loosecontracts/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/loosecontracts/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/loosecontracts/composer.json
+++ b/layers/Engine/packages/loosecontracts/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/modulerouting/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/modulerouting/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/modulerouting/composer.json
+++ b/layers/Engine/packages/modulerouting/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/query-parsing/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/query-parsing/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/query-parsing/composer.json
+++ b/layers/Engine/packages/query-parsing/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/root/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/root/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/root/composer.json
+++ b/layers/Engine/packages/root/composer.json
@@ -43,7 +43,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/routing-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/routing-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/routing-wp/composer.json
+++ b/layers/Engine/packages/routing-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/routing/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/routing/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/routing/composer.json
+++ b/layers/Engine/packages/routing/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/trace-tools/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/trace-tools/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/trace-tools/composer.json
+++ b/layers/Engine/packages/trace-tools/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/translation-wp/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/translation-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/translation-wp/composer.json
+++ b/layers/Engine/packages/translation-wp/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Engine/packages/translation/.github/workflows/phpstan.yml
+++ b/layers/Engine/packages/translation/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Engine/packages/translation/composer.json
+++ b/layers/Engine/packages/translation/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/phpstan.yml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/phpstan.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -83,7 +83,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/phpstan.yml
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/composer.json
@@ -46,7 +46,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLByPoP/packages/graphql-parser/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-parser/composer.json
@@ -32,7 +32,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-query/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLByPoP/packages/graphql-query/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-query/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-request/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLByPoP/packages/graphql-request/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-request/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/phpstan.yml
+++ b/layers/GraphQLByPoP/packages/graphql-server/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/GraphQLByPoP/packages/graphql-server/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-server/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Misc/packages/examples-for-pop/.github/workflows/phpstan.yml
+++ b/layers/Misc/packages/examples-for-pop/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Misc/packages/examples-for-pop/composer.json
+++ b/layers/Misc/packages/examples-for-pop/composer.json
@@ -47,7 +47,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/basic-directives/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/basic-directives/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/basic-directives/composer.json
+++ b/layers/Schema/packages/basic-directives/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/block-metadata-for-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/block-metadata-for-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/block-metadata-for-wp/composer.json
+++ b/layers/Schema/packages/block-metadata-for-wp/composer.json
@@ -49,7 +49,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/categories-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/categories-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/categories-wp/composer.json
+++ b/layers/Schema/packages/categories-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/categories/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/categories/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/categories/composer.json
+++ b/layers/Schema/packages/categories/composer.json
@@ -45,7 +45,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/cdn-directive/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/cdn-directive/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/cdn-directive/composer.json
+++ b/layers/Schema/packages/cdn-directive/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/comment-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comment-mutations-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/comment-mutations-wp/composer.json
+++ b/layers/Schema/packages/comment-mutations-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/comment-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comment-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/comment-mutations/composer.json
+++ b/layers/Schema/packages/comment-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/commentmeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/commentmeta-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/commentmeta-wp/composer.json
+++ b/layers/Schema/packages/commentmeta-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/commentmeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/commentmeta/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/commentmeta/composer.json
+++ b/layers/Schema/packages/commentmeta/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/comments-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comments-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/comments-wp/composer.json
+++ b/layers/Schema/packages/comments-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/comments/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/comments/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/comments/composer.json
+++ b/layers/Schema/packages/comments/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/convert-case-directives/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/convert-case-directives/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/convert-case-directives/composer.json
+++ b/layers/Schema/packages/convert-case-directives/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompost-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompost-mutations-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompost-mutations-wp/composer.json
+++ b/layers/Schema/packages/custompost-mutations-wp/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompost-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompost-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompost-mutations/composer.json
+++ b/layers/Schema/packages/custompost-mutations/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompostmedia-mutations-wp/composer.json
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompostmedia-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompostmedia-mutations/composer.json
+++ b/layers/Schema/packages/custompostmedia-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompostmedia-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompostmedia-wp/composer.json
+++ b/layers/Schema/packages/custompostmedia-wp/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompostmedia/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmedia/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompostmedia/composer.json
+++ b/layers/Schema/packages/custompostmedia/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompostmeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmeta-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompostmeta-wp/composer.json
+++ b/layers/Schema/packages/custompostmeta-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/custompostmeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/custompostmeta/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/custompostmeta/composer.json
+++ b/layers/Schema/packages/custompostmeta/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/customposts-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/customposts-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/customposts-wp/composer.json
+++ b/layers/Schema/packages/customposts-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/customposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/customposts/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/customposts/composer.json
+++ b/layers/Schema/packages/customposts/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/event-mutations-wp-em/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/event-mutations-wp-em/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/event-mutations-wp-em/composer.json
+++ b/layers/Schema/packages/event-mutations-wp-em/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/event-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/event-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/event-mutations/composer.json
+++ b/layers/Schema/packages/event-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/events-wp-em/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/events-wp-em/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/events/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/events/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/events/composer.json
+++ b/layers/Schema/packages/events/composer.json
@@ -46,7 +46,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/everythingelse-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/everythingelse-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/everythingelse-wp/composer.json
+++ b/layers/Schema/packages/everythingelse-wp/composer.json
@@ -44,7 +44,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/everythingelse/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/everythingelse/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/everythingelse/composer.json
+++ b/layers/Schema/packages/everythingelse/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/generic-customposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/generic-customposts/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/generic-customposts/composer.json
+++ b/layers/Schema/packages/generic-customposts/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/google-translate-directive-for-customposts/composer.json
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/google-translate-directive/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/google-translate-directive/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/google-translate-directive/composer.json
+++ b/layers/Schema/packages/google-translate-directive/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/highlights-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/highlights-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/highlights-wp/composer.json
+++ b/layers/Schema/packages/highlights-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/highlights/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/highlights/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/highlights/composer.json
+++ b/layers/Schema/packages/highlights/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/locationposts-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locationposts-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/locationposts-wp/composer.json
+++ b/layers/Schema/packages/locationposts-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/locationposts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locationposts/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/locationposts/composer.json
+++ b/layers/Schema/packages/locationposts/composer.json
@@ -44,7 +44,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/locations-wp-em/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locations-wp-em/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/locations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/locations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/locations/composer.json
+++ b/layers/Schema/packages/locations/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/media-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/media-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/media-wp/composer.json
+++ b/layers/Schema/packages/media-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/media/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/media/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/media/composer.json
+++ b/layers/Schema/packages/media/composer.json
@@ -44,7 +44,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/menus-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/menus-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/menus-wp/composer.json
+++ b/layers/Schema/packages/menus-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/menus/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/menus/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/menus/composer.json
+++ b/layers/Schema/packages/menus/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/meta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/meta/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/meta/composer.json
+++ b/layers/Schema/packages/meta/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/metaquery-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/metaquery-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/metaquery-wp/composer.json
+++ b/layers/Schema/packages/metaquery-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/metaquery/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/metaquery/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/metaquery/composer.json
+++ b/layers/Schema/packages/metaquery/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/notifications-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/notifications-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/notifications-wp/composer.json
+++ b/layers/Schema/packages/notifications-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/notifications/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/notifications/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/notifications/composer.json
+++ b/layers/Schema/packages/notifications/composer.json
@@ -43,7 +43,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/pages-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/pages-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/pages-wp/composer.json
+++ b/layers/Schema/packages/pages-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/pages/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/pages/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/pages/composer.json
+++ b/layers/Schema/packages/pages/composer.json
@@ -45,7 +45,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/post-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/post-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/post-mutations/composer.json
+++ b/layers/Schema/packages/post-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/post-tags-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/post-tags-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/post-tags-wp/composer.json
+++ b/layers/Schema/packages/post-tags-wp/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/post-tags/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/post-tags/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/post-tags/composer.json
+++ b/layers/Schema/packages/post-tags/composer.json
@@ -46,7 +46,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/posts-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/posts-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/posts-wp/composer.json
+++ b/layers/Schema/packages/posts-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/posts/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/posts/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/posts/composer.json
+++ b/layers/Schema/packages/posts/composer.json
@@ -47,7 +47,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/queriedobject-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/queriedobject-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/queriedobject-wp/composer.json
+++ b/layers/Schema/packages/queriedobject-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/queriedobject/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/queriedobject/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/queriedobject/composer.json
+++ b/layers/Schema/packages/queriedobject/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/schema-commons/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/schema-commons/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/schema-commons/composer.json
+++ b/layers/Schema/packages/schema-commons/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/stances-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/stances-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/stances-wp/composer.json
+++ b/layers/Schema/packages/stances-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/stances/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/stances/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/stances/composer.json
+++ b/layers/Schema/packages/stances/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/tags-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/tags-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/tags-wp/composer.json
+++ b/layers/Schema/packages/tags-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/tags/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/tags/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/tags/composer.json
+++ b/layers/Schema/packages/tags/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/taxonomies-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomies-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/taxonomies-wp/composer.json
+++ b/layers/Schema/packages/taxonomies-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/taxonomies/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomies/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/taxonomies/composer.json
+++ b/layers/Schema/packages/taxonomies/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/taxonomymeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomymeta-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/taxonomymeta-wp/composer.json
+++ b/layers/Schema/packages/taxonomymeta-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/taxonomymeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomymeta/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/taxonomymeta/composer.json
+++ b/layers/Schema/packages/taxonomymeta/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/taxonomyquery-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomyquery-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/taxonomyquery-wp/composer.json
+++ b/layers/Schema/packages/taxonomyquery-wp/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/taxonomyquery/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/taxonomyquery/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/taxonomyquery/composer.json
+++ b/layers/Schema/packages/taxonomyquery/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/translate-directive-acl/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/translate-directive-acl/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/translate-directive-acl/composer.json
+++ b/layers/Schema/packages/translate-directive-acl/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/translate-directive/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/translate-directive/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/translate-directive/composer.json
+++ b/layers/Schema/packages/translate-directive/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-roles-access-control/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles-access-control/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-roles-access-control/composer.json
+++ b/layers/Schema/packages/user-roles-access-control/composer.json
@@ -43,7 +43,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-roles-acl/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles-acl/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-roles-acl/composer.json
+++ b/layers/Schema/packages/user-roles-acl/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-roles-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-roles-wp/composer.json
+++ b/layers/Schema/packages/user-roles-wp/composer.json
@@ -44,7 +44,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-roles/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-roles/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-roles/composer.json
+++ b/layers/Schema/packages/user-roles/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-state-access-control/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-access-control/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-state-access-control/composer.json
+++ b/layers/Schema/packages/user-state-access-control/composer.json
@@ -43,7 +43,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-state-mutations-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-mutations-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-state-mutations-wp/composer.json
+++ b/layers/Schema/packages/user-state-mutations-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-state-mutations/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-state-mutations/composer.json
+++ b/layers/Schema/packages/user-state-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-state-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-state-wp/composer.json
+++ b/layers/Schema/packages/user-state-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/user-state/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/user-state/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/user-state/composer.json
+++ b/layers/Schema/packages/user-state/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/usermeta-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/usermeta-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/usermeta-wp/composer.json
+++ b/layers/Schema/packages/usermeta-wp/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/usermeta/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/usermeta/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/usermeta/composer.json
+++ b/layers/Schema/packages/usermeta/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/users-wp/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/users-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/users-wp/composer.json
+++ b/layers/Schema/packages/users-wp/composer.json
@@ -45,7 +45,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Schema/packages/users/.github/workflows/phpstan.yml
+++ b/layers/Schema/packages/users/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Schema/packages/users/composer.json
+++ b/layers/Schema/packages/users/composer.json
@@ -47,7 +47,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/application-wp/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/application-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/application-wp/composer.json
+++ b/layers/SiteBuilder/packages/application-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/application/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/application/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/application/composer.json
+++ b/layers/SiteBuilder/packages/application/composer.json
@@ -41,7 +41,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/component-model-configuration/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/component-model-configuration/composer.json
+++ b/layers/SiteBuilder/packages/component-model-configuration/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/definitionpersistence/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/definitionpersistence/composer.json
+++ b/layers/SiteBuilder/packages/definitionpersistence/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/definitions-base36/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/definitions-base36/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/definitions-base36/composer.json
+++ b/layers/SiteBuilder/packages/definitions-base36/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/definitions-emoji/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/definitions-emoji/composer.json
+++ b/layers/SiteBuilder/packages/definitions-emoji/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/multisite/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/multisite/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/multisite/composer.json
+++ b/layers/SiteBuilder/packages/multisite/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/resourceloader/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/resourceloader/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/resourceloader/composer.json
+++ b/layers/SiteBuilder/packages/resourceloader/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/resources/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/resources/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/resources/composer.json
+++ b/layers/SiteBuilder/packages/resources/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/site-wp/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/site-wp/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/site-wp/composer.json
+++ b/layers/SiteBuilder/packages/site-wp/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/site/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/site/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/site/composer.json
+++ b/layers/SiteBuilder/packages/site/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/spa/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/spa/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/spa/composer.json
+++ b/layers/SiteBuilder/packages/spa/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/SiteBuilder/packages/static-site-generator/.github/workflows/phpstan.yml
+++ b/layers/SiteBuilder/packages/static-site-generator/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/SiteBuilder/packages/static-site-generator/composer.json
+++ b/layers/SiteBuilder/packages/static-site-generator/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/comment-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/comment-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/comment-mutations/composer.json
+++ b/layers/Wassup/packages/comment-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/contactus-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/contactus-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/contactus-mutations/composer.json
+++ b/layers/Wassup/packages/contactus-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/contactuser-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/contactuser-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/contactuser-mutations/composer.json
+++ b/layers/Wassup/packages/contactuser-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/custompost-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/custompost-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/custompost-mutations/composer.json
+++ b/layers/Wassup/packages/custompost-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/custompostlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/custompostlink-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/custompostlink-mutations/composer.json
+++ b/layers/Wassup/packages/custompostlink-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/event-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/event-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/event-mutations/composer.json
+++ b/layers/Wassup/packages/event-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/eventlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/eventlink-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/eventlink-mutations/composer.json
+++ b/layers/Wassup/packages/eventlink-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/everythingelse-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/everythingelse-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/everythingelse-mutations/composer.json
+++ b/layers/Wassup/packages/everythingelse-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/flag-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/flag-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/flag-mutations/composer.json
+++ b/layers/Wassup/packages/flag-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/form-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/form-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/form-mutations/composer.json
+++ b/layers/Wassup/packages/form-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/gravityforms-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/gravityforms-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/gravityforms-mutations/composer.json
+++ b/layers/Wassup/packages/gravityforms-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/highlight-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/highlight-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/highlight-mutations/composer.json
+++ b/layers/Wassup/packages/highlight-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/location-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/location-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/location-mutations/composer.json
+++ b/layers/Wassup/packages/location-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/locationpost-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/locationpost-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/locationpost-mutations/composer.json
+++ b/layers/Wassup/packages/locationpost-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/locationpostlink-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/locationpostlink-mutations/composer.json
+++ b/layers/Wassup/packages/locationpostlink-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/newsletter-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/newsletter-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/newsletter-mutations/composer.json
+++ b/layers/Wassup/packages/newsletter-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/notification-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/notification-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/notification-mutations/composer.json
+++ b/layers/Wassup/packages/notification-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/post-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/post-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/post-mutations/composer.json
+++ b/layers/Wassup/packages/post-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/postlink-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/postlink-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/postlink-mutations/composer.json
+++ b/layers/Wassup/packages/postlink-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/share-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/share-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/share-mutations/composer.json
+++ b/layers/Wassup/packages/share-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/socialnetwork-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/socialnetwork-mutations/composer.json
+++ b/layers/Wassup/packages/socialnetwork-mutations/composer.json
@@ -40,7 +40,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/stance-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/stance-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/stance-mutations/composer.json
+++ b/layers/Wassup/packages/stance-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/system-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/system-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/system-mutations/composer.json
+++ b/layers/Wassup/packages/system-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/user-state-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/user-state-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/user-state-mutations/composer.json
+++ b/layers/Wassup/packages/user-state-mutations/composer.json
@@ -38,7 +38,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/volunteer-mutations/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/volunteer-mutations/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/volunteer-mutations/composer.json
+++ b/layers/Wassup/packages/volunteer-mutations/composer.json
@@ -39,7 +39,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {

--- a/layers/Wassup/packages/wassup/.github/workflows/phpstan.yml
+++ b/layers/Wassup/packages/wassup/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+        run: vendor/bin/phpstan analyse
 

--- a/layers/Wassup/packages/wassup/composer.json
+++ b/layers/Wassup/packages/wassup/composer.json
@@ -93,7 +93,7 @@
         "test": "phpunit",
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
-        "analyse": "phpstan analyse -c phpstan.neon.dist",
+        "analyse": "phpstan analyse",
         "preview-code-downgrade": "rector process src --config=rector-downgrade-code.php --dry-run --ansi"
     },
     "extra": {


### PR DESCRIPTION
The `phpstan.neon.dist` config file is already retrieved by default, so there's no need to specify it as a param when executing `phpstan analyse`. So it was removed.