### PR TITLE
Register CompilerPass in System container

### DIFF
--- a/layers/Engine/packages/component-model/config/system-services.yaml
+++ b/layers/Engine/packages/component-model/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoP\ComponentModel\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -5,13 +5,6 @@ declare(strict_types=1);
 namespace PoP\ComponentModel;
 
 use PoP\ComponentModel\Component\ApplicationEvents;
-use PoP\ComponentModel\Container\CompilerPasses\AfterBootAttachExtensionCompilerPass;
-use PoP\ComponentModel\Container\CompilerPasses\BeforeBootAttachExtensionCompilerPass;
-use PoP\ComponentModel\Container\CompilerPasses\RegisterDataStructureFormatterCompilerPass;
-use PoP\ComponentModel\Container\CompilerPasses\RegisterDirectiveResolverCompilerPass;
-use PoP\ComponentModel\Container\CompilerPasses\RegisterFieldInterfaceResolverCompilerPass;
-use PoP\ComponentModel\Container\CompilerPasses\RegisterMandatoryDirectiveServiceTagCompilerPass;
-use PoP\ComponentModel\Container\CompilerPasses\RegisterTypeResolverCompilerPass;
 use PoP\ComponentModel\Environment;
 use PoP\ComponentModel\Facades\AttachableExtensions\AttachExtensionServiceFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
@@ -62,6 +55,18 @@ class Component extends AbstractComponent
     }
 
     /**
+     * Initialize services for the system container
+     *
+     * @param array<string, mixed> $configuration
+     */
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
+    }
+
+    /**
      * Boot component
      *
      * @return void
@@ -106,23 +111,5 @@ class Component extends AbstractComponent
 
         // This value will be used in the response. If compact, make sure each JS Key is unique
         define('POP_RESPONSE_PROP_SUBMODULES', Environment::compactResponseJsonKeys() ? 'ms' : 'submodules');
-    }
-
-    /**
-     * Get all the compiler pass classes required to register on the container
-     *
-     * @return string[]
-     */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            RegisterDirectiveResolverCompilerPass::class,
-            BeforeBootAttachExtensionCompilerPass::class,
-            AfterBootAttachExtensionCompilerPass::class,
-            RegisterFieldInterfaceResolverCompilerPass::class,
-            RegisterDataStructureFormatterCompilerPass::class,
-            RegisterMandatoryDirectiveServiceTagCompilerPass::class,
-            RegisterTypeResolverCompilerPass::class,
-        ];
     }
 }

--- a/layers/Engine/packages/modulerouting/config/system-services.yaml
+++ b/layers/Engine/packages/modulerouting/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoP\ModuleRouting\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/Engine/packages/modulerouting/src/Component.php
+++ b/layers/Engine/packages/modulerouting/src/Component.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\ModuleRouting;
 
-use PoP\ModuleRouting\Container\CompilerPasses\RegisterRouteModuleProcessorCompilerPass;
 use PoP\Root\Component\AbstractComponent;
 
 /**
@@ -27,14 +26,14 @@ class Component extends AbstractComponent
     }
 
     /**
-     * Get all the compiler pass classes required to register on the container
+     * Initialize services for the system container
      *
-     * @return string[]
+     * @param array<string, mixed> $configuration
      */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            RegisterRouteModuleProcessorCompilerPass::class,
-        ];
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/root/config/system-services.yaml
+++ b/layers/Engine/packages/root/config/system-services.yaml
@@ -1,0 +1,10 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoP\Root\Registries\CompilerPassRegistryInterface:
+        class: \PoP\Root\Registries\CompilerPassRegistry
+
+    PoP\Root\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -233,34 +233,11 @@ class AppLoader
         // Register CompilerPasses, Compile and Cache
         // Symfony's DependencyInjection Application Container
         $systemCompilerPassRegistry = SystemCompilerPassRegistryFacade::getInstance();
-        $compilerPasses = $systemCompilerPassRegistry->getCompilerPasses();
-        $compilerPasses = array_merge(
-            $compilerPasses,
-            array_map(
-                fn ($class) => new $class(),
-                self::getApplicationContainerCompilerPasses()
-            )
-        );
-        ContainerBuilderFactory::maybeCompileAndCacheContainer($compilerPasses);
+        $systemCompilerPasses = $systemCompilerPassRegistry->getCompilerPasses();
+        ContainerBuilderFactory::maybeCompileAndCacheContainer($systemCompilerPasses);
 
         // Finally boot the components
         static::bootComponents();
