### PR TITLE
Convert comma separated string to array

### DIFF
--- a/layers/Engine/packages/component-model/src/ComponentConfiguration/EnvironmentValueHelpers.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration/EnvironmentValueHelpers.php
@@ -31,4 +31,15 @@ class EnvironmentValueHelpers
     {
         return (int) $value;
     }
+
+    /**
+     * Convert the environment value from a comma separated string to array
+     *
+     * @param string $value environment value
+     * @return array
+     */
+    public static function commaSeparatedStringToArray(string $value): array
+    {
+        return explode(',', $value);
+    }
 }

--- a/layers/Schema/packages/generic-customposts/src/ComponentConfiguration.php
+++ b/layers/Schema/packages/generic-customposts/src/ComponentConfiguration.php
@@ -57,7 +57,7 @@ class ComponentConfiguration
         $envVariable = Environment::GENERIC_CUSTOMPOST_TYPES;
         $selfProperty = &self::$getGenericCustomPostTypes;
         $defaultValue = ['post'];
-        $callback = [EnvironmentValueHelpers::class, 'toInt'];
+        $callback = [EnvironmentValueHelpers::class, 'commaSeparatedStringToArray'];
 
         // Initialize property from the environment/hook
         self::maybeInitializeConfigurationValue(


### PR DESCRIPTION
Convert environment values, from a comma separated string, to an array

Eg:

```env
GENERIC_CUSTOMPOST_TYPES=post,page
```