### PR TITLE
Replace current time with time

### DIFF
--- a/layers/Engine/packages/migrate-component-model/migrate/kernel/library/constants.php
+++ b/layers/Engine/packages/migrate-component-model/migrate/kernel/library/constants.php
@@ -7,7 +7,7 @@ define('POP_MSG_STARTUPERROR', TranslationAPIFacade::getInstance()->__('PoP cann
 // This Constant is needed to be able to retrieve the timestamp and replace it for nothing when generating the ETag,
 // so that this random value does not modify the hash of the overall html output
 define('POP_CONSTANT_UNIQUE_ID', GeneralUtils::generateRandomString());
-define('POP_CONSTANT_CURRENTTIMESTAMP', current_time('timestamp'));
+define('POP_CONSTANT_CURRENTTIMESTAMP', time());
 define('POP_CONSTANT_RAND', rand());
 define('POP_CONSTANT_TIME', time());
 

--- a/layers/Schema/packages/migrate-events-wp-em/migrate/library/functions/placeholders.php
+++ b/layers/Schema/packages/migrate-events-wp-em/migrate/library/functions/placeholders.php
@@ -49,7 +49,7 @@ function gdEmEventOutputShowConditionAddDateCondition($show_condition = false, $
         $today = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP);
         $show_condition = gdEmEventEventOnGivenDay($today, $event);
     } elseif ($condition == 'is_tomorrow') {
-        $tomorrow = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP+86400);    // add a day
+        $tomorrow = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP + 86400);    // add a day
         $show_condition = gdEmEventEventOnGivenDay($tomorrow, $event);
     }
 

--- a/layers/Schema/packages/migrate-events-wp-em/migrate/library/functions/placeholders.php
+++ b/layers/Schema/packages/migrate-events-wp-em/migrate/library/functions/placeholders.php
@@ -11,7 +11,7 @@ function gdEmEventOutputShowCondition($show_condition = false, $condition, $cond
     } elseif ($condition == 'no_attendees') {
         return !gdEventHasAttendees($event);
     }
-    
+
     return $show_condition;
 }
 
@@ -26,16 +26,16 @@ function gdEmEventOutputShowConditionAddAttCondition($show_condition = false, $c
         //event has this attribute
         $att = $tag_match[1];
         $attributes = $event->event_attributes;
-       
+
         $show_condition = is_array($event->event_attributes) && array_key_exists($att, $attributes) && $attributes[$att];
     } elseif (preg_match('/^no_att_([a-zA-Z0-9_\-]+)$/', $condition, $tag_match)) {
         //event doesn't have this attribute
         $att = $tag_match[1];
         $attributes = $event->event_attributes;
-       
+
         $show_condition = !(is_array($event->event_attributes) && array_key_exists($att, $attributes) && $attributes[$att]);
     }
-    
+
     return $show_condition;
 }
 
@@ -46,13 +46,13 @@ HooksAPIFacade::getInstance()->addFilter('em_event_output_show_condition', 'gdEm
 function gdEmEventOutputShowConditionAddDateCondition($show_condition = false, $condition, $conditional_value, $event)
 {
     if ($condition == 'is_today') {
-        $today = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/);
+        $today = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP);
         $show_condition = gdEmEventEventOnGivenDay($today, $event);
     } elseif ($condition == 'is_tomorrow') {
-        $tomorrow = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/+86400);    // add a day
+        $tomorrow = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP+86400);    // add a day
         $show_condition = gdEmEventEventOnGivenDay($tomorrow, $event);
     }
-    
+
     return $show_condition;
 }
 

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-automatedemails/plugins/pop-userplatform/library/automatedemails/loopusers-processorautomatedemails-base.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-automatedemails/plugins/pop-userplatform/library/automatedemails/loopusers-processorautomatedemails-base.php
@@ -30,7 +30,7 @@ class PoP_LoopUsersProcessorAutomatedEmailsBase extends PoP_ProcessorAutomatedEm
             $pagesection_settings_id = $this->getPagesectionSettingsid();
             $block_module = $this->getBlockModule();
             $block_settings_id = ModuleUtils::getModuleOutputName($block_module);
