### PR TITLE
Remove COMPONENT_DIR const

### DIFF
--- a/layers/API/packages/api-clients/src/Component.php
+++ b/layers/API/packages/api-clients/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/API/packages/api-endpoints/src/Component.php
+++ b/layers/API/packages/api-endpoints/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/API/packages/api-graphql/src/Component.php
+++ b/layers/API/packages/api-graphql/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/API/packages/api-rest/src/Component.php
+++ b/layers/API/packages/api-rest/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/API/packages/api/src/Component.php
+++ b/layers/API/packages/api/src/Component.php
@@ -16,9 +16,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    public static $COMPONENT_DIR;
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -84,13 +81,12 @@ class Component extends AbstractComponent
         if (self::isEnabled()) {
             parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
-            self::$COMPONENT_DIR = dirname(__DIR__);
-            self::initYAMLServices(self::$COMPONENT_DIR);
-            self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+            self::initYAMLServices(dirname(__DIR__));
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
             // Conditional packages
             if (class_exists('\PoP\AccessControl\Component')) {
-                self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/AccessControl');
+                self::initYAMLServices(dirname(__DIR__), '/Conditional/AccessControl');
             }
             if (
                 class_exists('\PoP\CacheControl\Component')
@@ -99,7 +95,7 @@ class Component extends AbstractComponent
                 && !in_array(\PoP\AccessControl\Component::class, $skipSchemaComponentClasses)
                 && AccessControlComponentConfiguration::canSchemaBePrivate()
             ) {
-                self::maybeInitPHPSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema');
+                self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema');
             }
         }
     }

--- a/layers/Engine/packages/access-control/src/Component.php
+++ b/layers/Engine/packages/access-control/src/Component.php
@@ -15,10 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -46,9 +42,8 @@ class Component extends AbstractComponent
         if (self::isEnabled()) {
             parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
-            self::$COMPONENT_DIR = dirname(__DIR__);
-            self::initYAMLServices(self::$COMPONENT_DIR);
-            self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+            self::initYAMLServices(dirname(__DIR__));
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
         }
     }
 

--- a/layers/Engine/packages/cache-control/src/Component.php
+++ b/layers/Engine/packages/cache-control/src/Component.php
@@ -14,8 +14,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Engine/packages/guzzle-helpers/src/Component.php
+++ b/layers/Engine/packages/guzzle-helpers/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Engine/packages/modulerouting/src/Component.php
+++ b/layers/Engine/packages/modulerouting/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Engine/packages/routing/src/Component.php
+++ b/layers/Engine/packages/routing/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Engine/packages/translation/src/Component.php
+++ b/layers/Engine/packages/translation/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/GraphQLByPoP/packages/graphql-request/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-request/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -25,10 +25,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -95,26 +91,25 @@ class Component extends AbstractComponent
         if (self::isEnabled()) {
             parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
-            self::$COMPONENT_DIR = dirname(__DIR__);
-            self::initYAMLServices(self::$COMPONENT_DIR);
-            self::initYAMLServices(self::$COMPONENT_DIR, '/Overrides');
-            self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+            self::initYAMLServices(dirname(__DIR__));
+            self::initYAMLServices(dirname(__DIR__), '/Overrides');
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
             // Boot conditional on having variables treated as expressions for @export directive
             if (GraphQLQueryComponentConfiguration::enableVariablesAsExpressions()) {
-                self::maybeInitPHPSchemaServices(self::$COMPONENT_DIR, $skipSchema, '/ConditionalOnEnvironment/VariablesAsExpressions');
+                self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/VariablesAsExpressions');
             }
             // Boot conditional on having embeddable fields
             if (APIComponentConfiguration::enableEmbeddableFields()) {
-                self::maybeInitPHPSchemaServices(self::$COMPONENT_DIR, $skipSchema, '/ConditionalOnEnvironment/EmbeddableFields');
+                self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/EmbeddableFields');
             }
             // The @export directive depends on the Multiple Query Execution being enabled
             if (GraphQLRequestComponentConfiguration::enableMultipleQueryExecution()) {
-                self::maybeInitPHPSchemaServices(self::$COMPONENT_DIR, $skipSchema, '/ConditionalOnEnvironment/MultipleQueryExecution');
+                self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/MultipleQueryExecution');
             }
             // Attach @removeIfNull?
             if (ComponentConfiguration::enableRemoveIfNullDirective()) {
-                self::maybeInitPHPSchemaServices(self::$COMPONENT_DIR, $skipSchema, '/ConditionalOnEnvironment/RemoveIfNull');
+                self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/RemoveIfNull');
             }
             if (
                 class_exists('\PoP\CacheControl\Component')
@@ -123,7 +118,7 @@ class Component extends AbstractComponent
                 && !in_array(\PoP\AccessControl\Component::class, $skipSchemaComponentClasses)
                 && AccessControlComponentConfiguration::canSchemaBePrivate()
             ) {
-                self::maybeInitPHPSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema');
+                self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema');
             }
         }
     }

