### PR TITLE
Replace using service definition IDs with services

### DIFF
--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterDataStructureFormatterCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterDataStructureFormatterCompilerPass.php
@@ -6,9 +6,9 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 
 use PoP\ComponentModel\DataStructure\DataStructureFormatterInterface;
 use PoP\ComponentModel\DataStructure\DataStructureManagerInterface;
-use PoP\Root\Container\CompilerPasses\AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
 
-class RegisterDataStructureFormatterCompilerPass extends AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass
+class RegisterDataStructureFormatterCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
 {
     protected function getRegistryServiceDefinition(): string
     {
@@ -17,5 +17,9 @@ class RegisterDataStructureFormatterCompilerPass extends AbstractInjectServiceDe
     protected function getServiceClass(): string
     {
         return DataStructureFormatterInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addDataStructureFormatter';
     }
 }

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterDirectiveResolverCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterDirectiveResolverCompilerPass.php
@@ -7,9 +7,9 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 use PoP\ComponentModel\ComponentConfiguration;
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\Registries\DirectiveRegistryInterface;
-use PoP\Root\Container\CompilerPasses\AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
 
-class RegisterDirectiveResolverCompilerPass extends AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass
+class RegisterDirectiveResolverCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
 {
     protected function getRegistryServiceDefinition(): string
     {
@@ -18,6 +18,10 @@ class RegisterDirectiveResolverCompilerPass extends AbstractInjectServiceDefinit
     protected function getServiceClass(): string
     {
         return DirectiveResolverInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addDirectiveResolver';
     }
     protected function enabled(): bool
     {

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterFieldInterfaceResolverCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterFieldInterfaceResolverCompilerPass.php
@@ -7,9 +7,9 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 use PoP\ComponentModel\ComponentConfiguration;
 use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
 use PoP\ComponentModel\Registries\FieldInterfaceRegistryInterface;
-use PoP\Root\Container\CompilerPasses\AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
 
-class RegisterFieldInterfaceResolverCompilerPass extends AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass
+class RegisterFieldInterfaceResolverCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
 {
     protected function getRegistryServiceDefinition(): string
     {
@@ -18,6 +18,10 @@ class RegisterFieldInterfaceResolverCompilerPass extends AbstractInjectServiceDe
     protected function getServiceClass(): string
     {
         return FieldInterfaceResolverInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addFieldInterfaceResolver';
     }
     protected function enabled(): bool
     {

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterMandatoryDirectiveServiceTagCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterMandatoryDirectiveServiceTagCompilerPass.php
@@ -6,9 +6,9 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 
 use PoP\ComponentModel\Container\ServiceTags\MandatoryDirectiveServiceTagInterface;
 use PoP\ComponentModel\Engine\DataloadingEngineInterface;
-use PoP\Root\Container\CompilerPasses\AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
 
-class RegisterMandatoryDirectiveServiceTagCompilerPass extends AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass
+class RegisterMandatoryDirectiveServiceTagCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
 {
     protected function getRegistryServiceDefinition(): string
     {
@@ -17,5 +17,9 @@ class RegisterMandatoryDirectiveServiceTagCompilerPass extends AbstractInjectSer
     protected function getServiceClass(): string
     {
         return MandatoryDirectiveServiceTagInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addMandatoryDirectiveResolver';
     }
 }

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterModuleFilterCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterModuleFilterCompilerPass.php
@@ -6,9 +6,9 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 
 use PoP\ComponentModel\ModuleFiltering\ModuleFilterManagerInterface;
 use PoP\ComponentModel\ModuleFilters\ModuleFilterInterface;
-use PoP\Root\Container\CompilerPasses\AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
 
-class RegisterModuleFilterCompilerPass extends AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass
+class RegisterModuleFilterCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
 {
     protected function getRegistryServiceDefinition(): string
     {
@@ -17,5 +17,9 @@ class RegisterModuleFilterCompilerPass extends AbstractInjectServiceDefinitionID
     protected function getServiceClass(): string
     {
         return ModuleFilterInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addModuleFilter';
     }
 }

--- a/layers/Engine/packages/component-model/src/DataStructure/DataStructureManager.php
+++ b/layers/Engine/packages/component-model/src/DataStructure/DataStructureManager.php
@@ -9,34 +9,18 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class DataStructureManager implements DataStructureManagerInterface
 {
-    protected bool $initialized = false;
     /**
      * @var array<string, DataStructureFormatterInterface>
      */
     public array $formatters = [];
-    /**
-     * @var DataStructureFormatterInterface[]
-     */
-    public array $dataStructureFormatters = [];
-
-    protected function maybeInitialize(): void
-    {
-        if (!$this->initialized) {
-            $this->initialized = true;
-            foreach ($this->dataStructureFormatters as $formatter) {
-                $this->formatters[$formatter::getName()] = $formatter;
-            }
-        }
-    }
 
     public function addDataStructureFormatter(DataStructureFormatterInterface $formatter): void
     {
-        $this->dataStructureFormatters[] = $formatter;
+        $this->formatters[$formatter::getName()] = $formatter;
     }
 
     public function getDataStructureFormatter(string $name = null): DataStructureFormatterInterface
     {
-        $this->maybeInitialize();
         // Return the formatter if it exists
         if ($name && isset($this->formatters[$name])) {
             return $this->formatters[$name];

--- a/layers/Engine/packages/component-model/src/DataStructure/DataStructureManager.php
+++ b/layers/Engine/packages/component-model/src/DataStructure/DataStructureManager.php
@@ -6,32 +6,32 @@ namespace PoP\ComponentModel\DataStructure;
 
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\State\ApplicationState;
-use PoP\Root\Registries\AbstractServiceDefinitionIDRegistry;
 
-class DataStructureManager extends AbstractServiceDefinitionIDRegistry implements DataStructureManagerInterface
+class DataStructureManager implements DataStructureManagerInterface
 {
     protected bool $initialized = false;
     /**
      * @var array<string, DataStructureFormatterInterface>
      */
     public array $formatters = [];
+    /**
+     * @var DataStructureFormatterInterface[]
+     */
+    public array $dataStructureFormatters = [];
 
     protected function maybeInitialize(): void
     {
         if (!$this->initialized) {
             $this->initialized = true;
-            $instanceManager = InstanceManagerFacade::getInstance();
-            foreach ($this->getServiceDefinitionIDs() as $serviceDefinitionID) {
-                /** @var DataStructureFormatterInterface */
-                $service = $instanceManager->getInstance($serviceDefinitionID);
-                $this->add($service);
+            foreach ($this->dataStructureFormatters as $formatter) {
+                $this->formatters[$formatter::getName()] = $formatter;
             }
         }
     }
 
-    protected function add(DataStructureFormatterInterface $formatter): void
+    public function addDataStructureFormatter(DataStructureFormatterInterface $formatter): void
     {
-        $this->formatters[$formatter::getName()] = $formatter;
+        $this->dataStructureFormatters[] = $formatter;
     }
 
     public function getDataStructureFormatter(string $name = null): DataStructureFormatterInterface

--- a/layers/Engine/packages/component-model/src/DataStructure/DataStructureManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/DataStructure/DataStructureManagerInterface.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\DataStructure;
 
-use PoP\Root\Registries\ServiceDefinitionIDRegistryInterface;
-
-interface DataStructureManagerInterface extends ServiceDefinitionIDRegistryInterface
+interface DataStructureManagerInterface
 {
+    public function addDataStructureFormatter(DataStructureFormatterInterface $formatter): void;
     public function getDataStructureFormatter(string $name = null): DataStructureFormatterInterface;
 }

--- a/layers/Engine/packages/component-model/src/Engine/DataloadingEngine.php
+++ b/layers/Engine/packages/component-model/src/Engine/DataloadingEngine.php
@@ -4,8 +4,24 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Engine;
 
-use PoP\Root\Registries\AbstractServiceDefinitionIDRegistry;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 
-class DataloadingEngine extends AbstractServiceDefinitionIDRegistry implements DataloadingEngineInterface
+class DataloadingEngine implements DataloadingEngineInterface
 {
+    /**
+     * @var DirectiveResolverInterface[]
+     */
+    protected array $mandatoryDirectiveResolvers = [];
+
+    public function addMandatoryDirectiveResolver(DirectiveResolverInterface $directiveResolver): void
+    {
+        $this->mandatoryDirectiveResolvers[] = $directiveResolver;
+    }
+    /**
+     * @return DirectiveResolverInterface[]
+     */
+    public function getMandatoryDirectiveResolvers(): array
+    {
+        return $this->mandatoryDirectiveResolvers;
+    }
 }

--- a/layers/Engine/packages/component-model/src/Engine/DataloadingEngineInterface.php
+++ b/layers/Engine/packages/component-model/src/Engine/DataloadingEngineInterface.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Engine;
 
-use PoP\Root\Registries\ServiceDefinitionIDRegistryInterface;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 
-interface DataloadingEngineInterface extends ServiceDefinitionIDRegistryInterface
+interface DataloadingEngineInterface
 {
+    public function addMandatoryDirectiveResolver(DirectiveResolverInterface $directiveResolver): void;
+    /**
+     * @return DirectiveResolverInterface[]
+     */
+    public function getMandatoryDirectiveResolvers(): array;
 }

--- a/layers/Engine/packages/component-model/src/ModuleFiltering/ModuleFilterManager.php
+++ b/layers/Engine/packages/component-model/src/ModuleFiltering/ModuleFilterManager.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModuleFiltering;
 
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\ModuleFilters\ModuleFilterInterface;
 use PoP\ComponentModel\ModulePath\ModulePathHelpersInterface;
 use PoP\ComponentModel\ModulePath\ModulePathManagerInterface;
-use PoP\Root\Registries\AbstractServiceDefinitionIDRegistry;
 
-class ModuleFilterManager extends AbstractServiceDefinitionIDRegistry implements ModuleFilterManagerInterface
+class ModuleFilterManager implements ModuleFilterManagerInterface
 {
     public const URLPARAM_MODULEFILTER = 'modulefilter';
 
@@ -48,15 +46,13 @@ class ModuleFilterManager extends AbstractServiceDefinitionIDRegistry implements
         $this->modulePathHelpers = $modulePathHelpers;
     }
 
+    public function addModuleFilter(ModuleFilterInterface $moduleFilter): void
+    {
+        $this->modulefilters[$moduleFilter->getName()] = $moduleFilter;
+    }
+
     protected function init()
     {
-        $instanceManager = InstanceManagerFacade::getInstance();
-        foreach ($this->getServiceDefinitionIDs() as $serviceDefinitionID) {
-            /** @var ModuleFilterInterface */
-            $moduleFilter = $instanceManager->getInstance($serviceDefinitionID);
-            $this->modulefilters[$moduleFilter->getName()] = $moduleFilter;
-        }
-
         // Lazy initialize so that we can inject all the moduleFilters before checking the selected one
         $this->selected_filter_name = $this->selected_filter_name ?? $this->getSelectedModuleFilterName();
         if ($this->selected_filter_name) {

--- a/layers/Engine/packages/component-model/src/ModuleFiltering/ModuleFilterManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/ModuleFiltering/ModuleFilterManagerInterface.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModuleFiltering;
 
-use PoP\Root\Registries\ServiceDefinitionIDRegistryInterface;
+use PoP\ComponentModel\ModuleFilters\ModuleFilterInterface;
 
-interface ModuleFilterManagerInterface extends ServiceDefinitionIDRegistryInterface
+interface ModuleFilterManagerInterface
 {
+    public function addModuleFilter(ModuleFilterInterface $moduleFilter): void;
     public function getSelectedModuleFilterName(): ?string;
     public function setSelectedModuleFilterName(string $selectedModuleFilterName);
     public function getNotExcludedModuleSets();

--- a/layers/Engine/packages/component-model/src/Registries/DirectiveRegistry.php
+++ b/layers/Engine/packages/component-model/src/Registries/DirectiveRegistry.php
@@ -4,8 +4,24 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Registries;
 
-use PoP\Root\Registries\AbstractServiceDefinitionIDRegistry;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 
-class DirectiveRegistry extends AbstractServiceDefinitionIDRegistry implements DirectiveRegistryInterface
+class DirectiveRegistry implements DirectiveRegistryInterface
 {
+    /**
+     * @var DirectiveResolverInterface[]
+     */
+    protected array $directiveResolvers = [];
+
+    public function addDirectiveResolver(DirectiveResolverInterface $directiveResolver): void
+    {
+        $this->directiveResolvers[] = $directiveResolver;
+    }
+    /**
+     * @return DirectiveResolverInterface[]
+     */
+    public function getDirectiveResolvers(): array
+    {
+        return $this->directiveResolvers;
+    }
 }

--- a/layers/Engine/packages/component-model/src/Registries/DirectiveRegistryInterface.php
+++ b/layers/Engine/packages/component-model/src/Registries/DirectiveRegistryInterface.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Registries;
 
-use PoP\Root\Registries\ServiceDefinitionIDRegistryInterface;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 
-interface DirectiveRegistryInterface extends ServiceDefinitionIDRegistryInterface
+interface DirectiveRegistryInterface
 {
+    public function addDirectiveResolver(DirectiveResolverInterface $directiveResolver): void;
+    /**
+     * @return DirectiveResolverInterface[]
+     */
+    public function getDirectiveResolvers(): array;
 }

--- a/layers/Engine/packages/component-model/src/Registries/FieldInterfaceRegistry.php
+++ b/layers/Engine/packages/component-model/src/Registries/FieldInterfaceRegistry.php
@@ -4,8 +4,24 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Registries;
 
-use PoP\Root\Registries\AbstractServiceDefinitionIDRegistry;
+use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
 
-class FieldInterfaceRegistry extends AbstractServiceDefinitionIDRegistry implements FieldInterfaceRegistryInterface
+class FieldInterfaceRegistry implements FieldInterfaceRegistryInterface
 {
+    /**
+     * @var FieldInterfaceResolverInterface[]
+     */
+    protected array $fieldInterfaceResolvers = [];
+
+    public function addFieldInterfaceResolver(FieldInterfaceResolverInterface $fieldInterfaceResolver): void
+    {
+        $this->fieldInterfaceResolvers[] = $fieldInterfaceResolver;
+    }
+    /**
+     * @return FieldInterfaceResolverInterface[]
+     */
+    public function getFieldInterfaceResolvers(): array
+    {
+        return $this->fieldInterfaceResolvers;
+    }
 }

--- a/layers/Engine/packages/component-model/src/Registries/FieldInterfaceRegistryInterface.php
+++ b/layers/Engine/packages/component-model/src/Registries/FieldInterfaceRegistryInterface.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Registries;
 
-use PoP\Root\Registries\ServiceDefinitionIDRegistryInterface;
+use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
 
-interface FieldInterfaceRegistryInterface extends ServiceDefinitionIDRegistryInterface
+interface FieldInterfaceRegistryInterface
 {
+    public function addFieldInterfaceResolver(FieldInterfaceResolverInterface $fieldInterfaceResolver): void;
+    /**
+     * @return FieldInterfaceResolverInterface[]
+     */
+    public function getFieldInterfaceResolvers(): array;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -178,13 +178,11 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
         $dataloadingEngine = DataloadingEngineFacade::getInstance();
-        return array_merge(
-            array_map(
-                function ($directiveClass) use ($fieldQueryInterpreter) {
-                    return $fieldQueryInterpreter->listFieldDirective($directiveClass::getDirectiveName());
-                },
-                $dataloadingEngine->getServiceDefinitionIDs()
-            )
+        return array_map(
+            function ($directiveResolver) use ($fieldQueryInterpreter) {
+                return $fieldQueryInterpreter->listFieldDirective($directiveResolver::getDirectiveName());
+            },
+            $dataloadingEngine->getMandatoryDirectiveResolvers()
         );
     }
 

--- a/layers/Engine/packages/modulerouting/src/AbstractRouteModuleProcessorManager.php
+++ b/layers/Engine/packages/modulerouting/src/AbstractRouteModuleProcessorManager.php
@@ -4,31 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\ModuleRouting;
 
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
-use PoP\Root\Registries\AbstractServiceDefinitionIDRegistry;
-
-abstract class AbstractRouteModuleProcessorManager extends AbstractServiceDefinitionIDRegistry implements RouteModuleProcessorManagerInterface
+abstract class AbstractRouteModuleProcessorManager implements RouteModuleProcessorManagerInterface
 {
-    protected bool $initialized = false;
     /**
      * @var array<string, AbstractRouteModuleProcessor[]>
      */
     protected array $processors = [];
 
-    protected function maybeInitialize(): void
-    {
-        if (!$this->initialized) {
-            $this->initialized = true;
-            $instanceManager = InstanceManagerFacade::getInstance();
-            foreach ($this->getServiceDefinitionIDs() as $serviceDefinitionID) {
-                /** @var AbstractRouteModuleProcessor */
-                $service = $instanceManager->getInstance($serviceDefinitionID);
-                $this->add($service);
-            }
-        }
-    }
-
-    protected function add(AbstractRouteModuleProcessor $processor): void
+    public function addRouteModuleProcessor(AbstractRouteModuleProcessor $processor): void
     {
         foreach ($processor->getGroups() as $group) {
             $this->processors[$group] ??= [];
@@ -41,7 +24,6 @@ abstract class AbstractRouteModuleProcessorManager extends AbstractServiceDefini
      */
     public function getProcessors(string $group = null): array
     {
-        $this->maybeInitialize();
         $group ??= $this->getDefaultGroup();
         return $this->processors[$group] ?? array();
     }

--- a/layers/Engine/packages/modulerouting/src/Container/CompilerPasses/RegisterRouteModuleProcessorCompilerPass.php
+++ b/layers/Engine/packages/modulerouting/src/Container/CompilerPasses/RegisterRouteModuleProcessorCompilerPass.php
@@ -6,9 +6,9 @@ namespace PoP\ModuleRouting\Container\CompilerPasses;
 
 use PoP\ModuleRouting\AbstractRouteModuleProcessor;
 use PoP\ModuleRouting\RouteModuleProcessorManagerInterface;
-use PoP\Root\Container\CompilerPasses\AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
 
-class RegisterRouteModuleProcessorCompilerPass extends AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass
+class RegisterRouteModuleProcessorCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
 {
     protected function getRegistryServiceDefinition(): string
     {
@@ -17,5 +17,9 @@ class RegisterRouteModuleProcessorCompilerPass extends AbstractInjectServiceDefi
     protected function getServiceClass(): string
     {
         return AbstractRouteModuleProcessor::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addRouteModuleProcessor';
     }
 }

--- a/layers/Engine/packages/modulerouting/src/RouteModuleProcessorManagerInterface.php
+++ b/layers/Engine/packages/modulerouting/src/RouteModuleProcessorManagerInterface.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace PoP\ModuleRouting;
 
 use PoP\ModuleRouting\AbstractRouteModuleProcessor;
-use PoP\Root\Registries\ServiceDefinitionIDRegistryInterface;
 
-interface RouteModuleProcessorManagerInterface extends ServiceDefinitionIDRegistryInterface
+interface RouteModuleProcessorManagerInterface
 {
+    public function addRouteModuleProcessor(AbstractRouteModuleProcessor $processor): void;
     /**
      * @return AbstractRouteModuleProcessor[]
      */

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Container\CompilerPasses;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+abstract class AbstractInjectServiceIntoRegistryCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $containerBuilder): void
+    {
+        if (!$this->enabled()) {
+            return;
+        }
+        $registryDefinition = $containerBuilder->getDefinition($this->getRegistryServiceDefinition());
+        $definitions = $containerBuilder->getDefinitions();
+        $serviceClass = $this->getServiceClass();
+        foreach ($definitions as $definitionID => $definition) {
+            $definitionClass = $definition->getClass();
+            if (
+                $definitionClass === null
+                || !is_a(
+                    $definitionClass,
+                    $serviceClass,
+                    true
+                )
+            ) {
+                continue;
+            }
+
+            // Register the service in the corresponding registry
+            $registryDefinition->addMethodCall(
+                $this->getRegistryMethodCallName(),
+                [new Reference($definitionID)]
+            );
+        }
+    }
+
+    abstract protected function getRegistryServiceDefinition(): string;
+    abstract protected function getServiceClass(): string;
+    abstract protected function getRegistryMethodCallName(): string;
+
+    protected function enabled(): bool
+    {
+        return true;
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Blocks/WithTypeFieldControlBlockTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Blocks/WithTypeFieldControlBlockTrait.php
@@ -39,13 +39,9 @@ trait WithTypeFieldControlBlockTrait
             $namespacedTypeNameNames[$typeResolverNamespacedName] = $typeResolver->getMaybeNamespacedTypeName();
         }
         // For each interface, obtain its namespacedInterfaceName
-        $fieldInterfaceResolverClasses = $fieldInterfaceRegistry->getServiceDefinitionIDs();
+        $fieldInterfaceResolvers = $fieldInterfaceRegistry->getFieldInterfaceResolvers();
         $namespacedFieldInterfaceNameClasses = [];
-        foreach ($fieldInterfaceResolverClasses as $fieldInterfaceResolverClass) {
-            /**
-             * @var FieldInterfaceResolverInterface
-             */
-            $fieldInterfaceResolver = $instanceManager->getInstance($fieldInterfaceResolverClass);
+        foreach ($fieldInterfaceResolvers as $fieldInterfaceResolver) {
             $fieldInterfaceResolverNamespacedName = $fieldInterfaceResolver->getNamespacedInterfaceName();
             $namespacedFieldInterfaceNameClasses[$fieldInterfaceResolverNamespacedName] = $fieldInterfaceResolver->getMaybeNamespacedInterfaceName();
         }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/RegisterAccessControlRuleBlockCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/RegisterAccessControlRuleBlockCompilerPass.php
@@ -6,9 +6,9 @@ namespace GraphQLAPI\GraphQLAPI\Container\CompilerPasses;
 
 use GraphQLAPI\GraphQLAPI\Blocks\AccessControlRuleBlocks\AbstractAccessControlRuleBlock;
 use GraphQLAPI\GraphQLAPI\Registries\AccessControlRuleBlockRegistryInterface;
-use PoP\Root\Container\CompilerPasses\AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
 
-class RegisterAccessControlRuleBlockCompilerPass extends AbstractInjectServiceDefinitionIDIntoRegistryCompilerPass
+class RegisterAccessControlRuleBlockCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
 {
     protected function getRegistryServiceDefinition(): string
     {
@@ -17,5 +17,9 @@ class RegisterAccessControlRuleBlockCompilerPass extends AbstractInjectServiceDe
     protected function getServiceClass(): string
     {
         return AbstractAccessControlRuleBlock::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addAccessControlRuleBlock';
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PostTypes/GraphQLAccessControlListPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PostTypes/GraphQLAccessControlListPostType.php
@@ -7,7 +7,6 @@ namespace GraphQLAPI\GraphQLAPI\PostTypes;
 use GraphQLAPI\GraphQLAPI\Blocks\AccessControlBlock;
 use GraphQLAPI\GraphQLAPI\PostTypes\AbstractPostType;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
-use GraphQLAPI\GraphQLAPI\Blocks\AccessControlRuleBlocks\AbstractAccessControlRuleBlock;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\AccessControlRuleBlockRegistryFacade;
 
 class GraphQLAccessControlListPostType extends AbstractPostType
@@ -85,13 +84,8 @@ class GraphQLAccessControlListPostType extends AbstractPostType
          * @var AccessControlBlock
          */
         $aclBlock = $instanceManager->getInstance(AccessControlBlock::class);
-        /**
-         * @var AbstractAccessControlRuleBlock[]
-         */
-        $aclNestedBlocks = array_map(
-            fn ($serviceClass) => $instanceManager->getInstance($serviceClass),
-            AccessControlRuleBlockRegistryFacade::getInstance()->getServiceDefinitionIDs()
-        );
+        $accessControlRuleBlockRegistry = AccessControlRuleBlockRegistryFacade::getInstance();
+        $aclNestedBlocks = $accessControlRuleBlockRegistry->getAccessControlRuleBlocks();
         return array_merge(
             [
                 $aclBlock->getBlockFullName(),

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/AccessControlRuleBlockRegistry.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/AccessControlRuleBlockRegistry.php
@@ -4,8 +4,24 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Registries;
 
-use PoP\Root\Registries\AbstractServiceDefinitionIDRegistry;
+use GraphQLAPI\GraphQLAPI\Blocks\AccessControlRuleBlocks\AbstractAccessControlRuleBlock;
 
-class AccessControlRuleBlockRegistry extends AbstractServiceDefinitionIDRegistry implements AccessControlRuleBlockRegistryInterface
+class AccessControlRuleBlockRegistry implements AccessControlRuleBlockRegistryInterface
 {
+    /**
+     * @var AbstractAccessControlRuleBlock[]
+     */
+    protected array $accessControlRuleBlocks = [];
+
+    public function addAccessControlRuleBlock(AbstractAccessControlRuleBlock $accessControlRuleBlock): void
+    {
+        $this->accessControlRuleBlocks[] = $accessControlRuleBlock;
+    }
+    /**
+     * @return AbstractAccessControlRuleBlock[]
+     */
+    public function getAccessControlRuleBlocks(): array
+    {
+        return $this->accessControlRuleBlocks;
+    }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/AccessControlRuleBlockRegistryInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/AccessControlRuleBlockRegistryInterface.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Registries;
 
-use PoP\Root\Registries\ServiceDefinitionIDRegistryInterface;
+use GraphQLAPI\GraphQLAPI\Blocks\AccessControlRuleBlocks\AbstractAccessControlRuleBlock;
 
-interface AccessControlRuleBlockRegistryInterface extends ServiceDefinitionIDRegistryInterface
+interface AccessControlRuleBlockRegistryInterface
 {
+    public function addAccessControlRuleBlock(AbstractAccessControlRuleBlock $accessControlRuleBlock): void;
+    /**
+     * @return AbstractAccessControlRuleBlock[]
+     */
+    public function getAccessControlRuleBlocks(): array;
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/SchemaConfigurators/AbstractGraphQLQueryConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/SchemaConfigurators/AbstractGraphQLQueryConfigurator.php
@@ -50,7 +50,7 @@ abstract class AbstractGraphQLQueryConfigurator implements SchemaConfiguratorInt
      *
      * @return array<string, array>
      */
-    protected function getNamespacedFieldInterfaceNameResolvers(): array
+    protected function getNamespacedFieldInterfaceNameClasses(): array
     {
         if (is_null($this->namespacedFieldInterfaceNameClasses)) {
             $this->initNamespacedFieldInterfaceNameClasses();
@@ -152,7 +152,7 @@ abstract class AbstractGraphQLQueryConfigurator implements SchemaConfiguratorInt
             ];
         }
         // If it is an interface, add all the types implementing that interface!
-        $namespacedFieldInterfaceNameClasses = $this->getNamespacedFieldInterfaceNameResolvers();
+        $namespacedFieldInterfaceNameClasses = $this->getNamespacedFieldInterfaceNameClasses();
         if ($fieldInterfaceResolverClass = $namespacedFieldInterfaceNameClasses[$maybeNamespacedFieldInterfaceName] ?? null) {
             // Check `getConfigurationEntries` to understand format of each entry
             return [

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -127,12 +127,8 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
                     );
                     $directiveRegistry = DirectiveRegistryFacade::getInstance();
                     $ofTypeDirectiveResolverClasses = array_filter(
-                        $directiveRegistry->getServiceDefinitionIDs(),
-                        function ($directiveResolverClass) use ($instanceManager, $ofTypes) {
-                            /**
-                             * @var DirectiveResolverInterface
-                             */
-                            $directiveResolver = $instanceManager->getInstance($directiveResolverClass);
+                        $directiveRegistry->getDirectiveResolvers(),
+                        function ($directiveResolver) use ($ofTypes) {
                             return in_array($directiveResolver->getDirectiveType(), $ofTypes);
                         }
                     );


### PR DESCRIPTION
When injecting a service using dependency injection, we can already inject the final service, instead of the service definition ID (for which we still need to retrieve the service from the container)