-            
+
             // Set the recipient as the "current-user-id", pretending this user is logged in
             $vars = &ApplicationState::$vars;
             // First, save the old values, to restore them later
@@ -45,8 +45,8 @@ class PoP_LoopUsersProcessorAutomatedEmailsBase extends PoP_ProcessorAutomatedEm
             }
             // Then, can start to modify the global state
             $vars['global-userstate']['is-user-logged-in'] = true;
-            
-            $yesterday = strtotime("-1 day", POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/);
+
+            $yesterday = strtotime("-1 day", POP_CONSTANT_CURRENTTIMESTAMP);
             foreach ($users as $user_id) {
                 // Set the recipient as the "current-user-id", pretending this user is logged in
                 $vars['global-userstate']['current-user'] = $cmsusersapi->getUserById($user_id)/*new WP_User($user_id, '')*/;
@@ -75,7 +75,7 @@ class PoP_LoopUsersProcessorAutomatedEmailsBase extends PoP_ProcessorAutomatedEm
 
                 // Initialize the popManager once again, so that it merges the new data into the context
                 $serverside_rendering->initPopmanager();
-                
+
                 // Now we can call again function getContent(), which will have the right context for that user
                 $emails[] = array(
                     'users' => array($user_id),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/library/processors/dataloads/sections.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/library/processors/dataloads/sections.php
@@ -108,7 +108,7 @@ class PoPTheme_Wassup_AE_Module_Processor_SectionDataloads extends PoP_CommonAut
                 PoP_Application_SectionUtils::addDataloadqueryargsAllcontent($ret);
 
                 // Return the posts created after the given timestamp
-                $start_date = strtotime("-7 day", POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/);
+                $start_date = strtotime("-7 day", POP_CONSTANT_CURRENTTIMESTAMP);
                 // $ret['date-query'] = array(
                 //     array(
                 //         'after' => date('Y-m-d H:i:s', $start_date),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/plugins/pop-userplatform/plugins/pop-notifications-processors/library/processors/dataloads/sections.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/plugins/pop-userplatform/plugins/pop-notifications-processors/library/processors/dataloads/sections.php
@@ -94,7 +94,7 @@ class PoPTheme_Wassup_AAL_AE_Module_Processor_SectionDataloads extends PoP_Commo
             case self::MODULE_DATALOAD_AUTOMATEDEMAILS_NOTIFICATIONS_SCROLL_DETAILS:
             case self::MODULE_DATALOAD_AUTOMATEDEMAILS_NOTIFICATIONS_SCROLL_LIST:
                 // Return the notifications from within the last 24 hs
-                $yesterday = strtotime("-1 day", POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/);
+                $yesterday = strtotime("-1 day", POP_CONSTANT_CURRENTTIMESTAMP);
                 $ret['hist_time'] = $yesterday;
                 break;
         }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/events-manager-pop-events/library/scopes.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/events-manager-pop-events/library/scopes.php
@@ -7,12 +7,12 @@ use PoP\Hooks\Facades\HooksAPIFacade;
 HooksAPIFacade::getInstance()->addFilter('em_events_build_sql_conditions', 'popEmAeEventsBuildSqlConditions', 1, 2);
 function popEmAeEventsBuildSqlConditions($conditions, $args)
 {
-    
+
        // Somehow the scope could be an array, so `preg_match` below would fail, so make sure it is not an array
     if (!empty($args['scope']) && $args['scope'] == 'week') {
         // $end_date: if doing 7 days, then must produce +6 day, etc
-        $start_date = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/);
-        $end_date = date('Y-m-d', strtotime("+6 day", POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/));
+        $start_date = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP);
+        $end_date = date('Y-m-d', strtotime("+6 day", POP_CONSTANT_CURRENTTIMESTAMP));
         $conditions['scope'] = " ((event_start_date BETWEEN CAST('$start_date' AS DATE) AND CAST('$end_date' AS DATE)) OR (event_end_date BETWEEN CAST('$start_date' AS DATE) AND CAST('$end_date' AS DATE)))";
     }
     return $conditions;

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/library/notifications/notifications-api.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/library/notifications/notifications-api.php
@@ -55,7 +55,7 @@ class PoP_Notifications_API
 
         // // Normalize the args
         // $args = self::convertArgs($args);
