### PR TITLE
Ignore the root build folder in .gitignore

### DIFF
--- a/layers/API/packages/api-clients/.gitignore
+++ b/layers/API/packages/api-clients/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/api-endpoints-for-wp/.gitignore
+++ b/layers/API/packages/api-endpoints-for-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/api-endpoints/.gitignore
+++ b/layers/API/packages/api-endpoints/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/api-graphql/.gitignore
+++ b/layers/API/packages/api-graphql/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/api-mirrorquery/.gitignore
+++ b/layers/API/packages/api-mirrorquery/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/api-rest/.gitignore
+++ b/layers/API/packages/api-rest/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/api/.gitignore
+++ b/layers/API/packages/api/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/migrate-api-graphql/.gitignore
+++ b/layers/API/packages/migrate-api-graphql/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/API/packages/migrate-api/.gitignore
+++ b/layers/API/packages/migrate-api/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/access-control/.gitignore
+++ b/layers/Engine/packages/access-control/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/cache-control/.gitignore
+++ b/layers/Engine/packages/cache-control/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/component-model/.gitignore
+++ b/layers/Engine/packages/component-model/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/configurable-schema-feedback/.gitignore
+++ b/layers/Engine/packages/configurable-schema-feedback/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/definitions/.gitignore
+++ b/layers/Engine/packages/definitions/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/engine-wp-bootloader/.gitignore
+++ b/layers/Engine/packages/engine-wp-bootloader/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/engine-wp/.gitignore
+++ b/layers/Engine/packages/engine-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/engine/.gitignore
+++ b/layers/Engine/packages/engine/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/field-query/.gitignore
+++ b/layers/Engine/packages/field-query/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/filestore/.gitignore
+++ b/layers/Engine/packages/filestore/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/function-fields/.gitignore
+++ b/layers/Engine/packages/function-fields/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/guzzle-helpers/.gitignore
+++ b/layers/Engine/packages/guzzle-helpers/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/hooks-wp/.gitignore
+++ b/layers/Engine/packages/hooks-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/hooks/.gitignore
+++ b/layers/Engine/packages/hooks/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/loosecontracts/.gitignore
+++ b/layers/Engine/packages/loosecontracts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/mandatory-directives-by-configuration/.gitignore
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/migrate-component-model/.gitignore
+++ b/layers/Engine/packages/migrate-component-model/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/migrate-engine-wp/.gitignore
+++ b/layers/Engine/packages/migrate-engine-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/migrate-engine/.gitignore
+++ b/layers/Engine/packages/migrate-engine/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/modulerouting/.gitignore
+++ b/layers/Engine/packages/modulerouting/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/query-parsing/.gitignore
+++ b/layers/Engine/packages/query-parsing/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/root/.gitignore
+++ b/layers/Engine/packages/root/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/routing-wp/.gitignore
+++ b/layers/Engine/packages/routing-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/routing/.gitignore
+++ b/layers/Engine/packages/routing/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/trace-tools/.gitignore
+++ b/layers/Engine/packages/trace-tools/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/translation-wp/.gitignore
+++ b/layers/Engine/packages/translation-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Engine/packages/translation/.gitignore
+++ b/layers/Engine/packages/translation/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.gitignore
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/clients/graphiql-with-explorer/.gitignore
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/clients/graphiql-with-explorer/.gitignore
@@ -8,11 +8,9 @@
 # testing
 /coverage
 
-# Add build because those are the actually loaded files
-# production
-# /build
+# Allow build because those are the actually loaded files
 !build
