### PR TITLE
Make sure the package ends with "/" when filtering

### DIFF
--- a/src/Extensions/Symplify/MonorepoBuilder/Utils/PackageUtils.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Utils/PackageUtils.php
@@ -11,6 +11,10 @@ final class PackageUtils
      */
     public function isPackageInFileList(string $package, array $fileListFilter): bool
     {
+        // Make sure the package ends with "/". Otherwise,
+        // file `api-clients/README.md` produces not just `api-clients`
+        // but also `api`
+        $package .= str_ends_with($package, '/') ? '' : '/';
         $matchingPackages = array_filter(
             $fileListFilter,
             fn (string $file) => str_starts_with($file, $package)


### PR DESCRIPTION
Make sure the package ends with `/` when doing the filtering. Otherwise, filtering by file `layers/API/packages/api-clients/README.md` produces not only packge `api-clients`, but also `api`, which is not right