### PR TITLE
Improve code quality (import classnames)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -635,7 +635,8 @@
         "propagate-monorepo": "monorepo-builder propagate --ansi",
         "validate-monorepo": "monorepo-builder validate --ansi",
         "release": "monorepo-builder release patch --ansi",
-        "merge-phpstan": "monorepo-builder merge-phpstan --skip-unmigrated --ansi"
+        "merge-phpstan": "monorepo-builder merge-phpstan --skip-unmigrated --ansi",
+        "improve-code-quality": "rector process --config=rector-code-quality.php --ansi"
     },
     "scripts-descriptions": {
         "test": "Execute PHPUnit tests",
@@ -652,7 +653,8 @@
         "merge-monorepo": "Create the monorepo's composer.json file, containing all dependencies from all packages",
         "propagate-monorepo": "Propagate versions from the monorepo's composer.json file to all packages",
         "release": "Release a new version (bump version, commit, push, tag, revert to 'dev-master', commit, push)",
-        "merge-phpstan": "Generate a single PHPStan config for the monorepo, invoking the config for the PHPStan config for all packages"
+        "merge-phpstan": "Generate a single PHPStan config for the monorepo, invoking the config for the PHPStan config for all packages",
+        "improve-code-quality": "Improve code quality (via Rector)"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/NativeAPIEndpointHandler.php
+++ b/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/NativeAPIEndpointHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\APIEndpointsForWP\EndpointHandlers;
 
+use PoP\API\Component;
+use PoP\ComponentModel\Constants\Params;
 use PoP\APIEndpointsForWP\EndpointHandlers\AbstractEndpointHandler;
 use PoP\APIEndpointsForWP\ComponentConfiguration;
 use PoP\API\Response\Schemes as APISchemes;
@@ -40,7 +42,7 @@ class NativeAPIEndpointHandler extends AbstractEndpointHandler
     protected function isNativeAPIEnabled(): bool
     {
         return
-            \PoP\API\Component::isEnabled()
+            Component::isEnabled()
             && !ComponentConfiguration::isNativeAPIEndpointDisabled();
     }
 
@@ -52,7 +54,7 @@ class NativeAPIEndpointHandler extends AbstractEndpointHandler
     protected function executeEndpoint(): void
     {
         // Set the params on the request, to emulate that they were added by the user
-        $_REQUEST[\PoP\ComponentModel\Constants\Params::SCHEME] = APISchemes::API;
+        $_REQUEST[Params::SCHEME] = APISchemes::API;
         // Enable hooks
         \do_action('EndpointHandler:setDoingAPI');
     }

--- a/layers/API/packages/api/src/Component.php
+++ b/layers/API/packages/api/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\API;
 
+use PoP\API\Conditional\AccessControl\ConditionalComponent;
 use PoP\API\Configuration\Request;
 use PoP\API\Config\ServiceConfiguration;
 use PoP\Root\Component\AbstractComponent;
@@ -95,7 +96,7 @@ class Component extends AbstractComponent
                 class_exists('\PoP\AccessControl\Component')
                 && !in_array(\PoP\AccessControl\Component::class, $skipSchemaComponentClasses)
             ) {
-                \PoP\API\Conditional\AccessControl\ConditionalComponent::initialize(
+                ConditionalComponent::initialize(
                     $configuration,
                     $skipSchema
                 );
@@ -124,7 +125,7 @@ class Component extends AbstractComponent
 
         // Boot conditional on API package being installed
         if (class_exists('\PoP\AccessControl\Component')) {
-            \PoP\API\Conditional\AccessControl\ConditionalComponent::beforeBoot();
+            ConditionalComponent::beforeBoot();
         }
     }
 }

--- a/layers/API/packages/api/src/Engine/RemoveEntryModuleFromOutputEngineTrait.php
+++ b/layers/API/packages/api/src/Engine/RemoveEntryModuleFromOutputEngineTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\API\Engine;
 
+use PoP\API\Constants\Actions;
+use PoP\ComponentModel\Constants\DataOutputModes;
 use PoP\API\Component as APIComponent;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\API\Response\Schemes as APISchemes;
@@ -20,8 +22,8 @@ trait RemoveEntryModuleFromOutputEngineTrait
         if (
             APIComponent::isEnabled() &&
             $vars['scheme'] == APISchemes::API &&
-            in_array(\PoP\API\Constants\Actions::REMOVE_ENTRYMODULE_FROM_OUTPUT, $vars['actions']) &&
-            $vars['dataoutputmode'] == \PoP\ComponentModel\Constants\DataOutputModes::COMBINED
+            in_array(Actions::REMOVE_ENTRYMODULE_FROM_OUTPUT, $vars['actions']) &&
+            $vars['dataoutputmode'] == DataOutputModes::COMBINED
         ) {
             if ($data['datasetmodulesettings'] ?? null) {
                 $data['datasetmodulesettings'] = $this->removeEntryModuleFromOutput($data['datasetmodulesettings']);

--- a/layers/API/packages/api/src/Hooks/VarsHooks.php
+++ b/layers/API/packages/api/src/Hooks/VarsHooks.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\API\Hooks;
 
+use PoP\ComponentModel\Constants\Outputs;
+use PoP\ComponentModel\Constants\DataOutputItems;
+use PoP\ComponentModel\Constants\DataOutputModes;
+use PoP\ComponentModel\Constants\DatabasesOutputModes;
+use PoP\Engine\Constants\Stratum;
+use PoP\API\Constants\Actions;
 use PoP\API\ComponentConfiguration;
 use PoP\API\Schema\QueryInputs;
 use PoP\API\Configuration\Request;
@@ -50,30 +56,30 @@ class VarsHooks extends AbstractHookSet
         [&$vars] = $vars_in_array;
         if (isset($vars['scheme']) && $vars['scheme'] == APISchemes::API) {
             // For the API, the response is always JSON
-            $vars['output'] = \PoP\ComponentModel\Constants\Outputs::JSON;
+            $vars['output'] = Outputs::JSON;
 
             // Fetch datasetmodulesettings: needed to obtain the dbKeyPath to know where to find the database entries
             $vars['dataoutputitems'] = [
-                \PoP\ComponentModel\Constants\DataOutputItems::DATASET_MODULE_SETTINGS,
-                \PoP\ComponentModel\Constants\DataOutputItems::MODULE_DATA,
-                \PoP\ComponentModel\Constants\DataOutputItems::DATABASES,
+                DataOutputItems::DATASET_MODULE_SETTINGS,
+                DataOutputItems::MODULE_DATA,
+                DataOutputItems::DATABASES,
             ];
 
             // dataoutputmode => Combined: there is no need to split the sources, then already combined them
-            $vars['dataoutputmode'] = \PoP\ComponentModel\Constants\DataOutputModes::COMBINED;
+            $vars['dataoutputmode'] = DataOutputModes::COMBINED;
 
             // dboutputmode => Combined: needed since we don't know under what database does the dbKeyPath point to. Then simply integrate all of them
             // Also, needed for REST/GraphQL APIs since all their data comes bundled all together
-            $vars['dboutputmode'] = \PoP\ComponentModel\Constants\DatabasesOutputModes::COMBINED;
+            $vars['dboutputmode'] = DatabasesOutputModes::COMBINED;
 
             // Only the data stratum is needed
             $platformmanager = StratumManagerFactory::getInstance();
-            $vars['stratum'] = \PoP\Engine\Constants\Stratum::DATA;
+            $vars['stratum'] = Stratum::DATA;
             $vars['strata'] = $platformmanager->getStrata($vars['stratum']);
             $vars['stratum-isdefault'] = $vars['stratum'] == $platformmanager->getDefaultStratum();
 
             // Do not print the entry module
-            $vars['actions'][] = \PoP\API\Constants\Actions::REMOVE_ENTRYMODULE_FROM_OUTPUT;
+            $vars['actions'][] = Actions::REMOVE_ENTRYMODULE_FROM_OUTPUT;
 
             // Enable mutations?
             $vars['are-mutations-enabled'] = ComponentConfiguration::enableMutations();

--- a/layers/API/packages/api/src/Hooks/VarsHooks.php
+++ b/layers/API/packages/api/src/Hooks/VarsHooks.php
@@ -12,7 +12,6 @@ use PoP\Engine\Constants\Stratum;
 use PoP\API\Constants\Actions;
 use PoP\API\ComponentConfiguration;
 use PoP\API\Schema\QueryInputs;
-use PoP\API\Configuration\Request;
 use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\StratumManagerFactory;
 use PoP\ComponentModel\State\ApplicationState;

--- a/layers/API/packages/api/src/ModuleProcessors/AbstractRelationalFieldDataloadModuleProcessor.php
+++ b/layers/API/packages/api/src/ModuleProcessors/AbstractRelationalFieldDataloadModuleProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\API\ModuleProcessors;
 
+use PoP\API\Constants\Formats;
 use PoP\ComponentModel\ModuleProcessors\AbstractDataloadModuleProcessor;
 
 abstract class AbstractRelationalFieldDataloadModuleProcessor extends AbstractDataloadModuleProcessor
@@ -18,6 +19,6 @@ abstract class AbstractRelationalFieldDataloadModuleProcessor extends AbstractDa
 
     public function getFormat(array $module): ?string
     {
-        return \PoP\API\Constants\Formats::FIELDS;
+        return Formats::FIELDS;
     }
 }

--- a/layers/API/packages/api/src/ModuleProcessors/AddAPIQueryToSourcesModuleProcessorTrait.php
+++ b/layers/API/packages/api/src/ModuleProcessors/AddAPIQueryToSourcesModuleProcessorTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\API\ModuleProcessors;
 
+use PoP\ComponentModel\Constants\DataOutputItems;
 use PoP\FieldQuery\QuerySyntax;
 use PoP\API\Schema\QueryInputs;
 use PoP\ComponentModel\Misc\GeneralUtils;
@@ -59,9 +60,9 @@ trait AddAPIQueryToSourcesModuleProcessorTrait
                             APIUtils::getEndpoint(
                                 $source,
                                 [
-                                    \PoP\ComponentModel\Constants\DataOutputItems::MODULE_DATA,
-                                    \PoP\ComponentModel\Constants\DataOutputItems::DATABASES,
-                                    \PoP\ComponentModel\Constants\DataOutputItems::META,
+                                    DataOutputItems::MODULE_DATA,
+                                    DataOutputItems::DATABASES,
+                                    DataOutputItems::META,
                                 ]
                             )
                         );

--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel;
 
+use PoP\ComponentModel\Constants\Params;
+use PoP\ComponentModel\Tokens\Param;
 use PoP\ComponentModel\ComponentConfiguration\EnvironmentValueHelpers;
 use PoP\ComponentModel\ComponentConfiguration\ComponentConfigurationTrait;
 
@@ -36,7 +38,7 @@ class ComponentConfiguration
         // Whatever fields are not there, will be considered "false"
         self::$overrideConfiguration = array();
         if (self::enableConfigByParams()) {
-            self::$overrideConfiguration = isset($_REQUEST[\PoP\ComponentModel\Constants\Params::CONFIG]) ? explode(\PoP\ComponentModel\Tokens\Param::VALUE_SEPARATOR, $_REQUEST[\PoP\ComponentModel\Constants\Params::CONFIG]) : array();
+            self::$overrideConfiguration = isset($_REQUEST[Params::CONFIG]) ? explode(Param::VALUE_SEPARATOR, $_REQUEST[Params::CONFIG]) : array();
         }
     }
 

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Engine;
 
+use PoP\ComponentModel\Constants\Params;
+use PoP\ComponentModel\Constants\DataSourceSelectors;
+use PoP\ComponentModel\Constants\DataOutputItems;
+use PoP\ComponentModel\Constants\Response;
+use PoP\ComponentModel\Constants\DataOutputModes;
+use PoP\ComponentModel\Constants\Props;
+use PoP\ComponentModel\Constants\DataLoading;
+use PoP\ComponentModel\Constants\DataSources;
+use PoP\ComponentModel\Constants\Actions;
+use PoP\ComponentModel\Constants\DatabasesOutputModes;
 use Exception;
 use PoP\ComponentModel\Misc\RequestUtils;
 use PoP\ComponentModel\State\ApplicationState;
@@ -149,7 +159,7 @@ class Engine implements EngineInterface
         $this->extra_routes = array();
 
         if (Environment::enableExtraRoutesByParams()) {
-            $this->extra_routes = $_REQUEST[\PoP\ComponentModel\Constants\Params::EXTRA_ROUTES] ?? array();
+            $this->extra_routes = $_REQUEST[Params::EXTRA_ROUTES] ?? array();
             $this->extra_routes = is_array($this->extra_routes) ? $this->extra_routes : array($this->extra_routes);
         }
 
@@ -299,7 +309,7 @@ class Engine implements EngineInterface
         $this->model_props = $this->getModelPropsModuletree($module);
 
         // If only getting static content, then no need to add the mutableonrequest props
