### PR TITLE
Use generated GraphQL API plugin release from leoloso/PoP

### DIFF
--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -85,7 +85,7 @@ jobs:
                 uses: montudor/action-zip@v0.1.1
 
             -   name: Create plugin as zip
-                run: zip -X -r ../../../../build/graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php *.dist composer.* **/package-lock.json dev-helpers/\* docs/images/\* tests/\* **/tests/\*
+                run: zip -X -r ../../../../build/graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
 
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/disabled-workflows/generate_plugin.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/disabled-workflows/generate_plugin.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Create artifact
         uses: montudor/action-zip@v0.1.0
         with:
-          args: zip -X -r build/graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php *.dist composer.* "**/package-lock.json" build** ci** dev-helpers** docs/images** tests** "**/tests**"
+          args: zip -X -r build/graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php *.dist composer.* "**/package-lock.json" build** ci** dev-helpers** lando** docs/images** tests** "**/tests**"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
@@ -75,7 +75,7 @@ Add the following configuration to your `composer.json`:
                 "type": "wordpress-plugin",
                 "version": "0.7.6",
                 "dist": {
-                    "url": "https://github.com/GraphQLAPI/graphql-api-for-wp/releases/latest/download/graphql-api.zip",
+                    "url": "https://github.com/leoloso/PoP/releases/latest/download/graphql-api.zip",
                     "type": "zip"
                 },
                 "require": {
@@ -99,7 +99,7 @@ Add the following configuration to your `composer.json`:
 To install via [WP-CLI](http://wp-cli.org/), execute this command:
 
 ```bash
-wp plugin install --activate https://github.com/GraphQLAPI/graphql-api-for-wp/releases/latest/download/graphql-api.zip
+wp plugin install --activate https://github.com/leoloso/PoP/releases/latest/download/graphql-api.zip
 ```
 
 ### GitHub Updater
@@ -428,7 +428,7 @@ GPLv2 or later. Please see [License File](LICENSE.md) for more information.
 [link-contributors]: ../../../../../../contributors
 [link-author]: https://github.com/leoloso
 
-[latest-release-url]: https://github.com/GraphQLAPI/graphql-api-for-wp/releases/latest/download/graphql-api.zip
+[latest-release-url]: https://github.com/leoloso/PoP/releases/latest/download/graphql-api.zip
 
 
 <!--

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
@@ -12,8 +12,7 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: graphql-api
 Domain Path: /languages
-GitHub Plugin URI: https://github.com/GraphQLAPI/graphql-api-for-wp
-Release Asset: true
+GitHub Plugin URI: GraphQLAPI/graphql-api-for-wp-dist
 */
 
 // Exit if accessed directly


### PR DESCRIPTION
Replaced the plugin download URL:
- from the [GraphQLAPI/graphql-api-for-wp asset](https://github.com/GraphQLAPI/graphql-api-for-wp/releases/latest/download/graphql-api.zip)
- to the [leoloso/PoP asset](https://github.com/leoloso/PoP/releases/latest/download/graphql-api.zip)