-        
+
         // Delete a previous entry
         global $wpdb;
         $wpdb->query(
@@ -91,7 +91,7 @@ class PoP_Notifications_API
                 'array' => false,
                 'fields' => '*',
                 'user_id' => '',
-                'hist_time' => POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/,
+                'hist_time' => POP_CONSTANT_CURRENTTIMESTAMP,
                 'hist_time_compare' => '<',
                 'order' => 'ASC',
                 'orderby' => '',
@@ -194,7 +194,7 @@ class PoP_Notifications_API
             //----------------------------------
             if ($user_id) {
                 // Below, create an array of AND statements for the given user
-                
+
                 //----------------------------------
                 // Helper WHERE statements
                 //----------------------------------
@@ -224,7 +224,7 @@ class PoP_Notifications_API
                     foreach ($usernetwork_metakeys as $metakey) {
                         $usernetwork_keys[] = \PoPSchema\UserMeta\Utils::getMetaKey($metakey);
                     }
-                    
+
                     // $user_network_conditions: allow to hook more conditions into it
                     // Needed for User Role Editor to add Community Members from this user's communities
                     // ------------------------------
@@ -239,9 +239,9 @@ class PoP_Notifications_API
                     $user_network_conditions[] = sprintf(
                         '
 							%4$s.user_id in (
-								SELECT 
-									meta_value 
-								FROM 
+								SELECT
+									meta_value
+								FROM
 									%2$s
 								WHERE
 									(
@@ -315,9 +315,9 @@ class PoP_Notifications_API
                 $useractivityposts_object_id_unions = array(
                     sprintf(
                         '
-							SELECT 
-								ID 
-							FROM 
+							SELECT
+								ID
+							FROM
 								%1$s
 							WHERE
 									post_status = "publish"
@@ -357,9 +357,9 @@ class PoP_Notifications_API
 							%3$s.user_id != %1$s
 						AND
 							%3$s.object_id in (
-									SELECT 
-										ID 
-									FROM 
+									SELECT
+										ID
+									FROM
 										%2$s
 									WHERE
 										post_author = %1$s
@@ -508,7 +508,7 @@ class PoP_Notifications_API
                         $wpdb->pop_notifications
                     );
                 }
-                
+
                 // User Activity + Network Notifications:
                 $useractivityplusnetwork_notification_actions = HooksAPIFacade::getInstance()->applyFilters(
                     'AAL_PoP_API:notifications:useractivityplusnetwork:actions',
@@ -549,7 +549,7 @@ class PoP_Notifications_API
                         $wpdb->posts
                     );
                 }
-            
+
 
                 // Allow plug-ins to keep adding WHERE statements
                 $sql_where_user_ors = HooksAPIFacade::getInstance()->applyFilters('PoP_Notifications_API:sql:wheres', $sql_where_user_ors, $args, $actions, $user_id, $userposts_where, $useractivityposts_where, $user_plus_network_where);
@@ -667,9 +667,9 @@ class PoP_Notifications_API
             // }
             $joinstatusclause = sprintf(
                 '
-					LEFT OUTER JOIN 
+					LEFT OUTER JOIN
 						`%2$s`
-					ON 
+					ON
 						(
 							%2$s.status_histid = %1$s.histid
 						AND
@@ -684,12 +684,12 @@ class PoP_Notifications_API
 
         $sql = sprintf(//$wpdb->prepare(
             '
-				SELECT 
+				SELECT
 					%s
 				FROM
 					`%s`
 				%s
-				WHERE 
+				WHERE
 					%s
 				%s
 				%s
@@ -747,7 +747,7 @@ class PoP_Notifications_API
 				histid
 			FROM
 				`%1$s`
-			WHERE 
+			WHERE
 				(
 					`user_id` = %2$d
 				AND
@@ -797,7 +797,7 @@ class PoP_Notifications_API
 				histid
 			FROM
 				`%1$s`
-			WHERE 
+			WHERE
 				(
 					`user_id` = %2$d
 				OR
@@ -823,7 +823,7 @@ class PoP_Notifications_API
                     '
 					DELETE FROM
 						`%1$s`
-					WHERE 
+					WHERE
 						`histid` in (%2$s)
 					',
                     $wpdb->pop_notifications,
@@ -846,7 +846,7 @@ class PoP_Notifications_API
                 '
 				DELETE FROM
 					`%1$s`
-				WHERE 
+				WHERE
 					%2$s
 				',
                 $wpdb->pop_notifications_status,
@@ -860,14 +860,14 @@ class PoP_Notifications_API
         global $wpdb;
 
         $joined_histids = implode(',', $histids);
-        
+
         // Delete all records from the activity log
         $wpdb->query(
             sprintf(
                 '
 				DELETE FROM
 					`%1$s`
-				WHERE 
+				WHERE
 					`histid` in (%2$s)
 				',
                 $wpdb->pop_notifications,
@@ -881,7 +881,7 @@ class PoP_Notifications_API
                 '
 				DELETE FROM
 					`%1$s`
-				WHERE 
+				WHERE
 					`status_histid` in (%2$s)
 				',
                 $wpdb->pop_notifications_status,
@@ -902,7 +902,7 @@ class PoP_Notifications_API
                 '
 				DELETE FROM
 					`%1$s`
-				WHERE 
+				WHERE
 					(
 						`status_histid` = %2$d
 					AND

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/plugins/events-manager-pop-events/library/functions/scopes.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/plugins/events-manager-pop-events/library/functions/scopes.php
@@ -7,7 +7,7 @@ use PoP\Hooks\Facades\HooksAPIFacade;
 HooksAPIFacade::getInstance()->addFilter('em_events_build_sql_conditions', 'popEmRssEventsBuildSqlConditions', 1, 2);
 function popEmRssEventsBuildSqlConditions($conditions, $args)
 {
-    
+
        // Somehow the scope could be an array, so `preg_match` below would fail, so make sure it is not an array
     if (!empty($args['scope']) && !is_array($args['scope'])) {
         // Check if it suits the regex, and if so, get how many days
@@ -16,8 +16,8 @@ function popEmRssEventsBuildSqlConditions($conditions, $args)
             $days = $matches[1];
 
             // $end_date: if doing 2 days, then must produce +1 day, etc
-            $start_date = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/);
-            $end_date = date('Y-m-d', strtotime(sprintf("+%s day", $days-1), POP_CONSTANT_CURRENTTIMESTAMP/*current_time('timestamp')*/));
+            $start_date = date('Y-m-d', POP_CONSTANT_CURRENTTIMESTAMP);
+            $end_date = date('Y-m-d', strtotime(sprintf("+%s day", $days-1), POP_CONSTANT_CURRENTTIMESTAMP));
             $conditions['scope'] = " ((event_start_date BETWEEN CAST('$start_date' AS DATE) AND CAST('$end_date' AS DATE)) OR (event_end_date BETWEEN CAST('$start_date' AS DATE) AND CAST('$end_date' AS DATE)))";
         }
     }


### PR DESCRIPTION
Replace `current_time` with `time`, since the former belongs to WordPress, not to PHP, so it creates trouble when applying PHP-Scoper.