### PR TITLE
ServiceConfiguration::initialize() goes at the end

### DIFF
--- a/layers/API/packages/api/src/Component.php
+++ b/layers/API/packages/api/src/Component.php
@@ -88,7 +88,6 @@ class Component extends AbstractComponent
             self::$COMPONENT_DIR = dirname(__DIR__);
             self::initYAMLServices(self::$COMPONENT_DIR);
             self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
-            ServiceConfiguration::initialize();
 
             // Conditional packages
             if (class_exists('\PoP\AccessControl\Component')) {
@@ -103,6 +102,7 @@ class Component extends AbstractComponent
             ) {
                 self::maybeInitPHPSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema');
             }
+            ServiceConfiguration::initialize();
         }
     }
 

--- a/layers/Schema/packages/categories/src/Component.php
+++ b/layers/Schema/packages/categories/src/Component.php
@@ -66,10 +66,11 @@ class Component extends AbstractComponent
         self::$COMPONENT_DIR = dirname(__DIR__);
         self::initYAMLServices(self::$COMPONENT_DIR);
         self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
-        ServiceConfiguration::initialize();
 
         if (!in_array(\PoP\RESTAPI\Component::class, $skipSchemaComponentClasses)) {
             self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/RESTAPI');
         }
+
+        ServiceConfiguration::initialize();
     }
 }

--- a/layers/Schema/packages/post-tags/src/Component.php
+++ b/layers/Schema/packages/post-tags/src/Component.php
@@ -69,11 +69,11 @@ class Component extends AbstractComponent
         self::$COMPONENT_DIR = dirname(__DIR__);
         self::initYAMLServices(self::$COMPONENT_DIR);
         self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
-        ServiceConfiguration::initialize();
 
         if (class_exists('\PoP\RESTAPI\Component::class') && !in_array(\PoP\RESTAPI\Component::class, $skipSchemaComponentClasses)) {
             self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/RESTAPI');
         }
+        ServiceConfiguration::initialize();
     }
 
     /**

--- a/layers/Schema/packages/users/src/Component.php
+++ b/layers/Schema/packages/users/src/Component.php
@@ -69,7 +69,6 @@ class Component extends AbstractComponent
         self::$COMPONENT_DIR = dirname(__DIR__);
         self::initYAMLServices(self::$COMPONENT_DIR);
         self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
-        ServiceConfiguration::initialize();
 
         if (
             class_exists('\PoP\API\Component')
@@ -97,6 +96,7 @@ class Component extends AbstractComponent
                 }
             }
         }
+        ServiceConfiguration::initialize();
     }
 
     /**


### PR DESCRIPTION
Fixed issue of `RouteModuleProcessor`s not being registered, because `ServiceConfiguration::initialize();` was called before loading the corresponding container services.