--- a/layers/Misc/packages/examples-for-pop/src/Component.php
+++ b/layers/Misc/packages/examples-for-pop/src/Component.php
@@ -12,8 +12,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public const VERSION = '0.2.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/categories/src/Component.php
+++ b/layers/Schema/packages/categories/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -62,9 +58,8 @@ class Component extends AbstractComponent
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::initYAMLServices(dirname(__DIR__));
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
         if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
             self::initYAMLServices(dirname(__DIR__), '/Conditional/API');
         }

--- a/layers/Schema/packages/comment-mutations/src/Component.php
+++ b/layers/Schema/packages/comment-mutations/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -40,7 +36,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/commentmeta-wp/src/Component.php
+++ b/layers/Schema/packages/commentmeta-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/commentmeta/src/Component.php
+++ b/layers/Schema/packages/commentmeta/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/comments/src/Component.php
+++ b/layers/Schema/packages/comments/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -60,22 +56,21 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::initYAMLServices(dirname(__DIR__));
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
         if (
             class_exists('\PoP\RESTAPI\Component')
             && !in_array(\PoP\RESTAPI\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/RESTAPI');
+            self::initYAMLServices(dirname(__DIR__), '/Conditional/RESTAPI');
         }
 
         if (
             class_exists('\PoPSchema\Users\Component')
             && !in_array(\PoPSchema\Users\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/Users');
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/Users');
         }
     }
 }

--- a/layers/Schema/packages/custompostmedia-mutations/src/Component.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -40,8 +36,7 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::initYAMLServices(dirname(__DIR__));
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/custompostmedia-wp/src/Component.php
+++ b/layers/Schema/packages/custompostmedia-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/custompostmeta-wp/src/Component.php
+++ b/layers/Schema/packages/custompostmeta-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/custompostmeta/src/Component.php
+++ b/layers/Schema/packages/custompostmeta/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/events-wp-em/src/Component.php
+++ b/layers/Schema/packages/events-wp-em/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/events/src/Component.php
+++ b/layers/Schema/packages/events/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -63,26 +59,25 @@ class Component extends AbstractComponent
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::initYAMLServices(dirname(__DIR__));
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
         if (
             class_exists('\PoPSchema\Tags\Component')
             && !in_array(\PoPSchema\Tags\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/Tags');
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/Tags');
         }
 
         if (
             class_exists('\PoPSchema\Users\Component')
             && !in_array(\PoPSchema\Users\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/Users');
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/Users');
         }
 
         if (Environment::addEventTypeToCustomPostUnionTypes()) {
-            self::maybeInitPHPSchemaServices(self::$COMPONENT_DIR, $skipSchema, '/ConditionalOnEnvironment/AddEventTypeToCustomPostUnionTypes');
+            self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddEventTypeToCustomPostUnionTypes');
         }
     }
 }

--- a/layers/Schema/packages/everythingelse-wp/src/Component.php
+++ b/layers/Schema/packages/everythingelse-wp/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -52,13 +48,11 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-
         if (
             class_exists('\PoPSchema\CustomPosts\Component')
             && !in_array(\PoPSchema\CustomPosts\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/CustomPosts');
+            self::initYAMLServices(dirname(__DIR__), '/Conditional/CustomPosts');
         }
     }
 }

--- a/layers/Schema/packages/everythingelse/src/Component.php
+++ b/layers/Schema/packages/everythingelse/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -48,7 +44,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/locationposts/src/Component.php
+++ b/layers/Schema/packages/locationposts/src/Component.php
@@ -12,10 +12,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -53,8 +49,7 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
         if (Environment::addLocationPostTypeToCustomPostUnionTypes()) {
             self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddLocationPostTypeToCustomPostUnionTypes');
@@ -64,14 +59,14 @@ class Component extends AbstractComponent
             class_exists('\PoPSchema\Tags\Component')
             && !in_array(\PoPSchema\Tags\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/Tags');
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/Tags');
         }
 
         if (
             class_exists('\PoPSchema\Users\Component')
             && !in_array(\PoPSchema\Users\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/Users');
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/Users');
         }
     }
 }

