### PR TITLE
Remove "type:wordpress-theme" from Composer install instructions

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
@@ -88,9 +88,6 @@ Add the following configuration to your `composer.json`:
         "installer-paths": {
             "wp-content/plugins/{$name}/": [
                 "type:wordpress-plugin"
-            ],
-            "wp-content/themes/{$name}/": [
-                "type:wordpress-theme"
             ]
         }
     }


### PR DESCRIPTION
Installing the theme info is irrelevant for installing the plugin, so removed it