### PR TITLE
Fixed typos in docs

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
@@ -1,6 +1,6 @@
 # Composable Directives
 
-Have a directive modify the behavior of another directive. It introduces a directive argument `nestedUnder` on each directive, to indicate which is its parent directive. This number is a negative integer, defining the the parent directive's relative position.
+Have a directive modify the behavior of another directive. It introduces a directive argument `nestedUnder` on each directive, to indicate which is its parent directive. This number is a negative integer, defining the parent directive's relative position.
 
 In this example below, we have:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
@@ -12,11 +12,16 @@ In this example below, we have:
 {
   someField
     @directive1
-    @directive11(nestedUnder:-1)
-    @directive12(nestedUnder:-2)
-    @directive121(nestedUnder:-1)
+      @directive11(nestedUnder:-1)
+      @directive12(nestedUnder:-2)
+        @directive121(nestedUnder:-1)
 }
 ```
+
+Then, directives modify each other's behavior:
+
+- `@directive1` influences  `@directive11` and `@directive12`
+- `@directive12` influences `@directive 121`
 
 ## When to use
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
@@ -20,7 +20,7 @@ In this example below, we have:
 
 Then, directives modify each other's behavior:
 
-- `@directive1` influences  `@directive11` and `@directive12`
+- `@directive1` influences `@directive11` and `@directive12`
 - `@directive12` influences `@directive 121`
 
 ## When to use

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
@@ -46,7 +46,7 @@ For instance, directive `@forEach` can iterate over an array of elements, and ap
   users {
     capabilities
       @forEach
-      @upperCase(nestedUnder: -1)
+        @upperCase(nestedUnder: -1)
   }
 }
 ```
@@ -71,12 +71,12 @@ query {
       blockName: "core/paragraph"
     )
       @advancePointerInArray(path: "meta.content")
-      @forEach(nestedUnder: -1)
-      @translate(
-        from: "en",
-        to: "fr",
-        nestedUnder: -1
-      )
+        @forEach(nestedUnder: -1)
+          @translate(
+            from: "en",
+            to: "fr",
+            nestedUnder: -1
+          )
   }
 }
 ```

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/composable-directives.md
@@ -1,6 +1,6 @@
 # Composable Directives
 
-Have a directive modify the behavior of another directives. It introduces a directive argument `nestedUnder` on each directive, to indicate which is its parent directive. This number is a negative integer, defining the the parent directive's relative position.
+Have a directive modify the behavior of another directive. It introduces a directive argument `nestedUnder` on each directive, to indicate which is its parent directive. This number is a negative integer, defining the the parent directive's relative position.
 
 In this example below, we have:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/embeddable-fields.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/embeddable-fields.md
@@ -52,7 +52,7 @@ query {
 }
 ```
 
-Send a a newsletter defining the `to`, `subject` and `content` data through fields `newsletterTo`, `newsletterSubject` and `newsletterContent` from the `Root` type:
+Send a newsletter defining the `to`, `subject` and `content` data through fields `newsletterTo`, `newsletterSubject` and `newsletterContent` from the `Root` type:
 
 ```graphql
 mutation {
@@ -90,7 +90,7 @@ mutation {
 }
 ```
 
-Send a single email to many users, adding them all in the to field:
+Send a single email to many users, adding them all in the `to` field:
 
 ```graphql
 mutation {


### PR DESCRIPTION
Fixed several typos in markdown docs for GraphQL API for WordPress