--- a/layers/Schema/packages/locations-wp-em/src/Component.php
+++ b/layers/Schema/packages/locations-wp-em/src/Component.php
@@ -14,8 +14,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/media/src/Component.php
+++ b/layers/Schema/packages/media/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -61,14 +57,13 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
         if (
             class_exists('\PoPSchema\Users\Component')
             && !in_array(\PoPSchema\Users\Component::class, $skipSchemaComponentClasses)
         ) {
-            self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/Users');
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/Users');
         }
     }
 }

--- a/layers/Schema/packages/meta/src/Component.php
+++ b/layers/Schema/packages/meta/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/metaquery-wp/src/Component.php
+++ b/layers/Schema/packages/metaquery-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/metaquery/src/Component.php
+++ b/layers/Schema/packages/metaquery/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/notifications-wp/src/Component.php
+++ b/layers/Schema/packages/notifications-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/post-mutations/src/Component.php
+++ b/layers/Schema/packages/post-mutations/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -40,7 +36,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/post-tags/src/Component.php
+++ b/layers/Schema/packages/post-tags/src/Component.php
@@ -13,10 +13,6 @@ use PoP\Definitions\Facades\DefinitionManagerFacade;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -65,8 +61,7 @@ class Component extends AbstractComponent
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
         if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
             self::initYAMLServices(dirname(__DIR__), '/Conditional/API');
         }

--- a/layers/Schema/packages/posts/src/Component.php
+++ b/layers/Schema/packages/posts/src/Component.php
@@ -13,10 +13,6 @@ use PoP\Definitions\Facades\DefinitionManagerFacade;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -65,8 +61,7 @@ class Component extends AbstractComponent
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
         if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
             self::initYAMLServices(dirname(__DIR__), '/Conditional/API');
@@ -76,9 +71,9 @@ class Component extends AbstractComponent
         }
 
         if (class_exists('\PoPSchema\Users\Component')) {
-            self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/Users');
+            self::initYAMLServices(dirname(__DIR__), '/Conditional/Users');
             if (!in_array(\PoPSchema\Users\Component::class, $skipSchemaComponentClasses)) {
-                self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/Users');
+                self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/Users');
             }
             if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
                 self::initYAMLServices(dirname(__DIR__), '/Conditional/Users/Conditional/API');
@@ -89,7 +84,7 @@ class Component extends AbstractComponent
         }
 
         if (ComponentConfiguration::addPostTypeToCustomPostUnionTypes()) {
-            self::maybeInitPHPSchemaServices(self::$COMPONENT_DIR, $skipSchema, '/ConditionalOnEnvironment/AddPostTypeToCustomPostUnionTypes');
+            self::maybeInitPHPSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddPostTypeToCustomPostUnionTypes');
         }
     }
 

