### PR TITLE
Temporarily downgrade Rector to version 0.9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "johnpbloch/wordpress": ">=5.5",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/var-dumper": "^5.1",
         "symplify/monorepo-builder": "^9.0",

--- a/layers/API/packages/api-clients/composer.json
+++ b/layers/API/packages/api-clients/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/API/packages/api-endpoints-for-wp/composer.json
+++ b/layers/API/packages/api-endpoints-for-wp/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/API/packages/api-endpoints/composer.json
+++ b/layers/API/packages/api-endpoints/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/API/packages/api-graphql/composer.json
+++ b/layers/API/packages/api-graphql/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/API/packages/api-mirrorquery/composer.json
+++ b/layers/API/packages/api-mirrorquery/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/API/packages/api-rest/composer.json
+++ b/layers/API/packages/api-rest/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/API/packages/api/composer.json
+++ b/layers/API/packages/api/composer.json
@@ -23,7 +23,7 @@
         "getpop/access-control": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Engine/packages/access-control/composer.json
+++ b/layers/Engine/packages/access-control/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/cache-control/composer.json
+++ b/layers/Engine/packages/cache-control/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/component-model/composer.json
+++ b/layers/Engine/packages/component-model/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/configurable-schema-feedback/composer.json
+++ b/layers/Engine/packages/configurable-schema-feedback/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/definitions/composer.json
+++ b/layers/Engine/packages/definitions/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/engine-wp/composer.json
+++ b/layers/Engine/packages/engine-wp/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Engine/packages/engine/composer.json
+++ b/layers/Engine/packages/engine/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/field-query/composer.json
+++ b/layers/Engine/packages/field-query/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/filestore/composer.json
+++ b/layers/Engine/packages/filestore/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/function-fields/composer.json
+++ b/layers/Engine/packages/function-fields/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/guzzle-helpers/composer.json
+++ b/layers/Engine/packages/guzzle-helpers/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/hooks-wp/composer.json
+++ b/layers/Engine/packages/hooks-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Engine/packages/hooks/composer.json
+++ b/layers/Engine/packages/hooks/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/loosecontracts/composer.json
+++ b/layers/Engine/packages/loosecontracts/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/modulerouting/composer.json
+++ b/layers/Engine/packages/modulerouting/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/query-parsing/composer.json
+++ b/layers/Engine/packages/query-parsing/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/root/composer.json
+++ b/layers/Engine/packages/root/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/routing-wp/composer.json
+++ b/layers/Engine/packages/routing-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Engine/packages/routing/composer.json
+++ b/layers/Engine/packages/routing/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/trace-tools/composer.json
+++ b/layers/Engine/packages/trace-tools/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Engine/packages/translation-wp/composer.json
+++ b/layers/Engine/packages/translation-wp/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Engine/packages/translation/composer.json
+++ b/layers/Engine/packages/translation/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -48,7 +48,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "symfony/var-dumper": "^5.1",

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/GraphQLByPoP/packages/graphql-query/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-query/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/GraphQLByPoP/packages/graphql-request/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-request/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/GraphQLByPoP/packages/graphql-server/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-server/composer.json
@@ -22,7 +22,7 @@
         "getpop/access-control": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Misc/packages/examples-for-pop/composer.json
+++ b/layers/Misc/packages/examples-for-pop/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/basic-directives/composer.json
+++ b/layers/Schema/packages/basic-directives/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/block-metadata-for-wp/composer.json
+++ b/layers/Schema/packages/block-metadata-for-wp/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "wpackagist-plugin/block-metadata": "^1.0",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/categories-wp/composer.json
+++ b/layers/Schema/packages/categories-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/categories/composer.json
+++ b/layers/Schema/packages/categories/composer.json
@@ -24,7 +24,7 @@
         "getpop/api-rest": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/cdn-directive/composer.json