-        if ($datasources == \PoP\ComponentModel\Constants\DataSourceSelectors::ONLYMODEL) {
+        if ($datasources == DataSourceSelectors::ONLYMODEL) {
             $this->props = $this->model_props;
         } else {
             $this->props = $this->addRequestPropsModuletree($module, $this->model_props);
@@ -314,7 +324,7 @@ class Engine implements EngineInterface
         );
 
         $data = [];
-        if (in_array(\PoP\ComponentModel\Constants\DataOutputItems::DATASET_MODULE_SETTINGS, $dataoutputitems)) {
+        if (in_array(DataOutputItems::DATASET_MODULE_SETTINGS, $dataoutputitems)) {
             $data = array_merge(
                 $data,
                 $this->getModuleDatasetSettings($module, $this->model_props, $this->props)
@@ -327,15 +337,15 @@ class Engine implements EngineInterface
         // which is done through an action, called through getData()
         // Data = dbobjectids (data-ids) + feedback + database
         if (
-            in_array(\PoP\ComponentModel\Constants\DataOutputItems::MODULE_DATA, $dataoutputitems)
-            || in_array(\PoP\ComponentModel\Constants\DataOutputItems::DATABASES, $dataoutputitems)
+            in_array(DataOutputItems::MODULE_DATA, $dataoutputitems)
+            || in_array(DataOutputItems::DATABASES, $dataoutputitems)
         ) {
             $data = array_merge(
                 $data,
                 $this->getModuleData($module, $this->model_props, $this->props)
             );
 
-            if (in_array(\PoP\ComponentModel\Constants\DataOutputItems::DATABASES, $dataoutputitems)) {
+            if (in_array(DataOutputItems::DATABASES, $dataoutputitems)) {
                 $data = array_merge(
                     $data,
                     $this->getDatabases()
@@ -346,7 +356,7 @@ class Engine implements EngineInterface
         list($has_extra_routes, $model_instance_id, $current_uri) = $this->listExtraRouteVars();
 
         if (
-            in_array(\PoP\ComponentModel\Constants\DataOutputItems::META, $dataoutputitems)
+            in_array(DataOutputItems::META, $dataoutputitems)
         ) {
             // Also add the request, session and site meta.
             // IMPORTANT: Call these methods after doing ->getModuleData, since the background_urls and other info is calculated there and printed here
@@ -397,19 +407,19 @@ class Engine implements EngineInterface
         $dataoutputitems = $vars['dataoutputitems'];
 
         if (
-            in_array(\PoP\ComponentModel\Constants\DataOutputItems::META, $dataoutputitems)
+            in_array(DataOutputItems::META, $dataoutputitems)
         ) {
             // Also add the request, session and site meta.
             // IMPORTANT: Call these methods after doing ->getModuleData, since the background_urls and other info is calculated there and printed here
             // If it has extra-uris, pass along this information, so that the client can fetch the setting from under $model_instance_id ("mutableonmodel") and $uri ("mutableonrequest")
             if ($this->getExtraRoutes()) {
-                $this->data['requestmeta'][\PoP\ComponentModel\Constants\Response::MULTIPLE_ROUTES] = true;
+                $this->data['requestmeta'][Response::MULTIPLE_ROUTES] = true;
             }
             if ($sitemeta = $this->getSiteMeta()) {
                 $this->data['sitemeta'] = $sitemeta;
             }
 
-            if (in_array(\PoP\ComponentModel\Constants\DataOutputItems::SESSION, $dataoutputitems)) {
+            if (in_array(DataOutputItems::SESSION, $dataoutputitems)) {
                 if ($sessionmeta = $this->getSessionMeta()) {
                     $this->data['sessionmeta'] = $sessionmeta;
                 }
@@ -454,11 +464,11 @@ class Engine implements EngineInterface
         // If there are multiple URIs, then the results must be returned under the corresponding $model_instance_id for "mutableonmodel", and $url for "mutableonrequest"
         list($has_extra_routes, $model_instance_id, $current_uri) = $this->listExtraRouteVars();
 
-        if ($dataoutputmode == \PoP\ComponentModel\Constants\DataOutputModes::SPLITBYSOURCES) {
+        if ($dataoutputmode == DataOutputModes::SPLITBYSOURCES) {
             if ($immutable_datasetsettings) {
                 $ret['datasetmodulesettings']['immutable'] = $immutable_datasetsettings;
             }
-        } elseif ($dataoutputmode == \PoP\ComponentModel\Constants\DataOutputModes::COMBINED) {
+        } elseif ($dataoutputmode == DataOutputModes::COMBINED) {
             // If everything is combined, then it belongs under "mutableonrequest"
             if ($combined_datasetsettings = $immutable_datasetsettings) {
                 $ret['datasetmodulesettings'] = $has_extra_routes ? array($current_uri => $combined_datasetsettings) : $combined_datasetsettings;
@@ -471,14 +481,14 @@ class Engine implements EngineInterface
     public function getRequestMeta()
     {
         $meta = array(
-            \PoP\ComponentModel\Constants\Response::ENTRY_MODULE => $this->getEntryModule()[1],
-            \PoP\ComponentModel\Constants\Response::UNIQUE_ID => POP_CONSTANT_UNIQUE_ID,
-            \PoP\ComponentModel\Constants\Response::URL => RequestUtils::getCurrentUrl(),
+            Response::ENTRY_MODULE => $this->getEntryModule()[1],
+            Response::UNIQUE_ID => POP_CONSTANT_UNIQUE_ID,
+            Response::URL => RequestUtils::getCurrentUrl(),
             'modelinstanceid' => ModelInstanceFacade::getInstance()->getModelInstanceId(),
         );
 
         if ($this->backgroundload_urls) {
-            $meta[\PoP\ComponentModel\Constants\Response::BACKGROUND_LOAD_URLS] = $this->backgroundload_urls;
+            $meta[Response::BACKGROUND_LOAD_URLS] = $this->backgroundload_urls;
         };
 
         // Starting from what modules must do the rendering. Allow for empty arrays (eg: modulepaths[]=somewhatevervalue)
@@ -499,7 +509,7 @@ class Engine implements EngineInterface
 
         // Any errors? Send them back
         if (RequestUtils::$errors) {
-            $meta[\PoP\ComponentModel\Constants\Response::ERROR] = count(RequestUtils::$errors) > 1 ?
+            $meta[Response::ERROR] = count(RequestUtils::$errors) > 1 ?
                 TranslationAPIFacade::getInstance()->__('Oops, there were some errors:', 'pop-engine') . implode('<br/>', RequestUtils::$errors)
                 : TranslationAPIFacade::getInstance()->__('Oops, there was an error: ', 'pop-engine') . RequestUtils::$errors[0];
         }
@@ -523,21 +533,21 @@ class Engine implements EngineInterface
         $meta = array();
         if (RequestUtils::fetchingSite()) {
             $vars = ApplicationState::getVars();
-            $meta[\PoP\ComponentModel\Constants\Params::VERSION] = $vars['version'];
-            $meta[\PoP\ComponentModel\Constants\Params::DATAOUTPUTMODE] = $vars['dataoutputmode'];
-            $meta[\PoP\ComponentModel\Constants\Params::DATABASESOUTPUTMODE] = $vars['dboutputmode'];
+            $meta[Params::VERSION] = $vars['version'];
+            $meta[Params::DATAOUTPUTMODE] = $vars['dataoutputmode'];
+            $meta[Params::DATABASESOUTPUTMODE] = $vars['dboutputmode'];
 
             if ($vars['format'] ?? null) {
-                $meta[\PoP\ComponentModel\Constants\Params::SETTINGSFORMAT] = $vars['format'];
+                $meta[Params::SETTINGSFORMAT] = $vars['format'];
             }
             if ($vars['mangled'] ?? null) {
                 $meta[Request::URLPARAM_MANGLED] = $vars['mangled'];
             }
             if (ComponentConfiguration::enableConfigByParams() && $vars['config']) {
-                $meta[\PoP\ComponentModel\Constants\Params::CONFIG] = $vars['config'];
+                $meta[Params::CONFIG] = $vars['config'];
             }
             if ($vars['stratum'] ?? null) {
-                $meta[\PoP\ComponentModel\Constants\Params::STRATUM] = $vars['stratum'];
+                $meta[Params::STRATUM] = $vars['stratum'];
             }
 
             // Tell the front-end: are the results from the cache? Needed for the editor, to initialize it since WP will not execute the code
@@ -688,7 +698,7 @@ class Engine implements EngineInterface
         // This function must be called always, to register matching modules into requestmeta.filtermodules even when the module has no submodules
         $modulefilter_manager->prepareForPropagation($module, $props);
         foreach ($submodules as $submodule) {
-            $this->addInterreferencedModuleFullpaths($paths, $submodule_path, $submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES]);
+            $this->addInterreferencedModuleFullpaths($paths, $submodule_path, $submodule, $props[$moduleFullName][Props::SUBMODULES]);
         }
         $modulefilter_manager->restoreFromPropagation($module, $props);
     }
@@ -735,7 +745,7 @@ class Engine implements EngineInterface
         // This function must be called always, to register matching modules into requestmeta.filtermodules even when the module has no submodules
         $modulefilter_manager->prepareForPropagation($module, $props);
         foreach ($submodules as $submodule) {
-            $this->addDataloadingModuleFullpaths($paths, $submodule_path, $submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES]);
+            $this->addDataloadingModuleFullpaths($paths, $submodule_path, $submodule, $props[$moduleFullName][Props::SUBMODULES]);
         }
         $modulefilter_manager->restoreFromPropagation($module, $props);
     }
@@ -798,7 +808,7 @@ class Engine implements EngineInterface
         $datasources = $vars['datasources'];
         $dataoutputmode = $vars['dataoutputmode'];
         $dataoutputitems = $vars['dataoutputitems'];
-        $add_meta = in_array(\PoP\ComponentModel\Constants\DataOutputItems::META, $dataoutputitems);
+        $add_meta = in_array(DataOutputItems::META, $dataoutputitems);
 
         $immutable_moduledata = $mutableonmodel_moduledata = $mutableonrequest_moduledata = array();
         $immutable_datasetmoduledata = $mutableonmodel_datasetmoduledata = $mutableonrequest_datasetmoduledata = array();
@@ -849,7 +859,7 @@ class Engine implements EngineInterface
             $mutableonmodel_data_properties
         );
 
-        if ($datasources == \PoP\ComponentModel\Constants\DataSourceSelectors::ONLYMODEL) {
+        if ($datasources == DataSourceSelectors::ONLYMODEL) {
             $root_data_properties = $model_data_properties;
         } else {
             $mutableonrequest_data_properties = $root_processor->getMutableonrequestDataPropertiesDatasetmoduletree($root_module, $root_props);
@@ -885,11 +895,11 @@ class Engine implements EngineInterface
                 $submoduleFullName = ModuleUtils::getModuleFullName($submodule);
                 $data_properties = &$data_properties[$submoduleFullName][POP_RESPONSE_PROP_SUBMODULES];
             }
-            $data_properties = &$data_properties[$moduleFullName][\PoP\ComponentModel\Constants\DataLoading::DATA_PROPERTIES];
+            $data_properties = &$data_properties[$moduleFullName][DataLoading::DATA_PROPERTIES];
             $datasource = $data_properties[DataloadingConstants::DATASOURCE] ?? null;
 
             // If we are only requesting data from the model alone, and this dataloading module depends on mutableonrequest, then skip it
-            if ($datasources == \PoP\ComponentModel\Constants\DataSourceSelectors::ONLYMODEL && $datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) {
+            if ($datasources == DataSourceSelectors::ONLYMODEL && $datasource == DataSources::MUTABLEONREQUEST) {
                 continue;
             }
 
@@ -901,7 +911,7 @@ class Engine implements EngineInterface
             // ------------------------------------------
             // Load data if the checkpoint did not fail
             $dataaccess_checkpoint_validation = null;
-            if ($load_data && $checkpoints = ($data_properties[\PoP\ComponentModel\Constants\DataLoading::DATA_ACCESS_CHECKPOINTS] ?? null)) {
+            if ($load_data && $checkpoints = ($data_properties[DataLoading::DATA_ACCESS_CHECKPOINTS] ?? null)) {
                 // Check if the module fails checkpoint validation. If so, it must not load its data or execute the componentMutationResolverBridge
                 $dataaccess_checkpoint_validation = $this->validateCheckpoints($checkpoints);
                 $load_data = !GeneralUtils::isError($dataaccess_checkpoint_validation);
@@ -912,21 +922,21 @@ class Engine implements EngineInterface
             $model_props = &$root_model_props;
             foreach ($module_path as $submodule) {
                 $submoduleFullName = ModuleUtils::getModuleFullName($submodule);
-                $props = &$props[$submoduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES];
-                $model_props = &$model_props[$submoduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES];
+                $props = &$props[$submoduleFullName][Props::SUBMODULES];
+                $model_props = &$model_props[$submoduleFullName][Props::SUBMODULES];
             }
 
             if (
                 in_array(
                     $datasource,
                     array(
-                    \PoP\ComponentModel\Constants\DataSources::IMMUTABLE,
-                    \PoP\ComponentModel\Constants\DataSources::MUTABLEONMODEL,
+                    DataSources::IMMUTABLE,
+                    DataSources::MUTABLEONMODEL,
                     )
                 )
             ) {
                 $module_props = &$model_props;
-            } elseif ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) {
+            } elseif ($datasource == DataSources::MUTABLEONREQUEST) {
                 $module_props = &$props;
             }
 
@@ -951,7 +961,7 @@ class Engine implements EngineInterface
                         // Validate that the actionexecution must be triggered through its own checkpoints
                         $execute = true;
                         $mutation_checkpoint_validation = null;
-                        if ($mutation_checkpoints = $data_properties[\PoP\ComponentModel\Constants\DataLoading::ACTION_EXECUTION_CHECKPOINTS] ?? null) {
+                        if ($mutation_checkpoints = $data_properties[DataLoading::ACTION_EXECUTION_CHECKPOINTS] ?? null) {
                             // Check if the module fails checkpoint validation. If so, it must not load its data or execute the componentMutationResolverBridge
                             $mutation_checkpoint_validation = $this->validateCheckpoints($mutation_checkpoints);
                             $execute = !GeneralUtils::isError($mutation_checkpoint_validation);
@@ -1011,7 +1021,7 @@ class Engine implements EngineInterface
                     // these ones must be fetched even if the block has a static typeResolver
                     // If it has extend, add those ids under its typeResolver_class
                     $dataload_extend_settings = $processor->getModelSupplementaryDbobjectdataModuletree($module, $model_props);
-                    if ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) {
+                    if ($datasource == DataSources::MUTABLEONREQUEST) {
                         $dataload_extend_settings = array_merge_recursive(
                             $dataload_extend_settings,
                             $processor->getMutableonrequestSupplementaryDbobjectdataModuletree($module, $props)
@@ -1035,19 +1045,19 @@ class Engine implements EngineInterface
             }
 
             // Save the results on either the static or mutableonrequest branches
-            if ($datasource == \PoP\ComponentModel\Constants\DataSources::IMMUTABLE) {
+            if ($datasource == DataSources::IMMUTABLE) {
                 $datasetmoduledata = &$immutable_datasetmoduledata;
                 if ($add_meta) {
                     $datasetmodulemeta = &$immutable_datasetmodulemeta;
                 }
                 $this->moduledata = &$immutable_moduledata;
-            } elseif ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONMODEL) {
+            } elseif ($datasource == DataSources::MUTABLEONMODEL) {
                 $datasetmoduledata = &$mutableonmodel_datasetmoduledata;
                 if ($add_meta) {
                     $datasetmodulemeta = &$mutableonmodel_datasetmodulemeta;
                 }
                 $this->moduledata = &$mutableonmodel_moduledata;
-            } elseif ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) {
+            } elseif ($datasource == DataSources::MUTABLEONREQUEST) {
                 $datasetmoduledata = &$mutableonrequest_datasetmoduledata;
                 if ($add_meta) {
                     $datasetmodulemeta = &$mutableonrequest_datasetmodulemeta;
@@ -1058,14 +1068,14 @@ class Engine implements EngineInterface
             // Integrate the dbobjectids into $datasetmoduledata
             // ALWAYS print the $dbobjectids, even if its an empty array. This to indicate that this is a dataloading module, so the application in the webplatform knows if to load a new batch of dbobjectids, or reuse the ones from the previous module when iterating down
             if (!is_null($datasetmoduledata)) {
-                $this->assignValueForModule($datasetmoduledata, $module_path, $module, \PoP\ComponentModel\Constants\DataLoading::DB_OBJECT_IDS, $typeDBObjectIDOrIDs);
+                $this->assignValueForModule($datasetmoduledata, $module_path, $module, DataLoading::DB_OBJECT_IDS, $typeDBObjectIDOrIDs);
             }
 
             // Save the meta into $datasetmodulemeta
             if ($add_meta) {
                 if (!is_null($datasetmodulemeta)) {
                     if ($dataset_meta = $processor->getDatasetmeta($module, $module_props, $data_properties, $dataaccess_checkpoint_validation, $mutation_checkpoint_validation, $executed, $dbObjectIDOrIDs)) {
-                        $this->assignValueForModule($datasetmodulemeta, $module_path, $module, \PoP\ComponentModel\Constants\DataLoading::META, $dataset_meta);
+                        $this->assignValueForModule($datasetmodulemeta, $module_path, $module, DataLoading::META, $dataset_meta);
                     }
                 }
             }
@@ -1082,21 +1092,21 @@ class Engine implements EngineInterface
                     $referencer_model_props = &$root_model_props;
                     foreach ($referencer_modulepath as $submodule) {
                         $submoduleFullName = ModuleUtils::getModuleFullName($submodule);
-                        $referencer_props = &$referencer_props[$submoduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES];
-                        $referencer_model_props = &$referencer_model_props[$submoduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES];
+                        $referencer_props = &$referencer_props[$submoduleFullName][Props::SUBMODULES];
+                        $referencer_model_props = &$referencer_model_props[$submoduleFullName][Props::SUBMODULES];
                     }
 
                     if (
                         in_array(
                             $datasource,
                             array(
-                            \PoP\ComponentModel\Constants\DataSources::IMMUTABLE,
-                            \PoP\ComponentModel\Constants\DataSources::MUTABLEONMODEL,
+                            DataSources::IMMUTABLE,
+                            DataSources::MUTABLEONMODEL,
                             )
                         )
                     ) {
                         $referencer_module_props = &$referencer_model_props;
-                    } elseif ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) {
+                    } elseif ($datasource == DataSources::MUTABLEONREQUEST) {
                         $referencer_module_props = &$referencer_props;
                     }
                     $this->processAndAddModuleData($referencer_modulepath, $referencer_module, $referencer_module_props, $data_properties, $dataaccess_checkpoint_validation, $mutation_checkpoint_validation, $executed, $dbObjectIDs);
@@ -1130,11 +1140,11 @@ class Engine implements EngineInterface
 
         $ret = array();
 
-        if (in_array(\PoP\ComponentModel\Constants\DataOutputItems::MODULE_DATA, $dataoutputitems)) {
+        if (in_array(DataOutputItems::MODULE_DATA, $dataoutputitems)) {
             // If there are multiple URIs, then the results must be returned under the corresponding $model_instance_id for "mutableonmodel", and $url for "mutableonrequest"
             list($has_extra_routes, $model_instance_id, $current_uri) = $this->listExtraRouteVars();
 
-            if ($dataoutputmode == \PoP\ComponentModel\Constants\DataOutputModes::SPLITBYSOURCES) {
+            if ($dataoutputmode == DataOutputModes::SPLITBYSOURCES) {
                 if ($immutable_moduledata) {
                     $ret['moduledata']['immutable'] = $immutable_moduledata;
                 }
@@ -1165,7 +1175,7 @@ class Engine implements EngineInterface
                         $ret['datasetmodulemeta']['mutableonrequest'] = $has_extra_routes ? array($current_uri => $mutableonrequest_datasetmodulemeta) : $mutableonrequest_datasetmodulemeta;
                     }
                 }
-            } elseif ($dataoutputmode == \PoP\ComponentModel\Constants\DataOutputModes::COMBINED) {
+            } elseif ($dataoutputmode == DataOutputModes::COMBINED) {
                 // If everything is combined, then it belongs under "mutableonrequest"
                 if (
                     $combined_moduledata = array_merge_recursive(
@@ -1567,7 +1577,7 @@ class Engine implements EngineInterface
 
         // Show logs only if both enabled, and passing the action in the URL
         if (Environment::enableShowLogs()) {
-            if (in_array(\PoP\ComponentModel\Constants\Actions::SHOW_LOGS, $vars['actions'])) {
+            if (in_array(Actions::SHOW_LOGS, $vars['actions'])) {
                 $ret['logEntries'] = $feedbackMessageStore->getLogEntries();
             }
         }
@@ -1722,9 +1732,9 @@ class Engine implements EngineInterface
             $dboutputmode = $vars['dboutputmode'];
 
             // Combine all the databases or send them separate
-            if ($dboutputmode == \PoP\ComponentModel\Constants\DatabasesOutputModes::SPLITBYDATABASES) {
+            if ($dboutputmode == DatabasesOutputModes::SPLITBYDATABASES) {
                 $ret[$name] = $entries;
-            } elseif ($dboutputmode == \PoP\ComponentModel\Constants\DatabasesOutputModes::COMBINED) {
+            } elseif ($dboutputmode == DatabasesOutputModes::COMBINED) {
                 // Filter to make sure there are entries
                 if ($entries = array_filter($entries)) {
                     $combined_databases = array();
@@ -1753,9 +1763,9 @@ class Engine implements EngineInterface
             $dboutputmode = $vars['dboutputmode'];
 
             // Combine all the databases or send them separate
-            if ($dboutputmode == \PoP\ComponentModel\Constants\DatabasesOutputModes::SPLITBYDATABASES) {
+            if ($dboutputmode == DatabasesOutputModes::SPLITBYDATABASES) {
                 $ret[$name] = $entries;
-            } elseif ($dboutputmode == \PoP\ComponentModel\Constants\DatabasesOutputModes::COMBINED) {
+            } elseif ($dboutputmode == DatabasesOutputModes::COMBINED) {
                 // Filter to make sure there are entries
                 if ($entries = array_filter($entries)) {
                     $combined_databases = array();

--- a/layers/Engine/packages/component-model/src/Misc/GeneralUtils.php
+++ b/layers/Engine/packages/component-model/src/Misc/GeneralUtils.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Misc;
 
+use PoP\ComponentModel\ErrorHandling\Error;
 class GeneralUtils
 {
     // Taken from http://stackoverflow.com/questions/4356289/php-random-string-generator
@@ -27,7 +28,7 @@ class GeneralUtils
      */
     public static function isError($thing): bool
     {
-        return $thing !== null && $thing instanceof \PoP\ComponentModel\ErrorHandling\Error;
+        return $thing !== null && $thing instanceof Error;
     }
 
     // Taken from https://gist.github.com/SeanCannon/6585889

--- a/layers/Engine/packages/component-model/src/Misc/RequestUtils.php
+++ b/layers/Engine/packages/component-model/src/Misc/RequestUtils.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Misc;
 
+use PoP\ComponentModel\Constants\Params;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\ModuleFiltering\ModuleFilterManager;
 use PoP\ComponentModel\ModuleFilters\ModulePaths;
@@ -69,22 +70,22 @@ class RequestUtils
         $remove_params = (array) HooksAPIFacade::getInstance()->applyFilters(
             'RequestUtils:current_url:remove_params',
             array(
-                \PoP\ComponentModel\Constants\Params::SETTINGSFORMAT,
-                \PoP\ComponentModel\Constants\Params::VERSION,
-                \PoP\ComponentModel\Constants\Params::TARGET,
+                Params::SETTINGSFORMAT,
+                Params::VERSION,
+                Params::TARGET,
                 ModuleFilterManager::URLPARAM_MODULEFILTER,
                 ModulePaths::URLPARAM_MODULEPATHS,
-                \PoP\ComponentModel\Constants\Params::ACTION_PATH,
-                \PoP\ComponentModel\Constants\Params::DATA_OUTPUT_ITEMS,
-                \PoP\ComponentModel\Constants\Params::DATA_SOURCE,
-                \PoP\ComponentModel\Constants\Params::DATAOUTPUTMODE,
-                \PoP\ComponentModel\Constants\Params::DATABASESOUTPUTMODE,
-                \PoP\ComponentModel\Constants\Params::OUTPUT,
-                \PoP\ComponentModel\Constants\Params::DATASTRUCTURE,
+                Params::ACTION_PATH,
+                Params::DATA_OUTPUT_ITEMS,
+                Params::DATA_SOURCE,
+                Params::DATAOUTPUTMODE,
+                Params::DATABASESOUTPUTMODE,
+                Params::OUTPUT,
+                Params::DATASTRUCTURE,
                 Request::URLPARAM_MANGLED,
-                \PoP\ComponentModel\Constants\Params::EXTRA_ROUTES,
-                \PoP\ComponentModel\Constants\Params::ACTIONS, // Needed to remove ?actions[]=preload, ?actions[]=loaduserstate, ?actions[]=loadlazy
-                \PoP\ComponentModel\Constants\Params::STRATUM,
+                Params::EXTRA_ROUTES,
+                Params::ACTIONS, // Needed to remove ?actions[]=preload, ?actions[]=loaduserstate, ?actions[]=loadlazy
+                Params::STRATUM,
             )
         );
         $url = GeneralUtils::removeQueryArgs($remove_params, self::getRequestedFullURL());

--- a/layers/Engine/packages/component-model/src/ModulePath/ModulePathHelpers.php
+++ b/layers/Engine/packages/component-model/src/ModulePath/ModulePathHelpers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModulePath;
 
+use PoP\ComponentModel\Tokens\ModulePath;
 use PoP\ComponentModel\Modules\ModuleUtils;
 
 class ModulePathHelpers implements ModulePathHelpersInterface
@@ -25,7 +26,7 @@ class ModulePathHelpers implements ModulePathHelpersInterface
     public function stringifyModulePath(array $modulepath)
     {
         return implode(
-            \PoP\ComponentModel\Tokens\ModulePath::MODULE_SEPARATOR,
+            ModulePath::MODULE_SEPARATOR,
             array_map(
                 [ModuleUtils::class, 'getModuleOutputName'],
                 $modulepath
@@ -38,7 +39,7 @@ class ModulePathHelpers implements ModulePathHelpersInterface
         return array_map(
             [ModuleUtils::class, 'getModuleFromOutputName'],
             explode(
-                \PoP\ComponentModel\Tokens\ModulePath::MODULE_SEPARATOR,
+                ModulePath::MODULE_SEPARATOR,
                 $modulepath_as_string
             )
         );

--- a/layers/Engine/packages/component-model/src/ModulePath/ModulePathUtils.php
+++ b/layers/Engine/packages/component-model/src/ModulePath/ModulePathUtils.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModulePath;
 
+use PoP\ComponentModel\Tokens\ModulePath;
 use PoP\ComponentModel\ModuleFilters\ModulePaths;
 use PoP\ComponentModel\Facades\ModulePath\ModulePathHelpersFacade;
 
@@ -24,7 +25,7 @@ class ModulePathUtils
                 $paths,
                 function ($item) use ($paths) {
                     foreach ($paths as $path) {
-                        if (strlen($item) > strlen($path) && strpos($item, $path) === 0 && $item[strlen($path)] == \PoP\ComponentModel\Tokens\ModulePath::MODULE_SEPARATOR) {
+                        if (strlen($item) > strlen($path) && strpos($item, $path) === 0 && $item[strlen($path)] == ModulePath::MODULE_SEPARATOR) {
                             return false;
                         }
                     }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModuleProcessors;
 
+use PoP\ComponentModel\Constants\Props;
+use PoP\ComponentModel\Constants\DataSources;
+use PoP\ComponentModel\Constants\DataLoading;
+use PoP\ComponentModel\Constants\Params;
 use PoP\ComponentModel\DataloadUtils;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
@@ -80,8 +84,8 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         }
 
         // Before initiating the current level, set the children attributes on the array, so that doing ->setProp, ->appendProp, etc, keeps working
-        $module_props[$moduleFullName][\PoP\ComponentModel\Constants\Props::DESCENDANT_ATTRIBUTES] = array_merge(
-            $module_props[$moduleFullName][\PoP\ComponentModel\Constants\Props::DESCENDANT_ATTRIBUTES] ?? array(),
+        $module_props[$moduleFullName][Props::DESCENDANT_ATTRIBUTES] = array_merge(
+            $module_props[$moduleFullName][Props::DESCENDANT_ATTRIBUTES] ?? array(),
             $targetted_props_to_propagate ?? array()
         );
 
@@ -89,8 +93,8 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         $this->$eval_self_fn($module, $module_props);
 
         // Immediately after initiating the current level, extract all child attributes out from the $props, and place it on the other variable
-        $targetted_props_to_propagate = $module_props[$moduleFullName][\PoP\ComponentModel\Constants\Props::DESCENDANT_ATTRIBUTES];
-        unset($module_props[$moduleFullName][\PoP\ComponentModel\Constants\Props::DESCENDANT_ATTRIBUTES]);
+        $targetted_props_to_propagate = $module_props[$moduleFullName][Props::DESCENDANT_ATTRIBUTES];
+        unset($module_props[$moduleFullName][Props::DESCENDANT_ATTRIBUTES]);
 
         // But because modules can't repeat themselves down the line (or it would generate an infinite loop), then can remove the current module from the targeted props
         unset($targetted_props_to_propagate[$moduleFullName]);
@@ -109,7 +113,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         // This function must be called always, to register matching modules into requestmeta.filtermodules even when the module has no submodules
         $modulefilter_manager->prepareForPropagation($module, $props);
         if ($submodules) {
-            $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES] = $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES] ?? array();
+            $props[$moduleFullName][Props::SUBMODULES] = $props[$moduleFullName][Props::SUBMODULES] ?? array();
             foreach ($submodules as $submodule) {
                 $submodule_processor = $moduleprocessor_manager->getProcessor($submodule);
                 $submodule_wildcard_props_to_propagate = $wildcard_props_to_propagate;
@@ -122,7 +126,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                     );
                 }
 
-                $submodule_processor->$propagate_fn($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES], $submodule_wildcard_props_to_propagate, $targetted_props_to_propagate);
+                $submodule_processor->$propagate_fn($submodule, $props[$moduleFullName][Props::SUBMODULES], $submodule_wildcard_props_to_propagate, $targetted_props_to_propagate);
             }
         }
         $modulefilter_manager->restoreFromPropagation($module, $props);
@@ -321,8 +325,8 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                 $last_module_props = &$module_props;
                 $lastModuleFullName = $pathlevelModuleFullName;
 
-                $module_props[$pathlevelModuleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES] = $module_props[$pathlevelModuleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES] ?? array();
-                $module_props = &$module_props[$pathlevelModuleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES];
+                $module_props[$pathlevelModuleFullName][Props::SUBMODULES] = $module_props[$pathlevelModuleFullName][Props::SUBMODULES] ?? array();
+                $module_props = &$module_props[$pathlevelModuleFullName][Props::SUBMODULES];
             }
 
             // This is the new $props, so it starts from here
@@ -345,8 +349,8 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
             $moduleFullName = $this->getPathHeadModule($props);
 
             // Set the child attributes under a different entry
-            $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::DESCENDANT_ATTRIBUTES] = $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::DESCENDANT_ATTRIBUTES] ?? array();
-            $module_props = &$props[$moduleFullName][\PoP\ComponentModel\Constants\Props::DESCENDANT_ATTRIBUTES];
+            $props[$moduleFullName][Props::DESCENDANT_ATTRIBUTES] = $props[$moduleFullName][Props::DESCENDANT_ATTRIBUTES] ?? array();
+            $module_props = &$props[$moduleFullName][Props::DESCENDANT_ATTRIBUTES];
         } else {
             // Calculate the path to iterate down
             $modulepath = $this->getModulepath($module_or_modulepath, $props);
@@ -357,8 +361,8 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
             // Descend into the path to find the module for which to add the att
             $module_props = &$props;
             foreach ($modulepath as $pathlevelFullName) {
-                $module_props[$pathlevelFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES] = $module_props[$pathlevelFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES] ?? array();
-                $module_props = &$module_props[$pathlevelFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES];
+                $module_props[$pathlevelFullName][Props::SUBMODULES] = $module_props[$pathlevelFullName][Props::SUBMODULES] ?? array();
+                $module_props = &$module_props[$pathlevelFullName][Props::SUBMODULES];
             }
         }
 
@@ -417,7 +421,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         $module_props = &$props;
         foreach ($starting_from_modulepath as $pathlevelModule) {
             $pathlevelModuleFullName = ModuleUtils::getModuleFullName($pathlevelModule);
-            $module_props = &$module_props[$pathlevelModuleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES];
+            $module_props = &$module_props[$pathlevelModuleFullName][Props::SUBMODULES];
         }
 
         $moduleFullName = ModuleUtils::getModuleFullName($module);
@@ -429,7 +433,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     }
     public function setProp(array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
-        $this->addGroupProp(\PoP\ComponentModel\Constants\Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
+        $this->addGroupProp(Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
     }
     public function appendGroupProp(string $group, array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
@@ -437,7 +441,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     }
     public function appendProp(array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
-        $this->appendGroupProp(\PoP\ComponentModel\Constants\Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
+        $this->appendGroupProp(Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
     }
     public function mergeGroupProp(string $group, array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
@@ -445,7 +449,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     }
     public function mergeProp(array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
-        $this->mergeGroupProp(\PoP\ComponentModel\Constants\Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
+        $this->mergeGroupProp(Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
     }
     public function getGroupProp(string $group, array $module, array &$props, string $field, array $starting_from_modulepath = array())
     {
@@ -453,7 +457,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     }
     public function getProp(array $module, array &$props, string $field, array $starting_from_modulepath = array())
     {
-        return $this->getGroupProp(\PoP\ComponentModel\Constants\Props::ATTRIBUTES, $module, $props, $field, $starting_from_modulepath);
+        return $this->getGroupProp(Props::ATTRIBUTES, $module, $props, $field, $starting_from_modulepath);
     }
     public function mergeGroupIterateKeyProp(string $group, array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
@@ -461,7 +465,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     }
     public function mergeIterateKeyProp(array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
-        $this->mergeGroupIterateKeyProp(\PoP\ComponentModel\Constants\Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
+        $this->mergeGroupIterateKeyProp(Props::ATTRIBUTES, $module_or_modulepath, $props, $field, $value, $starting_from_modulepath);
     }
     public function pushProp(string $group, array $module_or_modulepath, array &$props, string $field, $value, array $starting_from_modulepath = array()): void
     {
@@ -564,7 +568,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                 return !$moduleprocessor_manager->getProcessor($submodule)->startDataloadingSection($submodule);
             });
             foreach ($subcomponent_modules as $subcomponent_module) {
-                $moduleprocessor_manager->getProcessor($subcomponent_module)->addToDatasetDatabaseKeys($subcomponent_module, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES], array_merge($path, [$subcomponent_data_field_outputkey]), $ret);
+                $moduleprocessor_manager->getProcessor($subcomponent_module)->addToDatasetDatabaseKeys($subcomponent_module, $props[$moduleFullName][Props::SUBMODULES], array_merge($path, [$subcomponent_data_field_outputkey]), $ret);
             }
         }
         foreach ($this->getConditionalOnDataFieldDomainSwitchingSubmodules($module) as $conditionDataField => $dataFieldTypeResolverOptionsConditionalSubmodules) {
@@ -575,7 +579,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                     return !$moduleprocessor_manager->getProcessor($submodule)->startDataloadingSection($submodule);
                 });
                 foreach ($subcomponent_modules as $subcomponent_module) {
-                    $moduleprocessor_manager->getProcessor($subcomponent_module)->addToDatasetDatabaseKeys($subcomponent_module, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES], array_merge($path, [$subcomponent_data_field_outputkey]), $ret);
+                    $moduleprocessor_manager->getProcessor($subcomponent_module)->addToDatasetDatabaseKeys($subcomponent_module, $props[$moduleFullName][Props::SUBMODULES], array_merge($path, [$subcomponent_data_field_outputkey]), $ret);
                 }
             }
         }
@@ -585,7 +589,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
             return !$moduleprocessor_manager->getProcessor($submodule)->startDataloadingSection($submodule);
         });
         foreach ($submodules as $submodule) {
-            $moduleprocessor_manager->getProcessor($submodule)->addToDatasetDatabaseKeys($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES], $path, $ret);
+            $moduleprocessor_manager->getProcessor($submodule)->addToDatasetDatabaseKeys($submodule, $props[$moduleFullName][Props::SUBMODULES], $path, $ret);
         }
         $modulefilter_manager->restoreFromPropagation($module, $props);
     }
@@ -605,7 +609,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     {
         // Each module can only return one piece of data, and it must be indicated if it static or mutableonrequest
         // Retrieving only 1 piece is needed so that its children do not get confused what data their getDataFields applies to
-        return \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST;
+        return DataSources::MUTABLEONREQUEST;
     }
 
     public function getDBObjectIDOrIDs(array $module, array &$props, &$data_properties)
@@ -683,7 +687,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
             );
 
             if ($properties) {
-                $ret[\PoP\ComponentModel\Constants\DataLoading::DATA_PROPERTIES] = $properties;
+                $ret[DataLoading::DATA_PROPERTIES] = $properties;
             }
         }
 
@@ -782,7 +786,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         $ret[DataloadingConstants::DATASOURCE] = $datasource;
 
         // Add the properties below either as static or mutableonrequest
-        if ($datasource == \PoP\ComponentModel\Constants\DataSources::IMMUTABLE) {
+        if ($datasource == DataSources::IMMUTABLE) {
             $this->addHeaddatasetmoduleDataProperties($ret, $module, $props);
         }
 
@@ -816,7 +820,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         if ($this->moduleLoadsData($module)) {
             $properties = $this->getMutableonmodelHeaddatasetmoduleDataProperties($module, $props);
             if ($properties) {
-                $ret[\PoP\ComponentModel\Constants\DataLoading::DATA_PROPERTIES] = $properties;
+                $ret[DataLoading::DATA_PROPERTIES] = $properties;
             }
         }
 
@@ -829,7 +833,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
 
         // Add the properties below either as static or mutableonrequest
         $datasource = $this->getDatasource($module, $props);
-        if ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONMODEL) {
+        if ($datasource == DataSources::MUTABLEONMODEL) {
             $this->addHeaddatasetmoduleDataProperties($ret, $module, $props);
         }
 
@@ -862,7 +866,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
             $properties = $this->getMutableonrequestHeaddatasetmoduleDataProperties($module, $props);
 
             if ($properties) {
-                $ret[\PoP\ComponentModel\Constants\DataLoading::DATA_PROPERTIES] = $properties;
+                $ret[DataLoading::DATA_PROPERTIES] = $properties;
             }
         }
 
@@ -875,7 +879,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
 
         // Add the properties below either as static or mutableonrequest
         $datasource = $this->getDatasource($module, $props);
-        if ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) {
+        if ($datasource == DataSources::MUTABLEONREQUEST) {
             $this->addHeaddatasetmoduleDataProperties($ret, $module, $props);
         }
 
@@ -892,7 +896,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
 
             // Pass info for PoP Engine
             // $ret[\PoP\ComponentModel\Constants\DataLoading::DATA_ACCESS_CHECKPOINTS] = $checkpoint_configuration['checkpoints'];
-            $ret[\PoP\ComponentModel\Constants\DataLoading::DATA_ACCESS_CHECKPOINTS] = $checkpoints;
+            $ret[DataLoading::DATA_ACCESS_CHECKPOINTS] = $checkpoints;
             // }
         }
 
@@ -903,7 +907,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
 
             // Pass info for PoP Engine
             // $ret[\PoP\ComponentModel\Constants\DataLoading::ACTION_EXECUTION_CHECKPOINTS] = $checkpoint_configuration['checkpoints'];
-            $ret[\PoP\ComponentModel\Constants\DataLoading::ACTION_EXECUTION_CHECKPOINTS] = $checkpoints;
+            $ret[DataLoading::ACTION_EXECUTION_CHECKPOINTS] = $checkpoints;
             // }
         }
 
@@ -924,7 +928,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         $ret = array();
 
         if ($feedback = $this->getDataFeedback($module, $props, $data_properties, $dataaccess_checkpoint_validation, $actionexecution_checkpoint_validation, $executed, $dbobjectids)) {
-            $ret[\PoP\ComponentModel\Constants\DataLoading::FEEDBACK] = $feedback;
+            $ret[DataLoading::FEEDBACK] = $feedback;
         }
 
         return $ret;
@@ -980,7 +984,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
 
     public function getRelevantRouteCheckpointTarget(array $module, array &$props): string
     {
-        return \PoP\ComponentModel\Constants\DataLoading::DATA_ACCESS_CHECKPOINTS;
+        return DataLoading::DATA_ACCESS_CHECKPOINTS;
     }
 
     protected function maybeOverrideCheckpoints($checkpoints)
@@ -997,7 +1001,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     public function getDataaccessCheckpoints(array $module, array &$props): array
     {
         if ($route = $this->getRelevantRoute($module, $props)) {
-            if ($this->getRelevantRouteCheckpointTarget($module, $props) == \PoP\ComponentModel\Constants\DataLoading::DATA_ACCESS_CHECKPOINTS) {
+            if ($this->getRelevantRouteCheckpointTarget($module, $props) == DataLoading::DATA_ACCESS_CHECKPOINTS) {
                 return $this->maybeOverrideCheckpoints(SettingsManagerFactory::getInstance()->getCheckpoints($route));
             }
         }
@@ -1010,7 +1014,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
     public function getActionexecutionCheckpoints(array $module, array &$props): array
     {
         if ($route = $this->getRelevantRoute($module, $props)) {
-            if ($this->getRelevantRouteCheckpointTarget($module, $props) == \PoP\ComponentModel\Constants\DataLoading::ACTION_EXECUTION_CHECKPOINTS) {
+            if ($this->getRelevantRouteCheckpointTarget($module, $props) == DataLoading::ACTION_EXECUTION_CHECKPOINTS) {
                 return $this->maybeOverrideCheckpoints(SettingsManagerFactory::getInstance()->getCheckpoints($route));
             }
         }
@@ -1032,7 +1036,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         // then, by default, we simply set the dataload source to point to itself!
         $stringified_module_propagation_current_path = ModulePathHelpersFacade::getInstance()->getStringifiedModulePropagationCurrentPath($module);
         $ret = GeneralUtils::addQueryArgs([
-            ModuleFilterManager::URLPARAM_MODULEFILTER => \PoP\ComponentModel\ModuleFilters\ModulePaths::NAME,
+            ModuleFilterManager::URLPARAM_MODULEFILTER => ModulePaths::NAME,
             ModulePaths::URLPARAM_MODULEPATHS . '[]' => $stringified_module_propagation_current_path,
         ], RequestUtils::getCurrentUrl());
 
@@ -1040,7 +1044,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         $vars = ApplicationState::getVars();
         if ($scheme = $vars['scheme']) {
             $ret = GeneralUtils::addQueryArgs([
-                \PoP\ComponentModel\Constants\Params::SCHEME => $scheme,
+                Params::SCHEME => $scheme,
             ], $ret);
         }
 
@@ -1056,7 +1060,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         // Add the actionpath too
         if ($this->getComponentMutationResolverBridgeClass($module)) {
             $ret = GeneralUtils::addQueryArgs([
-                \PoP\ComponentModel\Constants\Params::ACTION_PATH => $stringified_module_propagation_current_path,
+                Params::ACTION_PATH => $stringified_module_propagation_current_path,
             ], $ret);
         }
 
@@ -1064,7 +1068,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         if ($this instanceof FormattableModuleInterface) {
             if ($format = $this->getFormat($module)) {
                 $ret = GeneralUtils::addQueryArgs([
-                    \PoP\ComponentModel\Constants\Params::FORMAT => $format,
+                    Params::FORMAT => $format,
                 ], $ret);
             }
         }
@@ -1117,8 +1121,8 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                         $submodule_processor = $moduleprocessor_manager->getProcessor($submodule);
 
                         // Propagate only if the submodule doesn't load data. If it does, this is the end of the data line, and the submodule is the beginning of a new datasetmoduletree
-                        if (!$submodule_processor->startDataloadingSection($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES])) {
-                            if ($submodule_ret = $submodule_processor->$propagate_fn($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES])) {
+                        if (!$submodule_processor->startDataloadingSection($submodule, $props[$moduleFullName][Props::SUBMODULES])) {
+                            if ($submodule_ret = $submodule_processor->$propagate_fn($submodule, $props[$moduleFullName][Props::SUBMODULES])) {
                                 // Chain the "data-fields" from the sublevels under the current "conditional-data-fields"
                                 // Move from "data-fields" to "conditional-data-fields"
                                 if ($submodule_ret['data-fields'] ?? null) {
@@ -1162,8 +1166,8 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                 $submodule_processor = $moduleprocessor_manager->getProcessor($submodule);
 
                 // Propagate only if the submodule doesn't load data. If it does, this is the end of the data line, and the submodule is the beginning of a new datasetmoduletree
-                if (!$submodule_processor->startDataloadingSection($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES])) {
-                    if ($submodule_ret = $submodule_processor->$propagate_fn($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES])) {
+                if (!$submodule_processor->startDataloadingSection($submodule, $props[$moduleFullName][Props::SUBMODULES])) {
+                    if ($submodule_ret = $submodule_processor->$propagate_fn($submodule, $props[$moduleFullName][Props::SUBMODULES])) {
                         // array_merge_recursive => data-fields from different sidebar-components can be integrated all together
                         $ret = array_merge_recursive(
                             $ret,
@@ -1208,7 +1212,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
             );
             foreach ($subcomponent_modules as $subcomponent_module) {
                 $subcomponent_processor = $moduleprocessor_manager->getProcessor($subcomponent_module);
-                if ($subcomponent_module_data_properties = $subcomponent_processor->$propagate_fn($subcomponent_module, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES])) {
+                if ($subcomponent_module_data_properties = $subcomponent_processor->$propagate_fn($subcomponent_module, $props[$moduleFullName][Props::SUBMODULES])) {
                     $subcomponent_modules_data_properties = array_merge_recursive(
                         $subcomponent_modules_data_properties,
                         $subcomponent_module_data_properties

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/ModulePathProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/ModulePathProcessorTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModuleProcessors;
 
+use PoP\ComponentModel\Constants\Props;
 use PoP\ComponentModel\Facades\ModuleFiltering\ModuleFilterManagerFacade;
 use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 use PoP\ComponentModel\Modules\ModuleUtils;
@@ -42,7 +43,7 @@ trait ModulePathProcessorTrait
         foreach ($submodules as $submodule) {
             $submodules_ret = array_merge(
                 $submodules_ret,
-                $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES], $data_properties, $dataaccess_checkpoint_validation, $actionexecution_checkpoint_validation, $executed, $dbobjectids)
+                $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][Props::SUBMODULES], $data_properties, $dataaccess_checkpoint_validation, $actionexecution_checkpoint_validation, $executed, $dbobjectids)
             );
         }
         if ($submodules_ret) {
@@ -76,7 +77,7 @@ trait ModulePathProcessorTrait
         foreach ($submodules as $submodule) {
             $ret = array_merge_recursive(
                 $ret,
-                $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES], $data_properties, $dataaccess_checkpoint_validation, $actionexecution_checkpoint_validation, $executed, $dbobjectids)
+                $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][Props::SUBMODULES], $data_properties, $dataaccess_checkpoint_validation, $actionexecution_checkpoint_validation, $executed, $dbobjectids)
             );
         }
         $modulefilter_manager->restoreFromPropagation($module, $props);
@@ -112,7 +113,7 @@ trait ModulePathProcessorTrait
         foreach ($submodules as $submodule) {
             $submodules_ret = array_merge(
                 $submodules_ret,
-                $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES])
+                $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][Props::SUBMODULES])
             );
         }
         if ($submodules_ret) {
@@ -141,7 +142,7 @@ trait ModulePathProcessorTrait
         // This function must be called always, to register matching modules into requestmeta.filtermodules even when the module has no submodules
         $modulefilter_manager->prepareForPropagation($module, $props);
         foreach ($submodules as $submodule) {
-            $submodule_ret = $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][\PoP\ComponentModel\Constants\Props::SUBMODULES], $recursive);
+            $submodule_ret = $this->getModuleProcessor($submodule)->$propagate_fn($submodule, $props[$moduleFullName][Props::SUBMODULES], $recursive);
             $ret = $recursive ?
                 array_merge_recursive(
                     $ret,

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModuleProcessors;
 
+use PoP\ComponentModel\Constants\DataSources;
+use PoP\ComponentModel\Constants\Params;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\ModuleProcessors\DataloadingConstants;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
@@ -110,7 +112,7 @@ trait QueryDataModuleProcessorTrait
         return array_values(array_filter(
             $this->getDatasetmoduletreeSectionFlattenedModules($module),
             function ($module) use ($moduleprocessor_manager) {
-                return $moduleprocessor_manager->getProcessor($module) instanceof \PoP\ComponentModel\ModuleProcessors\DataloadQueryArgsFilterInputModuleProcessorInterface;
+                return $moduleprocessor_manager->getProcessor($module) instanceof DataloadQueryArgsFilterInputModuleProcessorInterface;
             }
         ));
     }
@@ -130,15 +132,15 @@ trait QueryDataModuleProcessorTrait
 
         // Prepare the Query to get data from the DB
         $datasource = $data_properties[DataloadingConstants::DATASOURCE] ?? null;
-        if ($datasource == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST && !$data_properties[DataloadingConstants::IGNOREREQUESTPARAMS]) {
+        if ($datasource == DataSources::MUTABLEONREQUEST && !$data_properties[DataloadingConstants::IGNOREREQUESTPARAMS]) {
             // Merge with $_REQUEST, so that params passed through the URL can be used for the query (eg: ?limit=5)
             // But whitelist the params that can be taken, to avoid hackers peering inside the system and getting custom data (eg: params "include", "post-status" => "draft", etc)
             $whitelisted_params = (array)HooksAPIFacade::getInstance()->applyFilters(
                 Constants::HOOK_QUERYDATA_WHITELISTEDPARAMS,
                 array(
                     GD_URLPARAM_REDIRECTTO,
-                    \PoP\ComponentModel\Constants\Params::PAGE_NUMBER,
-                    \PoP\ComponentModel\Constants\Params::LIMIT,
+                    Params::PAGE_NUMBER,
+                    Params::LIMIT,
                 )
             );
             $params_from_request = array_filter(

--- a/layers/Engine/packages/component-model/src/QueryInputOutputHandlers/ListQueryInputOutputHandler.php
+++ b/layers/Engine/packages/component-model/src/QueryInputOutputHandlers/ListQueryInputOutputHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\QueryInputOutputHandlers;
 
+use PoP\ComponentModel\Constants\Params;
 use PoP\ComponentModel\QueryInputOutputHandlers\AbstractQueryInputOutputHandler;
 
 class ListQueryInputOutputHandler extends AbstractQueryInputOutputHandler
@@ -14,16 +15,16 @@ class ListQueryInputOutputHandler extends AbstractQueryInputOutputHandler
 
         // Handle edge cases for the limit (for security measures)
         $configuredLimit = $this->getLimit();
-        if (isset($query_args[\PoP\ComponentModel\Constants\Params::LIMIT])) {
-            $limit = $query_args[\PoP\ComponentModel\Constants\Params::LIMIT];
+        if (isset($query_args[Params::LIMIT])) {
+            $limit = $query_args[Params::LIMIT];
             if ($limit === -1 || $limit === 0 || $limit > $configuredLimit) {
                 $limit = $configuredLimit;
             }
         } else {
             $limit = $configuredLimit;
         }
-        $query_args[\PoP\ComponentModel\Constants\Params::LIMIT] = intval($limit);
-        $query_args[\PoP\ComponentModel\Constants\Params::PAGE_NUMBER] = $query_args[\PoP\ComponentModel\Constants\Params::PAGE_NUMBER] ? intval($query_args[\PoP\ComponentModel\Constants\Params::PAGE_NUMBER]) : 1;
+        $query_args[Params::LIMIT] = intval($limit);
+        $query_args[Params::PAGE_NUMBER] = $query_args[Params::PAGE_NUMBER] ? intval($query_args[Params::PAGE_NUMBER]) : 1;
     }
 
     protected function getLimit()

--- a/layers/Engine/packages/component-model/src/State/ApplicationState.php
+++ b/layers/Engine/packages/component-model/src/State/ApplicationState.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\State;
 
+use PoP\ComponentModel\Constants\Params;
+use PoP\ComponentModel\Constants\Outputs;
+use PoP\ComponentModel\Constants\DataSourceSelectors;
+use PoP\ComponentModel\Constants\DataOutputModes;
+use PoP\ComponentModel\Constants\DatabasesOutputModes;
+use PoP\ComponentModel\Tokens\Param;
+use PoP\ComponentModel\Constants\DataOutputItems;
+use PoP\ComponentModel\Constants\Targets;
+use PoP\ComponentModel\Constants\Values;
 use PoP\Routing\RouteNatures;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\Configuration\Request;
@@ -37,61 +46,61 @@ class ApplicationState
         $route = $routingManager->getCurrentRoute();
 
         // Convert them to lower to make it insensitive to upper/lower case values
-        $output = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::OUTPUT] ?? '');
-        $dataoutputitems = $_REQUEST[\PoP\ComponentModel\Constants\Params::DATA_OUTPUT_ITEMS] ?? [];
-        $datasources = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::DATA_SOURCE] ?? '');
-        $datastructure = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::DATASTRUCTURE] ?? '');
-        $dataoutputmode = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::DATAOUTPUTMODE] ?? '');
-        $dboutputmode = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::DATABASESOUTPUTMODE] ?? '');
-        $target = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::TARGET] ?? '');
+        $output = strtolower($_REQUEST[Params::OUTPUT] ?? '');
+        $dataoutputitems = $_REQUEST[Params::DATA_OUTPUT_ITEMS] ?? [];
+        $datasources = strtolower($_REQUEST[Params::DATA_SOURCE] ?? '');
+        $datastructure = strtolower($_REQUEST[Params::DATASTRUCTURE] ?? '');
+        $dataoutputmode = strtolower($_REQUEST[Params::DATAOUTPUTMODE] ?? '');
+        $dboutputmode = strtolower($_REQUEST[Params::DATABASESOUTPUTMODE] ?? '');
+        $target = strtolower($_REQUEST[Params::TARGET] ?? '');
         $mangled = Request::isMangled() ? '' : Request::URLPARAMVALUE_MANGLED_NONE;
-        $actions = isset($_REQUEST[\PoP\ComponentModel\Constants\Params::ACTIONS]) ?
-            array_map('strtolower', $_REQUEST[\PoP\ComponentModel\Constants\Params::ACTIONS]) : [];
-        $scheme = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::SCHEME] ?? '');
+        $actions = isset($_REQUEST[Params::ACTIONS]) ?
+            array_map('strtolower', $_REQUEST[Params::ACTIONS]) : [];
+        $scheme = strtolower($_REQUEST[Params::SCHEME] ?? '');
         // The version could possibly be set from outside
         $version = Environment::enableVersionByParams() ?
-            $_REQUEST[\PoP\ComponentModel\Constants\Params::VERSION] ?? ApplicationInfoFacade::getInstance()->getVersion()
+            $_REQUEST[Params::VERSION] ?? ApplicationInfoFacade::getInstance()->getVersion()
             : ApplicationInfoFacade::getInstance()->getVersion();
 
         $outputs = (array) HooksAPIFacade::getInstance()->applyFilters(
             'ApplicationState:outputs',
             array(
-                \PoP\ComponentModel\Constants\Outputs::HTML,
-                \PoP\ComponentModel\Constants\Outputs::JSON,
+                Outputs::HTML,
+                Outputs::JSON,
             )
         );
         if (!in_array($output, $outputs)) {
-            $output = \PoP\ComponentModel\Constants\Outputs::HTML;
+            $output = Outputs::HTML;
         }
 
         // Target/Module default values (for either empty, or if the user is playing around with the url)
         $alldatasources = array(
-            \PoP\ComponentModel\Constants\DataSourceSelectors::ONLYMODEL,
-            \PoP\ComponentModel\Constants\DataSourceSelectors::MODELANDREQUEST,
+            DataSourceSelectors::ONLYMODEL,
+            DataSourceSelectors::MODELANDREQUEST,
         );
         if (!in_array($datasources, $alldatasources)) {
-            $datasources = \PoP\ComponentModel\Constants\DataSourceSelectors::MODELANDREQUEST;
+            $datasources = DataSourceSelectors::MODELANDREQUEST;
         }
 
         $dataoutputmodes = array(
-            \PoP\ComponentModel\Constants\DataOutputModes::SPLITBYSOURCES,
-            \PoP\ComponentModel\Constants\DataOutputModes::COMBINED,
+            DataOutputModes::SPLITBYSOURCES,
+            DataOutputModes::COMBINED,
         );
         if (!in_array($dataoutputmode, $dataoutputmodes)) {
-            $dataoutputmode = \PoP\ComponentModel\Constants\DataOutputModes::SPLITBYSOURCES;
+            $dataoutputmode = DataOutputModes::SPLITBYSOURCES;
         }
 
         $dboutputmodes = array(
-            \PoP\ComponentModel\Constants\DatabasesOutputModes::SPLITBYDATABASES,
-            \PoP\ComponentModel\Constants\DatabasesOutputModes::COMBINED,
+            DatabasesOutputModes::SPLITBYDATABASES,
+            DatabasesOutputModes::COMBINED,
         );
         if (!in_array($dboutputmode, $dboutputmodes)) {
-            $dboutputmode = \PoP\ComponentModel\Constants\DatabasesOutputModes::SPLITBYDATABASES;
+            $dboutputmode = DatabasesOutputModes::SPLITBYDATABASES;
         }
 
         if ($dataoutputitems) {
             if (!is_array($dataoutputitems)) {
-                $dataoutputitems = explode(\PoP\ComponentModel\Tokens\Param::VALUE_SEPARATOR, strtolower($dataoutputitems));
+                $dataoutputitems = explode(Param::VALUE_SEPARATOR, strtolower($dataoutputitems));
             } else {
                 $dataoutputitems = array_map('strtolower', $dataoutputitems);
             }
@@ -99,11 +108,11 @@ class ApplicationState
         $alldataoutputitems = (array) HooksAPIFacade::getInstance()->applyFilters(
             'ApplicationState:dataoutputitems',
             array(
-                \PoP\ComponentModel\Constants\DataOutputItems::META,
-                \PoP\ComponentModel\Constants\DataOutputItems::DATASET_MODULE_SETTINGS,
-                \PoP\ComponentModel\Constants\DataOutputItems::MODULE_DATA,
-                \PoP\ComponentModel\Constants\DataOutputItems::DATABASES,
-                \PoP\ComponentModel\Constants\DataOutputItems::SESSION,
+                DataOutputItems::META,
+                DataOutputItems::DATASET_MODULE_SETTINGS,
+                DataOutputItems::MODULE_DATA,
+                DataOutputItems::DATABASES,
+                DataOutputItems::SESSION,
             )
         );
         $dataoutputitems = array_intersect(
@@ -114,11 +123,11 @@ class ApplicationState
             $dataoutputitems = HooksAPIFacade::getInstance()->applyFilters(
                 'ApplicationState:default-dataoutputitems',
                 array(
-                    \PoP\ComponentModel\Constants\DataOutputItems::META,
-                    \PoP\ComponentModel\Constants\DataOutputItems::DATASET_MODULE_SETTINGS,
-                    \PoP\ComponentModel\Constants\DataOutputItems::MODULE_DATA,
-                    \PoP\ComponentModel\Constants\DataOutputItems::DATABASES,
-                    \PoP\ComponentModel\Constants\DataOutputItems::SESSION,
+                    DataOutputItems::META,
+                    DataOutputItems::DATASET_MODULE_SETTINGS,
+                    DataOutputItems::MODULE_DATA,
+                    DataOutputItems::DATABASES,
+                    DataOutputItems::SESSION,
                 )
             );
         }
@@ -129,11 +138,11 @@ class ApplicationState
         $targets = (array) HooksAPIFacade::getInstance()->applyFilters(
             'ApplicationState:targets',
             array(
-                \PoP\ComponentModel\Constants\Targets::MAIN,
+                Targets::MAIN,
             )
         );
         if (!in_array($target, $targets)) {
-            $target = \PoP\ComponentModel\Constants\Targets::MAIN;
+            $target = Targets::MAIN;
         }
 
         $platformmanager = StratumManagerFactory::getInstance();
@@ -147,7 +156,7 @@ class ApplicationState
         // If there is not format, then set it to 'default'
         // This is needed so that the /generate/ generated configurations under a $model_instance_id (based on the value of $vars)
         // can match the same $model_instance_id when visiting that page
-        $format = isset($_REQUEST[\PoP\ComponentModel\Constants\Params::FORMAT]) ? strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::FORMAT]) : \PoP\ComponentModel\Constants\Values::DEFAULT;
+        $format = isset($_REQUEST[Params::FORMAT]) ? strtolower($_REQUEST[Params::FORMAT]) : Values::DEFAULT;
 
         // By default, get the variables from the request
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
@@ -158,7 +167,7 @@ class ApplicationState
             'route' => $route,
             'output' => $output,
             'modulefilter' => $modulefilter,
-            'actionpath' => $_REQUEST[\PoP\ComponentModel\Constants\Params::ACTION_PATH] ?? '',
+            'actionpath' => $_REQUEST[Params::ACTION_PATH] ?? '',
             'target' => $target,
             'dataoutputitems' => $dataoutputitems,
             'datasources' => $datasources,
@@ -184,7 +193,7 @@ class ApplicationState
         );
 
         if (ComponentConfiguration::enableConfigByParams()) {
-            self::$vars['config'] = $_REQUEST[\PoP\ComponentModel\Constants\Params::CONFIG] ?? null;
+            self::$vars['config'] = $_REQUEST[Params::CONFIG] ?? null;
         }
 
         // Set the routing state (eg: PoP Queried Object can add its information)

--- a/layers/Engine/packages/component-model/src/TypeDataLoaders/AbstractTypeQueryableDataLoader.php
+++ b/layers/Engine/packages/component-model/src/TypeDataLoaders/AbstractTypeQueryableDataLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeDataLoaders;
 
+use PoP\ComponentModel\Constants\Params;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\ModuleProcessors\DataloadingConstants;
 use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
@@ -27,14 +28,14 @@ abstract class AbstractTypeQueryableDataLoader extends AbstractTypeDataLoader im
     {
         return HooksAPIFacade::getInstance()->applyFilters(
             'GD_Dataloader_List:query:pagenumber',
-            $query_args[\PoP\ComponentModel\Constants\Params::PAGE_NUMBER]
+            $query_args[Params::PAGE_NUMBER]
         );
     }
     protected function getLimitParam($query_args)
     {
         return HooksAPIFacade::getInstance()->applyFilters(
             'GD_Dataloader_List:query:limit',
-            $query_args[\PoP\ComponentModel\Constants\Params::LIMIT]
+            $query_args[Params::LIMIT]
         );
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
 use Exception;
 use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\ComponentModel\Schema\SchemaDefinition;
@@ -204,7 +205,7 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
         do {
             // All the pickers and their priorities for this class level
             // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
-            $extensionPickerClassPriorities = array_reverse($attachableExtensionManager->getExtensionClasses($class, \PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::TYPERESOLVERPICKERS));
+            $extensionPickerClassPriorities = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
             $classPickerPriorities = array_values($extensionPickerClassPriorities);
             $classPickerClasses = array_keys($extensionPickerClassPriorities);
             $classPickers = array_map(function ($extensionClass) use ($instanceManager) {

--- a/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
+++ b/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
@@ -1,4 +1,6 @@
 <?php
+
+use PoP\Engine\ComponentLoader;
 /*
 Plugin Name: PoP Engine Bootloader for WordPress
 Version: 0.1
@@ -6,6 +8,5 @@ Description: Bootload the PoP Engine for WordPress
 Plugin URI: https://github.com/getpop/engine-wp-bootloader/
 Author: Leonardo Losoviz
 */
-
 // Initialize PoP Engine through the Bootloader
-\PoP\Engine\ComponentLoader::bootComponents();
+ComponentLoader::bootComponents();

--- a/layers/Engine/packages/engine/src/DataStructureFormatters/DBItemListDataStructureFormatter.php
+++ b/layers/Engine/packages/engine/src/DataStructureFormatters/DBItemListDataStructureFormatter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\Engine\DataStructureFormatters;
 
+use PoP\ComponentModel\Constants\DataOutputItems;
+use PoP\ComponentModel\Constants\DatabasesOutputModes;
 use PoP\ComponentModel\DataStructure\AbstractJSONDataStructureFormatter;
 use PoP\ComponentModel\State\ApplicationState;
 
@@ -38,7 +40,7 @@ class DBItemListDataStructureFormatter extends AbstractJSONDataStructureFormatte
         // If we are requesting only the databases, then return these as a list of items
         $vars = ApplicationState::getVars();
         $dataoutputitems = $vars['dataoutputitems'];
-        if (in_array(\PoP\ComponentModel\Constants\DataOutputItems::DATABASES, $dataoutputitems)) {
+        if (in_array(DataOutputItems::DATABASES, $dataoutputitems)) {
             $ret = array();
 
             // If there are no "databases" entry, then there are no results, so return an empty array
@@ -47,11 +49,11 @@ class DBItemListDataStructureFormatter extends AbstractJSONDataStructureFormatte
                 // Eg: notifications can appear under "database" and "userstatedatabase", showing different fields on each
                 $merged_databases = array();
                 $dboutputmode = $vars['dboutputmode'];
-                if ($dboutputmode == \PoP\ComponentModel\Constants\DatabasesOutputModes::SPLITBYDATABASES) {
+                if ($dboutputmode == DatabasesOutputModes::SPLITBYDATABASES) {
                     foreach ($databases as $database_name => $database) {
                         $this->addDBEntries($database, $merged_databases);
                     }
-                } elseif ($dboutputmode == \PoP\ComponentModel\Constants\DatabasesOutputModes::COMBINED) {
+                } elseif ($dboutputmode == DatabasesOutputModes::COMBINED) {
                     $this->addDBEntries($databases, $merged_databases);
                 }
 

--- a/layers/Engine/packages/engine/src/Misc/OperatorHelpers.php
+++ b/layers/Engine/packages/engine/src/Misc/OperatorHelpers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Engine\Misc;
 
+use PoP\Engine\Constants\OperationSymbols;
 use Exception;
 use PoP\Translation\Facades\TranslationAPIFacade;
 
@@ -23,7 +24,7 @@ class OperatorHelpers
         $dataPointer = &$data;
 
         // Iterate the data array to the provided path.
-        foreach (explode(\PoP\Engine\Constants\OperationSymbols::ARRAY_PATH_DELIMITER, $path) as $pathLevel) {
+        foreach (explode(OperationSymbols::ARRAY_PATH_DELIMITER, $path) as $pathLevel) {
             if (!$dataPointer) {
                 // If we reached the end of the array and can't keep going down any level more, then it's an error
                 return self::throwNoArrayItemUnderPathException($data, $path);
@@ -49,7 +50,7 @@ class OperatorHelpers
         $dataPointer = &$data;
 
         // Iterate the data array to the provided path.
-        foreach (explode(\PoP\Engine\Constants\OperationSymbols::ARRAY_PATH_DELIMITER, $path) as $pathLevel) {
+        foreach (explode(OperationSymbols::ARRAY_PATH_DELIMITER, $path) as $pathLevel) {
             if (!isset($dataPointer[$pathLevel])) {
                 // If we reached the end of the array and can't keep going down any level more, then it's an error
                 self::throwNoArrayItemUnderPathException($data, $path);

--- a/layers/Engine/packages/guzzle-helpers/src/GuzzleHelpers.php
+++ b/layers/Engine/packages/guzzle-helpers/src/GuzzleHelpers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\GuzzleHelpers;
 
+use function GuzzleHttp\Promise\unwrap;
+use function GuzzleHttp\Promise\settle;
 use GuzzleHttp\Client;
 use GuzzleHttp\Promise;
 use PoP\ComponentModel\ErrorHandling\Error;
@@ -132,10 +134,10 @@ class GuzzleHelpers
 
             // Wait on all of the requests to complete. Throws a ConnectException
             // if any of the requests fail
-            $results = Promise\unwrap($promises);
+            $results = unwrap($promises);
 
             // Wait for the requests to complete, even if some of them fail
-            $results = Promise\settle($promises)->wait();
+            $results = settle($promises)->wait();
 
             // You can access each result using the key provided to the unwrap function.
             return array_map(

--- a/layers/Engine/packages/hooks-wp/src/HooksAPI.php
+++ b/layers/Engine/packages/hooks-wp/src/HooksAPI.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\HooksWP;
 
-class HooksAPI implements \PoP\Hooks\HooksAPIInterface
+use PoP\Hooks\HooksAPIInterface;
+class HooksAPI implements HooksAPIInterface
 {
     public function addFilter(string $tag, callable $function_to_add, int $priority = 10, int $accepted_args = 1): void
     {

--- a/layers/Engine/packages/hooks-wp/tests/HooksAPITest.php
+++ b/layers/Engine/packages/hooks-wp/tests/HooksAPITest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\HooksWP;
 
+use PHPUnit\Framework\TestCase;
 use PoP\Hooks\Facades\HooksAPIFacade;
 
-class HooksAPITest extends \PHPUnit\Framework\TestCase
+class HooksAPITest extends TestCase
 {
     /**
      * Test that applyFilter returns $value

--- a/layers/Engine/packages/hooks/tests/ContractImplementations/HooksAPI.php
+++ b/layers/Engine/packages/hooks/tests/ContractImplementations/HooksAPI.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\Hooks\ContractImplementations;
 
-class HooksAPI implements \PoP\Hooks\HooksAPIInterface
+use PoP\Hooks\HooksAPIInterface;
+class HooksAPI implements HooksAPIInterface
 {
     public function addFilter(string $tag, callable $function_to_add, int $priority = 10, int $accepted_args = 1): void
     {

--- a/layers/Engine/packages/hooks/tests/HooksAPITest.php
+++ b/layers/Engine/packages/hooks/tests/HooksAPITest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\Hooks;
 
+use PHPUnit\Framework\TestCase;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\Hooks\ContractImplementations\HooksAPI;
 use PoP\Root\Container\ContainerBuilderFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class HooksAPITest extends \PHPUnit\Framework\TestCase
+class HooksAPITest extends TestCase
 {
     public function __construct()
     {

--- a/layers/Engine/packages/translation-wp/src/TranslationAPI.php
+++ b/layers/Engine/packages/translation-wp/src/TranslationAPI.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\TranslationWP;
 
+use PoP\Translation\TranslationAPIInterface;
 use function __;
 
-class TranslationAPI implements \PoP\Translation\TranslationAPIInterface
+class TranslationAPI implements TranslationAPIInterface
 {
     public function __(string $text, string $domain = 'default'): string
     {

--- a/layers/Engine/packages/translation/tests/ContractImplementations/TranslationAPI.php
+++ b/layers/Engine/packages/translation/tests/ContractImplementations/TranslationAPI.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\Translation\ContractImplementations;
 
-class TranslationAPI implements \PoP\Translation\TranslationAPIInterface
+use PoP\Translation\TranslationAPIInterface;
+class TranslationAPI implements TranslationAPIInterface
 {
     public function __(string $text, string $domain = 'default'): string
     {

--- a/layers/Engine/packages/translation/tests/TranslationAPITest.php
+++ b/layers/Engine/packages/translation/tests/TranslationAPITest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\Translation;
 
+use PHPUnit\Framework\TestCase;
 use PoP\Translation\TranslationAPIInterface;
 use PoP\Root\Container\ContainerBuilderFactory;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\Translation\ContractImplementations\TranslationAPI;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class TranslationAPITest extends \PHPUnit\Framework\TestCase
+class TranslationAPITest extends TestCase
 {
     public function __construct()
     {

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
@@ -1,4 +1,5 @@
 <?php
+use GraphQLAPI\ConvertCaseDirectives\Plugin;
 /*
 Plugin Name: GraphQL API - Convert Case Directives
 Plugin URI: https://github.com/GraphQLAPI/convert-case-directives
@@ -26,4 +27,4 @@ define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_VERSION', '0.1.0');
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Create and set-up the plugin instance
-(new \GraphQLAPI\ConvertCaseDirectives\Plugin())->setup();
+(new Plugin())->setup();

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
@@ -1,4 +1,5 @@
 <?php
+use GraphQLAPI\GraphQLAPI\Plugin;
 /*
 Plugin Name: GraphQL API for WordPress
 Plugin URI: https://graphql-api.com
@@ -66,4 +67,4 @@ if (!file_exists($autoloadFile)) {
 require_once($autoloadFile);
 
 // Create and set-up the plugin instance
-(new \GraphQLAPI\GraphQLAPI\Plugin())->setup();
+(new Plugin())->setup();

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Config/ServiceConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Config;
 
+use GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLClient;
+use GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLWithExplorerClient;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use GraphQLAPI\GraphQLAPI\Blocks\PersistedQueryGraphiQLBlock;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
@@ -87,13 +89,13 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLClient::class,
+            GraphiQLClient::class,
             \GraphQLAPI\GraphQLAPI\Clients\Overrides\GraphiQLClient::class
         );
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLWithExplorerClient::class,
+            GraphiQLWithExplorerClient::class,
             \GraphQLAPI\GraphQLAPI\Clients\Overrides\GraphiQLWithExplorerClient::class
         );
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -308,7 +308,7 @@ class Plugin
         // all its dependencies from PoP
         ComponentLoader::initializeComponents(
             [
-                \GraphQLAPI\GraphQLAPI\Component::class,
+                Component::class,
             ],
             $componentClassConfiguration,
             $skipSchemaComponentClasses

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI;
 
+use PoP\Engine\Component;
 use PoP\APIEndpoints\EndpointUtils;
 use GraphQLAPI\GraphQLAPI\Environment;
 use PoP\AccessControl\Schema\SchemaModes;
@@ -549,7 +550,7 @@ class PluginConfiguration
         $moduleRegistry = ModuleRegistryFacade::getInstance();
         $isDev = PluginEnvironment::isPluginEnvironmentDev();
 
-        $componentClassConfiguration[\PoP\Engine\Component::class] = [
+        $componentClassConfiguration[Component::class] = [
             \PoP\Engine\Environment::ADD_MANDATORY_CACHE_CONTROL_DIRECTIVE => false,
         ];
         $componentClassConfiguration[\GraphQLByPoP\GraphQLClientsForWP\Component::class] = [

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/graphql-api-schema-feedback.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/graphql-api-schema-feedback.php
@@ -1,4 +1,5 @@
 <?php
+use GraphQLAPI\SchemaFeedback\Plugin;
 /*
 Plugin Name: GraphQL API - Schema Feedback
 Plugin URI: https://github.com/GraphQLAPI/schema-feedback
@@ -25,7 +26,7 @@ use PoP\Engine\ComponentLoader;
 require_once(__DIR__ . '/vendor/autoload.php');
 
 // Plugin instance
-$plugin = new \GraphQLAPI\SchemaFeedback\Plugin();
+$plugin = new Plugin();
 
 // Functions to execute when activating/deactivating the plugin
 \register_activation_hook(__FILE__, [$plugin, 'activate']);

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/src/EndpointHandlers/GraphQLEndpointHandler.php
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/src/EndpointHandlers/GraphQLEndpointHandler.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLEndpointForWP\EndpointHandlers;
 
+use PoP\GraphQLAPI\Component;
+use PoP\ComponentModel\Constants\Params;
+use PoP\GraphQLAPI\DataStructureFormatters\GraphQLDataStructureFormatter;
 use PoP\APIEndpointsForWP\EndpointHandlers\AbstractEndpointHandler;
 use GraphQLByPoP\GraphQLEndpointForWP\ComponentConfiguration;
 use PoP\API\Response\Schemes as APISchemes;
@@ -41,7 +44,7 @@ class GraphQLEndpointHandler extends AbstractEndpointHandler
     {
         return
             class_exists('\PoP\GraphQLAPI\Component')
-            && \PoP\GraphQLAPI\Component::isEnabled()
+            && Component::isEnabled()
             && !ComponentConfiguration::isGraphQLAPIEndpointDisabled();
     }
 
@@ -53,9 +56,9 @@ class GraphQLEndpointHandler extends AbstractEndpointHandler
     protected function executeEndpoint(): void
     {
         // Set the params on the request, to emulate that they were added by the user
-        $_REQUEST[\PoP\ComponentModel\Constants\Params::SCHEME] = APISchemes::API;
+        $_REQUEST[Params::SCHEME] = APISchemes::API;
         // Include qualified namespace here (instead of `use`) since we do didn't know if component is installed
-        $_REQUEST[\PoP\ComponentModel\Constants\Params::DATASTRUCTURE] = \PoP\GraphQLAPI\DataStructureFormatters\GraphQLDataStructureFormatter::getName();
+        $_REQUEST[Params::DATASTRUCTURE] = GraphQLDataStructureFormatter::getName();
         // Enable hooks
         \do_action('EndpointHandler:setDoingGraphQL');
     }

--- a/layers/GraphQLByPoP/packages/graphql-parser/tests/Library/Validator/RequestValidatorTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/tests/Library/Validator/RequestValidatorTest.php
@@ -8,6 +8,7 @@
 
 namespace GraphQLByPoP\GraphQLParser\Library\Validator;
 
+use GraphQLByPoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use GraphQLByPoP\GraphQLParser\Execution\Request;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\Argument;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\Variable;
@@ -29,7 +30,7 @@ class RequestValidatorTest extends TestCase
      */
     public function testInvalidRequests(Request $request)
     {
-        $this->expectException(\GraphQLByPoP\GraphQLParser\Exception\Parser\InvalidRequestException::class);
+        $this->expectException(InvalidRequestException::class);
         (new RequestValidator())->validate($request);
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-parser/tests/Parser/ParserTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/tests/Parser/ParserTest.php
@@ -8,6 +8,7 @@
 
 namespace GraphQLByPoP\GraphQLParser\Parser;
 
+use GraphQLByPoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\Argument;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\InputList;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\InputObject;
@@ -46,7 +47,7 @@ class ParserTest extends TestCase
 
     public function testInvalidSelection()
     {
-        $this->expectException(\GraphQLByPoP\GraphQLParser\Exception\Parser\SyntaxErrorException::class);
+        $this->expectException(SyntaxErrorException::class);
         $parser = new Parser();
         $data   = $parser->parse('
         {
@@ -151,7 +152,7 @@ GRAPHQL;
      */
     public function testWrongQueries($query)
     {
-        $this->expectException(\GraphQLByPoP\GraphQLParser\Exception\Parser\SyntaxErrorException::class);
+        $this->expectException(SyntaxErrorException::class);
         $parser = new Parser();
 
         $parser->parse($query);

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer;
 
+use GraphQLByPoP\GraphQLServer\Conditional\AccessControl\ComponentBoot;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use GraphQLByPoP\GraphQLServer\Environment;
@@ -138,7 +139,7 @@ class Component extends AbstractComponent
 
         // Boot conditional on API package being installed
         if (class_exists('\PoP\AccessControl\Component')) {
-            \GraphQLByPoP\GraphQLServer\Conditional\AccessControl\ComponentBoot::beforeBoot();
+            ComponentBoot::beforeBoot();
         }
 
         // Boot conditional on having variables treated as expressions for @export directive

--- a/layers/Schema/packages/categories/src/Component.php
+++ b/layers/Schema/packages/categories/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Categories;
 
+use PoPSchema\Categories\Conditional\RESTAPI\ConditionalComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use PoPSchema\Categories\Config\ServiceConfiguration;
@@ -73,7 +74,7 @@ class Component extends AbstractComponent
         ServiceConfiguration::initialize();
 
         if (!in_array(\PoP\RESTAPI\Component::class, $skipSchemaComponentClasses)) {
-            \PoPSchema\Categories\Conditional\RESTAPI\ConditionalComponent::initialize(
+            ConditionalComponent::initialize(
                 $configuration,
                 $skipSchema
             );
@@ -95,7 +96,7 @@ class Component extends AbstractComponent
 
         // If $skipSchema for `Condition` is `true`, then services are not registered
         if (!empty(ContainerBuilderUtils::getServiceClassesUnderNamespace(__NAMESPACE__ . '\\Conditional\\RESTAPI\\Hooks'))) {
-            \PoPSchema\Categories\Conditional\RESTAPI\ConditionalComponent::beforeBoot();
+            ConditionalComponent::beforeBoot();
         }
     }
 }

--- a/layers/Schema/packages/categories/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/categories/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Categories\Config;
 
+use PoP\API\Component;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ModuleRouting\RouteModuleProcessorManagerInterface;
@@ -16,7 +17,7 @@ class ServiceConfiguration
     {
         // Add RouteModuleProcessors to the Manager
         // Load API and RESTAPI conditional classes
-        if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
+        if (class_exists('\PoP\API\Component') && Component::isEnabled()) {
             ContainerBuilderUtils::injectServicesIntoService(
                 RouteModuleProcessorManagerInterface::class,
                 'PoPSchema\\Categories\\Conditional\\API\\RouteModuleProcessors',

--- a/layers/Schema/packages/comments/src/Component.php
+++ b/layers/Schema/packages/comments/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Comments;
 
+use PoPSchema\Comments\Conditional\RESTAPI\ConditionalComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
@@ -72,7 +73,7 @@ class Component extends AbstractComponent
             class_exists('\PoP\RESTAPI\Component')
             && !in_array(\PoP\RESTAPI\Component::class, $skipSchemaComponentClasses)
         ) {
-            \PoPSchema\Comments\Conditional\RESTAPI\ConditionalComponent::initialize(
+            ConditionalComponent::initialize(
                 $configuration,
                 $skipSchema
             );
@@ -105,7 +106,7 @@ class Component extends AbstractComponent
         ContainerBuilderUtils::registerFieldInterfaceResolversFromNamespace(__NAMESPACE__ . '\\FieldInterfaceResolvers');
 
         if (class_exists('\PoP\RESTAPI\Component')) {
-            \PoPSchema\Comments\Conditional\RESTAPI\ConditionalComponent::beforeBoot();
+            ConditionalComponent::beforeBoot();
         }
         if (class_exists('\PoPSchema\Users\Component')) {
             \PoPSchema\Comments\Conditional\Users\ConditionalComponent::beforeBoot();

--- a/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Comments\FieldResolvers;
 
+use PoPSchema\Comments\Constants\Status;
 use PoP\LooseContracts\Facades\NameResolverFacade;
 use PoPSchema\Comments\TypeResolvers\CommentTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
@@ -79,7 +80,7 @@ class CustomPostFieldResolver extends AbstractQueryableFieldResolver
 
             case 'comments':
                 $query = array(
-                    'status' => \PoPSchema\Comments\Constants\Status::APPROVED,
+                    'status' => Status::APPROVED,
                     // 'type' => 'comment', // Only comments, no trackbacks or pingbacks
                     'customPostID' => $typeResolver->getID($post),
                     // The Order must always be date > ASC so the jQuery works in inserting sub-comments in already-created parent comments

--- a/layers/Schema/packages/comments/src/Hooks/WhitelistParamHooks.php
+++ b/layers/Schema/packages/comments/src/Hooks/WhitelistParamHooks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Comments\Hooks;
 
+use PoPSchema\Comments\Constants\Params;
 use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\ModuleProcessors\Constants;
 
@@ -20,7 +21,7 @@ class WhitelistParamHooks extends AbstractHookSet
     public function getWhitelistedParams(array $params): array
     {
         // Used for the Comments to know what post to fetch comments from when filtering
-        $params[] = \PoPSchema\Comments\Constants\Params::COMMENT_POST_ID;
+        $params[] = Params::COMMENT_POST_ID;
         return $params;
     }
 }

--- a/layers/Schema/packages/comments/src/TypeDataLoaders/CommentTypeDataLoader.php
+++ b/layers/Schema/packages/comments/src/TypeDataLoaders/CommentTypeDataLoader.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\Comments\TypeDataLoaders;
 
+use PoPSchema\Comments\Constants\Status;
+use PoPSchema\Comments\Constants\Params;
 use PoP\ComponentModel\TypeDataLoaders\AbstractTypeQueryableDataLoader;
 use PoPSchema\Comments\ModuleProcessors\CommentRelationalFieldDataloadModuleProcessor;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
@@ -28,9 +30,9 @@ class CommentTypeDataLoader extends AbstractTypeQueryableDataLoader
     {
         $query = parent::getQuery($query_args);
 
-        $query['status'] = \PoPSchema\Comments\Constants\Status::APPROVED;
+        $query['status'] = Status::APPROVED;
         // $query['type'] = 'comment'; // Only comments, no trackbacks or pingbacks
-        $query['customPostID'] = $query_args[\PoPSchema\Comments\Constants\Params::COMMENT_POST_ID];
+        $query['customPostID'] = $query_args[Params::COMMENT_POST_ID];
 
         return $query;
     }

--- a/layers/Schema/packages/customposts-wp/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/customposts-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostsWP\Config;
 
+use PoPSchema\CustomPosts\TypeDataLoaders\CustomPostUnionTypeDataLoader;
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,14 +19,14 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\CustomPosts\TypeDataLoaders\CustomPostUnionTypeDataLoader::class,
+            CustomPostUnionTypeDataLoader::class,
             \PoPSchema\CustomPostsWP\TypeDataLoaders\Overrides\CustomPostUnionTypeDataLoader::class
         );
 
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver::class,
+            CustomPostUnionTypeResolver::class,
             \PoPSchema\CustomPostsWP\TypeResolvers\Overrides\CustomPostUnionTypeResolver::class
         );
     }

--- a/layers/Schema/packages/customposts/src/Hooks/VarsHooks.php
+++ b/layers/Schema/packages/customposts/src/Hooks/VarsHooks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\Hooks;
 
+use PoPSchema\CustomPosts\Constants\ModelInstanceComponentTypes;
 use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\ModelInstance\ModelInstance;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -36,10 +37,10 @@ class VarsHooks extends AbstractHookSet
                 $component_types = (array)HooksAPIFacade::getInstance()->applyFilters(
                     '\PoP\ComponentModel\ModelInstanceProcessor_Utils:components_from_vars:type:single',
                     array(
-                        \PoPSchema\CustomPosts\Constants\ModelInstanceComponentTypes::SINGLE_CUSTOMPOST,
+                        ModelInstanceComponentTypes::SINGLE_CUSTOMPOST,
                     )
                 );
-                if (in_array(\PoPSchema\CustomPosts\Constants\ModelInstanceComponentTypes::SINGLE_CUSTOMPOST, $component_types)) {
+                if (in_array(ModelInstanceComponentTypes::SINGLE_CUSTOMPOST, $component_types)) {
                     $customPostType = $vars['routing-state']['queried-object-post-type'];
                     $components[] =
                         TranslationAPIFacade::getInstance()->__('post type:', 'pop-engine')

--- a/layers/Schema/packages/events-wp-em/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/events-wp-em/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\EventsWPEM\Config;
 
+use PoPSchema\Events\TypeResolverPickers\Optional\EventCustomPostTypeResolverPicker;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,7 +18,7 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\Events\TypeResolverPickers\Optional\EventCustomPostTypeResolverPicker::class,
+            EventCustomPostTypeResolverPicker::class,
             \PoPSchema\EventsWPEM\TypeResolverPickers\Overrides\EventCustomPostTypeResolverPicker::class
         );
     }

--- a/layers/Schema/packages/events/src/Component.php
+++ b/layers/Schema/packages/events/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Events;
 
+use PoPSchema\Events\Conditional\Tags\ComponentBoot;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
@@ -87,7 +88,7 @@ class Component extends AbstractComponent
 
         // Boot conditionals
         if (class_exists('\PoPSchema\Tags\Component')) {
-            \PoPSchema\Events\Conditional\Tags\ComponentBoot::beforeBoot();
+            ComponentBoot::beforeBoot();
         }
         if (class_exists('\PoPSchema\Users\Component')) {
             \PoPSchema\Events\Conditional\Users\ComponentBoot::beforeBoot();

--- a/layers/Schema/packages/everythingelse-wp/src/Component.php
+++ b/layers/Schema/packages/everythingelse-wp/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\EverythingElseWP;
 
+use PoPSchema\EverythingElseWP\Conditional\CustomPosts\ConditionalComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 
@@ -61,7 +62,7 @@ class Component extends AbstractComponent
             class_exists('\PoPSchema\CustomPosts\Component')
             && !in_array(\PoPSchema\CustomPosts\Component::class, $skipSchemaComponentClasses)
         ) {
-            \PoPSchema\EverythingElseWP\Conditional\CustomPosts\ConditionalComponent::initialize(
+            ConditionalComponent::initialize(
                 $configuration,
                 $skipSchema
             );

--- a/layers/Schema/packages/highlights-wp/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/highlights-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\HighlightsWP\Config;
 
+use PoPSchema\Highlights\TypeResolverPickers\Optional\HighlightCustomPostTypeResolverPicker;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,7 +18,7 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\Highlights\TypeResolverPickers\Optional\HighlightCustomPostTypeResolverPicker::class,
+            HighlightCustomPostTypeResolverPicker::class,
             \PoPSchema\HighlightsWP\TypeResolverPickers\Overrides\HighlightCustomPostTypeResolverPicker::class
         );
     }

--- a/layers/Schema/packages/locationposts-wp/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/locationposts-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\LocationPostsWP\Config;
 
+use PoPSchema\LocationPosts\TypeResolverPickers\Optional\LocationPostCustomPostTypeResolverPicker;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,7 +18,7 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\LocationPosts\TypeResolverPickers\Optional\LocationPostCustomPostTypeResolverPicker::class,
+            LocationPostCustomPostTypeResolverPicker::class,
             \PoPSchema\LocationPostsWP\TypeResolverPickers\Overrides\LocationPostCustomPostTypeResolverPicker::class
         );
     }

--- a/layers/Schema/packages/locationposts/src/Component.php
+++ b/layers/Schema/packages/locationposts/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\LocationPosts;
 
+use PoPSchema\LocationPosts\Conditional\Tags\ComponentBoot;
 use PoPSchema\LocationPosts\Environment;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
@@ -77,7 +78,7 @@ class Component extends AbstractComponent
 
         // Boot conditionals
         if (class_exists('\PoPSchema\Tags\Component')) {
-            \PoPSchema\LocationPosts\Conditional\Tags\ComponentBoot::beforeBoot();
+            ComponentBoot::beforeBoot();
         }
         if (class_exists('\PoPSchema\Users\Component')) {
             \PoPSchema\LocationPosts\Conditional\Users\ComponentBoot::beforeBoot();

--- a/layers/Schema/packages/locations/src/FieldResolvers/CustomPostLocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/CustomPostLocationFunctionalFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Locations\FieldResolvers;
 
+use PoPSchema\Posts\Constants\InputNames;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 
 class CustomPostLocationFunctionalFieldResolver extends AbstractLocationFunctionalFieldResolver
@@ -17,6 +18,6 @@ class CustomPostLocationFunctionalFieldResolver extends AbstractLocationFunction
 
     protected function getDbobjectIdField()
     {
-        return \PoPSchema\Posts\Constants\InputNames::POST_ID;
+        return InputNames::POST_ID;
     }
 }

--- a/layers/Schema/packages/locations/src/FieldResolvers/UserLocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/UserLocationFunctionalFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Locations\FieldResolvers;
 
+use PoPSchema\Users\Constants\InputNames;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class UserLocationFunctionalFieldResolver extends AbstractLocationFunctionalFieldResolver
@@ -17,6 +18,6 @@ class UserLocationFunctionalFieldResolver extends AbstractLocationFunctionalFiel
 
     protected function getDbobjectIdField()
     {
-        return \PoPSchema\Users\Constants\InputNames::USER_ID;
+        return InputNames::USER_ID;
     }
 }

--- a/layers/Schema/packages/media/src/Component.php
+++ b/layers/Schema/packages/media/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Media;
 
+use PoPSchema\Media\Conditional\Users\ConditionalComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
@@ -72,7 +73,7 @@ class Component extends AbstractComponent
             class_exists('\PoPSchema\Users\Component')
             && !in_array(\PoPSchema\Users\Component::class, $skipSchemaComponentClasses)
         ) {
-            \PoPSchema\Media\Conditional\Users\ConditionalComponent::initialize(
+            ConditionalComponent::initialize(
                 $configuration,
                 $skipSchema
             );
@@ -93,7 +94,7 @@ class Component extends AbstractComponent
         ContainerBuilderUtils::attachFieldResolversFromNamespace(__NAMESPACE__ . '\\FieldResolvers');
 
         if (class_exists('\PoPSchema\Users\Component')) {
-            \PoPSchema\Media\Conditional\Users\ConditionalComponent::beforeBoot();
+            ConditionalComponent::beforeBoot();
         }
     }
 }

--- a/layers/Schema/packages/notifications/src/TypeDataLoaders/NotificationTypeDataLoader.php
+++ b/layers/Schema/packages/notifications/src/TypeDataLoaders/NotificationTypeDataLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Notifications\TypeDataLoaders;
 
+use PoP\ComponentModel\Constants\Params;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\TypeDataLoaders\AbstractTypeQueryableDataLoader;
 use PoP\ComponentModel\State\ApplicationState;
@@ -31,10 +32,10 @@ class NotificationTypeDataLoader extends AbstractTypeQueryableDataLoader
             $query['pagenumber'] = 1;
             $query['limit'] = -1; // Limit=-1 => Bring all results
         } else {
-            if ($pagenumber = $query_args[\PoP\ComponentModel\Constants\Params::PAGE_NUMBER]) {
+            if ($pagenumber = $query_args[Params::PAGE_NUMBER]) {
                 $query['pagenumber'] = $pagenumber;
             }
-            if ($limit = $query_args[\PoP\ComponentModel\Constants\Params::LIMIT]) {
+            if ($limit = $query_args[Params::LIMIT]) {
                 $query['limit'] = $limit;
             }
         }

--- a/layers/Schema/packages/pages-wp/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/pages-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\PagesWP\Config;
 
+use PoPSchema\Pages\TypeResolverPickers\Optional\PageCustomPostTypeResolverPicker;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,7 +18,7 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\Pages\TypeResolverPickers\Optional\PageCustomPostTypeResolverPicker::class,
+            PageCustomPostTypeResolverPicker::class,
             \PoPSchema\PagesWP\TypeResolverPickers\Overrides\PageCustomPostTypeResolverPicker::class
         );
     }

--- a/layers/Schema/packages/pages/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/pages/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Pages\Config;
 
+use PoP\API\Component;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ModuleRouting\RouteModuleProcessorManagerInterface;
@@ -16,7 +17,7 @@ class ServiceConfiguration
     {
         // Add RouteModuleProcessors to the Manager
         // Load API and RESTAPI conditional classes
-        if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
+        if (class_exists('\PoP\API\Component') && Component::isEnabled()) {
             ContainerBuilderUtils::injectServicesIntoService(
                 RouteModuleProcessorManagerInterface::class,
                 'PoPSchema\\Pages\\Conditional\\API\\RouteModuleProcessors',

--- a/layers/Schema/packages/pages/src/Hooks/VarsHooks.php
+++ b/layers/Schema/packages/pages/src/Hooks/VarsHooks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Pages\Hooks;
 
+use PoPSchema\Pages\Constants\ModelInstanceComponentTypes;
 use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\ModelInstance\ModelInstance;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -30,7 +31,7 @@ class VarsHooks extends AbstractHookSet
                     '\PoPSchema\Pages\ModelInstanceProcessor_Utils:components_from_vars:type:page',
                     []
                 );
-                if (in_array(\PoPSchema\Pages\Constants\ModelInstanceComponentTypes::SINGLE_PAGE, $component_types)) {
+                if (in_array(ModelInstanceComponentTypes::SINGLE_PAGE, $component_types)) {
                     $page_id = $vars['routing-state']['queried-object-id'];
                     $components[] = TranslationAPIFacade::getInstance()->__('page id:', 'pop-engine').$page_id;
                 }

--- a/layers/Schema/packages/post-tags/src/Component.php
+++ b/layers/Schema/packages/post-tags/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\PostTags;
 
+use PoPSchema\PostTags\Conditional\RESTAPI\ConditionalComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use PoPSchema\PostTags\Config\ServiceConfiguration;
@@ -76,7 +77,7 @@ class Component extends AbstractComponent
         ServiceConfiguration::initialize();
 
         if (!in_array(\PoP\RESTAPI\Component::class, $skipSchemaComponentClasses)) {
-            \PoPSchema\PostTags\Conditional\RESTAPI\ConditionalComponent::initialize(
+            ConditionalComponent::initialize(
                 $configuration,
                 $skipSchema
             );
@@ -98,7 +99,7 @@ class Component extends AbstractComponent
 
         // If $skipSchema for `Condition` is `true`, then services are not registered
         if (!empty(ContainerBuilderUtils::getServiceClassesUnderNamespace(__NAMESPACE__ . '\\Conditional\\RESTAPI\\Hooks'))) {
-            \PoPSchema\PostTags\Conditional\RESTAPI\ConditionalComponent::beforeBoot();
+            ConditionalComponent::beforeBoot();
         }
     }
 

--- a/layers/Schema/packages/post-tags/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/post-tags/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\PostTags\Config;
 
+use PoP\API\Component;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ModuleRouting\RouteModuleProcessorManagerInterface;
@@ -16,7 +17,7 @@ class ServiceConfiguration
     {
         // Add RouteModuleProcessors to the Manager
         // Load API and RESTAPI conditional classes
-        if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
+        if (class_exists('\PoP\API\Component') && Component::isEnabled()) {
             ContainerBuilderUtils::injectServicesIntoService(
                 RouteModuleProcessorManagerInterface::class,
                 'PoPSchema\\PostTags\\Conditional\\API\\RouteModuleProcessors',

--- a/layers/Schema/packages/posts-wp/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/posts-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\PostsWP\Config;
 
+use PoPSchema\Posts\TypeResolverPickers\Optional\PostCustomPostTypeResolverPicker;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,7 +18,7 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\Posts\TypeResolverPickers\Optional\PostCustomPostTypeResolverPicker::class,
+            PostCustomPostTypeResolverPicker::class,
             \PoPSchema\PostsWP\TypeResolverPickers\Overrides\PostCustomPostTypeResolverPicker::class
         );
     }

--- a/layers/Schema/packages/posts/src/Component.php
+++ b/layers/Schema/packages/posts/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Posts;
 
+use PoPSchema\Posts\Conditional\Users\ConditionalComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use PoPSchema\Posts\Config\ServiceConfiguration;
@@ -80,7 +81,7 @@ class Component extends AbstractComponent
             class_exists('\PoPSchema\Users\Component')
             && !in_array(\PoPSchema\Users\Component::class, $skipSchemaComponentClasses)
         ) {
-            \PoPSchema\Posts\Conditional\Users\ConditionalComponent::initialize(
+            ConditionalComponent::initialize(
                 $configuration,
                 $skipSchema
             );
@@ -105,7 +106,7 @@ class Component extends AbstractComponent
         self::attachTypeResolverPickers();
 
         if (class_exists('\PoPSchema\Users\Component')) {
-            \PoPSchema\Posts\Conditional\Users\ConditionalComponent::beforeBoot();
+            ConditionalComponent::beforeBoot();
         }
     }
 

--- a/layers/Schema/packages/posts/src/Conditional/Users/Conditional/RESTAPI/RouteModuleProcessors/EntryRouteModuleProcessor.php
+++ b/layers/Schema/packages/posts/src/Conditional/Users/Conditional/RESTAPI/RouteModuleProcessors/EntryRouteModuleProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Posts\Conditional\Users\Conditional\RESTAPI\RouteModuleProcessors;
 
+use PoPSchema\Users\Conditional\CustomPosts\Conditional\RESTAPI\Hooks\CustomPostHooks;
 use PoP\ModuleRouting\AbstractEntryRouteModuleProcessor;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\Hooks\Facades\HooksAPIFacade;
@@ -36,7 +37,7 @@ class EntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
             self::$restFieldsQuery = (string) HooksAPIFacade::getInstance()->applyFilters(
                 'Users:Posts:RESTFields',
                 str_replace(
-                    ',' . \PoPSchema\Users\Conditional\CustomPosts\Conditional\RESTAPI\Hooks\CustomPostHooks::AUTHOR_RESTFIELDS,
+                    ',' . CustomPostHooks::AUTHOR_RESTFIELDS,
                     '',
                     EntryRouteModuleProcessorHelpers::getRESTFieldsQuery()
                 )

--- a/layers/Schema/packages/posts/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/posts/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Posts\Config;
 
+use PoP\API\Component;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ModuleRouting\RouteModuleProcessorManagerInterface;
@@ -16,7 +17,7 @@ class ServiceConfiguration
     {
         // Add RouteModuleProcessors to the Manager
         // Load API and RESTAPI conditional classes
-        if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
+        if (class_exists('\PoP\API\Component') && Component::isEnabled()) {
             ContainerBuilderUtils::injectServicesIntoService(
                 RouteModuleProcessorManagerInterface::class,
                 'PoPSchema\\Posts\\Conditional\\API\\RouteModuleProcessors',
@@ -34,7 +35,7 @@ class ServiceConfiguration
         // Load conditional classes
         if (class_exists('\PoPSchema\Users\Component')) {
             // Load API and RESTAPI conditional classes
-            if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
+            if (class_exists('\PoP\API\Component') && Component::isEnabled()) {
                 ContainerBuilderUtils::injectServicesIntoService(
                     RouteModuleProcessorManagerInterface::class,
                     'PoPSchema\\Posts\\Conditional\\Users\\Conditional\\API\\RouteModuleProcessors',
@@ -52,7 +53,7 @@ class ServiceConfiguration
 
         if (class_exists('\PoPSchema\Tags\Component')) {
             // Load API and RESTAPI conditional classes
-            if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
+            if (class_exists('\PoP\API\Component') && Component::isEnabled()) {
                 ContainerBuilderUtils::injectServicesIntoService(
                     RouteModuleProcessorManagerInterface::class,
                     'PoPSchema\\Posts\\Conditional\\Tags\\Conditional\\API\\RouteModuleProcessors',

--- a/layers/Schema/packages/stances-wp/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/stances-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\StancesWP\Config;
 
+use PoPSchema\Stances\TypeResolverPickers\Optional\StanceCustomPostTypeResolverPicker;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,7 +18,7 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\Stances\TypeResolverPickers\Optional\StanceCustomPostTypeResolverPicker::class,
+            StanceCustomPostTypeResolverPicker::class,
             \PoPSchema\StancesWP\TypeResolverPickers\Overrides\StanceCustomPostTypeResolverPicker::class
         );
     }

--- a/layers/Schema/packages/user-roles-access-control/src/Component.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRolesAccessControl;
 
+use PoPSchema\UserRolesAccessControl\Conditional\CacheControl\ConditionalComponent;
 use PoP\AccessControl\Component as AccessControlComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
@@ -67,7 +68,7 @@ class Component extends AbstractComponent
                 class_exists('\PoP\CacheControl\Component')
                 && !in_array(\PoP\CacheControl\Component::class, $skipSchemaComponentClasses)
             ) {
-                \PoPSchema\UserRolesAccessControl\Conditional\CacheControl\ConditionalComponent::initialize(
+                ConditionalComponent::initialize(
                     $configuration,
                     $skipSchema
                 );
@@ -107,7 +108,7 @@ class Component extends AbstractComponent
         ContainerBuilderUtils::attachTypeResolverDecoratorsFromNamespace(__NAMESPACE__ . '\\TypeResolverDecorators');
 
         if (class_exists('\PoP\CacheControl\Component')) {
-            \PoPSchema\UserRolesAccessControl\Conditional\CacheControl\ConditionalComponent::afterBoot();
+            ConditionalComponent::afterBoot();
         }
     }
 }

--- a/layers/Schema/packages/user-roles-wp/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/user-roles-wp/src/Config/ServiceConfiguration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRolesWP\Config;
 
+use PoPSchema\UserRoles\FieldResolvers\RootRolesFieldResolver;
+use PoPSchema\UserRoles\FieldResolvers\UserFieldResolver;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -17,13 +19,13 @@ class ServiceConfiguration
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\UserRoles\FieldResolvers\RootRolesFieldResolver::class,
+            RootRolesFieldResolver::class,
             \PoPSchema\UserRolesWP\FieldResolvers\Overrides\RootRolesFieldResolver::class
         );
         ContainerBuilderUtils::injectValuesIntoService(
             InstanceManagerInterface::class,
             'overrideClass',
-            \PoPSchema\UserRoles\FieldResolvers\UserFieldResolver::class,
+            UserFieldResolver::class,
             \PoPSchema\UserRolesWP\FieldResolvers\Overrides\UserFieldResolver::class
         );
     }

--- a/layers/Schema/packages/user-roles/src/Hooks/VarsHooks.php
+++ b/layers/Schema/packages/user-roles/src/Hooks/VarsHooks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRoles\Hooks;
 
+use PoPSchema\UserRoles\Constants\ModelInstanceComponentTypes;
 use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\ModelInstance\ModelInstance;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -33,10 +34,10 @@ class VarsHooks extends AbstractHookSet
                 $component_types = HooksAPIFacade::getInstance()->applyFilters(
                     '\PoP\ComponentModel\ModelInstanceProcessor_Utils:components_from_vars:type:userrole',
                     array(
-                        \PoPSchema\UserRoles\Constants\ModelInstanceComponentTypes::USER_ROLE,
+                        ModelInstanceComponentTypes::USER_ROLE,
                     )
                 );
-                if (in_array(\PoPSchema\UserRoles\Constants\ModelInstanceComponentTypes::USER_ROLE, $component_types)) {
+                if (in_array(ModelInstanceComponentTypes::USER_ROLE, $component_types)) {
                     $userRoleTypeDataResolver = UserRoleTypeDataResolverFacade::getInstance();
                     $components[] = TranslationAPIFacade::getInstance()->__('user role:', 'pop-engine') . $userRoleTypeDataResolver->getTheUserRole($user_id);
                 }

--- a/layers/Schema/packages/user-state-access-control/src/Component.php
+++ b/layers/Schema/packages/user-state-access-control/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserStateAccessControl;
 
+use PoPSchema\UserStateAccessControl\Conditional\CacheControl\ConditionalComponent;
 use PoP\AccessControl\Component as AccessControlComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
@@ -68,7 +69,7 @@ class Component extends AbstractComponent
                 class_exists('\PoP\CacheControl\Component')
                 && !in_array(\PoP\CacheControl\Component::class, $skipSchemaComponentClasses)
             ) {
-                \PoPSchema\UserStateAccessControl\Conditional\CacheControl\ConditionalComponent::initialize(
+                ConditionalComponent::initialize(
                     $configuration,
                     $skipSchema
                 );
@@ -109,7 +110,7 @@ class Component extends AbstractComponent
 
         // Boot conditional on API package being installed
         if (class_exists('\PoP\CacheControl\Component')) {
-            \PoPSchema\UserStateAccessControl\Conditional\CacheControl\ConditionalComponent::afterBoot();
+            ConditionalComponent::afterBoot();
         }
     }
 }

--- a/layers/Schema/packages/users/src/Component.php
+++ b/layers/Schema/packages/users/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Users;
 
+use PoPSchema\Users\Conditional\CustomPosts\ConditionalComponent;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\YAMLServicesTrait;
 use PoPSchema\Users\Config\ServiceConfiguration;
@@ -79,7 +80,7 @@ class Component extends AbstractComponent
             class_exists('\PoPSchema\CustomPosts\Component')
             && !in_array(\PoPSchema\CustomPosts\Component::class, $skipSchemaComponentClasses)
         ) {
-            \PoPSchema\Users\Conditional\CustomPosts\ConditionalComponent::initialize(
+            ConditionalComponent::initialize(
                 $configuration,
                 $skipSchema
             );
@@ -102,7 +103,7 @@ class Component extends AbstractComponent
 
         // Initialize all conditional components
         if (!empty(ContainerBuilderUtils::getServiceClassesUnderNamespace(__NAMESPACE__ . '\\Conditional\\CustomPosts\\FieldResolvers'))) {
-            \PoPSchema\Users\Conditional\CustomPosts\ConditionalComponent::beforeBoot();
+            ConditionalComponent::beforeBoot();
         }
     }
 

--- a/layers/Schema/packages/users/src/Config/ServiceConfiguration.php
+++ b/layers/Schema/packages/users/src/Config/ServiceConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Users\Config;
 
+use PoP\API\Component;
 use PoP\Root\Component\PHPServiceConfigurationTrait;
 use PoP\ComponentModel\Container\ContainerBuilderUtils;
 use PoP\ModuleRouting\RouteModuleProcessorManagerInterface;
@@ -15,7 +16,7 @@ class ServiceConfiguration
     protected static function configure(): void
     {
         // Load API and RESTAPI conditional classes
-        if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
+        if (class_exists('\PoP\API\Component') && Component::isEnabled()) {
             ContainerBuilderUtils::injectServicesIntoService(
                 RouteModuleProcessorManagerInterface::class,
                 'PoPSchema\\Users\\Conditional\\API\\RouteModuleProcessors',

--- a/layers/SiteBuilder/packages/application/src/Hooks/LazyLoadHookSet.php
+++ b/layers/SiteBuilder/packages/application/src/Hooks/LazyLoadHookSet.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\Application\Hooks;
 
+use PoP\ComponentModel\Constants\Params;
+use PoP\ComponentModel\Constants\DataOutputItems;
+use PoP\ComponentModel\Constants\Targets;
 use PoP\ComponentModel\ModuleFiltering\ModuleFilterManager;
 use PoP\Application\ModuleProcessors\DataloadingConstants;
 use PoP\ComponentModel\Misc\GeneralUtils;
@@ -59,15 +62,15 @@ class LazyLoadHookSet extends AbstractHookSet
         // Fetch the lazy-loaded data using the Background URL load
         if ($helperCalculations['has-lazy-load'] ?? null) {
             $url = GeneralUtils::addQueryArgs([
-                \PoP\ComponentModel\Constants\Params::DATA_OUTPUT_ITEMS => [
-                    \PoP\ComponentModel\Constants\DataOutputItems::META,
-                    \PoP\ComponentModel\Constants\DataOutputItems::MODULE_DATA,
-                    \PoP\ComponentModel\Constants\DataOutputItems::DATABASES,
+                Params::DATA_OUTPUT_ITEMS => [
+                    DataOutputItems::META,
+                    DataOutputItems::MODULE_DATA,
+                    DataOutputItems::DATABASES,
                 ],
                 ModuleFilterManager::URLPARAM_MODULEFILTER => Lazy::NAME,
-                \PoP\ComponentModel\Constants\Params::ACTIONS . '[]' => Actions::LOADLAZY,
+                Params::ACTIONS . '[]' => Actions::LOADLAZY,
             ], RequestUtils::getCurrentUrl());
-            $engine->addBackgroundUrl($url, array(\PoP\ComponentModel\Constants\Targets::MAIN));
+            $engine->addBackgroundUrl($url, array(Targets::MAIN));
         }
     }
 }

--- a/layers/SiteBuilder/packages/application/src/Hooks/WhitelistParamHooks.php
+++ b/layers/SiteBuilder/packages/application/src/Hooks/WhitelistParamHooks.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Application\Hooks;
 
+use PoP\Application\Constants\Response;
 use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\ModuleProcessors\Constants;
 
@@ -19,7 +20,7 @@ class WhitelistParamHooks extends AbstractHookSet
 
     public function getWhitelistedParams(array $params): array
     {
-        $params[] = \PoP\Application\Constants\Response::REDIRECT_TO;
+        $params[] = Response::REDIRECT_TO;
         return $params;
     }
 }

--- a/layers/SiteBuilder/packages/application/src/QueryInputOutputHandlers/ListQueryInputOutputHandler.php
+++ b/layers/SiteBuilder/packages/application/src/QueryInputOutputHandlers/ListQueryInputOutputHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\Application\QueryInputOutputHandlers;
 
+use PoP\ComponentModel\Constants\DataSources;
+use PoP\ComponentModel\Constants\Params;
 use PoP\Application\ModuleProcessors\DataloadingConstants;
 use PoP\LooseContracts\Facades\NameResolverFacade;
 use PoP\ComponentModel\State\ApplicationState;
@@ -22,12 +24,12 @@ class ListQueryInputOutputHandler extends \PoP\ComponentModel\QueryInputOutputHa
         $vars = ApplicationState::getVars();
 
         // Needed to loadLatest, to know from what time to get results
-        if (isset($data_properties[DataloadingConstants::DATASOURCE]) && $data_properties[DataloadingConstants::DATASOURCE] == \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) {
+        if (isset($data_properties[DataloadingConstants::DATASOURCE]) && $data_properties[DataloadingConstants::DATASOURCE] == DataSources::MUTABLEONREQUEST) {
             $ret[GD_URLPARAM_TIMESTAMP] = POP_CONSTANT_TIME;
         }
 
         // If it is lazy load, no need to calculate pagenumber / stop-fetching / etc
-        if (($data_properties[DataloadingConstants::LAZYLOAD] ?? null) || ($data_properties[DataloadingConstants::EXTERNALLOAD] ?? null) || (isset($data_properties[DataloadingConstants::DATASOURCE]) && $data_properties[DataloadingConstants::DATASOURCE] != \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST) || ($vars['loading-latest'] ?? null)) {
+        if (($data_properties[DataloadingConstants::LAZYLOAD] ?? null) || ($data_properties[DataloadingConstants::EXTERNALLOAD] ?? null) || (isset($data_properties[DataloadingConstants::DATASOURCE]) && $data_properties[DataloadingConstants::DATASOURCE] != DataSources::MUTABLEONREQUEST) || ($vars['loading-latest'] ?? null)) {
             return $ret;
         }
 
@@ -48,22 +50,22 @@ class ListQueryInputOutputHandler extends \PoP\ComponentModel\QueryInputOutputHa
         $vars = ApplicationState::getVars();
 
         // If data is not to be loaded, then "stop-fetching" as to not show the Load More button
-        if (($data_properties[DataloadingConstants::SKIPDATALOAD] ?? null) || (isset($data_properties[DataloadingConstants::DATASOURCE]) && $data_properties[DataloadingConstants::DATASOURCE] != \PoP\ComponentModel\Constants\DataSources::MUTABLEONREQUEST)) {
+        if (($data_properties[DataloadingConstants::SKIPDATALOAD] ?? null) || (isset($data_properties[DataloadingConstants::DATASOURCE]) && $data_properties[DataloadingConstants::DATASOURCE] != DataSources::MUTABLEONREQUEST)) {
             return $ret;
         }
 
         $query_args = $data_properties[DataloadingConstants::QUERYARGS];
 
-        if ($limit = $query_args[\PoP\ComponentModel\Constants\Params::LIMIT]) {
-            $ret[\PoP\ComponentModel\Constants\Params::LIMIT] = $limit;
+        if ($limit = $query_args[Params::LIMIT]) {
+            $ret[Params::LIMIT] = $limit;
         }
 
-        $pagenumber = $query_args[\PoP\ComponentModel\Constants\Params::PAGE_NUMBER];
+        $pagenumber = $query_args[Params::PAGE_NUMBER];
         if (!Utils::stopFetching($dbObjectIDOrIDs, $data_properties)) {
             // When loading latest, we need to return the same $pagenumber as we got, because it must not alter the params
             $nextpagenumber = (isset($vars['loading-latest']) && $vars['loading-latest']) ? $pagenumber : $pagenumber + 1;
         }
-        $ret[\PoP\ComponentModel\Constants\Params::PAGE_NUMBER] = $nextpagenumber;
+        $ret[Params::PAGE_NUMBER] = $nextpagenumber;
 
         return $ret;
     }

--- a/layers/SiteBuilder/packages/application/src/QueryInputOutputHandlers/RedirectQueryInputOutputHandler.php
+++ b/layers/SiteBuilder/packages/application/src/QueryInputOutputHandlers/RedirectQueryInputOutputHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Application\QueryInputOutputHandlers;
 
+use PoP\Application\Constants\Response;
 use PoP\ComponentModel\ModuleProcessors\DataloadingConstants;
 use PoP\ComponentModel\QueryInputOutputHandlers\ActionExecutionQueryInputOutputHandler;
 
@@ -26,7 +27,7 @@ class RedirectQueryInputOutputHandler extends ActionExecutionQueryInputOutputHan
 
         // Add the Redirect to Param. If there is none, use the referrer.
         // This is useful when coming from the Login link above the Template, which can't pass the 'redirect_to' data
-        $ret[\PoP\Application\Constants\Response::REDIRECT_TO] = $query_args[\PoP\Application\Constants\Response::REDIRECT_TO] ?? $_SERVER['HTTP_REFERER'];
+        $ret[Response::REDIRECT_TO] = $query_args[Response::REDIRECT_TO] ?? $_SERVER['HTTP_REFERER'];
 
         return $ret;
     }

--- a/layers/SiteBuilder/packages/application/src/QueryInputOutputHandlers/Utils.php
+++ b/layers/SiteBuilder/packages/application/src/QueryInputOutputHandlers/Utils.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Application\QueryInputOutputHandlers;
 
+use PoP\ComponentModel\Constants\Params;
 use PoP\ComponentModel\ModuleProcessors\DataloadingConstants;
 use PoP\ComponentModel\State\ApplicationState;
 
@@ -26,7 +27,7 @@ class Utils
 
         // Keep loading? (If limit = 0 or -1, this will always return false => keep fetching!)
         // If limit = 0 or -1, then it brought already all the results, so stop fetching
-        $limit = $query_args[\PoP\ComponentModel\Constants\Params::LIMIT];
+        $limit = $query_args[Params::LIMIT];
         if ($data_properties[GD_DATALOAD_QUERYHANDLERPROPERTY_LIST_STOPFETCHING] || $limit <= 0) {
             return true;
         }

--- a/layers/SiteBuilder/packages/component-model-configuration/src/Engine/Engine.php
+++ b/layers/SiteBuilder/packages/component-model-configuration/src/Engine/Engine.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\ConfigurationComponentModel\Engine;
 
+use PoP\ComponentModel\Constants\DataOutputItems;
+use PoP\ComponentModel\Constants\DataSourceSelectors;
+use PoP\ComponentModel\Constants\DataOutputModes;
 use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 use PoP\ComponentModel\ComponentConfiguration as ComponentModelComponentConfiguration;
@@ -31,7 +34,7 @@ class Engine extends \PoP\Engine\Engine\Engine implements EngineInterface
         $dataoutputitems = $vars['dataoutputitems'];
 
         $data = [];
-        if (in_array(\PoP\ComponentModel\Constants\DataOutputItems::MODULESETTINGS, $dataoutputitems)) {
+        if (in_array(DataOutputItems::MODULESETTINGS, $dataoutputitems)) {
             $data = array_merge(
                 $data,
                 $this->getModuleSettings($module, $this->model_props, $this->props)
@@ -81,14 +84,14 @@ class Engine extends \PoP\Engine\Engine\Engine implements EngineInterface
                 $cachemanager->storeCacheByModelInstance(self::CACHETYPE_STATEFULSETTINGS, $mutableonmodel_settings);
             }
         }
-        if ($datasources == \PoP\ComponentModel\Constants\DataSourceSelectors::MODELANDREQUEST) {
+        if ($datasources == DataSourceSelectors::MODELANDREQUEST) {
             $mutableonrequest_settings = $processor->getMutableonrequestSettingsModuletree($module, $props);
         }
 
         // If there are multiple URIs, then the results must be returned under the corresponding $model_instance_id for "mutableonmodel", and $url for "mutableonrequest"
         list($has_extra_routes, $model_instance_id, $current_uri) = $this->listExtraRouteVars();
 
-        if ($dataoutputmode == \PoP\ComponentModel\Constants\DataOutputModes::SPLITBYSOURCES) {
+        if ($dataoutputmode == DataOutputModes::SPLITBYSOURCES) {
             // Save the model settings
             if ($immutable_settings) {
                 $ret['modulesettings']['immutable'] = $immutable_settings;
@@ -99,7 +102,7 @@ class Engine extends \PoP\Engine\Engine\Engine implements EngineInterface
             if ($mutableonrequest_settings) {
                 $ret['modulesettings']['mutableonrequest'] = $has_extra_routes ? array($current_uri => $mutableonrequest_settings) : $mutableonrequest_settings;
             }
-        } elseif ($dataoutputmode == \PoP\ComponentModel\Constants\DataOutputModes::COMBINED) {
+        } elseif ($dataoutputmode == DataOutputModes::COMBINED) {
             // If everything is combined, then it belongs under "mutableonrequest"
             if (
                 $combined_settings = array_merge_recursive(

--- a/layers/SiteBuilder/packages/spa/src/Hooks/VarsHookSet.php
+++ b/layers/SiteBuilder/packages/spa/src/Hooks/VarsHookSet.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\SPA\Hooks;
 
+use PoP\ComponentModel\Constants\Outputs;
+use PoP\ComponentModel\Constants\Params;
 use PoP\Hooks\AbstractHookSet;
 
 class VarsHookSet extends AbstractHookSet
@@ -25,17 +27,17 @@ class VarsHookSet extends AbstractHookSet
     {
         [&$vars] = $vars_in_array;
         $vars['fetching-site'] = is_null($vars['modulefilter']);
-        $vars['loading-site'] = $vars['fetching-site'] && $vars['output'] == \PoP\ComponentModel\Constants\Outputs::HTML;
+        $vars['loading-site'] = $vars['fetching-site'] && $vars['output'] == Outputs::HTML;
 
         // Settings format: the format set by the application when first visiting it, configurable by the user
         if ($vars['loading-site'] ?? null) {
-            $vars['settingsformat'] = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::FORMAT] ?? '');
+            $vars['settingsformat'] = strtolower($_REQUEST[Params::FORMAT] ?? '');
         } else {
-            $vars['settingsformat'] = strtolower($_REQUEST[\PoP\ComponentModel\Constants\Params::SETTINGSFORMAT] ?? '');
+            $vars['settingsformat'] = strtolower($_REQUEST[Params::SETTINGSFORMAT] ?? '');
         }
 
         // Format: if not set, then use the 'settingsFormat' value if it has been set.
-        if (!isset($_REQUEST[\PoP\ComponentModel\Constants\Params::FORMAT]) && isset($_REQUEST[\PoP\ComponentModel\Constants\Params::SETTINGSFORMAT])) {
+        if (!isset($_REQUEST[Params::FORMAT]) && isset($_REQUEST[Params::SETTINGSFORMAT])) {
             $vars['format'] = $vars['settingsformat'];
         }
     }

--- a/layers/Wassup/packages/custompost-mutations/src/MutationResolverBridges/AbstractCreateUpdateCustomPostMutationResolverBridge.php
+++ b/layers/Wassup/packages/custompost-mutations/src/MutationResolverBridges/AbstractCreateUpdateCustomPostMutationResolverBridge.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\CustomPostMutations\MutationResolverBridges;
 
+use PoPSchema\Posts\Constants\InputNames;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoPSchema\CustomPosts\Types\Status;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -39,7 +40,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolverBridge extends Abst
      */
     protected function getUpdateCustomPostID()
     {
-        return $_REQUEST[\PoPSchema\Posts\Constants\InputNames::POST_ID] ?? null;
+        return $_REQUEST[InputNames::POST_ID] ?? null;
     }
 
     abstract protected function isUpdate(): bool;

--- a/layers/Wassup/packages/everythingelse-mutations/src/MutationResolverBridges/EditMembershipMutationResolverBridge.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/MutationResolverBridges/EditMembershipMutationResolverBridge.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\EverythingElseMutations\MutationResolverBridges;
 
+use PoPSchema\Users\Constants\InputNames;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 use PoP\ComponentModel\MutationResolverBridges\AbstractComponentMutationResolverBridge;
@@ -26,7 +27,7 @@ class EditMembershipMutationResolverBridge extends AbstractComponentMutationReso
         $tags = $moduleprocessor_manager->getProcessor([\GD_URE_Module_Processor_ProfileMultiSelectFormInputs::class, \GD_URE_Module_Processor_ProfileMultiSelectFormInputs::MODULE_URE_FORMINPUT_MEMBERTAGS])->getValue([\GD_URE_Module_Processor_ProfileMultiSelectFormInputs::class, \GD_URE_Module_Processor_ProfileMultiSelectFormInputs::MODULE_URE_FORMINPUT_MEMBERTAGS]);
         $form_data = array(
             'community' => $community,
-            'user_id' => $_REQUEST[\PoPSchema\Users\Constants\InputNames::USER_ID] ?? null,
+            'user_id' => $_REQUEST[InputNames::USER_ID] ?? null,
             // 'nonce' => $_REQUEST[POP_INPUTNAME_NONCE],
             'status' => trim($moduleprocessor_manager->getProcessor([\GD_URE_Module_Processor_SelectFormInputs::class, \GD_URE_Module_Processor_SelectFormInputs::MODULE_URE_FORMINPUT_MEMBERSTATUS])->getValue([\GD_URE_Module_Processor_SelectFormInputs::class, \GD_URE_Module_Processor_SelectFormInputs::MODULE_URE_FORMINPUT_MEMBERSTATUS])),
             'privileges' => $privileges ?? array(),

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolverBridges/AbstractCustomPostUpdateUserMetaValueMutationResolverBridge.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolverBridges/AbstractCustomPostUpdateUserMetaValueMutationResolverBridge.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\SocialNetworkMutations\MutationResolverBridges;
 
+use PoPSchema\Posts\Constants\InputNames;
 abstract class AbstractCustomPostUpdateUserMetaValueMutationResolverBridge extends AbstractUpdateUserMetaValueMutationResolverBridge
 {
     protected function getRequestKey()
     {
-        return \PoPSchema\Posts\Constants\InputNames::POST_ID;
+        return InputNames::POST_ID;
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolverBridges/AbstractTagUpdateUserMetaValueMutationResolverBridge.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolverBridges/AbstractTagUpdateUserMetaValueMutationResolverBridge.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\SocialNetworkMutations\MutationResolverBridges;
 
+use PoPSchema\Tags\Constants\InputNames;
 abstract class AbstractTagUpdateUserMetaValueMutationResolverBridge extends AbstractUpdateUserMetaValueMutationResolverBridge
 {
     protected function getRequestKey()
     {
-        return \PoPSchema\Tags\Constants\InputNames::TAG_ID;
+        return InputNames::TAG_ID;
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolverBridges/AbstractUserUpdateUserMetaValueMutationResolverBridge.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolverBridges/AbstractUserUpdateUserMetaValueMutationResolverBridge.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\SocialNetworkMutations\MutationResolverBridges;
 
+use PoPSchema\Users\Constants\InputNames;
 abstract class AbstractUserUpdateUserMetaValueMutationResolverBridge extends AbstractUpdateUserMetaValueMutationResolverBridge
 {
     protected function getRequestKey()
     {
-        return \PoPSchema\Users\Constants\InputNames::USER_ID;
+        return InputNames::USER_ID;
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractCustomPostUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractCustomPostUpdateUserMetaValueMutationResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\SocialNetworkMutations\MutationResolvers;
 
+use PoPSchema\Posts\Constants\InputNames;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
@@ -39,7 +40,7 @@ class AbstractCustomPostUpdateUserMetaValueMutationResolver extends AbstractUpda
 
     protected function getRequestKey()
     {
-        return \PoPSchema\Posts\Constants\InputNames::POST_ID;
+        return InputNames::POST_ID;
     }
 
     protected function additionals($target_id, $form_data)

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUserUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUserUpdateUserMetaValueMutationResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\SocialNetworkMutations\MutationResolvers;
 
+use PoPSchema\Users\Constants\InputNames;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\Hooks\Facades\HooksAPIFacade;
 
@@ -27,7 +28,7 @@ class AbstractUserUpdateUserMetaValueMutationResolver extends AbstractUpdateUser
 
     protected function getRequestKey()
     {
-        return \PoPSchema\Users\Constants\InputNames::USER_ID;
+        return InputNames::USER_ID;
     }
 
     protected function additionals($target_id, $form_data)

--- a/layers/Wassup/packages/wassup/src/MutationResolvers/CreateOrUpdateStanceMutationResolver.php
+++ b/layers/Wassup/packages/wassup/src/MutationResolvers/CreateOrUpdateStanceMutationResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSitesWassup\Wassup\MutationResolvers;
 
+use PoP\ComponentModel\Environment;
 class CreateOrUpdateStanceMutationResolver extends \PoPSitesWassup\StanceMutations\MutationResolvers\CreateOrUpdateStanceMutationResolver
 {
     protected function getCreatepostData($form_data)
@@ -11,7 +12,7 @@ class CreateOrUpdateStanceMutationResolver extends \PoPSitesWassup\StanceMutatio
         $post_data = parent::getCreatepostData($form_data);
 
         // Property 'menu-order' only works for WordPress
-        if (\PoP\ComponentModel\Environment::disableCustomCMSCode()) {
+        if (Environment::disableCustomCMSCode()) {
             return $post_data;
         }
 

--- a/rector-code-quality.php
+++ b/rector-code-quality.php
@@ -6,6 +6,12 @@ use Rector\CodeQuality\Rector\LogicalAnd\AndAssignsToSeparateLinesRector;
 use Rector\Core\Configuration\Option;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+/**
+ * This Rector configuration imports the fully qualified classnames
+ * using `use`, and removing it from the body.
+ * Rule `AndAssignsToSeparateLinesRector` is not needed, but we need
+ * to run at least 1 rule.
+ */
 return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();
@@ -32,6 +38,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // files to skip downgrading
     $parameters->set(Option::SKIP, [
+        '*/migrate-*',
         '*/vendor/*',
     ]);
 

--- a/rector-code-quality.php
+++ b/rector-code-quality.php
@@ -27,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // files to skip downgrading
     $parameters->set(Option::PATHS, [
         __DIR__ . '/src/*',
-        // __DIR__ . '/layers/*',
+        __DIR__ . '/layers/*',
     ]);
 
     // files to skip downgrading

--- a/rector-code-quality.php
+++ b/rector-code-quality.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\LogicalAnd\AndAssignsToSeparateLinesRector;
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::SETS, []);
+
+    $services = $containerConfigurator->services();
+    $services->set(AndAssignsToSeparateLinesRector::class);
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+
+    // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
+    $parameters->set(Option::AUTOLOAD_PATHS, [
+        // full directory
+        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
+        // Avoid error: "Class EM_Event not found"
+        __DIR__ . '/stubs/wpackagist-plugin/events-manager/em-stubs.php',
+    ]);
+
+    // files to skip downgrading
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src/*',
+        // __DIR__ . '/layers/*',
+    ]);
+
+    // files to skip downgrading
+    $parameters->set(Option::SKIP, [
+        '*/vendor/*',
+    ]);
+
+    // /**
+    //  * This constant is defined in wp-load.php, but never loaded.
+    //  * It is read when resolving class WP_Upgrader in Plugin.php.
+    //  * Define it here again, or otherwise Rector fails with message:
+    //  *
+    //  * "PHP Warning:  Use of undefined constant ABSPATH -
+    //  * assumed 'ABSPATH' (this will throw an Error in a future version of PHP)
+    //  * in .../graphql-api-for-wp/vendor/wordpress/wordpress/wp-admin/includes/class-wp-upgrader.php
+    //  * on line 13"
+    //  */
+    // /** Define ABSPATH as this file's directory */
+    // if (!defined('ABSPATH')) {
+    //     define('ABSPATH', __DIR__ . '/vendor/wordpress/wordpress/');
+    // }
+};

--- a/src/Extensions/Symplify/MonorepoBuilder/CustomDependencyUpdater.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/CustomDependencyUpdater.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder;
 
-use Nette\Utils\Strings;
 use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
 use Symplify\SmartFileSystem\SmartFileInfo;


### PR DESCRIPTION
Run Rector to import the classnames using `use`, and removing it from the body:

```diff
+use PoPSchema\Users\Constants\InputNames;

 public function getRequestKey()
 {
-        return \PoPSchema\Users\Constants\InputNames::USER_ID;
+        return InputNames::USER_ID;
 }
```

This functionality is done through an option, not through a rule. Then, rule `AndAssignsToSeparateLinesRector` was added to the Rector config, because we need to run at least 1 rule (we don't actually need this rule otherwise).