### PR TITLE
Cast limit to int

### DIFF
--- a/layers/Schema/packages/customposts-wp/src/TypeAPIs/CustomPostTypeAPI.php
+++ b/layers/Schema/packages/customposts-wp/src/TypeAPIs/CustomPostTypeAPI.php
@@ -151,7 +151,7 @@ class CustomPostTypeAPI implements CustomPostTypeAPIInterface
         if (isset($query['limit'])) {
             // Maybe restrict the limit, if higher than the max limit
             // Allow to not limit by max when querying from within the application
-            $limit = $query['limit'];
+            $limit = (int) $query['limit'];
             if (!isset($options['skip-max-limit']) || !$options['skip-max-limit']) {
                 $limit = TypeAPIUtils::getLimitOrMaxLimit(
                     $limit,

--- a/layers/Schema/packages/events-wp-em/src/TypeAPIs/EventTypeAPI.php
+++ b/layers/Schema/packages/events-wp-em/src/TypeAPIs/EventTypeAPI.php
@@ -111,7 +111,7 @@ class EventTypeAPI extends CustomPostTypeAPI implements EventTypeAPIInterface
         $this->maybeFilterDataloadQueryArgs($query, $options);
 
         // To bring all results, limit is 0, not -1
-        if (isset($query['limit']) && $query['limit'] == -1) {
+        if (isset($query['limit']) && (int) $query['limit'] == -1) {
             $query['limit'] = 0;
         }
         $return_type = $options['return-type'] ?? null;

--- a/layers/Schema/packages/migrate-comments-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
+++ b/layers/Schema/packages/migrate-comments-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
@@ -81,7 +81,7 @@ class FunctionAPI extends \PoPSchema\Comments\FunctionAPI_Base
         }
         // For the comments, if there's no limit then it brings all results
         if (isset($query['limit'])) {
-            $query['number'] = $query['limit'];
+            $query['number'] = (int) $query['limit'];
             unset($query['limit']);
         }
         if (isset($query['search'])) {

--- a/layers/Schema/packages/migrate-media-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
+++ b/layers/Schema/packages/migrate-media-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
@@ -56,7 +56,7 @@ class FunctionAPI extends \PoPSchema\Media\FunctionAPI_Base
         if (isset($query['limit'])) {
             // Maybe restrict the limit, if higher than the max limit
             // Allow to not limit by max when querying from within the application
-            $limit = $query['limit'];
+            $limit = (int) $query['limit'];
             if (!isset($options['skip-max-limit']) || !$options['skip-max-limit']) {
                 $limit = TypeAPIUtils::getLimitOrMaxLimit(
                     $limit,

--- a/layers/Schema/packages/migrate-tags-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
+++ b/layers/Schema/packages/migrate-tags-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
@@ -116,7 +116,7 @@ abstract class AbstractFunctionAPI extends \PoPSchema\Taxonomies\WP\FunctionAPI 
         if (isset($query['limit'])) {
             // Maybe restrict the limit, if higher than the max limit
             // Allow to not limit by max when querying from within the application
-            $limit = $query['limit'];
+            $limit = (int) $query['limit'];
             if (!isset($options['skip-max-limit']) || !$options['skip-max-limit']) {
                 $limit = TypeAPIUtils::getLimitOrMaxLimit(
                     $limit,

--- a/layers/Schema/packages/migrate-users-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
+++ b/layers/Schema/packages/migrate-users-wp/migrate/contractimplementations/cms-apis/cms-functionapi.php
@@ -163,7 +163,7 @@ class FunctionAPI extends \PoPSchema\Users\FunctionAPI_Base
         if (isset($query['limit'])) {
             // Maybe restrict the limit, if higher than the max limit
             // Allow to not limit by max when querying from within the application
-            $limit = $query['limit'];
+            $limit = (int) $query['limit'];
             if (!isset($options['skip-max-limit']) || !$options['skip-max-limit']) {
                 $limit = TypeAPIUtils::getLimitOrMaxLimit(
                     $limit,


### PR DESCRIPTION
`$query["limit"]` takes the value from URL param: `?limit=...`, and in this case, it will be a string, not an int.

Then, calling function `TypeAPIUtils::getLimitOrMaxLimit` explodes:

```
Fatal error: Uncaught TypeError: Argument 1 passed to PoPSchema\QueriedObject\TypeAPIs\TypeAPIUtils::getLimitOrMaxLimit() must be of the type int or null, string given, called in /user/GitRepos/CodeCommit/Sites/PoPAPIDemoCloudways/vendor/pop-schema/customposts-wp/src/TypeAPIs/CustomPostTypeAPI.php on line 158 and defined in /user/GitRepos/CodeCommit/Sites/PoPAPIDemoCloudways/vendor/pop-schema/queriedobject/src/TypeAPIs/TypeAPIUtils.php:20
Stack trace:
#0 /user/GitRepos/CodeCommit/Sites/PoPAPIDemoCloudways/vendor/pop-schema/customposts-wp/src/TypeAPIs/CustomPostTypeAPI.php(158): PoPSchema\QueriedObject\TypeAPIs\TypeAPIUtils::getLimitOrMaxLimit('3', -1)
#1 /user/GitRepos/CodeCommit/Sites/PoPAPIDemoCloudways/vendor/pop-schema/customposts-wp/src/TypeAPIs/CustomPostTypeAPI.php(54): PoPSchema\CustomPostsWP\TypeAPIs\CustomPostTypeAPI->convertCustomPostsQuery(Array, Array)
#2 /user/GitRepos/CodeCommit/Sites/PoPAPIDemoCloudways/vendor/pop-schema/customposts/src/TypeDataLoaders/AbstractCustomPostTypeDataLoader.php(61): PoPSchema\Cu in /user/GitRepos/CodeCommit/Sites/PoPAPIDemoCloudways/vendor/pop-schema/queriedobject/src/TypeAPIs/TypeAPIUtils.php on line 20
```

This PR fixes the issue