### PR TITLE
Make Lando server work with /schema/

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -283,6 +283,7 @@ services:
         wp import
         layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/lando/assets/graphql-api-dev-sample-data.xml
         --authors=create --path=wordpress
+      - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/Schema/index.php
 
 env_file:
   - layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/lando/defaults.env

--- a/.lando.yml
+++ b/.lando.yml
@@ -284,6 +284,9 @@ services:
         layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/lando/assets/graphql-api-dev-sample-data.xml
         --authors=create --path=wordpress
       - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/Schema/index.php
+      - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/API/index.php
+      - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/Engine/index.php
+      - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/GraphQLByPoP/index.php
 
 env_file:
   - layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/lando/defaults.env

--- a/.lando.yml
+++ b/.lando.yml
@@ -284,9 +284,9 @@ services:
         layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/lando/assets/graphql-api-dev-sample-data.xml
         --authors=create --path=wordpress
       - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/Schema/index.php
-      - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/API/index.php
-      - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/Engine/index.php
-      - sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php > wordpress/GraphQLByPoP/index.php
+      - cp wordpress/Schema/index.php wordpress/API/index.php
+      - cp wordpress/Schema/index.php wordpress/Engine/index.php
+      - cp wordpress/Schema/index.php wordpress/GraphQLByPoP/index.php
 
 env_file:
   - layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/lando/defaults.env


### PR DESCRIPTION
After having Composer use `symlink: true` for all dependencies of  plugin`graphql-api/`, and combined with all volume overrides in `.lando.yml`, the following folders were created in the Lando server:

- `app/wordpress/API`
- `app/wordpress/Engine`
- `app/wordpress/GraphQLByPoP`
- `app/wordpress/Schema`

(Why does it do this? I have no clue!)

Folder `Schema/` is a real problem, because the GraphQL Voyager is by default accessed under `/schema/`. As a result, instead of executing the PHP logic, Apache would display the contents of the folder!

I couldn't find a proper solution to this, so instead I added a hack: I duplicated file `wordpress/index.php` under all of these locations, to force it to execute WordPress logic (replacing `__DIR__` with `dirname(__DIR__)`):

```php
<?php
/**
 * Front to the WordPress application. This file doesn't do anything, but loads
 * wp-blog-header.php which does and tells WordPress to load the theme.
 *
 * @package WordPress
 */

/**
 * Tells WordPress to load the WordPress theme and output it.
 *
 * @var bool
 */
define( 'WP_USE_THEMES', true );

/** Loads the WordPress Environment and Template */
require dirname(__DIR__) . '/wp-blog-header.php';

```

Now, calling `/schema/` works.