-    }
-
-    /**
-     * @return string[]
-     */
-    final protected static function getApplicationContainerCompilerPasses(): array
-    {
-        // Collect the compiler pass classes from all components
-        $compilerPassClasses = [];
-        foreach (ComponentManager::getComponentClasses() as $componentClass) {
-            $compilerPassClasses = [
-                ...$compilerPassClasses,
-                ...$componentClass::getContainerCompilerPassClasses()
-            ];
-        }
-        return array_values(array_unique($compilerPassClasses));
     }
 
     /**

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoP\Root;
 
 use PoP\Root\Component\AbstractComponent;
-use PoP\Root\Container\CompilerPasses\AutomaticallyInstantiatedServiceCompilerPass;
 use PoP\Root\Container\ContainerBuilderFactory;
 use PoP\Root\Container\ServiceInstantiatorInterface;
 
@@ -23,6 +22,22 @@ class Component extends AbstractComponent
     {
         return [];
     }
+
+    /**
+     * Initialize services for the system container
+     *
+     * @param array<string, mixed> $configuration
+     * @param string[] $skipSchemaComponentClasses
+     */
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+
+        // Only after initializing the containerBuilder, can inject a service
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
+    }
+
     /**
      * Initialize services
      *
@@ -53,17 +68,5 @@ class Component extends AbstractComponent
          */
         $serviceInstantiator = ContainerBuilderFactory::getInstance()->get(ServiceInstantiatorInterface::class);
         $serviceInstantiator->initializeServices();
-    }
-
-    /**
-     * Get all the compiler pass classes required to register on the container
-     *
-     * @return string[]
-     */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            AutomaticallyInstantiatedServiceCompilerPass::class,
-        ];
     }
 }

--- a/layers/Engine/packages/root/src/Component/AbstractComponent.php
+++ b/layers/Engine/packages/root/src/Component/AbstractComponent.php
@@ -141,14 +141,4 @@ abstract class AbstractComponent implements ComponentInterface
     public static function afterBoot(): void
     {
     }
-
-    /**
-     * Get all the compiler pass classes required to register on the container
-     *
-     * @return string[]
-     */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [];
-    }
 }