+++ b/layers/Schema/packages/cdn-directive/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/comment-mutations-wp/composer.json
+++ b/layers/Schema/packages/comment-mutations-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/comment-mutations/composer.json
+++ b/layers/Schema/packages/comment-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/commentmeta-wp/composer.json
+++ b/layers/Schema/packages/commentmeta-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/commentmeta/composer.json
+++ b/layers/Schema/packages/commentmeta/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/comments-wp/composer.json
+++ b/layers/Schema/packages/comments-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/comments/composer.json
+++ b/layers/Schema/packages/comments/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/convert-case-directives/composer.json
+++ b/layers/Schema/packages/convert-case-directives/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/custompost-mutations-wp/composer.json
+++ b/layers/Schema/packages/custompost-mutations-wp/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/custompost-mutations/composer.json
+++ b/layers/Schema/packages/custompost-mutations/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/custompostmedia-mutations-wp/composer.json
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/custompostmedia-mutations/composer.json
+++ b/layers/Schema/packages/custompostmedia-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/custompostmedia-wp/composer.json
+++ b/layers/Schema/packages/custompostmedia-wp/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/custompostmedia/composer.json
+++ b/layers/Schema/packages/custompostmedia/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/custompostmeta-wp/composer.json
+++ b/layers/Schema/packages/custompostmeta-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/custompostmeta/composer.json
+++ b/layers/Schema/packages/custompostmeta/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/customposts-wp/composer.json
+++ b/layers/Schema/packages/customposts-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/customposts/composer.json
+++ b/layers/Schema/packages/customposts/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/event-mutations-wp-em/composer.json
+++ b/layers/Schema/packages/event-mutations-wp-em/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/event-mutations/composer.json
+++ b/layers/Schema/packages/event-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/events-wp-em/composer.json
+++ b/layers/Schema/packages/events-wp-em/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "wpackagist-plugin/events-manager": "^5.9",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/events/composer.json
+++ b/layers/Schema/packages/events/composer.json
@@ -25,7 +25,7 @@
         "pop-schema/tags": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/everythingelse-wp/composer.json
+++ b/layers/Schema/packages/everythingelse-wp/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "pop-schema/customposts": "dev-master",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/everythingelse/composer.json
+++ b/layers/Schema/packages/everythingelse/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/generic-customposts/composer.json
+++ b/layers/Schema/packages/generic-customposts/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/google-translate-directive-for-customposts/composer.json
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/google-translate-directive/composer.json
+++ b/layers/Schema/packages/google-translate-directive/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/highlights-wp/composer.json
+++ b/layers/Schema/packages/highlights-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/highlights/composer.json
+++ b/layers/Schema/packages/highlights/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/locationposts-wp/composer.json
+++ b/layers/Schema/packages/locationposts-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/locationposts/composer.json
+++ b/layers/Schema/packages/locationposts/composer.json
@@ -23,7 +23,7 @@
         "pop-schema/tags": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/locations-wp-em/composer.json
+++ b/layers/Schema/packages/locations-wp-em/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "wpackagist-plugin/events-manager": "^5.9",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/locations/composer.json
+++ b/layers/Schema/packages/locations/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/media-wp/composer.json
+++ b/layers/Schema/packages/media-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/media/composer.json
+++ b/layers/Schema/packages/media/composer.json
@@ -24,7 +24,7 @@
         "pop-schema/users": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/menus-wp/composer.json
+++ b/layers/Schema/packages/menus-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/menus/composer.json
+++ b/layers/Schema/packages/menus/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/meta/composer.json
+++ b/layers/Schema/packages/meta/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/metaquery-wp/composer.json
+++ b/layers/Schema/packages/metaquery-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/metaquery/composer.json
+++ b/layers/Schema/packages/metaquery/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/notifications-wp/composer.json
+++ b/layers/Schema/packages/notifications-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/notifications/composer.json
+++ b/layers/Schema/packages/notifications/composer.json
@@ -23,7 +23,7 @@
         "pop-schema/customposts": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/pages-wp/composer.json
+++ b/layers/Schema/packages/pages-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/pages/composer.json
+++ b/layers/Schema/packages/pages/composer.json
@@ -24,7 +24,7 @@
         "getpop/api-rest": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/post-mutations/composer.json
+++ b/layers/Schema/packages/post-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/post-tags-wp/composer.json
+++ b/layers/Schema/packages/post-tags-wp/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/post-tags/composer.json
+++ b/layers/Schema/packages/post-tags/composer.json
@@ -25,7 +25,7 @@
         "getpop/api-rest": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/posts-wp/composer.json
+++ b/layers/Schema/packages/posts-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/posts/composer.json
+++ b/layers/Schema/packages/posts/composer.json
@@ -25,7 +25,7 @@
         "pop-schema/users": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/queriedobject-wp/composer.json
