### PR TITLE
Register Module Resolvers in System Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ composer.lock
 !/composer.lock
 /wordpress/
 .lando.local.yml
-layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp
+composer.json.tmp

--- a/.lando.yml
+++ b/.lando.yml
@@ -17,8 +17,6 @@ services:
         - >-
           layers/GraphQLAPIForWP/plugins/graphql-api-for-wp:/app/wordpress/wp-content/plugins/graphql-api
         - >-
-          layers/GraphQLAPIForWP/plugins/convert-case-directives:/app/wordpress/wp-content/plugins/graphql-api-convert-case-directives
-        - >-
           layers/GraphQLAPIForWP/packages/markdown-convertor:/app/wordpress/wp-content/plugins/graphql-api/vendor/graphql-api/markdown-convertor
         - >-
           layers/Engine/packages/access-control:/app/wordpress/wp-content/plugins/graphql-api/vendor/getpop/access-control
@@ -268,6 +266,10 @@ services:
           layers/Schema/packages/users:/app/wordpress/wp-content/plugins/graphql-api/vendor/pop-schema/users
         - >-
           layers/Schema/packages/users-wp:/app/wordpress/wp-content/plugins/graphql-api/vendor/pop-schema/users-wp
+        - >-
+          layers/GraphQLAPIForWP/plugins/convert-case-directives:/app/wordpress/wp-content/plugins/graphql-api-convert-case-directives
+        - >-
+          layers/Schema/packages/convert-case-directives:/app/wordpress/wp-content/plugins/graphql-api/vendor/pop-schema/convert-case-directives
     run:
       - >-
         wp config create --dbname=wordpress --dbuser=wordpress

--- a/.lando.yml
+++ b/.lando.yml
@@ -17,6 +17,8 @@ services:
         - >-
           layers/GraphQLAPIForWP/plugins/graphql-api-for-wp:/app/wordpress/wp-content/plugins/graphql-api
         - >-
+          layers/GraphQLAPIForWP/plugins/convert-case-directives:/app/wordpress/wp-content/plugins/graphql-api-convert-case-directives
+        - >-
           layers/GraphQLAPIForWP/packages/markdown-convertor:/app/wordpress/wp-content/plugins/graphql-api/vendor/graphql-api/markdown-convertor
         - >-
           layers/Engine/packages/access-control:/app/wordpress/wp-content/plugins/graphql-api/vendor/getpop/access-control

--- a/composer.json
+++ b/composer.json
@@ -635,13 +635,13 @@
         "symlink-vendor-for-graphql-api-for-wp-plugin": [
             "php -r \"copy('layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json', 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp');\"",
             "vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json",
-            "composer install --working-dir=layers/GraphQLAPIForWP/plugins/graphql-api-for-wp",
+            "composer install --no-dev --working-dir=layers/GraphQLAPIForWP/plugins/graphql-api-for-wp",
             "php -r \"copy('layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp', 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json');\""
         ],
         "symlink-vendor-for-graphql-api-convert-case-directives-plugin": [
             "php -r \"copy('layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json', 'layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json.tmp');\"",
             "vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json",
-            "composer install --working-dir=layers/GraphQLAPIForWP/plugins/convert-case-directives",
+            "composer install --no-dev --working-dir=layers/GraphQLAPIForWP/plugins/convert-case-directives",
             "php -r \"copy('layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json.tmp', 'layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json');\""
         ],
         "log-server-errors": "lando logs -t -f | grep \"error\"",

--- a/composer.json
+++ b/composer.json
@@ -645,7 +645,7 @@
             "php -r \"copy('layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json.tmp', 'layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json');\""
         ],
         "log-server-errors": "lando logs -t -f | grep \"error\"",
-        "rebuild-server": "lando rebuild -y",
+        "rebuild-server": "lando rebuild appserver -y",
         "merge-monorepo": "monorepo-builder merge --ansi",
         "propagate-monorepo": "monorepo-builder propagate --ansi",
         "validate-monorepo": "monorepo-builder validate --ansi",

--- a/composer.json
+++ b/composer.json
@@ -628,11 +628,21 @@
         ],
         "init-server": "@start-server",
         "start-server": [
+            "@symlink-vendor-for-graphql-api-for-wp-plugin",
+            "@symlink-vendor-for-graphql-api-convert-case-directives-plugin",
+            "lando start"
+        ],
+        "symlink-vendor-for-graphql-api-for-wp-plugin": [
             "php -r \"copy('layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json', 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp');\"",
             "vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json",
             "composer install --working-dir=layers/GraphQLAPIForWP/plugins/graphql-api-for-wp",
-            "php -r \"copy('layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp', 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json');\"",
-            "lando start"
+            "php -r \"copy('layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp', 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json');\""
+        ],
+        "symlink-vendor-for-graphql-api-convert-case-directives-plugin": [
+            "php -r \"copy('layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json', 'layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json.tmp');\"",
+            "vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json",
+            "composer install --working-dir=layers/GraphQLAPIForWP/plugins/convert-case-directives",
+            "php -r \"copy('layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json.tmp', 'layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json');\""
         ],
         "log-server-errors": "lando logs -t -f | grep \"error\"",
         "rebuild-server": "lando rebuild -y",
@@ -654,6 +664,8 @@
         "build-server": "Initialize the Lando webserver with the 'GraphQL API for WordPress' demo site, for development. To be executed only the first time",
         "init-server": "Alias of 'start-server",
         "start-server": "Start the Lando webserver with the 'GraphQL API for WordPress' demo site, for development",
+        "symlink-vendor-for-graphql-api-for-wp-plugin": "Install vendor dependencies for the \"GraphQL API\" plugin, symlinking them to local folders in the monorepo",
+        "symlink-vendor-for-graphql-api-convert-case-directives-plugin": "Install vendor dependencies for the \"Convert Case Directives\" plugin, symlinking them to local folders in the monorepo",
         "log-server-errors": "Show (on real time) the errors from the Lando webserver",
         "rebuild-server": "Rebuild the Lando webserver",
         "validate-monorepo": "Validate that version constraints for dependencies are the same for all packages",

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -56,13 +56,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 