--- a/layers/Engine/packages/root/src/Container/ContainerBuilderFactoryTrait.php
+++ b/layers/Engine/packages/root/src/Container/ContainerBuilderFactoryTrait.php
@@ -131,10 +131,10 @@ trait ContainerBuilderFactoryTrait
     /**
      * If the container is not cached, then compile it and cache it
      *
-     * @param string[] $compilerPassClasses Compiler Pass classes to register on the container
+     * @param CompilerPassInterface[] $compilerPasses Compiler Pass objects to register on the container
      */
     public static function maybeCompileAndCacheContainer(
-        array $compilerPassClasses = []
+        array $compilerPasses = []
     ): void {
         // Compile Symfony's DependencyInjection Container Builder
         // After compiling, cache it in disk for performance.
@@ -143,8 +143,8 @@ trait ContainerBuilderFactoryTrait
             /** @var ContainerBuilder */
             $containerBuilder = static::getInstance();
             // Inject all the compiler passes
-            foreach ($compilerPassClasses as $compilerPassClass) {
-                $containerBuilder->addCompilerPass(new $compilerPassClass());
+            foreach ($compilerPasses as $compilerPass) {
+                $containerBuilder->addCompilerPass($compilerPass);
             }
             // Compile the container
             $containerBuilder->compile();

--- a/layers/Engine/packages/root/src/Container/SystemCompilerPasses/RegisterSystemCompilerPassServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/SystemCompilerPasses/RegisterSystemCompilerPassServiceCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Container\SystemCompilerPasses;
+
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
+use PoP\Root\Registries\CompilerPassRegistryInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class RegisterSystemCompilerPassServiceCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
+{
+    protected function getRegistryServiceDefinition(): string
+    {
+        return CompilerPassRegistryInterface::class;
+    }
+    protected function getServiceClass(): string
+    {
+        return CompilerPassInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addCompilerPass';
+    }
+}

--- a/layers/Engine/packages/root/src/Facades/SystemCompilerPassRegistryFacade.php
+++ b/layers/Engine/packages/root/src/Facades/SystemCompilerPassRegistryFacade.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Facades;
+
+use PoP\Root\Container\SystemContainerBuilderFactory;
+use PoP\Root\Registries\CompilerPassRegistryInterface;
+
+class SystemCompilerPassRegistryFacade
+{
+    public static function getInstance(): CompilerPassRegistryInterface
+    {
+        $systemContainerBuilder = SystemContainerBuilderFactory::getInstance();
+        /**
+         * @var CompilerPassRegistryInterface
+         */
+        $service = $systemContainerBuilder->get(CompilerPassRegistryInterface::class);
+        return $service;
+    }
+}

--- a/layers/Engine/packages/root/src/Registries/CompilerPassRegistry.php
+++ b/layers/Engine/packages/root/src/Registries/CompilerPassRegistry.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Registries;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class CompilerPassRegistry implements CompilerPassRegistryInterface
+{
+    /**
+     * @var CompilerPassInterface[]
+     */
+    protected array $compilerPasses = [];
+
+    public function addCompilerPass(CompilerPassInterface $compilerPass): void
+    {
+        $this->compilerPasses[] = $compilerPass;
+    }
+    /**
+     * @return CompilerPassInterface[]
+     */
+    public function getCompilerPasses(): array
+    {
+        return $this->compilerPasses;
+    }
+}

--- a/layers/Engine/packages/root/src/Registries/CompilerPassRegistryInterface.php
+++ b/layers/Engine/packages/root/src/Registries/CompilerPassRegistryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Registries;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+interface CompilerPassRegistryInterface
+{
+    public function addCompilerPass(CompilerPassInterface $compilerPass): void;
+    /**
+     * @return CompilerPassInterface[]
+     */
+    public function getCompilerPasses(): array;
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    GraphQLAPI\GraphQLAPI\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI;
 
-use GraphQLAPI\GraphQLAPI\Container\CompilerPasses\ConfigureAccessControlCompilerPass;
-use GraphQLAPI\GraphQLAPI\Container\CompilerPasses\RegisterAccessControlRuleBlockCompilerPass;
 use GraphQLAPI\GraphQLAPI\Facades\ModuleRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\CacheFunctionalityModuleResolver;
@@ -131,6 +129,18 @@ class Component extends AbstractComponent
         }
     }
 
+    /**
+     * Initialize services for the system container
+     *
+     * @param array<string, mixed> $configuration
+     */
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
+    }
+
     protected static function initComponentConfiguration(): void
     {
         /**
@@ -162,18 +172,5 @@ class Component extends AbstractComponent
         (new PersistedQuerySchemaConfiguratorExecuter())->init();
         (new EndpointSchemaConfiguratorExecuter())->init();
         (new EditingPersistedQuerySchemaConfiguratorExecuter())->init();
-    }
-
-    /**
-     * Get all the compiler pass classes required to register on the container
-     *
-     * @return string[]
-     */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            RegisterAccessControlRuleBlockCompilerPass::class,
-            ConfigureAccessControlCompilerPass::class,
-        ];
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/config/system-services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-server/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    GraphQLByPoP\GraphQLServer\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -10,7 +10,6 @@ use GraphQLByPoP\GraphQLRequest\ComponentConfiguration as GraphQLRequestComponen
 use GraphQLByPoP\GraphQLServer\ComponentConfiguration;
 use GraphQLByPoP\GraphQLServer\Configuration\MutationSchemes;
 use GraphQLByPoP\GraphQLServer\Configuration\Request;
-use GraphQLByPoP\GraphQLServer\Container\CompilerPasses\ConfigureGraphQLPersistedQueryCompilerPass;
 use GraphQLByPoP\GraphQLServer\Environment;
 use PoP\AccessControl\ComponentConfiguration as AccessControlComponentConfiguration;
 use PoP\API\ComponentConfiguration as APIComponentConfiguration;
@@ -129,20 +128,22 @@ class Component extends AbstractComponent
         }
     }
 
+    /**
+     * Initialize services for the system container
+     *
+     * @param array<string, mixed> $configuration
+     */
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        if (self::isEnabled()) {
+            parent::initializeSystemContainerServices($configuration);
+            self::initYAMLSystemContainerServices(dirname(__DIR__));
+        }
+    }
+
     protected static function resolveEnabled()
     {
         return GraphQLRequestComponent::isEnabled();
-    }
-
-    /**
-     * Get all the compiler pass classes required to register on the container
-     *
-     * @return string[]
-     */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigureGraphQLPersistedQueryCompilerPass::class,
-        ];
     }
 }

--- a/layers/Misc/packages/examples-for-pop/config/system-services.yaml
+++ b/layers/Misc/packages/examples-for-pop/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    Leoloso\ExamplesForPoP\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/Misc/packages/examples-for-pop/src/Component.php
+++ b/layers/Misc/packages/examples-for-pop/src/Component.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Leoloso\ExamplesForPoP;
 