+++ b/layers/Schema/packages/queriedobject-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/queriedobject/composer.json
+++ b/layers/Schema/packages/queriedobject/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/schema-commons/composer.json
+++ b/layers/Schema/packages/schema-commons/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/stances-wp/composer.json
+++ b/layers/Schema/packages/stances-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/stances/composer.json
+++ b/layers/Schema/packages/stances/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/tags-wp/composer.json
+++ b/layers/Schema/packages/tags-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/tags/composer.json
+++ b/layers/Schema/packages/tags/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/taxonomies-wp/composer.json
+++ b/layers/Schema/packages/taxonomies-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/taxonomies/composer.json
+++ b/layers/Schema/packages/taxonomies/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/taxonomymeta-wp/composer.json
+++ b/layers/Schema/packages/taxonomymeta-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/taxonomymeta/composer.json
+++ b/layers/Schema/packages/taxonomymeta/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/taxonomyquery-wp/composer.json
+++ b/layers/Schema/packages/taxonomyquery-wp/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/taxonomyquery/composer.json
+++ b/layers/Schema/packages/taxonomyquery/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/translate-directive-acl/composer.json
+++ b/layers/Schema/packages/translate-directive-acl/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/translate-directive/composer.json
+++ b/layers/Schema/packages/translate-directive/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/user-roles-access-control/composer.json
+++ b/layers/Schema/packages/user-roles-access-control/composer.json
@@ -23,7 +23,7 @@
         "getpop/cache-control": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/user-roles-acl/composer.json
+++ b/layers/Schema/packages/user-roles-acl/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/user-roles-wp/composer.json
+++ b/layers/Schema/packages/user-roles-wp/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "pop-schema/user-state-wp": "dev-master",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/user-roles/composer.json
+++ b/layers/Schema/packages/user-roles/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/user-state-access-control/composer.json
+++ b/layers/Schema/packages/user-state-access-control/composer.json
@@ -23,7 +23,7 @@
         "getpop/cache-control": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/Schema/packages/user-state-mutations-wp/composer.json
+++ b/layers/Schema/packages/user-state-mutations-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/user-state-mutations/composer.json
+++ b/layers/Schema/packages/user-state-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/user-state-wp/composer.json
+++ b/layers/Schema/packages/user-state-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/user-state/composer.json
+++ b/layers/Schema/packages/user-state/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/usermeta-wp/composer.json
+++ b/layers/Schema/packages/usermeta-wp/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/usermeta/composer.json
+++ b/layers/Schema/packages/usermeta/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Schema/packages/users-wp/composer.json
+++ b/layers/Schema/packages/users-wp/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "pop-schema/customposts-wp": "dev-master",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/Schema/packages/users/composer.json
+++ b/layers/Schema/packages/users/composer.json
@@ -25,7 +25,7 @@
         "getpop/api-rest": "dev-master",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/layers/SiteBuilder/packages/application-wp/composer.json
+++ b/layers/SiteBuilder/packages/application-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/SiteBuilder/packages/application/composer.json
+++ b/layers/SiteBuilder/packages/application/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/component-model-configuration/composer.json
+++ b/layers/SiteBuilder/packages/component-model-configuration/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/definitionpersistence/composer.json
+++ b/layers/SiteBuilder/packages/definitionpersistence/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/definitions-base36/composer.json
+++ b/layers/SiteBuilder/packages/definitions-base36/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/definitions-emoji/composer.json
+++ b/layers/SiteBuilder/packages/definitions-emoji/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/multisite/composer.json
+++ b/layers/SiteBuilder/packages/multisite/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/resourceloader/composer.json
+++ b/layers/SiteBuilder/packages/resourceloader/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/resources/composer.json
+++ b/layers/SiteBuilder/packages/resources/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/site-wp/composer.json
+++ b/layers/SiteBuilder/packages/site-wp/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0",
         "szepeviktor/phpstan-wordpress": "^0.6.2",
         "johnpbloch/wordpress": ">=5.5"

