### PR TITLE
Bumped PHPStan to 0.12.76+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "johnpbloch/wordpress": ">=5.5",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",

--- a/layers/API/packages/api-graphql/composer.json
+++ b/layers/API/packages/api-graphql/composer.json
@@ -20,7 +20,7 @@
         "getpop/migrate-api-graphql": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/API/packages/api-mirrorquery/composer.json
+++ b/layers/API/packages/api-mirrorquery/composer.json
@@ -19,7 +19,7 @@
         "getpop/api": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/API/packages/api-rest/composer.json
+++ b/layers/API/packages/api-rest/composer.json
@@ -19,7 +19,7 @@
         "getpop/api-mirrorquery": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/API/packages/api/composer.json
+++ b/layers/API/packages/api/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "getpop/access-control": "^0.8",
         "getpop/cache-control": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/access-control/composer.json
+++ b/layers/Engine/packages/access-control/composer.json
@@ -20,7 +20,7 @@
         "getpop/engine": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/cache-control/composer.json
+++ b/layers/Engine/packages/cache-control/composer.json
@@ -19,7 +19,7 @@
         "getpop/mandatory-directives-by-configuration": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/component-model/composer.json
+++ b/layers/Engine/packages/component-model/composer.json
@@ -26,7 +26,7 @@
         "symfony/expression-language": "^5.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/configurable-schema-feedback/composer.json
+++ b/layers/Engine/packages/configurable-schema-feedback/composer.json
@@ -19,7 +19,7 @@
         "getpop/mandatory-directives-by-configuration": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/definitions/composer.json
+++ b/layers/Engine/packages/definitions/composer.json
@@ -19,7 +19,7 @@
         "getpop/root": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/engine/composer.json
+++ b/layers/Engine/packages/engine/composer.json
@@ -26,7 +26,7 @@
         "psr/cache": "^1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/field-query/composer.json
+++ b/layers/Engine/packages/field-query/composer.json
@@ -20,7 +20,7 @@
         "getpop/query-parsing": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/filestore/composer.json
+++ b/layers/Engine/packages/filestore/composer.json
@@ -19,7 +19,7 @@
         "getpop/root": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/function-fields/composer.json
+++ b/layers/Engine/packages/function-fields/composer.json
@@ -19,7 +19,7 @@
         "getpop/engine": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/guzzle-helpers/composer.json
+++ b/layers/Engine/packages/guzzle-helpers/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "~6.3"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/hooks/composer.json
+++ b/layers/Engine/packages/hooks/composer.json
@@ -19,7 +19,7 @@
         "getpop/translation": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/loosecontracts/composer.json
+++ b/layers/Engine/packages/loosecontracts/composer.json
@@ -19,7 +19,7 @@
         "getpop/hooks": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
@@ -19,7 +19,7 @@
         "getpop/component-model": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/modulerouting/composer.json
+++ b/layers/Engine/packages/modulerouting/composer.json
@@ -19,7 +19,7 @@
         "getpop/root": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/query-parsing/composer.json
+++ b/layers/Engine/packages/query-parsing/composer.json
@@ -19,7 +19,7 @@
         "getpop/root": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/root/composer.json
+++ b/layers/Engine/packages/root/composer.json
@@ -24,7 +24,7 @@
         "symfony/yaml": "^5.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/routing/composer.json
+++ b/layers/Engine/packages/routing/composer.json
@@ -20,7 +20,7 @@
         "getpop/definitions": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/trace-tools/composer.json
+++ b/layers/Engine/packages/trace-tools/composer.json
@@ -20,7 +20,7 @@
         "obsidian/polyfill-hrtime": "^0.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/translation/composer.json
+++ b/layers/Engine/packages/translation/composer.json
@@ -19,7 +19,7 @@
         "getpop/root": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/GraphQLAPIForWP/packages/markdown-convertor/composer.json
+++ b/layers/GraphQLAPIForWP/packages/markdown-convertor/composer.json
@@ -20,7 +20,7 @@
         "getpop/engine": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/convert-case-directives": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "squizlabs/php_codesniffer": "^3.0"
     },

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -45,7 +45,7 @@
         "pop-schema/user-state-mutations-wp": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/composer.json
