### PR TITLE
Removed stale const

### DIFF
--- a/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
@@ -138,7 +138,6 @@ trait QueryDataModuleProcessorTrait
             $whitelisted_params = (array)HooksAPIFacade::getInstance()->applyFilters(
                 Constants::HOOK_QUERYDATA_WHITELISTEDPARAMS,
                 array(
-                    GD_URLPARAM_REDIRECTTO,
                     Params::PAGE_NUMBER,
                     Params::LIMIT,
                 )


### PR DESCRIPTION
Const `GD_URLPARAM_REDIRECTTO` was deleted but was still present in the code, throwing an error on PHP 8.

It was now removed.