--- a/layers/Schema/packages/queriedobject-wp/src/Component.php
+++ b/layers/Schema/packages/queriedobject-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/tags/src/Component.php
+++ b/layers/Schema/packages/tags/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/taxonomies/src/Component.php
+++ b/layers/Schema/packages/taxonomies/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/taxonomymeta-wp/src/Component.php
+++ b/layers/Schema/packages/taxonomymeta-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/taxonomymeta/src/Component.php
+++ b/layers/Schema/packages/taxonomymeta/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/taxonomyquery-wp/src/Component.php
+++ b/layers/Schema/packages/taxonomyquery-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/taxonomyquery/src/Component.php
+++ b/layers/Schema/packages/taxonomyquery/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/translate-directive-acl/src/Component.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/translate-directive/src/Component.php
+++ b/layers/Schema/packages/translate-directive/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -40,8 +36,7 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
+        self::initYAMLServices(dirname(__DIR__));
     }
 
     /**

--- a/layers/Schema/packages/user-roles-access-control/src/Component.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Component.php
@@ -15,9 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    public static $COMPONENT_DIR;
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -56,15 +53,14 @@ class Component extends AbstractComponent
     ): void {
         if (self::isEnabled()) {
             parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-            self::$COMPONENT_DIR = dirname(__DIR__);
-            self::initYAMLServices(self::$COMPONENT_DIR);
-            self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+            self::initYAMLServices(dirname(__DIR__));
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
             if (
                 class_exists('\PoP\CacheControl\Component')
                 && !in_array(\PoP\CacheControl\Component::class, $skipSchemaComponentClasses)
             ) {
-                self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/CacheControl');
+                self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/CacheControl');
             }
         }
     }

--- a/layers/Schema/packages/user-roles-acl/src/Component.php
+++ b/layers/Schema/packages/user-roles-acl/src/Component.php
@@ -15,8 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/user-state-access-control/src/Component.php
+++ b/layers/Schema/packages/user-state-access-control/src/Component.php
@@ -15,9 +15,6 @@ class Component extends AbstractComponent
 {
     use CanDisableComponentTrait;
 
-    public static $COMPONENT_DIR;
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -56,16 +53,15 @@ class Component extends AbstractComponent
     ): void {
         if (self::isEnabled()) {
             parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-            self::$COMPONENT_DIR = dirname(__DIR__);
-            self::initYAMLServices(self::$COMPONENT_DIR);
-            self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+            self::initYAMLServices(dirname(__DIR__));
+            self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
             // Init conditional on API package being installed
             if (
                 class_exists('\PoP\CacheControl\Component')
                 && !in_array(\PoP\CacheControl\Component::class, $skipSchemaComponentClasses)
             ) {
-                self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/CacheControl');
+                self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/CacheControl');
             }
         }
     }

--- a/layers/Schema/packages/user-state-mutations/src/Component.php
+++ b/layers/Schema/packages/user-state-mutations/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -39,7 +35,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/usermeta-wp/src/Component.php
+++ b/layers/Schema/packages/usermeta-wp/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/usermeta/src/Component.php
+++ b/layers/Schema/packages/usermeta/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Schema/packages/users/src/Component.php
+++ b/layers/Schema/packages/users/src/Component.php
@@ -13,10 +13,6 @@ use PoP\Definitions\Facades\DefinitionManagerFacade;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -65,9 +61,8 @@ class Component extends AbstractComponent
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::initYAMLServices(dirname(__DIR__));
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
 
         if (class_exists('\PoP\API\Component') && \PoP\API\Component::isEnabled()) {
             self::initYAMLServices(dirname(__DIR__), '/Conditional/API');
@@ -77,14 +72,14 @@ class Component extends AbstractComponent
         }
 
         if (class_exists('\PoPSchema\CustomPosts\Component')) {
-            self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/CustomPosts');
+            self::initYAMLServices(dirname(__DIR__), '/Conditional/CustomPosts');
             if (!in_array(\PoPSchema\CustomPosts\Component::class, $skipSchemaComponentClasses)) {
-                self::maybeInitYAMLSchemaServices(Component::$COMPONENT_DIR, $skipSchema, '/Conditional/CustomPosts');
+                self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema, '/Conditional/CustomPosts');
                 if (
                     class_exists('\PoP\RESTAPI\Component')
                     && !in_array(\PoP\RESTAPI\Component::class, $skipSchemaComponentClasses)
                 ) {
-                    self::initYAMLServices(Component::$COMPONENT_DIR, '/Conditional/CustomPosts/Conditional/RESTAPI');
+                    self::initYAMLServices(dirname(__DIR__), '/Conditional/CustomPosts/Conditional/RESTAPI');
                 }
             }
         }

--- a/layers/SiteBuilder/packages/application-wp/src/Component.php
+++ b/layers/SiteBuilder/packages/application-wp/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -40,7 +36,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
+        self::initYAMLServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/multisite/src/Component.php
+++ b/layers/SiteBuilder/packages/multisite/src/Component.php
@@ -11,10 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -39,8 +35,7 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
-        self::maybeInitYAMLSchemaServices(self::$COMPONENT_DIR, $skipSchema);
+        self::initYAMLServices(dirname(__DIR__));
+        self::maybeInitYAMLSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/SiteBuilder/packages/resourceloader/src/Component.php
+++ b/layers/SiteBuilder/packages/resourceloader/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/SiteBuilder/packages/resources/src/Component.php
+++ b/layers/SiteBuilder/packages/resources/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    // const VERSION = '0.1.0';
-
     /**
      * Classes from PoP components that must be initialized before this component
      *

--- a/layers/Wassup/packages/wassup/src/Component.php
+++ b/layers/Wassup/packages/wassup/src/Component.php
@@ -11,8 +11,6 @@ use PoP\Root\Component\AbstractComponent;
  */
 class Component extends AbstractComponent
 {
-    public static $COMPONENT_DIR;
-
     /**
      * Classes from PoP components that must be initialized before this component
      *
@@ -96,8 +94,7 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-        self::$COMPONENT_DIR = dirname(__DIR__);
-        self::initYAMLServices(self::$COMPONENT_DIR);
-        self::initYAMLServices(self::$COMPONENT_DIR, '/Overrides');
+        self::initYAMLServices(dirname(__DIR__));
+        self::initYAMLServices(dirname(__DIR__), '/Overrides');
     }
 }


### PR DESCRIPTION
Since flattening the dependency injection config files, there's no need to pass `COMPONENT_DIR` to some conditional config file anymore