### PR TITLE
Fix injecting "%self%" to the container

### DIFF
--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
@@ -35,6 +35,7 @@ EOT;
          * so we must escape the dollar sign when doing %self%, or we'll
          * get an error:
          * "PHP Fatal error:  Uncaught Symfony\\Component\\DependencyInjection\\Exception\\InvalidArgumentException: The parameter "self" must be defined."
+         * @see https://symfony.com/doc/2.2/components/dependency_injection/parameters.html#parameters-in-configuration-files
          */
         $meshServiceDataPersistedFragment = <<<EOT
         --meshServices|

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
@@ -17,13 +17,6 @@ class ConfigurePersistedFragmentCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $containerBuilder): void
     {
-        /**
-         * Watch out: Symfony DI uses %...% for parameters,
-         * so we must escape the dollar sign when doing %self%, or we'll
-         * get an error:
-         * "PHP Fatal error:  Uncaught Symfony\\Component\\DependencyInjection\\Exception\\InvalidArgumentException: The parameter "self" must be defined."
-         */
-
         // 'contentMesh' persisted fragments
         // Initialization of parameters
         $githubRepo = $_REQUEST['githubRepo'] ?? 'leoloso/PoP';
@@ -37,6 +30,12 @@ class ConfigurePersistedFragmentCompilerPass implements CompilerPassInterface
             photos: "https://picsum.photos/v2/list?page=$photoPage&limit=10"
         ])@meshServices
 EOT;
+        /**
+         * Watch out: Symfony DI uses %...% for parameters,
+         * so we must escape the dollar sign when doing %self%, or we'll
+         * get an error:
+         * "PHP Fatal error:  Uncaught Symfony\\Component\\DependencyInjection\\Exception\\InvalidArgumentException: The parameter "self" must be defined."
+         */
         $meshServiceDataPersistedFragment = <<<EOT
         --meshServices|
         getAsyncJSON(getSelfProp(%%self%%, meshServices))@meshServiceData


### PR DESCRIPTION
Symfony DependencyInjection uses `%...%` for parameters, so we must [escape the dollar sign](https://symfony.com/doc/2.2/components/dependency_injection/parameters.html#parameters-in-configuration-files) when doing `%self%`, or we'll get an error:

```
PHP Fatal error:  Uncaught Symfony\\Component\\DependencyInjection\\Exception\\InvalidArgumentException: The parameter "self" must be defined.
```

Then, `%self%` becomes `%%self%%` when injecting it via the container config