### PR TITLE
Removed unneeded PHPStan WP includes

### DIFF
--- a/layers/API/packages/api-clients/phpstan.neon
+++ b/layers/API/packages/api-clients/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/API/packages/api-endpoints/phpstan.neon
+++ b/layers/API/packages/api-endpoints/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/API/packages/api-graphql/phpstan.neon
+++ b/layers/API/packages/api-graphql/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/API/packages/api-mirrorquery/phpstan.neon
+++ b/layers/API/packages/api-mirrorquery/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/API/packages/api-rest/phpstan.neon
+++ b/layers/API/packages/api-rest/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/API/packages/api/phpstan.neon
+++ b/layers/API/packages/api/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/access-control/phpstan.neon
+++ b/layers/Engine/packages/access-control/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/cache-control/phpstan.neon
+++ b/layers/Engine/packages/cache-control/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/component-model/phpstan.neon
+++ b/layers/Engine/packages/component-model/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/configurable-schema-feedback/phpstan.neon
+++ b/layers/Engine/packages/configurable-schema-feedback/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/definitions/phpstan.neon
+++ b/layers/Engine/packages/definitions/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/engine-wp-bootloader/phpstan.neon
+++ b/layers/Engine/packages/engine-wp-bootloader/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/engine/phpstan.neon
+++ b/layers/Engine/packages/engine/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/field-query/phpstan.neon
+++ b/layers/Engine/packages/field-query/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/filestore/phpstan.neon
+++ b/layers/Engine/packages/filestore/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/function-fields/phpstan.neon
+++ b/layers/Engine/packages/function-fields/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/guzzle-helpers/phpstan.neon
+++ b/layers/Engine/packages/guzzle-helpers/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/hooks/phpstan.neon
+++ b/layers/Engine/packages/hooks/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/loosecontracts/phpstan.neon
+++ b/layers/Engine/packages/loosecontracts/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/mandatory-directives-by-configuration/phpstan.neon
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/modulerouting/phpstan.neon
+++ b/layers/Engine/packages/modulerouting/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/query-parsing/phpstan.neon
+++ b/layers/Engine/packages/query-parsing/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/root/phpstan.neon
+++ b/layers/Engine/packages/root/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/routing/phpstan.neon
+++ b/layers/Engine/packages/routing/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/trace-tools/phpstan.neon
+++ b/layers/Engine/packages/trace-tools/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Engine/packages/translation/phpstan.neon
+++ b/layers/Engine/packages/translation/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/phpstan.neon
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/phpstan.neon
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-parser/phpstan.neon
+++ b/layers/GraphQLByPoP/packages/graphql-parser/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-query/phpstan.neon
+++ b/layers/GraphQLByPoP/packages/graphql-query/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-request/phpstan.neon
+++ b/layers/GraphQLByPoP/packages/graphql-request/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/GraphQLByPoP/packages/graphql-server/phpstan.neon
+++ b/layers/GraphQLByPoP/packages/graphql-server/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Misc/packages/examples-for-pop/phpstan.neon
+++ b/layers/Misc/packages/examples-for-pop/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/basic-directives/phpstan.neon
+++ b/layers/Schema/packages/basic-directives/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/categories/phpstan.neon
+++ b/layers/Schema/packages/categories/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/cdn-directive/phpstan.neon
+++ b/layers/Schema/packages/cdn-directive/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/comment-mutations/phpstan.neon
+++ b/layers/Schema/packages/comment-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/commentmeta/phpstan.neon
+++ b/layers/Schema/packages/commentmeta/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/comments/phpstan.neon
+++ b/layers/Schema/packages/comments/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/convert-case-directives/phpstan.neon
+++ b/layers/Schema/packages/convert-case-directives/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/custompost-mutations/phpstan.neon
+++ b/layers/Schema/packages/custompost-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/custompostmedia-mutations/phpstan.neon
+++ b/layers/Schema/packages/custompostmedia-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/custompostmedia/phpstan.neon
+++ b/layers/Schema/packages/custompostmedia/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/custompostmeta/phpstan.neon
+++ b/layers/Schema/packages/custompostmeta/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/customposts/phpstan.neon
+++ b/layers/Schema/packages/customposts/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/event-mutations-wp-em/phpstan.neon
+++ b/layers/Schema/packages/event-mutations-wp-em/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/event-mutations/phpstan.neon
+++ b/layers/Schema/packages/event-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/events-wp-em/phpstan.neon
+++ b/layers/Schema/packages/events-wp-em/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/events/phpstan.neon
+++ b/layers/Schema/packages/events/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/everythingelse/phpstan.neon
+++ b/layers/Schema/packages/everythingelse/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/generic-customposts/phpstan.neon
+++ b/layers/Schema/packages/generic-customposts/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/google-translate-directive-for-customposts/phpstan.neon
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/google-translate-directive/phpstan.neon
+++ b/layers/Schema/packages/google-translate-directive/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/highlights/phpstan.neon
+++ b/layers/Schema/packages/highlights/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/locationposts/phpstan.neon
+++ b/layers/Schema/packages/locationposts/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/locations-wp-em/phpstan.neon
+++ b/layers/Schema/packages/locations-wp-em/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/locations/phpstan.neon
+++ b/layers/Schema/packages/locations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/media/phpstan.neon
+++ b/layers/Schema/packages/media/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/menus/phpstan.neon
+++ b/layers/Schema/packages/menus/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/meta/phpstan.neon
+++ b/layers/Schema/packages/meta/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/metaquery/phpstan.neon
+++ b/layers/Schema/packages/metaquery/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/notifications/phpstan.neon
+++ b/layers/Schema/packages/notifications/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/pages/phpstan.neon
+++ b/layers/Schema/packages/pages/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/post-mutations/phpstan.neon
+++ b/layers/Schema/packages/post-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/post-tags/phpstan.neon
+++ b/layers/Schema/packages/post-tags/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/posts/phpstan.neon
+++ b/layers/Schema/packages/posts/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/queriedobject/phpstan.neon
+++ b/layers/Schema/packages/queriedobject/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/schema-commons/phpstan.neon
+++ b/layers/Schema/packages/schema-commons/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/stances/phpstan.neon
+++ b/layers/Schema/packages/stances/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/tags/phpstan.neon
+++ b/layers/Schema/packages/tags/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/taxonomies/phpstan.neon
+++ b/layers/Schema/packages/taxonomies/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/taxonomymeta/phpstan.neon
+++ b/layers/Schema/packages/taxonomymeta/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/taxonomyquery/phpstan.neon
+++ b/layers/Schema/packages/taxonomyquery/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/translate-directive-acl/phpstan.neon
+++ b/layers/Schema/packages/translate-directive-acl/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/translate-directive/phpstan.neon
+++ b/layers/Schema/packages/translate-directive/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/user-roles-access-control/phpstan.neon
+++ b/layers/Schema/packages/user-roles-access-control/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/user-roles-acl/phpstan.neon
+++ b/layers/Schema/packages/user-roles-acl/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/user-roles/phpstan.neon
+++ b/layers/Schema/packages/user-roles/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/user-state-access-control/phpstan.neon
+++ b/layers/Schema/packages/user-state-access-control/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/user-state-mutations/phpstan.neon
+++ b/layers/Schema/packages/user-state-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/user-state/phpstan.neon
+++ b/layers/Schema/packages/user-state/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/usermeta/phpstan.neon
+++ b/layers/Schema/packages/usermeta/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Schema/packages/users/phpstan.neon
+++ b/layers/Schema/packages/users/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/application/phpstan.neon
+++ b/layers/SiteBuilder/packages/application/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/component-model-configuration/phpstan.neon
+++ b/layers/SiteBuilder/packages/component-model-configuration/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/definitionpersistence/phpstan.neon
+++ b/layers/SiteBuilder/packages/definitionpersistence/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/definitions-base36/phpstan.neon
+++ b/layers/SiteBuilder/packages/definitions-base36/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/definitions-emoji/phpstan.neon
+++ b/layers/SiteBuilder/packages/definitions-emoji/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/multisite/phpstan.neon
+++ b/layers/SiteBuilder/packages/multisite/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/resourceloader/phpstan.neon
+++ b/layers/SiteBuilder/packages/resourceloader/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/resources/phpstan.neon
+++ b/layers/SiteBuilder/packages/resources/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/site/phpstan.neon
+++ b/layers/SiteBuilder/packages/site/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/spa/phpstan.neon
+++ b/layers/SiteBuilder/packages/spa/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/SiteBuilder/packages/static-site-generator/phpstan.neon
+++ b/layers/SiteBuilder/packages/static-site-generator/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/comment-mutations/phpstan.neon
+++ b/layers/Wassup/packages/comment-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/contactus-mutations/phpstan.neon
+++ b/layers/Wassup/packages/contactus-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/contactuser-mutations/phpstan.neon
+++ b/layers/Wassup/packages/contactuser-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/custompost-mutations/phpstan.neon
+++ b/layers/Wassup/packages/custompost-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/custompostlink-mutations/phpstan.neon
+++ b/layers/Wassup/packages/custompostlink-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/event-mutations/phpstan.neon
+++ b/layers/Wassup/packages/event-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/eventlink-mutations/phpstan.neon
+++ b/layers/Wassup/packages/eventlink-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/everythingelse-mutations/phpstan.neon
+++ b/layers/Wassup/packages/everythingelse-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/flag-mutations/phpstan.neon
+++ b/layers/Wassup/packages/flag-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/form-mutations/phpstan.neon
+++ b/layers/Wassup/packages/form-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/gravityforms-mutations/phpstan.neon
+++ b/layers/Wassup/packages/gravityforms-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/highlight-mutations/phpstan.neon
+++ b/layers/Wassup/packages/highlight-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/location-mutations/phpstan.neon
+++ b/layers/Wassup/packages/location-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/locationpost-mutations/phpstan.neon
+++ b/layers/Wassup/packages/locationpost-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/locationpostlink-mutations/phpstan.neon
+++ b/layers/Wassup/packages/locationpostlink-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/newsletter-mutations/phpstan.neon
+++ b/layers/Wassup/packages/newsletter-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/notification-mutations/phpstan.neon
+++ b/layers/Wassup/packages/notification-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/post-mutations/phpstan.neon
+++ b/layers/Wassup/packages/post-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/postlink-mutations/phpstan.neon
+++ b/layers/Wassup/packages/postlink-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/share-mutations/phpstan.neon
+++ b/layers/Wassup/packages/share-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/socialnetwork-mutations/phpstan.neon
+++ b/layers/Wassup/packages/socialnetwork-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/stance-mutations/phpstan.neon
+++ b/layers/Wassup/packages/stance-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/system-mutations/phpstan.neon
+++ b/layers/Wassup/packages/system-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/user-state-mutations/phpstan.neon
+++ b/layers/Wassup/packages/user-state-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/volunteer-mutations/phpstan.neon
+++ b/layers/Wassup/packages/volunteer-mutations/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist

--- a/layers/Wassup/packages/wassup/phpstan.neon
+++ b/layers/Wassup/packages/wassup/phpstan.neon
@@ -1,3 +1,2 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
     - phpstan.neon.dist


### PR DESCRIPTION
All `phpstan.neon.dist` files were doing this include:

```yaml
- vendor/szepeviktor/phpstan-wordpress/extension.neon
```

This is needed for WordPress packages only, so they are now removed for all the others.