@@ -19,7 +19,7 @@
         "getpop/configurable-schema-feedback": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "squizlabs/php_codesniffer": "^3.0"
     },

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
@@ -21,7 +21,7 @@
         "graphql-by-pop/graphql-server": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0",

--- a/layers/GraphQLByPoP/packages/graphql-query/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-query/composer.json
@@ -22,7 +22,7 @@
         "graphql-by-pop/graphql-parser": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/GraphQLByPoP/packages/graphql-request/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-request/composer.json
@@ -19,7 +19,7 @@
         "graphql-by-pop/graphql-query": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/GraphQLByPoP/packages/graphql-server/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-server/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "getpop/access-control": "^0.8",
         "getpop/cache-control": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Misc/packages/examples-for-pop/composer.json
+++ b/layers/Misc/packages/examples-for-pop/composer.json
@@ -28,7 +28,7 @@
         "pop-schema/cdn-directive": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/basic-directives/composer.json
+++ b/layers/Schema/packages/basic-directives/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/schema-commons": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/categories/composer.json
+++ b/layers/Schema/packages/categories/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "getpop/api": "^0.8",
         "getpop/api-rest": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/cdn-directive/composer.json
+++ b/layers/Schema/packages/cdn-directive/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/basic-directives": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/comment-mutations/composer.json
+++ b/layers/Schema/packages/comment-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/user-state-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/commentmeta/composer.json
+++ b/layers/Schema/packages/commentmeta/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/migrate-commentmeta": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/comments/composer.json
+++ b/layers/Schema/packages/comments/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/migrate-comments": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/convert-case-directives/composer.json
+++ b/layers/Schema/packages/convert-case-directives/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/basic-directives": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/custompost-mutations/composer.json
+++ b/layers/Schema/packages/custompost-mutations/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/user-state-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/custompostmedia-mutations/composer.json
+++ b/layers/Schema/packages/custompostmedia-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/custompostmedia": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/custompostmedia/composer.json
+++ b/layers/Schema/packages/custompostmedia/composer.json
@@ -22,7 +22,7 @@
         "pop-schema/migrate-custompostmedia": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/custompostmeta/composer.json
+++ b/layers/Schema/packages/custompostmeta/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/migrate-custompostmeta": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/customposts/composer.json
+++ b/layers/Schema/packages/customposts/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/migrate-customposts": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/event-mutations-wp-em/composer.json
+++ b/layers/Schema/packages/event-mutations-wp-em/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/event-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/event-mutations/composer.json
+++ b/layers/Schema/packages/event-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/events": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/events/composer.json
+++ b/layers/Schema/packages/events/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "pop-schema/users": "^0.8",
         "pop-schema/tags": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/everythingelse/composer.json
+++ b/layers/Schema/packages/everythingelse/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/migrate-everythingelse": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/generic-customposts/composer.json
+++ b/layers/Schema/packages/generic-customposts/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/customposts": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/google-translate-directive-for-customposts/composer.json
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/customposts": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/google-translate-directive/composer.json
+++ b/layers/Schema/packages/google-translate-directive/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/translate-directive": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/highlights/composer.json
+++ b/layers/Schema/packages/highlights/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/customposts": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/locationposts/composer.json
+++ b/layers/Schema/packages/locationposts/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "pop-schema/users": "^0.8",
         "pop-schema/tags": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/locations/composer.json
+++ b/layers/Schema/packages/locations/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/migrate-locations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/media/composer.json
+++ b/layers/Schema/packages/media/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "pop-schema/users": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/menus/composer.json
+++ b/layers/Schema/packages/menus/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/schema-commons": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/meta/composer.json
+++ b/layers/Schema/packages/meta/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/migrate-meta": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/metaquery/composer.json
+++ b/layers/Schema/packages/metaquery/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/migrate-metaquery": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/notifications/composer.json
+++ b/layers/Schema/packages/notifications/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "pop-schema/customposts": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/pages/composer.json
+++ b/layers/Schema/packages/pages/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "getpop/api": "^0.8",
         "getpop/api-rest": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/post-mutations/composer.json
