### PR TITLE
Move setting the Symfony Cache namespace to ComponentModel

### DIFF
--- a/layers/Engine/packages/component-model/composer.json
+++ b/layers/Engine/packages/component-model/composer.json
@@ -22,7 +22,8 @@
         "getpop/migrate-component-model": "dev-master",
         "jrfnl/php-cast-to-type": "^2.0",
         "league/pipeline": "^1.0",
-        "symfony/cache": "^5.1"
+        "symfony/cache": "^5.1",
+        "symfony/expression-language": "^5.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12",

--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -9,8 +9,14 @@ services:
     memory_cache_item_pool:
         class: \Symfony\Component\Cache\Adapter\ArrayAdapter
 
+    PoP\ComponentModel\Cache\CacheConfigurationManagerInterface:
+        class: \PoP\ComponentModel\Cache\CacheConfigurationManager
+
+    # Set a directory where to store the cache
     persistent_cache_item_pool:
         class: \Symfony\Component\Cache\Adapter\FilesystemAdapter
+        arguments:
+            $namespace: '@=service("PoP\ComponentModel\Cache\CacheConfigurationManagerInterface").getNamespace()'
 
     PoP\ComponentModel\Container\ObjectDictionaryInterface:
         class: \PoP\ComponentModel\Container\ObjectDictionary

--- a/layers/Engine/packages/component-model/src/Cache/CacheConfigurationManager.php
+++ b/layers/Engine/packages/component-model/src/Cache/CacheConfigurationManager.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Cache;
+
+use PoP\ComponentModel\Cache\CacheConfigurationManagerInterface;
+use PoP\Root\Environment;
+
+/**
+ * Inject configuration to the cache
+ *
+ * @author Leonardo Losoviz <leo@getpop.org>
+ */
+class CacheConfigurationManager implements CacheConfigurationManagerInterface
+{
+    /**
+     * Make the cache folder obsolete when increasing the application version,
+     * otherwise the cache uses a stale configuration
+     *
+     * @see https://symfony.com/doc/current/components/cache/adapters/filesystem_adapter.html
+     */
+    public function getNamespace(): string
+    {
+        // (Needed for development) Don't share cache among plugin versions
+        if ($version = Environment::getApplicationVersion()) {
+            return '_v' . $version;
+        }
+        return '';
+    }
+}

--- a/layers/Engine/packages/component-model/src/Cache/CacheConfigurationManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/Cache/CacheConfigurationManagerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\GraphQLAPI\Cache;
+namespace PoP\ComponentModel\Cache;
 
 /**
  * Inject configuration to the cache

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -42,8 +42,7 @@
         "pop-schema/custompostmedia-mutations-wp": "dev-master",
         "pop-schema/post-mutations": "dev-master",
         "pop-schema/comment-mutations-wp": "dev-master",
-        "pop-schema/user-state-mutations-wp": "dev-master",
-        "symfony/expression-language": "^5.1"
+        "pop-schema/user-state-mutations-wp": "dev-master"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12",

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/cache-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/cache-services.yaml
@@ -2,12 +2,6 @@ services:
     _defaults:
         public: true
 
-    # Configure the cache with dynamic values
-    cache_configuration_manager:
+    # Override to configure the cache with dynamic values
+    PoP\ComponentModel\Cache\CacheConfigurationManagerInterface:
         class: \GraphQLAPI\GraphQLAPI\Cache\CacheConfigurationManager
-
-    # Override the Cache Item Pool to set a directory where to store the cache
-    persistent_cache_item_pool:
-        class: \Symfony\Component\Cache\Adapter\FilesystemAdapter
-        arguments:
-            $namespace: '@=service("cache_configuration_manager").getNamespace()'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Cache/CacheConfigurationManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Cache/CacheConfigurationManager.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Cache;
 
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
-use GraphQLAPI\GraphQLAPI\Cache\CacheConfigurationManagerInterface;
+use PoP\ComponentModel\Cache\CacheConfigurationManagerInterface;
 
 /**
  * Inject configuration to the cache

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Facades/CacheConfigurationManagerFacade.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Facades/CacheConfigurationManagerFacade.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Facades;
 
 use GraphQLAPI\GraphQLAPI\Cache\CacheConfigurationManager;
-use GraphQLAPI\GraphQLAPI\Cache\CacheConfigurationManagerInterface;
+use PoP\ComponentModel\Cache\CacheConfigurationManagerInterface;
 
 /**
  * Obtain an instance of the CacheConfigurationManager.


### PR DESCRIPTION
So it can be used by GraphQL by PoP too, using environment variable `APPLICATION_VERSION`.