### PR TITLE
Start GraphQL API for WP server with symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ composer.lock
 !/composer.lock
 /wordpress/
 .lando.local.yml
+layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp

--- a/composer.json
+++ b/composer.json
@@ -627,7 +627,10 @@
             "@start-server"
         ],
         "start-server": [
-            "cd layers/GraphQLAPIForWP/plugins/graphql-api-for-wp && composer update",
+            "php -r \"copy('layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json', 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp');\"",
+            "vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json",
+            "composer update --working-dir=layers/GraphQLAPIForWP/plugins/graphql-api-for-wp",
+            "php -r \"copy('layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp', 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json');\"",
             "lando start"
         ],
         "rebuild-server": "lando rebuild -y",


### PR DESCRIPTION
Use symlinks to all packages in the monorepo when executing `composer start-server`, for launching the server for the GraphQL API for WordPress plugin (for which it must install its dependencies, under `vendor/`).

Then it won't download the packages from Packagist anymore.