--- a/layers/SiteBuilder/packages/site/composer.json
+++ b/layers/SiteBuilder/packages/site/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/spa/composer.json
+++ b/layers/SiteBuilder/packages/spa/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/SiteBuilder/packages/static-site-generator/composer.json
+++ b/layers/SiteBuilder/packages/static-site-generator/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/comment-mutations/composer.json
+++ b/layers/Wassup/packages/comment-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/contactus-mutations/composer.json
+++ b/layers/Wassup/packages/contactus-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/contactuser-mutations/composer.json
+++ b/layers/Wassup/packages/contactuser-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/custompost-mutations/composer.json
+++ b/layers/Wassup/packages/custompost-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/custompostlink-mutations/composer.json
+++ b/layers/Wassup/packages/custompostlink-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/event-mutations/composer.json
+++ b/layers/Wassup/packages/event-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/eventlink-mutations/composer.json
+++ b/layers/Wassup/packages/eventlink-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/everythingelse-mutations/composer.json
+++ b/layers/Wassup/packages/everythingelse-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/flag-mutations/composer.json
+++ b/layers/Wassup/packages/flag-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/form-mutations/composer.json
+++ b/layers/Wassup/packages/form-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/gravityforms-mutations/composer.json
+++ b/layers/Wassup/packages/gravityforms-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/highlight-mutations/composer.json
+++ b/layers/Wassup/packages/highlight-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/location-mutations/composer.json
+++ b/layers/Wassup/packages/location-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/locationpost-mutations/composer.json
+++ b/layers/Wassup/packages/locationpost-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/locationpostlink-mutations/composer.json
+++ b/layers/Wassup/packages/locationpostlink-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/newsletter-mutations/composer.json
+++ b/layers/Wassup/packages/newsletter-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/notification-mutations/composer.json
+++ b/layers/Wassup/packages/notification-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/post-mutations/composer.json
+++ b/layers/Wassup/packages/post-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/postlink-mutations/composer.json
+++ b/layers/Wassup/packages/postlink-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/share-mutations/composer.json
+++ b/layers/Wassup/packages/share-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/socialnetwork-mutations/composer.json
+++ b/layers/Wassup/packages/socialnetwork-mutations/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/stance-mutations/composer.json
+++ b/layers/Wassup/packages/stance-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/system-mutations/composer.json
+++ b/layers/Wassup/packages/system-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/user-state-mutations/composer.json
+++ b/layers/Wassup/packages/user-state-mutations/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/volunteer-mutations/composer.json
+++ b/layers/Wassup/packages/volunteer-mutations/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/layers/Wassup/packages/wassup/composer.json
+++ b/layers/Wassup/packages/wassup/composer.json
@@ -76,7 +76,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=9.3",
-        "rector/rector": "^0.9",
+        "rector/rector": "0.9.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Starting from `v0.9.7`, Rector is [throwing errors when doing the PHP code downgrade](https://github.com/leoloso/PoP/runs/1715537114), making the CI for this project fail:

```                                                                                
 [ERROR] Could not process "vendor/symfony/cache/CacheItem.php" file, due to:   
         "Analyze error: "Class  was not found while trying to analyse it -     
         discovering symbols is probably not configured properly.". Include your
         files in "$parameters->set(Option::AUTOLOAD_PATHS, [...]);" in         
         "rector.php" config.                                                   
         See https://github.com/rectorphp/rector#configuration".                
                                                                                

                                                                                
 [ERROR] Could not process "vendor/symfony/string/AbstractUnicodeString.php"    
         file, due to:                                                          
         "Analyze error: "Class  was not found while trying to analyse it -     
         discovering symbols is probably not configured properly.". Include your
         files in "$parameters->set(Option::AUTOLOAD_PATHS, [...]);" in         
         "rector.php" config.                                                   
         See https://github.com/rectorphp/rector#configuration".                
                                                                                

                                                                                
 [ERROR] Could not process "vendor/symfony/string/ByteString.php" file, due to: 
         "Analyze error: "Class  was not found while trying to analyse it -     
         discovering symbols is probably not configured properly.". Include your
         files in "$parameters->set(Option::AUTOLOAD_PATHS, [...]);" in         
         "rector.php" config.                                                   
         See https://github.com/rectorphp/rector#configuration".                
                                                                                

                                                                                
 [ERROR] Could not process "vendor/symfony/string/CodePointString.php" file, due
         to:                                                                    
         "Analyze error: "Class  was not found while trying to analyse it -     
         discovering symbols is probably not configured properly.". Include your
         files in "$parameters->set(Option::AUTOLOAD_PATHS, [...]);" in         
         "rector.php" config.                                                   
         See https://github.com/rectorphp/rector#configuration".                
                                                                                

                                                                                
 [ERROR] Could not process "vendor/symfony/string/UnicodeString.php" file, due  
         to:                                                                    
         "Analyze error: "Class  was not found while trying to analyse it -     
         discovering symbols is probably not configured properly.". Include your
         files in "$parameters->set(Option::AUTOLOAD_PATHS, [...]);" in         
         "rector.php" config.                                                   
         See https://github.com/rectorphp/rector#configuration".                
                                                                                
```

The issue is happening in Rector, and not a dependency, because switching from `0.9.6` to `0.9.7` doesn't update any other package, and the error starts happening.

Somehow, Rector is attempting to load some class without name, and of course it can't find it. There are no changes in class `CacheItem`, so the problem happens somewhere [in this new code](https://github.com/rectorphp/rector/compare/0.9.6...0.9.7).

So, this PR temporarily downgrades Rector to `0.9.6` until the issue is fixed.