### PR TITLE
bootComponents will be overriden, so execute with static, not self

### DIFF
--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -72,11 +72,11 @@ class AppLoader
      * @param string[] $componentClasses List of `Component` class to initialize
      * @return string[]
      */
-    protected static function getComponentsOrderedForInitialization(
+    final protected static function getComponentsOrderedForInitialization(
         array $componentClasses
     ): array {
         $orderedComponentClasses = [];
-        static::addComponentsOrderedForInitialization(
+        self::addComponentsOrderedForInitialization(
             $componentClasses,
             $orderedComponentClasses
         );
@@ -90,7 +90,7 @@ class AppLoader
      * @param string[] $componentClasses List of `Component` class to initialize
      * @param string[] $orderedComponentClasses List of `Component` class in order of initialization
      */
-    protected static function addComponentsOrderedForInitialization(
+    final protected static function addComponentsOrderedForInitialization(
         array $componentClasses,
         array &$orderedComponentClasses
     ): void {
@@ -106,13 +106,13 @@ class AppLoader
             self::$initializedClasses[] = $componentClass;
 
             // Initialize all depended-upon PoP components
-            static::addComponentsOrderedForInitialization(
+            self::addComponentsOrderedForInitialization(
                 $componentClass::getDependedComponentClasses(),
                 $orderedComponentClasses
             );
 
             // Initialize all depended-upon PoP conditional components, if they are installed
-            static::addComponentsOrderedForInitialization(
+            self::addComponentsOrderedForInitialization(
                 array_filter(
                     $componentClass::getDependedConditionalComponentClasses(),
                     'class_exists'
@@ -149,7 +149,7 @@ class AppLoader
         /**
          * Calculate the components in their initialization order
          */
-        $orderedComponentClasses = static::getComponentsOrderedForInitialization(
+        $orderedComponentClasses = self::getComponentsOrderedForInitialization(
             self::$componentClassesToInitialize
         );
 

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -76,7 +76,7 @@ class AppLoader
         array $componentClasses
     ): array {
         $orderedComponentClasses = [];
-        self::addComponentsOrderedForInitialization(
+        static::addComponentsOrderedForInitialization(
             $componentClasses,
             $orderedComponentClasses
         );
@@ -106,13 +106,13 @@ class AppLoader
             self::$initializedClasses[] = $componentClass;
 
             // Initialize all depended-upon PoP components
-            self::addComponentsOrderedForInitialization(
+            static::addComponentsOrderedForInitialization(
                 $componentClass::getDependedComponentClasses(),
                 $orderedComponentClasses
             );
 
             // Initialize all depended-upon PoP conditional components, if they are installed
-            self::addComponentsOrderedForInitialization(
+            static::addComponentsOrderedForInitialization(
                 array_filter(
                     $componentClass::getDependedConditionalComponentClasses(),
                     'class_exists'
@@ -149,7 +149,7 @@ class AppLoader
         /**
          * Calculate the components in their initialization order
          */
-        $orderedComponentClasses = self::getComponentsOrderedForInitialization(
+        $orderedComponentClasses = static::getComponentsOrderedForInitialization(
             self::$componentClassesToInitialize
         );
 
@@ -227,11 +227,11 @@ class AppLoader
 
         // Register CompilerPasses, Compile and Cache
         // Symfony's DependencyInjection Application Container
-        $compilerPassClasses = self::getApplicationContainerCompilerPasses();
+        $compilerPassClasses = static::getApplicationContainerCompilerPasses();
         ContainerBuilderFactory::maybeCompileAndCacheContainer($compilerPassClasses);
 
         // Finally boot the components
-        self::bootComponents();
+        static::bootComponents();
     }
 
     /**

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -227,7 +227,7 @@ class AppLoader
 
         // Register CompilerPasses, Compile and Cache
         // Symfony's DependencyInjection Application Container
-        $compilerPassClasses = static::getApplicationContainerCompilerPasses();
+        $compilerPassClasses = self::getApplicationContainerCompilerPasses();
         ContainerBuilderFactory::maybeCompileAndCacheContainer($compilerPassClasses);
 
         // Finally boot the components
@@ -237,7 +237,7 @@ class AppLoader
     /**
      * @return string[]
      */
-    protected static function getApplicationContainerCompilerPasses(): array
+    final protected static function getApplicationContainerCompilerPasses(): array
     {
         // Collect the compiler pass classes from all components
         $compilerPassClasses = [];


### PR DESCRIPTION
Fixed bug: `AppLoader` in `Engine` will override `bootComponents`, so this must be executed as `static::`, not `self::`