-use Leoloso\ExamplesForPoP\Container\CompilerPasses\ConfigurePersistedFragmentCompilerPass;
-use Leoloso\ExamplesForPoP\Container\CompilerPasses\ConfigurePersistedQueryCompilerPass;
 use PoP\ComponentModel\ComponentConfiguration as ComponentModelComponentConfiguration;
 use PoP\Root\Component\AbstractComponent;
 
@@ -50,15 +48,14 @@ class Component extends AbstractComponent
     }
 
     /**
-     * Get all the compiler pass classes required to register on the container
+     * Initialize services for the system container
      *
-     * @return string[]
+     * @param array<string, mixed> $configuration
      */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigurePersistedFragmentCompilerPass::class,
-            ConfigurePersistedQueryCompilerPass::class,
-        ];
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/translate-directive-acl/config/services.yaml
+++ b/layers/Schema/packages/translate-directive-acl/config/services.yaml
@@ -1,1 +1,0 @@
-services:

--- a/layers/Schema/packages/translate-directive-acl/config/system-services.yaml
+++ b/layers/Schema/packages/translate-directive-acl/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoPSchema\TranslateDirectiveACL\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/Schema/packages/translate-directive-acl/src/Component.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Component.php
@@ -6,7 +6,6 @@ namespace PoPSchema\TranslateDirectiveACL;
 
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\CanDisableComponentTrait;
-use PoPSchema\TranslateDirectiveACL\Container\CompilerPasses\ConfigureAccessControlCompilerPass;
 use PoPSchema\UserRolesAccessControl\Component as UserRolesAccessControlComponent;
 
 /**
@@ -32,36 +31,21 @@ class Component extends AbstractComponent
     }
 
     /**
-     * Initialize services
+     * Initialize services for the system container
      *
      * @param array<string, mixed> $configuration
-     * @param string[] $skipSchemaComponentClasses
      */
-    protected static function initializeContainerServices(
-        array $configuration = [],
-        bool $skipSchema = false,
-        array $skipSchemaComponentClasses = []
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-            self::initYAMLServices(dirname(__DIR__));
+            parent::initializeSystemContainerServices($configuration);
+            self::initYAMLSystemContainerServices(dirname(__DIR__));
         }
     }
 
     protected static function resolveEnabled()
     {
         return UserRolesAccessControlComponent::isEnabled();
-    }
-
-    /**
-     * Get all the compiler pass classes required to register on the container
-     *
-     * @return string[]
-     */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigureAccessControlCompilerPass::class,
-        ];
     }
 }

--- a/layers/Schema/packages/translate-directive/config/services.yaml
+++ b/layers/Schema/packages/translate-directive/config/services.yaml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        public: true
+        autowire: true
+
     PoPSchema\TranslateDirective\Translation\TranslationServiceInterface:
         class: \PoPSchema\TranslateDirective\Translation\TranslationService
-        public: true

--- a/layers/Schema/packages/translate-directive/config/system-services.yaml
+++ b/layers/Schema/packages/translate-directive/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoPSchema\TranslateDirective\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/Schema/packages/translate-directive/src/Component.php
+++ b/layers/Schema/packages/translate-directive/src/Component.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoPSchema\TranslateDirective;
 
 use PoP\Root\Component\AbstractComponent;
-use PoPSchema\TranslateDirective\Container\CompilerPasses\ConfigureTranslationServiceCompilerPass;
 
 /**
  * Initialize component
@@ -46,14 +45,14 @@ class Component extends AbstractComponent
     }
 
     /**
-     * Get all the compiler pass classes required to register on the container
+     * Initialize services for the system container
      *
-     * @return string[]
+     * @param array<string, mixed> $configuration
      */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigureTranslationServiceCompilerPass::class,
-        ];
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/user-roles-acl/config/services.yaml
+++ b/layers/Schema/packages/user-roles-acl/config/services.yaml
@@ -1,1 +1,0 @@
-services:

--- a/layers/Schema/packages/user-roles-acl/config/system-services.yaml
+++ b/layers/Schema/packages/user-roles-acl/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoPSchema\UserRolesACL\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/Schema/packages/user-roles-acl/src/Component.php
+++ b/layers/Schema/packages/user-roles-acl/src/Component.php
@@ -7,7 +7,6 @@ namespace PoPSchema\UserRolesACL;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Component\CanDisableComponentTrait;
 use PoPSchema\UserRolesAccessControl\Component as UserRolesAccessControlComponent;
