### PR TITLE
Removed version parameter from service config

### DIFF
--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -1,6 +1,3 @@
-parameters:
-    version: '0.1.0'
-
 services:
     _defaults:
         public: true
@@ -40,8 +37,6 @@ services:
 
     PoP\ComponentModel\Info\ApplicationInfoInterface:
         class: \PoP\ComponentModel\Info\ApplicationInfo
-        arguments:
-            $version: '%version%'
 
     PoP\ComponentModel\ModuleFiltering\ModuleFilterManagerInterface:
         class: '\PoP\ComponentModel\ModuleFiltering\ModuleFilterManager'

--- a/layers/Engine/packages/component-model/src/Info/ApplicationInfo.php
+++ b/layers/Engine/packages/component-model/src/Info/ApplicationInfo.php
@@ -10,14 +10,12 @@ class ApplicationInfo implements ApplicationInfoInterface
 {
     private string $version;
 
-    public function __construct(string $version)
+    /**
+     * Inject the version from the environment
+     */
+    public function __construct()
     {
-        $this->version = $version;
-
-        // If the version is provided by environment var, then use that one
-        if ($version = Environment::getApplicationVersion()) {
-            $this->version = $version;
-        }
+        $this->version = Environment::getApplicationVersion() ?? '';
     }
 
     public function getVersion(): string

--- a/layers/Engine/packages/component-model/src/State/ApplicationState.php
+++ b/layers/Engine/packages/component-model/src/State/ApplicationState.php
@@ -59,9 +59,10 @@ class ApplicationState
             array_map('strtolower', $_REQUEST[Params::ACTIONS]) : [];
         $scheme = strtolower($_REQUEST[Params::SCHEME] ?? '');
         // The version could possibly be set from outside
+        $appVersion = ApplicationInfoFacade::getInstance()->getVersion();
         $version = Environment::enableVersionByParams() ?
-            $_REQUEST[Params::VERSION] ?? ApplicationInfoFacade::getInstance()->getVersion()
-            : ApplicationInfoFacade::getInstance()->getVersion();
+            ($_REQUEST[Params::VERSION] ?? $appVersion)
+            : $appVersion;
 
         $outputs = (array) HooksAPIFacade::getInstance()->applyFilters(
             'ApplicationState:outputs',

--- a/layers/Engine/packages/field-query/config/services.yaml
+++ b/layers/Engine/packages/field-query/config/services.yaml
@@ -1,6 +1,3 @@
-parameters:
-    version: '0.1.0'
-
 services:
     _defaults:
         public: true

--- a/layers/Engine/packages/query-parsing/config/services.yaml
+++ b/layers/Engine/packages/query-parsing/config/services.yaml
@@ -1,6 +1,3 @@
-parameters:
-    version: '0.1.0'
-
 services:
     _defaults:
         public: true

--- a/layers/Schema/packages/categories/config/services.yaml
+++ b/layers/Schema/packages/categories/config/services.yaml
@@ -1,6 +1,3 @@
-parameters:
-    version: '0.1.0'
-
 services:
     _defaults:
         public: true

--- a/layers/Schema/packages/comments/config/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/comments/config/Conditional/RESTAPI/services.yaml
@@ -1,6 +1,3 @@
-parameters:
-    version: '0.1.0'
-
 services:
     _defaults:
         public: true

--- a/layers/Schema/packages/users/config/Conditional/CustomPosts/services.yaml
+++ b/layers/Schema/packages/users/config/Conditional/CustomPosts/services.yaml
@@ -1,6 +1,3 @@
-parameters:
-    version: '0.1.0'
-
 services:
     _defaults:
         public: true

--- a/layers/SiteBuilder/packages/component-model-configuration/config/services.yaml
+++ b/layers/SiteBuilder/packages/component-model-configuration/config/services.yaml
@@ -1,6 +1,3 @@
-parameters:
-    version: '0.1.0'
-
 services:
     _defaults:
         public: true


### PR DESCRIPTION
We were setting `version: '0.1.0'` in the service config. It's been removen whenever not used, and taken from ENV only when needed, from from the service config.