### PR TITLE
Increase phpstan level 8

### DIFF
--- a/layers/Engine/packages/root/phpstan.neon.dist
+++ b/layers/Engine/packages/root/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-	level: 0
+	level: 8
 	paths:
 		- src
 		- tests

--- a/layers/Engine/packages/root/src/ComponentLoader.php
+++ b/layers/Engine/packages/root/src/ComponentLoader.php
@@ -70,6 +70,7 @@ class ComponentLoader
      * following the Composer dependencies tree
      *
      * @param string[] $componentClasses List of `Component` class to initialize
+     * @return string[]
      */
     protected static function getComponentsOrderedForInitialization(
         array $componentClasses
@@ -87,6 +88,7 @@ class ComponentLoader
      * following the Composer dependencies tree
      *
      * @param string[] $componentClasses List of `Component` class to initialize
+     * @param string[] $orderedComponentClasses List of `Component` class in order of initialization
      */
     protected static function addComponentsOrderedForInitialization(
         array $componentClasses,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpstan.neon.dist
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpstan.neon.dist
@@ -19,7 +19,7 @@ parameters:
             path: src/PostTypes/AbstractPostType.php
     bootstrapFiles:
         - graphql-api.php
-    level: 0
+    level: 8
     paths:
         - src/
         - tests/


### PR DESCRIPTION
On packages `getpop/root` and `graphql-api/graphql-api-for-wp` it had been decreased to level 0, by accident. Push them to level 8 again.