-use PoPSchema\UserRolesACL\Container\CompilerPasses\ConfigureAccessControlCompilerPass;
 
 /**
  * Initialize component
@@ -30,37 +29,22 @@ class Component extends AbstractComponent
         ];
     }
 
-    /**
-     * Initialize services
-     *
-     * @param array<string, mixed> $configuration
-     * @param string[] $skipSchemaComponentClasses
-     */
-    protected static function initializeContainerServices(
-        array $configuration = [],
-        bool $skipSchema = false,
-        array $skipSchemaComponentClasses = []
-    ): void {
-        if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-            self::initYAMLServices(dirname(__DIR__));
-        }
-    }
-
     protected static function resolveEnabled()
     {
         return UserRolesAccessControlComponent::isEnabled();
     }
 
     /**
-     * Get all the compiler pass classes required to register on the container
+     * Initialize services for the system container
      *
-     * @return string[]
+     * @param array<string, mixed> $configuration
      */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigureAccessControlCompilerPass::class,
-        ];
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        if (self::isEnabled()) {
+            parent::initializeSystemContainerServices($configuration);
+            self::initYAMLSystemContainerServices(dirname(__DIR__));
+        }
     }
 }

--- a/layers/SiteBuilder/packages/application/config/system-services.yaml
+++ b/layers/SiteBuilder/packages/application/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoP\Application\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/SiteBuilder/packages/application/src/Component.php
+++ b/layers/SiteBuilder/packages/application/src/Component.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\Application;
 
-use PoP\Application\Container\CompilerPasses\ConfigureDefinitionCompilerPass;
 use PoP\Root\Component\AbstractComponent;
 
 /**
@@ -52,14 +51,14 @@ class Component extends AbstractComponent
     }
 
     /**
-     * Get all the compiler pass classes required to register on the container
+     * Initialize services for the system container
      *
-     * @return string[]
+     * @param array<string, mixed> $configuration
      */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigureDefinitionCompilerPass::class,
-        ];
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/definitionpersistence/config/services.yaml
+++ b/layers/SiteBuilder/packages/definitionpersistence/config/services.yaml
@@ -1,10 +1,14 @@
 services:
-    file_definition_persistence:
-        class: \PoP\DefinitionPersistence\FileDefinitionPersistence
+    _defaults:
         public: true
-        arguments:
-            $fileStore: '@json_file_store'
-            $file: '@definition_persistence_file'
+        autowire: true
 
     definition_persistence_file:
         class: \PoP\DefinitionPersistence\DefinitionPersistenceFile
+        public: false
+
+    file_definition_persistence:
+        class: \PoP\DefinitionPersistence\FileDefinitionPersistence
+        arguments:
+            $fileStore: '@json_file_store'
+            $file: '@definition_persistence_file'

--- a/layers/SiteBuilder/packages/definitionpersistence/config/system-services.yaml
+++ b/layers/SiteBuilder/packages/definitionpersistence/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoP\DefinitionPersistence\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\DefinitionPersistence;
 
-use PoP\DefinitionPersistence\Container\CompilerPasses\ConfigureDefinitionPersistenceCompilerPass;
 use PoP\Root\Component\AbstractComponent;
 
 /**
@@ -47,14 +46,14 @@ class Component extends AbstractComponent
     }
 
     /**
-     * Get all the compiler pass classes required to register on the container
+     * Initialize services for the system container
      *
-     * @return string[]
+     * @param array<string, mixed> $configuration
      */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigureDefinitionPersistenceCompilerPass::class,
-        ];
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/site/config/system-services.yaml
+++ b/layers/SiteBuilder/packages/site/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    PoP\Site\Container\CompilerPasses\:
+        resource: '../src/Container/CompilerPasses/*'

--- a/layers/SiteBuilder/packages/site/src/Component.php
+++ b/layers/SiteBuilder/packages/site/src/Component.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoP\Site;
 
 use PoP\Root\Component\AbstractComponent;
-use PoP\Site\Container\CompilerPasses\ConfigureDefinitionCompilerPass;
 
 /**
  * Initialize component
@@ -42,14 +41,14 @@ class Component extends AbstractComponent
     }
 
     /**
-     * Get all the compiler pass classes required to register on the container
+     * Initialize services for the system container
      *
-     * @return string[]
+     * @param array<string, mixed> $configuration
      */
-    public static function getContainerCompilerPassClasses(): array
-    {
-        return [
-            ConfigureDefinitionCompilerPass::class,
-        ];
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }


### PR DESCRIPTION
Instead of having each `Component` register `CompilerPass`es via `getContainerCompilerPassClasses`, these are injected into the System container via `system-services.yaml`