-# We don't need the generated media folder
+# But we don't need the generated media folder
 /build/static/media
 # No need for all the maps
 /build/static/js/*.map

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.gitignore
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/GraphQLByPoP/packages/graphql-parser/.gitignore
+++ b/layers/GraphQLByPoP/packages/graphql-parser/.gitignore
@@ -1,7 +1,7 @@
 composer.phar
 phpunit.xml
 .phpunit.result.cache
-build/
+/build/
 vendor/
 data/schema.graphql
 composer.lock

--- a/layers/GraphQLByPoP/packages/graphql-query/.gitignore
+++ b/layers/GraphQLByPoP/packages/graphql-query/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/GraphQLByPoP/packages/graphql-request/.gitignore
+++ b/layers/GraphQLByPoP/packages/graphql-request/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/GraphQLByPoP/packages/graphql-server/.gitignore
+++ b/layers/GraphQLByPoP/packages/graphql-server/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Misc/packages/examples-for-pop/.gitignore
+++ b/layers/Misc/packages/examples-for-pop/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/basic-directives/.gitignore
+++ b/layers/Schema/packages/basic-directives/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/block-metadata-for-wp/.gitignore
+++ b/layers/Schema/packages/block-metadata-for-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/categories-wp/.gitignore
+++ b/layers/Schema/packages/categories-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/categories/.gitignore
+++ b/layers/Schema/packages/categories/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/cdn-directive/.gitignore
+++ b/layers/Schema/packages/cdn-directive/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/comment-mutations-wp/.gitignore
+++ b/layers/Schema/packages/comment-mutations-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/comment-mutations/.gitignore
+++ b/layers/Schema/packages/comment-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/commentmeta-wp/.gitignore
+++ b/layers/Schema/packages/commentmeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/commentmeta/.gitignore
+++ b/layers/Schema/packages/commentmeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/comments-wp/.gitignore
+++ b/layers/Schema/packages/comments-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/comments/.gitignore
+++ b/layers/Schema/packages/comments/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/convert-case-directives/.gitignore
+++ b/layers/Schema/packages/convert-case-directives/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompost-mutations-wp/.gitignore
+++ b/layers/Schema/packages/custompost-mutations-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompost-mutations/.gitignore
+++ b/layers/Schema/packages/custompost-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompostmedia-mutations-wp/.gitignore
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompostmedia-mutations/.gitignore
+++ b/layers/Schema/packages/custompostmedia-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompostmedia-wp/.gitignore
+++ b/layers/Schema/packages/custompostmedia-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompostmedia/.gitignore
+++ b/layers/Schema/packages/custompostmedia/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompostmeta-wp/.gitignore
+++ b/layers/Schema/packages/custompostmeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/custompostmeta/.gitignore
+++ b/layers/Schema/packages/custompostmeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/customposts-wp/.gitignore
+++ b/layers/Schema/packages/customposts-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/customposts/.gitignore
+++ b/layers/Schema/packages/customposts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/event-mutations-wp-em/.gitignore
+++ b/layers/Schema/packages/event-mutations-wp-em/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/event-mutations/.gitignore
+++ b/layers/Schema/packages/event-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/events-wp-em/.gitignore
+++ b/layers/Schema/packages/events-wp-em/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/events/.gitignore
+++ b/layers/Schema/packages/events/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/everythingelse-wp/.gitignore
+++ b/layers/Schema/packages/everythingelse-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/everythingelse/.gitignore
+++ b/layers/Schema/packages/everythingelse/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/generic-customposts/.gitignore
+++ b/layers/Schema/packages/generic-customposts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/google-translate-directive-for-customposts/.gitignore
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/google-translate-directive/.gitignore
+++ b/layers/Schema/packages/google-translate-directive/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/highlights-wp/.gitignore
+++ b/layers/Schema/packages/highlights-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/highlights/.gitignore
+++ b/layers/Schema/packages/highlights/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/locationposts-wp/.gitignore
+++ b/layers/Schema/packages/locationposts-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/locationposts/.gitignore
+++ b/layers/Schema/packages/locationposts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/locations-wp-em/.gitignore
+++ b/layers/Schema/packages/locations-wp-em/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/locations/.gitignore
+++ b/layers/Schema/packages/locations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/media-wp/.gitignore
+++ b/layers/Schema/packages/media-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/media/.gitignore
+++ b/layers/Schema/packages/media/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/menus-wp/.gitignore
+++ b/layers/Schema/packages/menus-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/menus/.gitignore
+++ b/layers/Schema/packages/menus/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/meta/.gitignore
+++ b/layers/Schema/packages/meta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/metaquery-wp/.gitignore
+++ b/layers/Schema/packages/metaquery-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/metaquery/.gitignore
+++ b/layers/Schema/packages/metaquery/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-categories-wp/.gitignore
+++ b/layers/Schema/packages/migrate-categories-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-categories/.gitignore
+++ b/layers/Schema/packages/migrate-categories/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-commentmeta-wp/.gitignore
+++ b/layers/Schema/packages/migrate-commentmeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-commentmeta/.gitignore
+++ b/layers/Schema/packages/migrate-commentmeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-comments-wp/.gitignore
+++ b/layers/Schema/packages/migrate-comments-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-comments/.gitignore
+++ b/layers/Schema/packages/migrate-comments/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-custompostmedia-wp/.gitignore
+++ b/layers/Schema/packages/migrate-custompostmedia-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-custompostmedia/.gitignore
+++ b/layers/Schema/packages/migrate-custompostmedia/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-custompostmeta-wp/.gitignore
+++ b/layers/Schema/packages/migrate-custompostmeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-custompostmeta/.gitignore
+++ b/layers/Schema/packages/migrate-custompostmeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-customposts-wp/.gitignore
+++ b/layers/Schema/packages/migrate-customposts-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-customposts/.gitignore
+++ b/layers/Schema/packages/migrate-customposts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-events-wp-em/.gitignore
+++ b/layers/Schema/packages/migrate-events-wp-em/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-events/.gitignore
+++ b/layers/Schema/packages/migrate-events/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-everythingelse/.gitignore
+++ b/layers/Schema/packages/migrate-everythingelse/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-locations-wp-em/.gitignore
+++ b/layers/Schema/packages/migrate-locations-wp-em/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-locations/.gitignore
+++ b/layers/Schema/packages/migrate-locations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-media-wp/.gitignore
+++ b/layers/Schema/packages/migrate-media-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-media/.gitignore
+++ b/layers/Schema/packages/migrate-media/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-meta/.gitignore
+++ b/layers/Schema/packages/migrate-meta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-metaquery-wp/.gitignore
+++ b/layers/Schema/packages/migrate-metaquery-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-metaquery/.gitignore
+++ b/layers/Schema/packages/migrate-metaquery/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-pages-wp/.gitignore
+++ b/layers/Schema/packages/migrate-pages-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-pages/.gitignore
+++ b/layers/Schema/packages/migrate-pages/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-post-tags-wp/.gitignore
+++ b/layers/Schema/packages/migrate-post-tags-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-post-tags/.gitignore
+++ b/layers/Schema/packages/migrate-post-tags/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-posts-wp/.gitignore
+++ b/layers/Schema/packages/migrate-posts-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-posts/.gitignore
+++ b/layers/Schema/packages/migrate-posts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-queriedobject-wp/.gitignore
+++ b/layers/Schema/packages/migrate-queriedobject-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-queriedobject/.gitignore
+++ b/layers/Schema/packages/migrate-queriedobject/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-tags-wp/.gitignore
+++ b/layers/Schema/packages/migrate-tags-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-tags/.gitignore
+++ b/layers/Schema/packages/migrate-tags/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-taxonomies-wp/.gitignore
+++ b/layers/Schema/packages/migrate-taxonomies-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-taxonomies/.gitignore
+++ b/layers/Schema/packages/migrate-taxonomies/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-taxonomymeta-wp/.gitignore
+++ b/layers/Schema/packages/migrate-taxonomymeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-taxonomymeta/.gitignore
+++ b/layers/Schema/packages/migrate-taxonomymeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-taxonomyquery-wp/.gitignore
+++ b/layers/Schema/packages/migrate-taxonomyquery-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-taxonomyquery/.gitignore
+++ b/layers/Schema/packages/migrate-taxonomyquery/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-usermeta-wp/.gitignore
+++ b/layers/Schema/packages/migrate-usermeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-usermeta/.gitignore
+++ b/layers/Schema/packages/migrate-usermeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-users-wp/.gitignore
+++ b/layers/Schema/packages/migrate-users-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/migrate-users/.gitignore
+++ b/layers/Schema/packages/migrate-users/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/notifications-wp/.gitignore
+++ b/layers/Schema/packages/notifications-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/notifications/.gitignore
+++ b/layers/Schema/packages/notifications/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/pages-wp/.gitignore
+++ b/layers/Schema/packages/pages-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/pages/.gitignore
+++ b/layers/Schema/packages/pages/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/post-mutations/.gitignore
+++ b/layers/Schema/packages/post-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/post-tags-wp/.gitignore
+++ b/layers/Schema/packages/post-tags-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/post-tags/.gitignore
+++ b/layers/Schema/packages/post-tags/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/posts-wp/.gitignore
+++ b/layers/Schema/packages/posts-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/posts/.gitignore
+++ b/layers/Schema/packages/posts/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/queriedobject-wp/.gitignore
+++ b/layers/Schema/packages/queriedobject-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/queriedobject/.gitignore
+++ b/layers/Schema/packages/queriedobject/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/schema-commons/.gitignore
+++ b/layers/Schema/packages/schema-commons/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/stances-wp/.gitignore
+++ b/layers/Schema/packages/stances-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/stances/.gitignore
+++ b/layers/Schema/packages/stances/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/tags-wp/.gitignore
+++ b/layers/Schema/packages/tags-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/tags/.gitignore
+++ b/layers/Schema/packages/tags/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/taxonomies-wp/.gitignore
+++ b/layers/Schema/packages/taxonomies-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/taxonomies/.gitignore
+++ b/layers/Schema/packages/taxonomies/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/taxonomymeta-wp/.gitignore
+++ b/layers/Schema/packages/taxonomymeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/taxonomymeta/.gitignore
+++ b/layers/Schema/packages/taxonomymeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/taxonomyquery-wp/.gitignore
+++ b/layers/Schema/packages/taxonomyquery-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/taxonomyquery/.gitignore
+++ b/layers/Schema/packages/taxonomyquery/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/translate-directive-acl/.gitignore
+++ b/layers/Schema/packages/translate-directive-acl/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/translate-directive/.gitignore
+++ b/layers/Schema/packages/translate-directive/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-roles-access-control/.gitignore
+++ b/layers/Schema/packages/user-roles-access-control/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-roles-acl/.gitignore
+++ b/layers/Schema/packages/user-roles-acl/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-roles-wp/.gitignore
+++ b/layers/Schema/packages/user-roles-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-roles/.gitignore
+++ b/layers/Schema/packages/user-roles/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-state-access-control/.gitignore
+++ b/layers/Schema/packages/user-state-access-control/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-state-mutations-wp/.gitignore
+++ b/layers/Schema/packages/user-state-mutations-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-state-mutations/.gitignore
+++ b/layers/Schema/packages/user-state-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-state-wp/.gitignore
+++ b/layers/Schema/packages/user-state-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/user-state/.gitignore
+++ b/layers/Schema/packages/user-state/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/usermeta-wp/.gitignore
+++ b/layers/Schema/packages/usermeta-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/usermeta/.gitignore
+++ b/layers/Schema/packages/usermeta/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/users-wp/.gitignore
+++ b/layers/Schema/packages/users-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Schema/packages/users/.gitignore
+++ b/layers/Schema/packages/users/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/application-wp/.gitignore
+++ b/layers/SiteBuilder/packages/application-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/application/.gitignore
+++ b/layers/SiteBuilder/packages/application/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/component-model-configuration/.gitignore
+++ b/layers/SiteBuilder/packages/component-model-configuration/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/definitionpersistence/.gitignore
+++ b/layers/SiteBuilder/packages/definitionpersistence/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/definitions-base36/.gitignore
+++ b/layers/SiteBuilder/packages/definitions-base36/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/definitions-emoji/.gitignore
+++ b/layers/SiteBuilder/packages/definitions-emoji/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/migrate-component-model-configuration/.gitignore
+++ b/layers/SiteBuilder/packages/migrate-component-model-configuration/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/migrate-static-site-generator/.gitignore
+++ b/layers/SiteBuilder/packages/migrate-static-site-generator/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/multisite/.gitignore
+++ b/layers/SiteBuilder/packages/multisite/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/resourceloader/.gitignore
+++ b/layers/SiteBuilder/packages/resourceloader/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/resources/.gitignore
+++ b/layers/SiteBuilder/packages/resources/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/site-wp/.gitignore
+++ b/layers/SiteBuilder/packages/site-wp/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/site/.gitignore
+++ b/layers/SiteBuilder/packages/site/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/spa/.gitignore
+++ b/layers/SiteBuilder/packages/spa/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/SiteBuilder/packages/static-site-generator/.gitignore
+++ b/layers/SiteBuilder/packages/static-site-generator/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/comment-mutations/.gitignore
+++ b/layers/Wassup/packages/comment-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/contactus-mutations/.gitignore
+++ b/layers/Wassup/packages/contactus-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/contactuser-mutations/.gitignore
+++ b/layers/Wassup/packages/contactuser-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/custompost-mutations/.gitignore
+++ b/layers/Wassup/packages/custompost-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/custompostlink-mutations/.gitignore
+++ b/layers/Wassup/packages/custompostlink-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/event-mutations/.gitignore
+++ b/layers/Wassup/packages/event-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/eventlink-mutations/.gitignore
+++ b/layers/Wassup/packages/eventlink-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/everythingelse-mutations/.gitignore
+++ b/layers/Wassup/packages/everythingelse-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/flag-mutations/.gitignore
+++ b/layers/Wassup/packages/flag-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/form-mutations/.gitignore
+++ b/layers/Wassup/packages/form-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/gravityforms-mutations/.gitignore
+++ b/layers/Wassup/packages/gravityforms-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/highlight-mutations/.gitignore
+++ b/layers/Wassup/packages/highlight-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/location-mutations/.gitignore
+++ b/layers/Wassup/packages/location-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/locationpost-mutations/.gitignore
+++ b/layers/Wassup/packages/locationpost-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/locationpostlink-mutations/.gitignore
+++ b/layers/Wassup/packages/locationpostlink-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/newsletter-mutations/.gitignore
+++ b/layers/Wassup/packages/newsletter-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/notification-mutations/.gitignore
+++ b/layers/Wassup/packages/notification-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/post-mutations/.gitignore
+++ b/layers/Wassup/packages/post-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/postlink-mutations/.gitignore
+++ b/layers/Wassup/packages/postlink-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/share-mutations/.gitignore
+++ b/layers/Wassup/packages/share-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/socialnetwork-mutations/.gitignore
+++ b/layers/Wassup/packages/socialnetwork-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/stance-mutations/.gitignore
+++ b/layers/Wassup/packages/stance-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/system-mutations/.gitignore
+++ b/layers/Wassup/packages/system-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/user-state-mutations/.gitignore
+++ b/layers/Wassup/packages/user-state-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/volunteer-mutations/.gitignore
+++ b/layers/Wassup/packages/volunteer-mutations/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml

--- a/layers/Wassup/packages/wassup/.gitignore
+++ b/layers/Wassup/packages/wassup/.gitignore
@@ -1,4 +1,4 @@
-build
+/build/
 composer.lock
 vendor
 phpcs.xml


### PR DESCRIPTION
Replace `build` with `/build/` in all `.gitignore` files. This fixes #336 