+++ b/layers/Schema/packages/post-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/posts": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/post-tags/composer.json
+++ b/layers/Schema/packages/post-tags/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "getpop/api": "^0.8",
         "getpop/api-rest": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/posts/composer.json
+++ b/layers/Schema/packages/posts/composer.json
@@ -23,7 +23,7 @@
         "getpop/api": "^0.8",
         "getpop/api-rest": "^0.8",
         "pop-schema/users": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/queriedobject/composer.json
+++ b/layers/Schema/packages/queriedobject/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/migrate-queriedobject": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/schema-commons/composer.json
+++ b/layers/Schema/packages/schema-commons/composer.json
@@ -19,7 +19,7 @@
         "getpop/engine": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/stances/composer.json
+++ b/layers/Schema/packages/stances/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/customposts": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/tags/composer.json
+++ b/layers/Schema/packages/tags/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/migrate-tags": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/taxonomies/composer.json
+++ b/layers/Schema/packages/taxonomies/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/migrate-taxonomies": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/taxonomymeta/composer.json
+++ b/layers/Schema/packages/taxonomymeta/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/migrate-taxonomymeta": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/taxonomyquery/composer.json
+++ b/layers/Schema/packages/taxonomyquery/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/migrate-taxonomyquery": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/translate-directive-acl/composer.json
+++ b/layers/Schema/packages/translate-directive-acl/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/user-roles-access-control": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/translate-directive/composer.json
+++ b/layers/Schema/packages/translate-directive/composer.json
@@ -20,7 +20,7 @@
         "getpop/guzzle-helpers": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/user-roles-access-control/composer.json
+++ b/layers/Schema/packages/user-roles-access-control/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "getpop/cache-control": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/user-roles-acl/composer.json
+++ b/layers/Schema/packages/user-roles-acl/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/user-roles-access-control": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/user-roles/composer.json
+++ b/layers/Schema/packages/user-roles/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/users": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/user-state-access-control/composer.json
+++ b/layers/Schema/packages/user-state-access-control/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "getpop/cache-control": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/user-state-mutations/composer.json
+++ b/layers/Schema/packages/user-state-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/user-state": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/user-state/composer.json
+++ b/layers/Schema/packages/user-state/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/users": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/usermeta/composer.json
+++ b/layers/Schema/packages/usermeta/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/migrate-usermeta": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Schema/packages/users/composer.json
+++ b/layers/Schema/packages/users/composer.json
@@ -23,7 +23,7 @@
         "pop-schema/customposts": "^0.8",
         "getpop/api": "^0.8",
         "getpop/api-rest": "^0.8",
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/application/composer.json
+++ b/layers/SiteBuilder/packages/application/composer.json
@@ -22,7 +22,7 @@
         "getpop/definitionpersistence": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/component-model-configuration/composer.json
+++ b/layers/SiteBuilder/packages/component-model-configuration/composer.json
@@ -20,7 +20,7 @@
         "getpop/engine": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/definitionpersistence/composer.json
+++ b/layers/SiteBuilder/packages/definitionpersistence/composer.json
@@ -21,7 +21,7 @@
         "getpop/component-model": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/definitions-base36/composer.json
+++ b/layers/SiteBuilder/packages/definitions-base36/composer.json
@@ -19,7 +19,7 @@
         "getpop/definitions": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/definitions-emoji/composer.json
+++ b/layers/SiteBuilder/packages/definitions-emoji/composer.json
@@ -19,7 +19,7 @@
         "getpop/definitions": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/multisite/composer.json
+++ b/layers/SiteBuilder/packages/multisite/composer.json
@@ -19,7 +19,7 @@
         "getpop/engine": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/resourceloader/composer.json
+++ b/layers/SiteBuilder/packages/resourceloader/composer.json
@@ -19,7 +19,7 @@
         "getpop/resources": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/resources/composer.json
+++ b/layers/SiteBuilder/packages/resources/composer.json
@@ -19,7 +19,7 @@
         "getpop/component-model-configuration": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/site/composer.json
+++ b/layers/SiteBuilder/packages/site/composer.json
@@ -21,7 +21,7 @@
         "getpop/resourceloader": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/spa/composer.json