--- a/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
+++ b/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
@@ -10,4 +10,5 @@ Author: Leonardo Losoviz
 use PoP\Engine\AppLoader;
 
 // Initialize PoP Engine through the Bootloader
+AppLoader::bootSystem();
 AppLoader::bootApplication();

--- a/layers/Engine/packages/hooks-wp/src/Component.php
+++ b/layers/Engine/packages/hooks-wp/src/Component.php
@@ -40,13 +40,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         // The same services injected into the application are injected into the system container
         self::initYAMLSystemContainerServices(dirname(__DIR__), '', 'services.yaml');
     }

--- a/layers/Engine/packages/modulerouting/src/Component.php
+++ b/layers/Engine/packages/modulerouting/src/Component.php
@@ -25,13 +25,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -51,22 +51,38 @@ class AppLoader
      * Add Component classes to be initialized
      *
      * @param string[] $componentClasses List of `Component` class to initialize
-     * @param array<string, mixed> $componentClassConfiguration [key]: Component class, [value]: Configuration
-     * @param string[] $skipSchemaComponentClasses List of `Component` class which must not initialize their Schema services
      */
     public static function addComponentClassesToInitialize(
-        array $componentClasses,
-        array $componentClassConfiguration = [],
-        array $skipSchemaComponentClasses = []
+        array $componentClasses
     ): void {
         self::$componentClassesToInitialize = array_merge(
             self::$componentClassesToInitialize,
             $componentClasses
         );
+    }
+
+    /**
+     * Add configuration for the Component classes
+     *
+     * @param array<string, mixed> $componentClassConfiguration [key]: Component class, [value]: Configuration
+     */
+    public static function addComponentClassConfiguration(
+        array $componentClassConfiguration = []
+    ): void {
         self::$componentClassConfiguration = array_merge_recursive(
             self::$componentClassConfiguration,
             $componentClassConfiguration
         );
+    }
+
+    /**
+     * Add schema Component classes to skip initializing
+     *
+     * @param string[] $skipSchemaComponentClasses List of `Component` class which must not initialize their Schema services
+     */
+    public static function addSchemaComponentClassesToSkip(
+        array $skipSchemaComponentClasses = []
+    ): void {
         self::$skipSchemaComponentClasses = array_merge(
             self::$skipSchemaComponentClasses,
             $skipSchemaComponentClasses

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -200,10 +200,27 @@ class AppLoader
         foreach (self::$orderedComponentClasses as $componentClass) {
             $componentClass::initializeSystem();
         }
-        $systemCompilerPasses = [
-            new RegisterSystemCompilerPassServiceCompilerPass(),
-        ];
+        $systemCompilerPasses = array_map(
+            fn ($class) => new $class(),
+            self::getSystemContainerCompilerPasses()
+        );
         SystemContainerBuilderFactory::maybeCompileAndCacheContainer($systemCompilerPasses);
+    }
+
+    /**
+     * @return string[]
+     */
+    final protected static function getSystemContainerCompilerPasses(): array
+    {
+        // Collect the compiler pass classes from all components
+        $compilerPassClasses = [];
+        foreach (self::$orderedComponentClasses as $componentClass) {
+            $compilerPassClasses = [
+                ...$compilerPassClasses,
+                ...$componentClass::getSystemContainerCompilerPassClasses()
+            ];
+        }
+        return array_values(array_unique($compilerPassClasses));
     }
 
     /**

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -156,15 +156,6 @@ class AppLoader
         );
 
         /**
-         * Allow each component to customize the configuration for itself,
-         * and for its depended-upon components.
-         * Hence this is executed from bottom to top
-         */
-        foreach (array_reverse($orderedComponentClasses) as $componentClass) {
-            $componentClass::customizeComponentClassConfiguration(self::$componentClassConfiguration);
-        }
-
-        /**
          * Register all components in the ComponentManager
          */
         foreach ($orderedComponentClasses as $componentClass) {
@@ -187,15 +178,21 @@ class AppLoader
          * Application Container services.
          */
         foreach ($orderedComponentClasses as $componentClass) {
-            $componentConfiguration = self::$componentClassConfiguration[$componentClass] ?? [];
-            $componentClass::initializeSystem(
-                $componentConfiguration
-            );
+            $componentClass::initializeSystem();
         }
         $systemCompilerPasses = [
             new RegisterSystemCompilerPassServiceCompilerPass(),
         ];
         SystemContainerBuilderFactory::maybeCompileAndCacheContainer($systemCompilerPasses);
+
+        /**
+         * Allow each component to customize the configuration for itself,
+         * and for its depended-upon components.
+         * Hence this is executed from bottom to top
+         */
+        foreach (array_reverse($orderedComponentClasses) as $componentClass) {
+            $componentClass::customizeComponentClassConfiguration(self::$componentClassConfiguration);
+        }
 
         /**
          * Register all components in the ComponentManager

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -228,9 +228,14 @@ class AppLoader
      *
      * 1. Initialize the Application Container, have all Components inject services, and compile it
      * 2. Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components, for them to execute any custom extra logic
+     *
+     * @param boolean|null $cacheContainerConfiguration Indicate if to cache the container. If null, it gets the value from ENV
+     * @param boolean|null $namespace Provide the namespace, to regenerate the cache whenever the application is upgraded. If null, it gets the value from ENV
      */
-    public static function bootApplication(): void
-    {
+    public static function bootApplication(
+        ?bool $cacheContainerConfiguration = null,
+        ?string $containerNamespace = null
+    ): void {
         /**
          * Allow each component to customize the configuration for itself,
          * and for its depended-upon components.

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -25,14 +25,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
-     * @param string[] $skipSchemaComponentClasses
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
 
         // Only after initializing the containerBuilder, can inject a service
         self::initYAMLSystemContainerServices(dirname(__DIR__));

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -7,6 +7,7 @@ namespace PoP\Root;
 use PoP\Root\Component\AbstractComponent;
 use PoP\Root\Container\ContainerBuilderFactory;
 use PoP\Root\Container\ServiceInstantiatorInterface;
+use PoP\Root\Container\SystemCompilerPasses\RegisterSystemCompilerPassServiceCompilerPass;
 
 /**
  * Initialize component
@@ -21,6 +22,18 @@ class Component extends AbstractComponent
     public static function getDependedComponentClasses(): array
     {
         return [];
+    }
+
+    /**
+     * Compiler Passes for the System Container
+     *
+     * @return string[]
+     */
+    public static function getSystemContainerCompilerPassClasses(): array
+    {
+        return [
+            RegisterSystemCompilerPassServiceCompilerPass::class,
+        ];
     }
 
     /**

--- a/layers/Engine/packages/root/src/Component/AbstractComponent.php
+++ b/layers/Engine/packages/root/src/Component/AbstractComponent.php
@@ -87,6 +87,16 @@ abstract class AbstractComponent implements ComponentInterface
     }
 
     /**
+     * Compiler Passes for the System Container
+     *
+     * @return string[]
+     */
+    public static function getSystemContainerCompilerPassClasses(): array
+    {
+        return [];
+    }
+
+    /**
      * Initialize services
      *
      * @param array<string, mixed> $configuration

--- a/layers/Engine/packages/root/src/Component/AbstractComponent.php
+++ b/layers/Engine/packages/root/src/Component/AbstractComponent.php
@@ -45,23 +45,17 @@ abstract class AbstractComponent implements ComponentInterface
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    final public static function initializeSystem(
-        array $configuration = []
-    ): void {
-        static::initializeSystemContainerServices($configuration);
+    final public static function initializeSystem(): void
+    {
+        static::initializeSystemContainerServices();
     }
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
+    protected static function initializeSystemContainerServices(): void
+    {
         // Override
     }
 

--- a/layers/Engine/packages/translation-wp/src/Component.php
+++ b/layers/Engine/packages/translation-wp/src/Component.php
@@ -40,13 +40,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         // The same services injected into the application are injected into the system container
         self::initYAMLSystemContainerServices(dirname(__DIR__), '', 'services.yaml');
     }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
@@ -47,10 +47,30 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.8-dev"
+            "^0.8": "0.8-dev"
         }
     },
     "config": {
         "sort-packages": true
+    },
+    "replace": {
+        "getpop/migrate-component-model": "^0.8",
+        "getpop/root": "^0.8",
+        "getpop/translation": "^0.8",
+        "getpop/query-parsing": "^0.8",
+        "getpop/field-query": "^0.8",
+        "getpop/definitions": "^0.8",
+        "getpop/component-model": "^0.8",
+        "getpop/mandatory-directives-by-configuration": "^0.8",
+        "getpop/cache-control": "^0.8",
+        "getpop/guzzle-helpers": "^0.8",
+        "getpop/hooks": "^0.8",
+        "getpop/loosecontracts": "^0.8",
+        "getpop/routing": "^0.8",
+        "getpop/modulerouting": "^0.8",
+        "getpop/migrate-engine": "^0.8",
+        "getpop/engine": "^0.8",
+        "pop-schema/schema-commons": "^0.8",
+        "pop-schema/basic-directives": "^0.8"
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/config/system-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/config/system-services.yaml
@@ -1,0 +1,7 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+
+    GraphQLAPI\ConvertCaseDirectives\ModuleResolvers\:
+        resource: '../src/ModuleResolvers/*'

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
@@ -1,10 +1,9 @@
 <?php
-use GraphQLAPI\ConvertCaseDirectives\Plugin;
 /*
 Plugin Name: GraphQL API - Convert Case Directives
 Plugin URI: https://github.com/GraphQLAPI/convert-case-directives
 Description: Directives to convert lower/title/upper case for the GraphQL API
-Version: 0.1.0
+Version: 0.7.13
 Requires at least: 5.4
 Requires PHP: 7.1
 Author: Leonardo Losoviz
@@ -15,13 +14,15 @@ Text Domain: graphql-api-convert-case-directives
 Domain Path: /languages
 */
 
+use GraphQLAPI\ConvertCaseDirectives\Plugin;
+
 // Exit if accessed directly
 if (!defined('ABSPATH')) {
     exit;
 }
 
 define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_PLUGIN_FILE', __FILE__);
-define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_VERSION', '0.1.0');
+define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_VERSION', '0.7.13');
 
 // Load Composer’s autoloader
 require_once(__DIR__ . '/vendor/autoload.php');

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -14,7 +14,7 @@ class Component extends AbstractComponent
     public static function getDependedComponentClasses(): array
     {
         return [
-            \PoP\ConvertCaseDirectives\Component::class,
+            \GraphQLAPI\ConvertCaseDirectives\Component::class,
         ];
     }
 

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -23,7 +23,7 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeContainerServices($configuration);
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -20,12 +20,9 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
+    protected static function initializeSystemContainerServices(): void
+    {
         parent::initializeContainerServices($configuration);
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -17,4 +17,16 @@ class Component extends AbstractComponent
             \PoP\ConvertCaseDirectives\Component::class,
         ];
     }
+
+    /**
+     * Initialize services for the system container
+     *
+     * @param array<string, mixed> $configuration
+     */
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
+    }
 }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -14,7 +14,7 @@ class Component extends AbstractComponent
     public static function getDependedComponentClasses(): array
     {
         return [
-            \GraphQLAPI\ConvertCaseDirectives\Component::class,
+            \PoPSchema\ConvertCaseDirectives\Component::class,
         ];
     }
 

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
@@ -8,9 +8,9 @@ use GraphQLAPI\GraphQLAPI\Plugin;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\ModuleResolverTrait;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\EndpointFunctionalityModuleResolver;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\AbstractSchemaTypeModuleResolver;
-use PoP\ConvertCaseDirectives\DirectiveResolvers\LowerCaseStringDirectiveResolver;
-use PoP\ConvertCaseDirectives\DirectiveResolvers\TitleCaseStringDirectiveResolver;
-use PoP\ConvertCaseDirectives\DirectiveResolvers\UpperCaseStringDirectiveResolver;
+use GraphQLAPI\ConvertCaseDirectives\DirectiveResolvers\LowerCaseStringDirectiveResolver;
+use GraphQLAPI\ConvertCaseDirectives\DirectiveResolvers\TitleCaseStringDirectiveResolver;
+use GraphQLAPI\ConvertCaseDirectives\DirectiveResolvers\UpperCaseStringDirectiveResolver;
 
 class SchemaModuleResolver extends AbstractSchemaTypeModuleResolver
 {

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
@@ -8,9 +8,9 @@ use GraphQLAPI\GraphQLAPI\Plugin;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\ModuleResolverTrait;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\EndpointFunctionalityModuleResolver;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\AbstractSchemaTypeModuleResolver;
-use GraphQLAPI\ConvertCaseDirectives\DirectiveResolvers\LowerCaseStringDirectiveResolver;
-use GraphQLAPI\ConvertCaseDirectives\DirectiveResolvers\TitleCaseStringDirectiveResolver;
-use GraphQLAPI\ConvertCaseDirectives\DirectiveResolvers\UpperCaseStringDirectiveResolver;
+use PoPSchema\ConvertCaseDirectives\DirectiveResolvers\LowerCaseStringDirectiveResolver;
+use PoPSchema\ConvertCaseDirectives\DirectiveResolvers\TitleCaseStringDirectiveResolver;
+use PoPSchema\ConvertCaseDirectives\DirectiveResolvers\UpperCaseStringDirectiveResolver;
 
 class SchemaModuleResolver extends AbstractSchemaTypeModuleResolver
 {

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Plugin.php
@@ -55,16 +55,16 @@ class Plugin extends AbstractPlugin
      */
     public function doInitialize(): void
     {
-        // Component configuration
-        $skipSchemaComponentClasses = PluginConfiguration::getSkippingSchemaComponentClasses();
-
         // Initialize the plugin's Component and, with it, all its dependencies from PoP
         AppLoader::addComponentClassesToInitialize(
             [
                 \PoP\ConvertCaseDirectives\Component::class,
-            ],
-            [],
-            $skipSchemaComponentClasses
+            ]
+        );
+
+        // Maybe skip schema components
+        AppLoader::addSchemaComponentClassesToSkip(
+            PluginConfiguration::getSkippingSchemaComponentClasses()
         );
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Plugin.php
@@ -49,22 +49,24 @@ class Plugin extends AbstractPlugin
     }
 
     /**
-     * Plugin set-up
+     * Add Component classes to be initialized
      *
-     * @return void
+     * @return string[] List of `Component` class to initialize
      */
-    public function doInitialize(): void
+    public function getComponentClassesToInitialize(): array
     {
-        // Initialize the plugin's Component and, with it, all its dependencies from PoP
-        AppLoader::addComponentClassesToInitialize(
-            [
-                \PoP\ConvertCaseDirectives\Component::class,
-            ]
-        );
+        return [
+            \PoP\ConvertCaseDirectives\Component::class,
+        ];
+    }
 
-        // Maybe skip schema components
-        AppLoader::addSchemaComponentClassesToSkip(
-            PluginConfiguration::getSkippingSchemaComponentClasses()
-        );
+    /**
+     * Add schema Component classes to skip initializing
+     *
+     * @return string[] List of `Component` class which must not initialize their Schema services
+     */
+    public function getSchemaComponentClassesToSkip(): array
+    {
+        return PluginConfiguration::getSkippingSchemaComponentClasses();
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Plugin.php
@@ -56,7 +56,7 @@ class Plugin extends AbstractPlugin
     public function getComponentClassesToInitialize(): array
     {
         return [
-            \PoP\ConvertCaseDirectives\Component::class,
+            \GraphQLAPI\ConvertCaseDirectives\Component::class,
         ];
     }
 

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginConfiguration.php
@@ -19,7 +19,7 @@ class PluginConfiguration extends AbstractPluginConfiguration
     {
         return [
             SchemaModuleResolver::CONVERT_CASE_DIRECTIVES => [
-                \PoP\ConvertCaseDirectives\Component::class,
+                \GraphQLAPI\ConvertCaseDirectives\Component::class,
             ],
         ];
     }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginConfiguration.php
@@ -19,7 +19,7 @@ class PluginConfiguration extends AbstractPluginConfiguration
     {
         return [
             SchemaModuleResolver::CONVERT_CASE_DIRECTIVES => [
-                \GraphQLAPI\ConvertCaseDirectives\Component::class,
+                \PoPSchema\ConvertCaseDirectives\Component::class,
             ],
         ];
     }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginScaffolding/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginScaffolding/AbstractPlugin.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\ConvertCaseDirectives\PluginScaffolding;
 
-use GraphQLAPI\GraphQLAPI\Plugin as GraphQLAPIPlugin;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
+use GraphQLAPI\GraphQLAPI\Plugin as GraphQLAPIPlugin;
+use PoP\Engine\AppLoader;
 
 abstract class AbstractPlugin
 {
@@ -101,6 +102,36 @@ abstract class AbstractPlugin
     }
 
     /**
+     * Add Component classes to be initialized
+     *
+     * @return string[] List of `Component` class to initialize
+     */
+    public function getComponentClassesToInitialize(): array
+    {
+        return [];
+    }
+
+    /**
+     * Add configuration for the Component classes
+     *
+     * @return array<string, mixed> [key]: Component class, [value]: Configuration
+     */
+    public function getComponentClassConfiguration(): array
+    {
+        return [];
+    }
+
+    /**
+     * Add schema Component classes to skip initializing
+     *
+     * @return string[] List of `Component` class which must not initialize their Schema services
+     */
+    public function getSchemaComponentClassesToSkip(): array
+    {
+        return [];
+    }
+
+    /**
      * Plugin's initialization
      *
      * @return void
@@ -114,8 +145,21 @@ abstract class AbstractPlugin
             // Exit
             return;
         }
-        // Execute the plugin's custom setup
-        $this->doInitialize();
+
+        // Initialize the containers
+        AppLoader::addComponentClassesToInitialize(
+            $this->getComponentClassesToInitialize()
+        );
+
+        // Only after initializing the System Container,
+        // we can obtain the configuration
+        // (which may depend on hooks)
+        AppLoader::addComponentClassConfiguration(
+            $this->getComponentClassConfiguration()
+        );
+        AppLoader::addSchemaComponentClassesToSkip(
+            $this->getSchemaComponentClassesToSkip()
+        );
     }
 
     /**
@@ -154,15 +198,6 @@ abstract class AbstractPlugin
     public function doSetup(): void
     {
         // Function to override
-    }
-
-    /**
-     * Initialize plugin. Function to override
-     *
-     * @return void
-     */
-    protected function doInitialize(): void
-    {
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginScaffolding/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginScaffolding/AbstractPlugin.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GraphQLAPI\ConvertCaseDirectives\PluginScaffolding;
 
 use GraphQLAPI\GraphQLAPI\Plugin as GraphQLAPIPlugin;
-use GraphQLAPI\GraphQLAPI\Facades\ModuleRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 
 abstract class AbstractPlugin
@@ -77,11 +76,11 @@ abstract class AbstractPlugin
                     // Exit
                     return;
                 }
-                // Add to the registry the ModuleResolvers from this plugin
-                $moduleRegistry = ModuleRegistryFacade::getInstance();
-                foreach ($this->getModuleResolverClasses() as $moduleResolverClass) {
-                    $moduleRegistry->addModuleResolver(new $moduleResolverClass());
-                }
+                // // Add to the registry the ModuleResolvers from this plugin
+                // $moduleRegistry = ModuleRegistryFacade::getInstance();
+                // foreach ($this->getModuleResolverClasses() as $moduleResolverClass) {
+                //     $moduleRegistry->addModuleResolver(new $moduleResolverClass());
+                // }
                 // Execute the plugin's custom setup, if any
                 $this->doSetup();
 

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginScaffolding/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/PluginScaffolding/AbstractPlugin.php
@@ -86,11 +86,15 @@ abstract class AbstractPlugin
                 $this->doSetup();
 
                 /**
-                 * Initialize/boot this extension plugin
+                 * Initialize/configure/boot this extension plugin
                  */
                 \add_action(
                     GraphQLAPIPlugin::HOOK_INITIALIZE_EXTENSION_PLUGIN,
                     [$this, 'initialize']
+                );
+                \add_action(
+                    GraphQLAPIPlugin::HOOK_CONFIGURE_EXTENSION_PLUGIN,
+                    [$this, 'configure']
                 );
                 \add_action(
                     GraphQLAPIPlugin::HOOK_BOOT_EXTENSION_PLUGIN,
@@ -150,6 +154,20 @@ abstract class AbstractPlugin
         AppLoader::addComponentClassesToInitialize(
             $this->getComponentClassesToInitialize()
         );
+    }
+
+    /**
+     * Plugin's configuration
+     */
+    final public function configure(): void
+    {
+        /**
+         * Check that the GraphQL API plugin is installed and activated.
+         */
+        if (!$this->isGraphQLAPIPluginActive()) {
+            // Exit
+            return;
+        }
 
         // Only after initializing the System Container,
         // we can obtain the configuration

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/ConfigurationCache/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/ConfigurationCache/Overrides/services.yaml
@@ -1,8 +1,0 @@
-services:
-    _defaults:
-        public: true
-        autowire: true
-
-    # Override to configure the cache with dynamic values
-    PoP\ComponentModel\Cache\CacheConfigurationManagerInterface:
-        class: '\GraphQLAPI\GraphQLAPI\ConditionalOnEnvironment\ConfigurationCache\Overrides\CacheConfigurationManager'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/Overrides/services.yaml
@@ -9,3 +9,7 @@ services:
     # (for that case, it will be overriden once again by another ConditionalOnEnvironment)
     GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLClient:
         class: '\GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLClient'
+
+    # Override to configure the cache with dynamic values
+    PoP\ComponentModel\Cache\CacheConfigurationManagerInterface:
+        class: '\GraphQLAPI\GraphQLAPI\Overrides\Services\ConfigurationCache\CacheConfigurationManager'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
@@ -3,5 +3,11 @@ services:
         public: true
         autowire: true
 
+    GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface:
+        class: \GraphQLAPI\GraphQLAPI\Registries\ModuleRegistry
+
     GraphQLAPI\GraphQLAPI\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'
+
+    GraphQLAPI\GraphQLAPI\ModuleResolvers\:
+        resource: '../src/ModuleResolvers/*'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -57,6 +57,18 @@ class Component extends AbstractComponent
     }
 
     /**
+     * Initialize services for the system container
+     *
+     * @param array<string, mixed> $configuration
+     */
+    protected static function initializeSystemContainerServices(
+        array $configuration = []
+    ): void {
+        parent::initializeSystemContainerServices($configuration);
+        self::initYAMLSystemContainerServices(dirname(__DIR__));
+    }
+
+    /**
      * Initialize services
      *
      * @param array<string, mixed> $configuration
@@ -127,18 +139,6 @@ class Component extends AbstractComponent
                 self::initYAMLServices(dirname(__DIR__), '/ConditionalOnEnvironment/GraphiQLExplorerInCustomEndpointPublicClient/Overrides');
             }
         }
-    }
-
-    /**
-     * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
-     */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
-        self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 
     protected static function initComponentConfiguration(): void

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -106,11 +106,6 @@ class Component extends AbstractComponent
         if ($moduleRegistry->isModuleEnabled(PerformanceFunctionalityModuleResolver::CACHE_CONTROL)) {
             self::initYAMLServices(dirname(__DIR__), '/ConditionalOnEnvironment/CacheControl/Overrides');
         }
-        // Register the Container Cache services
-        // if ($moduleRegistry->isModuleEnabled(CacheFunctionalityModuleResolver::CONFIGURATION_CACHE)) {
-        if (PluginEnvironment::cacheContainers()) {
-            self::initYAMLServices(dirname(__DIR__), '/ConditionalOnEnvironment/ConfigurationCache/Overrides');
-        }
         // Maybe use GraphiQL with Explorer
         $userSettingsManager = UserSettingsManagerFacade::getInstance();
         $isGraphiQLExplorerEnabled = $moduleRegistry->isModuleEnabled(ClientFunctionalityModuleResolver::GRAPHIQL_EXPLORER);

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -93,8 +93,9 @@ class Component extends AbstractComponent
         if ($moduleRegistry->isModuleEnabled(PerformanceFunctionalityModuleResolver::CACHE_CONTROL)) {
             self::initYAMLServices(dirname(__DIR__), '/ConditionalOnEnvironment/CacheControl/Overrides');
         }
-        // Register the Cache services, if the module is not disabled
-        if ($moduleRegistry->isModuleEnabled(CacheFunctionalityModuleResolver::CONFIGURATION_CACHE)) {
+        // Register the Container Cache services
+        // if ($moduleRegistry->isModuleEnabled(CacheFunctionalityModuleResolver::CONFIGURATION_CACHE)) {
+        if (PluginEnvironment::cacheContainers()) {
             self::initYAMLServices(dirname(__DIR__), '/ConditionalOnEnvironment/ConfigurationCache/Overrides');
         }
         // Maybe use GraphiQL with Explorer

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI;
 
+use GraphQLAPI\GraphQLAPI\Container\SystemCompilerPasses\RegisterModuleResolverCompilerPass;
 use GraphQLAPI\GraphQLAPI\Facades\ModuleRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\CacheFunctionalityModuleResolver;
@@ -53,6 +54,18 @@ class Component extends AbstractComponent
             \GraphQLByPoP\GraphQLClientsForWP\Component::class,
             \GraphQLByPoP\GraphQLEndpointForWP\Component::class,
             \GraphQLAPI\MarkdownConvertor\Component::class,
+        ];
+    }
+
+    /**
+     * Compiler Passes for the System Container
+     *
+     * @return string[]
+     */
+    public static function getSystemContainerCompilerPassClasses(): array
+    {
+        return [
+            RegisterModuleResolverCompilerPass::class,
         ];
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -58,13 +58,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/RegisterModuleResolverCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/RegisterModuleResolverCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\GraphQLAPI\Container\CompilerPasses;
+
+use GraphQLAPI\GraphQLAPI\ModuleResolvers\ModuleResolverInterface;
+use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
+
+class RegisterModuleResolverCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
+{
+    protected function getRegistryServiceDefinition(): string
+    {
+        return ModuleRegistryInterface::class;
+    }
+    protected function getServiceClass(): string
+    {
+        return ModuleResolverInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addModuleResolver';
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/SystemCompilerPasses/RegisterModuleResolverCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/SystemCompilerPasses/RegisterModuleResolverCompilerPass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\GraphQLAPI\Container\CompilerPasses;
+namespace GraphQLAPI\GraphQLAPI\Container\SystemCompilerPasses;
 
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\ModuleResolverInterface;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Facades/CacheConfigurationManagerFacade.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Facades/CacheConfigurationManagerFacade.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Facades;
 
-use GraphQLAPI\GraphQLAPI\ConditionalOnEnvironment\ConfigurationCache\Overrides\CacheConfigurationManager;
+use GraphQLAPI\GraphQLAPI\Overrides\Services\ConfigurationCache\CacheConfigurationManager;
 use PoP\ComponentModel\Cache\CacheConfigurationManagerInterface;
 
 /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Facades/ModuleRegistryFacade.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Facades/ModuleRegistryFacade.php
@@ -4,48 +4,39 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Facades;
 
-use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistry;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\SchemaTypeModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\CacheFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\ClientFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\EndpointFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\VersioningFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\OperationalFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\PerformanceFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\AccessControlFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\UserInterfaceFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\PluginManagementFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\SchemaConfigurationFunctionalityModuleResolver;
+use PoP\Root\Container\SystemContainerBuilderFactory;
 
 /**
  * Obtain an instance of the ModuleRegistry.
- * Manage the instance internally instead of using the ContainerBuilder,
- * because it is required for setting configuration values before components
+ * Use the System Container because it is required for
+ * setting configuration values before components
  * are initialized, so the ContainerBuilder is still unavailable
  */
 class ModuleRegistryFacade
 {
-    private static ?ModuleRegistryInterface $instance = null;
-
     public static function getInstance(): ModuleRegistryInterface
     {
-        if (is_null(self::$instance)) {
-            // Instantiate
-            self::$instance = new ModuleRegistry();
-            // Add the ModuleResolvers
-            self::$instance->addModuleResolver(new PluginManagementFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new EndpointFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new SchemaConfigurationFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new AccessControlFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new VersioningFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new UserInterfaceFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new PerformanceFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new CacheFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new OperationalFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new ClientFunctionalityModuleResolver());
-            self::$instance->addModuleResolver(new SchemaTypeModuleResolver());
-        }
-        return self::$instance;
+        /**
+         * @var ModuleRegistryInterface
+         */
+        return SystemContainerBuilderFactory::getInstance()->get(ModuleRegistryInterface::class);
+        // if (is_null(self::$instance)) {
+        //     // Instantiate
+        //     self::$instance = new ModuleRegistry();
+        //     // Add the ModuleResolvers
+        //     self::$instance->addModuleResolver(new PluginManagementFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new EndpointFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new SchemaConfigurationFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new AccessControlFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new VersioningFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new UserInterfaceFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new PerformanceFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new CacheFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new OperationalFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new ClientFunctionalityModuleResolver());
+        //     self::$instance->addModuleResolver(new SchemaTypeModuleResolver());
+        // }
+        // return self::$instance;
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Overrides/Services/ConfigurationCache/CacheConfigurationManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Overrides/Services/ConfigurationCache/CacheConfigurationManager.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\GraphQLAPI\ConditionalOnEnvironment\ConfigurationCache\Overrides;
+namespace GraphQLAPI\GraphQLAPI\Overrides\Services\ConfigurationCache;
 
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use PoP\ComponentModel\Cache\CacheConfigurationManagerInterface;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -296,23 +296,26 @@ class Plugin
             }
         }
 
+        // Initialize the containers
+        AppLoader::addComponentClassesToInitialize(
+            [
+                Component::class,
+            ]
+        );
+
         // Configure the plugin. This defines hooks to set environment variables,
         // so must be executed
         // before those hooks are triggered for first time
         // (in ComponentConfiguration classes)
         PluginConfiguration::initialize();
 
-        // Component configuration
-        $componentClassConfiguration = PluginConfiguration::getComponentClassConfiguration();
-        $skipSchemaComponentClasses = PluginConfiguration::getSkippingSchemaComponentClasses();
-
-        // Initialize the containers
-        AppLoader::addComponentClassesToInitialize(
-            [
-                Component::class,
-            ],
-            $componentClassConfiguration,
-            $skipSchemaComponentClasses
+        // Only after initializing the System Container, we can obtain the configuration
+        // (which may depend on hooks)
+        AppLoader::addComponentClassConfiguration(
+            PluginConfiguration::getComponentClassConfiguration()
+        );
+        AppLoader::addSchemaComponentClassesToSkip(
+            PluginConfiguration::getSkippingSchemaComponentClasses()
         );
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -352,7 +352,9 @@ class Plugin
     public function bootSystem(): void
     {
         // Boot all PoP components, from this plugin and all extensions
-        AppLoader::bootSystem(...PluginConfiguration::getContainerCacheConfiguration());
+        AppLoader::bootSystem(
+            ...PluginConfiguration::getContainerCacheConfiguration()
+        );
     }
 
     /**
@@ -382,7 +384,9 @@ class Plugin
     public function bootApplication(): void
     {
         // Boot all PoP components, from this plugin and all extensions
-        AppLoader::bootApplication();
+        AppLoader::bootApplication(
+            ...PluginConfiguration::getContainerCacheConfiguration()
+        );
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -258,6 +258,38 @@ class Plugin
     }
 
     /**
+     * Add Component classes to be initialized
+     *
+     * @return string[] List of `Component` class to initialize
+     */
+    public function getComponentClassesToInitialize(): array
+    {
+        return [
+            Component::class,
+        ];
+    }
+
+    /**
+     * Add configuration for the Component classes
+     *
+     * @return array<string, mixed> [key]: Component class, [value]: Configuration
+     */
+    public function getComponentClassConfiguration(): array
+    {
+        return PluginConfiguration::getComponentClassConfiguration();
+    }
+
+    /**
+     * Add schema Component classes to skip initializing
+     *
+     * @return string[] List of `Component` class which must not initialize their Schema services
+     */
+    public function getSchemaComponentClassesToSkip(): array
+    {
+        return PluginConfiguration::getSkippingSchemaComponentClasses();
+    }
+
+    /**
      * Plugin initialization, executed on hook "plugins_loaded"
      * to wait for all extensions to be loaded
      *
@@ -298,24 +330,22 @@ class Plugin
 
         // Initialize the containers
         AppLoader::addComponentClassesToInitialize(
-            [
-                Component::class,
-            ]
+            $this->getComponentClassesToInitialize()
         );
 
         // Configure the plugin. This defines hooks to set environment variables,
-        // so must be executed
-        // before those hooks are triggered for first time
+        // so must be executed before those hooks are triggered for first time
         // (in ComponentConfiguration classes)
         PluginConfiguration::initialize();
 
-        // Only after initializing the System Container, we can obtain the configuration
+        // Only after initializing the System Container,
+        // we can obtain the configuration
         // (which may depend on hooks)
         AppLoader::addComponentClassConfiguration(
-            PluginConfiguration::getComponentClassConfiguration()
+            $this->getComponentClassConfiguration()
         );
         AppLoader::addSchemaComponentClassesToSkip(
-            PluginConfiguration::getSkippingSchemaComponentClasses()
+            $this->getSchemaComponentClassesToSkip()
         );
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI;
 
-use PoP\Engine\Component;
 use PoP\APIEndpoints\EndpointUtils;
 use GraphQLAPI\GraphQLAPI\Environment;
 use PoP\AccessControl\Schema\SchemaModes;
@@ -53,7 +52,6 @@ use GraphQLByPoP\GraphQLClientsForWP\ComponentConfiguration as GraphQLClientsFor
 use GraphQLByPoP\GraphQLEndpointForWP\ComponentConfiguration as GraphQLEndpointForWPComponentConfiguration;
 use GraphQLByPoP\GraphQLServer\Environment as GraphQLServerEnvironment;
 use GraphQLByPoP\GraphQLServer\ComponentConfiguration as GraphQLServerComponentConfiguration;
-use GraphQLByPoP\GraphQLQuery\Environment as GraphQLQueryEnvironment;
 
 /**
  * Sets the configuration in all the PoP components.
@@ -534,9 +532,8 @@ class PluginConfiguration
      */
     public static function getContainerCacheConfiguration(): array
     {
-        $moduleRegistry = ModuleRegistryFacade::getInstance();
         $containerConfigurationCacheNamespace = null;
-        if ($cacheContainerConfiguration = $moduleRegistry->isModuleEnabled(CacheFunctionalityModuleResolver::CONFIGURATION_CACHE)) {
+        if ($cacheContainerConfiguration = PluginEnvironment::cacheContainers()) {
             $cacheConfigurationManager = CacheConfigurationManagerFacade::getInstance();
             $containerConfigurationCacheNamespace = $cacheConfigurationManager->getNamespace();
         }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -77,6 +77,13 @@ class PluginConfiguration
     protected static ?array $normalizedOptionValuesCache = null;
 
     /**
+     * Cache the Container Cache Configuration
+     *
+     * @var array<mixed> Array with args to pass to `AppLoader::initializeContainers` - [0]: cache container? (bool), [1]: container namespace (string|null)
+     */
+    protected static ?array $containerCacheConfigurationCache = null;
+
+    /**
      * Initialize all configuration
      */
     public static function initialize(): void
@@ -532,15 +539,18 @@ class PluginConfiguration
      */
     public static function getContainerCacheConfiguration(): array
     {
-        $containerConfigurationCacheNamespace = null;
-        if ($cacheContainerConfiguration = PluginEnvironment::cacheContainers()) {
-            $cacheConfigurationManager = CacheConfigurationManagerFacade::getInstance();
-            $containerConfigurationCacheNamespace = $cacheConfigurationManager->getNamespace();
+        if (is_null(self::$containerCacheConfigurationCache)) {
+            $containerConfigurationCacheNamespace = null;
+            if ($cacheContainerConfiguration = PluginEnvironment::cacheContainers()) {
+                $cacheConfigurationManager = CacheConfigurationManagerFacade::getInstance();
+                $containerConfigurationCacheNamespace = $cacheConfigurationManager->getNamespace();
+            }
+            self::$containerCacheConfigurationCache = [
+                $cacheContainerConfiguration,
+                $containerConfigurationCacheNamespace
+            ];
         }
-        return [
-            $cacheContainerConfiguration,
-            $containerConfigurationCacheNamespace
-        ];
+        return self::$containerCacheConfigurationCache;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
@@ -19,6 +19,9 @@ class PluginEnvironment
      */
     public const PLUGIN_ENVIRONMENT_DEV = 'development';
 
+    public const CACHE_CONTAINERS = 'CACHE_CONTAINERS';
+
+
     /**
      * Return a value for a variable, checking if it is defined in the environment
      * first, and in the wp-config.php second
@@ -63,5 +66,15 @@ class PluginEnvironment
     public static function isPluginEnvironmentDev(): bool
     {
         return self::getPluginEnvironment() == self::PLUGIN_ENVIRONMENT_DEV;
+    }
+
+    /**
+     * By default, cache for PROD, do not cache for DEV
+     */
+    public static function cacheContainers(): bool
+    {
+        return getenv(self::CACHE_CONTAINERS) !== false ?
+            strtolower(getenv(self::CACHE_CONTAINERS)) == "true"
+            : self::isPluginEnvironmentProd();
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/graphql-api-schema-feedback.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/graphql-api-schema-feedback.php
@@ -4,7 +4,7 @@ use GraphQLAPI\SchemaFeedback\Plugin;
 Plugin Name: GraphQL API - Schema Feedback
 Plugin URI: https://github.com/GraphQLAPI/schema-feedback
 Description: Make the GraphQL API provide feedback in the response of the GraphQL query
-Version: 0.1.0
+Version: 0.7.13
 Requires at least: 5.4
 Requires PHP: 7.1
 Author: Leonardo Losoviz

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -125,14 +125,11 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
+    protected static function initializeSystemContainerServices(): void
+    {
         if (self::isEnabled()) {
-            parent::initializeSystemContainerServices($configuration);
+            parent::initializeSystemContainerServices();
             self::initYAMLSystemContainerServices(dirname(__DIR__));
         }
     }

--- a/layers/Misc/packages/examples-for-pop/src/Component.php
+++ b/layers/Misc/packages/examples-for-pop/src/Component.php
@@ -47,13 +47,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/translate-directive-acl/src/Component.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Component.php
@@ -30,14 +30,11 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
+    protected static function initializeSystemContainerServices(): void
+    {
         if (self::isEnabled()) {
-            parent::initializeSystemContainerServices($configuration);
+            parent::initializeSystemContainerServices();
             self::initYAMLSystemContainerServices(dirname(__DIR__));
         }
     }

--- a/layers/Schema/packages/translate-directive/src/Component.php
+++ b/layers/Schema/packages/translate-directive/src/Component.php
@@ -41,13 +41,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/user-roles-acl/src/Component.php
+++ b/layers/Schema/packages/user-roles-acl/src/Component.php
@@ -34,14 +34,11 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
+    protected static function initializeSystemContainerServices(): void
+    {
         if (self::isEnabled()) {
-            parent::initializeSystemContainerServices($configuration);
+            parent::initializeSystemContainerServices();
             self::initYAMLSystemContainerServices(dirname(__DIR__));
         }
     }

--- a/layers/SiteBuilder/packages/application/src/Component.php
+++ b/layers/SiteBuilder/packages/application/src/Component.php
@@ -53,13 +53,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
@@ -47,13 +47,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/site/src/Component.php
+++ b/layers/SiteBuilder/packages/site/src/Component.php
@@ -42,13 +42,10 @@ class Component extends AbstractComponent
 
     /**
      * Initialize services for the system container
-     *
-     * @param array<string, mixed> $configuration
      */
-    protected static function initializeSystemContainerServices(
-        array $configuration = []
-    ): void {
-        parent::initializeSystemContainerServices($configuration);
+    protected static function initializeSystemContainerServices(): void
+    {
+        parent::initializeSystemContainerServices();
         self::initYAMLSystemContainerServices(dirname(__DIR__));
     }
 }


### PR DESCRIPTION
Instead of individually initializing all ModuleResolvers, register them in the SystemContainer.

Other changes applied:

- Start Lando webserver with plugin Convert Case Directives
- Split booting the System and the Application into separate functions
- Removed the component configuration from booting the system
- Added a "configure" step between "initialize" and "boot" for components to register the configuration / schema components to be skipped
- Have components indicate their System `CompilerPass`es (these can't be registered in the container, since they are used to initialize the container itself)
- Decoupled Container Cache and Configuration Cache
- The container is always cached for PROD, not cached for DEV, and it doesn't depend on the `CONFIGURATION_CACHE` Module Resolver anymore