### PR TITLE
Fix service name

### DIFF
--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -16,7 +16,7 @@ services:
     persistent_cache_item_pool:
         class: \Symfony\Component\Cache\Adapter\FilesystemAdapter
         arguments:
-            $namespace: '@=service("PoP\ComponentModel\Cache\CacheConfigurationManagerInterface").getNamespace()'
+            $namespace: '@=service("PoP\\ComponentModel\\Cache\\CacheConfigurationManagerInterface").getNamespace()'
 
     PoP\ComponentModel\Container\ObjectDictionaryInterface:
         class: \PoP\ComponentModel\Container\ObjectDictionary


### PR DESCRIPTION
The service set on #358 must use `"\\"` instead of `"\"`