+++ b/layers/SiteBuilder/packages/spa/composer.json
@@ -19,7 +19,7 @@
         "getpop/application": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/SiteBuilder/packages/static-site-generator/composer.json
+++ b/layers/SiteBuilder/packages/static-site-generator/composer.json
@@ -20,7 +20,7 @@
         "getpop/migrate-static-site-generator": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/comment-mutations/composer.json
+++ b/layers/Wassup/packages/comment-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/comment-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/contactus-mutations/composer.json
+++ b/layers/Wassup/packages/contactus-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-sites-wassup/form-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/contactuser-mutations/composer.json
+++ b/layers/Wassup/packages/contactuser-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-sites-wassup/form-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/custompost-mutations/composer.json
+++ b/layers/Wassup/packages/custompost-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/custompostmedia-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/custompostlink-mutations/composer.json
+++ b/layers/Wassup/packages/custompostlink-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-sites-wassup/custompost-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/event-mutations/composer.json
+++ b/layers/Wassup/packages/event-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/event-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/eventlink-mutations/composer.json
+++ b/layers/Wassup/packages/eventlink-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-sites-wassup/event-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/everythingelse-mutations/composer.json
+++ b/layers/Wassup/packages/everythingelse-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/everythingelse": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/flag-mutations/composer.json
+++ b/layers/Wassup/packages/flag-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-sites-wassup/form-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/form-mutations/composer.json
+++ b/layers/Wassup/packages/form-mutations/composer.json
@@ -19,7 +19,7 @@
         "getpop/component-model": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/gravityforms-mutations/composer.json
+++ b/layers/Wassup/packages/gravityforms-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-sites-wassup/form-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/highlight-mutations/composer.json
+++ b/layers/Wassup/packages/highlight-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-sites-wassup/custompost-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/location-mutations/composer.json
+++ b/layers/Wassup/packages/location-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/locations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/locationpost-mutations/composer.json
+++ b/layers/Wassup/packages/locationpost-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/locationposts": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/locationpostlink-mutations/composer.json
+++ b/layers/Wassup/packages/locationpostlink-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-sites-wassup/locationpost-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/newsletter-mutations/composer.json
+++ b/layers/Wassup/packages/newsletter-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-sites-wassup/form-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/notification-mutations/composer.json
+++ b/layers/Wassup/packages/notification-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/user-state": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/post-mutations/composer.json
+++ b/layers/Wassup/packages/post-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-schema/post-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/postlink-mutations/composer.json
+++ b/layers/Wassup/packages/postlink-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-sites-wassup/post-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/share-mutations/composer.json
+++ b/layers/Wassup/packages/share-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-sites-wassup/form-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/socialnetwork-mutations/composer.json
+++ b/layers/Wassup/packages/socialnetwork-mutations/composer.json
@@ -21,7 +21,7 @@
         "pop-schema/user-state": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/stance-mutations/composer.json
+++ b/layers/Wassup/packages/stance-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-sites-wassup/custompost-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/system-mutations/composer.json
+++ b/layers/Wassup/packages/system-mutations/composer.json
@@ -19,7 +19,7 @@
         "getpop/component-model": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/user-state-mutations/composer.json
+++ b/layers/Wassup/packages/user-state-mutations/composer.json
@@ -19,7 +19,7 @@
         "pop-schema/user-state-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/volunteer-mutations/composer.json
+++ b/layers/Wassup/packages/volunteer-mutations/composer.json
@@ -20,7 +20,7 @@
         "pop-sites-wassup/form-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Wassup/packages/wassup/composer.json
+++ b/layers/Wassup/packages/wassup/composer.json
@@ -74,7 +74,7 @@
         "pop-sites-wassup/everythingelse-mutations": "^0.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12, <0.12.70",
+        "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "rector/rector": "^0.9",
         "squizlabs/php_codesniffer": "^3.0"


### PR DESCRIPTION
Bump PHPStan, because otherwise Rector is stuck to v0.9.28, and it [throws errors when downgrading code to generate the plugin](https://github.com/leoloso/PoP/actions/runs/591307201).