### PR TITLE
Re-enabled the Composable Directives module in GraphQL API

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/OperationalFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/OperationalFunctionalityModuleResolver.php
@@ -37,8 +37,7 @@ class OperationalFunctionalityModuleResolver extends AbstractFunctionalityModule
             self::REMOVE_IF_NULL_DIRECTIVE,
             self::PROACTIVE_FEEDBACK,
             self::EMBEDDABLE_FIELDS,
-            // Temporarily commented
-            // self::COMPOSABLE_DIRECTIVES,
+            self::COMPOSABLE_DIRECTIVES,
             self::MUTATIONS,
             self::NESTED_MUTATIONS,
         ];

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -591,8 +591,7 @@ class PluginConfiguration
         ];
         $componentClassConfiguration[\GraphQLByPoP\GraphQLQuery\Component::class] = [
             // Enable Composable Directives?
-            // Temporarily commented
-            // GraphQLQueryEnvironment::ENABLE_COMPOSABLE_DIRECTIVES => $moduleRegistry->isModuleEnabled(OperationalFunctionalityModuleResolver::COMPOSABLE_DIRECTIVES),
+            GraphQLQueryEnvironment::ENABLE_COMPOSABLE_DIRECTIVES => $moduleRegistry->isModuleEnabled(OperationalFunctionalityModuleResolver::COMPOSABLE_DIRECTIVES),
         ];
     }
 


### PR DESCRIPTION
Had been removed to generate `v0.7.7`. Added again, for `v0.8`