### PR TITLE
Trim elements in array

### DIFF
--- a/layers/Engine/packages/component-model/src/ComponentConfiguration/EnvironmentValueHelpers.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration/EnvironmentValueHelpers.php
@@ -40,6 +40,6 @@ class EnvironmentValueHelpers
      */
     public static function commaSeparatedStringToArray(string $value): array
     {
-        return explode(',', $value);
+        return array_map('trim', explode(',', $value));
     }
 }


### PR DESCRIPTION
Enable to pass env vars with space:

```env
GENERIC_CUSTOMPOST_TYPES=post, page
```