### PR TITLE
Replace static NAME property

### DIFF
--- a/layers/API/packages/api/src/Enums/SchemaFieldShapeEnum.php
+++ b/layers/API/packages/api/src/Enums/SchemaFieldShapeEnum.php
@@ -9,11 +9,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class SchemaFieldShapeEnum extends AbstractEnum
 {
-    public const NAME = 'SchemaOutputShape';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'SchemaOutputShape';
     }
     public function getValues(): array
     {

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -10,10 +10,9 @@ use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResol
 
 class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
-    public const NAME = 'Elemental';
     public function getInterfaceName(): string
     {
-        return self::NAME;
+        return 'Elemental';
     }
 
     public function getSchemaInterfaceDescription(): ?string

--- a/layers/Engine/packages/engine/src/Enums/FieldFeedbackTargetEnum.php
+++ b/layers/Engine/packages/engine/src/Enums/FieldFeedbackTargetEnum.php
@@ -8,14 +8,12 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class FieldFeedbackTargetEnum extends AbstractEnum
 {
-    public const NAME = 'FieldFeedbackTarget';
-
     public const DB = 'db';
     public const SCHEMA = 'schema';
 
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'FieldFeedbackTarget';
     }
     public function getValues(): array
     {

--- a/layers/Engine/packages/engine/src/Enums/FieldFeedbackTypeEnum.php
+++ b/layers/Engine/packages/engine/src/Enums/FieldFeedbackTypeEnum.php
@@ -8,15 +8,13 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class FieldFeedbackTypeEnum extends AbstractEnum
 {
-    public const NAME = 'FieldFeedbackType';
-
     public const WARNING = 'warning';
     public const DEPRECATION = 'deprecation';
     public const NOTICE = 'notice';
 
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'FieldFeedbackType';
     }
     public function getValues(): array
     {

--- a/layers/Engine/packages/engine/src/TypeResolvers/RootTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/RootTypeResolver.php
@@ -15,11 +15,9 @@ class RootTypeResolver extends AbstractTypeResolver
 {
     use ReservedNameTypeResolverTrait;
 
-    public const NAME = 'Root';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Root';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/SystemServices/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/SystemServices/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -62,6 +62,38 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
      */
     public const HOOK_GENERIC_CUSTOMPOST_TYPES = __CLASS__ . ':generic-custompost-types';
 
+    protected CommentTypeResolver $commentTypeResolver;
+    protected CustomPostUnionTypeResolver $customPostUnionTypeResolver;
+    protected GenericCustomPostTypeResolver $genericCustomPostTypeResolver;
+    protected MediaTypeResolver $mediaTypeResolver;
+    protected PageTypeResolver $pageTypeResolver;
+    protected PostTagTypeResolver $postTagTypeResolver;
+    protected PostTypeResolver $postTypeResolver;
+    protected UserRoleTypeResolver $userRoleTypeResolver;
+    protected UserTypeResolver $userTypeResolver;
+
+    public function __construct(
+        CommentTypeResolver $commentTypeResolver,
+        CustomPostUnionTypeResolver $customPostUnionTypeResolver,
+        GenericCustomPostTypeResolver $genericCustomPostTypeResolver,
+        MediaTypeResolver $mediaTypeResolver,
+        PageTypeResolver $pageTypeResolver,
+        PostTagTypeResolver $postTagTypeResolver,
+        PostTypeResolver $postTypeResolver,
+        UserRoleTypeResolver $userRoleTypeResolver,
+        UserTypeResolver $userTypeResolver
+    ) {
+        $this->commentTypeResolver = $commentTypeResolver;
+        $this->customPostUnionTypeResolver = $customPostUnionTypeResolver;
+        $this->genericCustomPostTypeResolver = $genericCustomPostTypeResolver;
+        $this->mediaTypeResolver = $mediaTypeResolver;
+        $this->pageTypeResolver = $pageTypeResolver;
+        $this->postTagTypeResolver = $postTagTypeResolver;
+        $this->postTypeResolver = $postTypeResolver;
+        $this->userRoleTypeResolver = $userRoleTypeResolver;
+        $this->userTypeResolver = $userTypeResolver;
+    }
+
     /**
      * @return string[]
      */
@@ -201,49 +233,49 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
             case self::SCHEMA_GENERIC_CUSTOMPOSTS:
                 return sprintf(
                     \__('Query any custom post type (added to the schema or not), through a generic type <code>%1$s</code>', 'graphql-api'),
-                    GenericCustomPostTypeResolver::NAME
+                    $this->genericCustomPostTypeResolver->getTypeName()
                 );
             case self::SCHEMA_POSTS:
                 return sprintf(
                     \__('Query %1$s, through type <code>%2$s</code> added to the schema', 'graphql-api'),
                     \__('posts', 'graphql-api'),
-                    PostTypeResolver::NAME
+                    $this->postTypeResolver->getTypeName()
                 );
             case self::SCHEMA_USERS:
                 return sprintf(
                     \__('Query %1$s, through type <code>%2$s</code> added to the schema', 'graphql-api'),
                     \__('users', 'graphql-api'),
-                    UserTypeResolver::NAME
+                    $this->userTypeResolver->getTypeName()
                 );
             case self::SCHEMA_USER_ROLES:
                 return sprintf(
                     \__('Query %1$s, through type <code>%2$s</code> added to the schema', 'graphql-api'),
                     \__('user roles', 'graphql-api'),
-                    UserRoleTypeResolver::NAME
+                    $this->userRoleTypeResolver->getTypeName()
                 );
             case self::SCHEMA_PAGES:
                 return sprintf(
                     \__('Query %1$s, through type <code>%2$s</code> added to the schema', 'graphql-api'),
                     \__('pages', 'graphql-api'),
-                    PageTypeResolver::NAME
+                    $this->pageTypeResolver->getTypeName()
                 );
             case self::SCHEMA_MEDIA:
                 return sprintf(
                     \__('Query %1$s, through type <code>%2$s</code> added to the schema', 'graphql-api'),
                     \__('media elements', 'graphql-api'),
-                    MediaTypeResolver::NAME
+                    $this->mediaTypeResolver->getTypeName()
                 );
             case self::SCHEMA_COMMENTS:
                 return sprintf(
                     \__('Query %1$s, through type <code>%2$s</code> added to the schema', 'graphql-api'),
                     \__('comments', 'graphql-api'),
-                    CommentTypeResolver::NAME
+                    $this->commentTypeResolver->getTypeName()
                 );
             case self::SCHEMA_POST_TAGS:
                 return sprintf(
                     \__('Query %1$s, through type <code>%2$s</code> added to the schema', 'graphql-api'),
                     \__('post tags', 'graphql-api'),
-                    PostTagTypeResolver::NAME
+                    $this->postTagTypeResolver->getTypeName()
                 );
             case self::SCHEMA_CUSTOMPOSTS:
                 return \__('Base functionality for all custom posts', 'graphql-api');
@@ -472,8 +504,8 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
                     Properties::TITLE => \__('Use single type instead of union type?', 'graphql-api'),
                     Properties::DESCRIPTION => sprintf(
                         \__('If type <code>%s</code> is composed of only one type (eg: <code>%s</code>), then return this single type directly in field <code>%s</code>?', 'graphql-api'),
-                        CustomPostUnionTypeResolver::NAME,
-                        PostTypeResolver::NAME,
+                        $this->customPostUnionTypeResolver->getTypeName(),
+                        $this->postTypeResolver->getTypeName(),
                         'customPosts'
                     ),
                     Properties::TYPE => Properties::TYPE_BOOL,
@@ -488,32 +520,32 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
             $titlePlaceholder = sprintf(
                 \__('Include type <code>%1$s</code> in <code>%2$s</code>?', 'graphql-api'),
                 '%1$s',
-                CustomPostUnionTypeResolver::NAME
+                $this->customPostUnionTypeResolver->getTypeName()
             );
             $moduleTitles = [
                 self::SCHEMA_POSTS => sprintf(
                     $titlePlaceholder,
-                    PostTypeResolver::NAME
+                    $this->postTypeResolver->getTypeName()
                 ),
                 self::SCHEMA_PAGES => sprintf(
                     $titlePlaceholder,
-                    PageTypeResolver::NAME
+                    $this->pageTypeResolver->getTypeName()
                 ),
             ];
             $descriptionPlaceholder = sprintf(
                 \__('Results of type <code>%1$s</code> will be included when querying a field of type <code>%2$s</code> (such as <code>%3$s</code>)', 'graphql-api'),
                 '%1$s',
-                CustomPostUnionTypeResolver::NAME,
+                $this->customPostUnionTypeResolver->getTypeName(),
                 'customPosts'
             );
             $moduleDescriptions = [
                 self::SCHEMA_POSTS => sprintf(
                     $descriptionPlaceholder,
-                    PostTypeResolver::NAME
+                    $this->postTypeResolver->getTypeName()
                 ),
                 self::SCHEMA_PAGES => sprintf(
                     $descriptionPlaceholder,
-                    PageTypeResolver::NAME
+                    $this->pageTypeResolver->getTypeName()
                 ),
             ];
             $option = self::OPTION_ADD_TYPE_TO_CUSTOMPOST_UNION_TYPE;
@@ -577,7 +609,7 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
                 Properties::TITLE => \__('Included custom post types', 'graphql-api'),
                 Properties::DESCRIPTION => sprintf(
                     \__('Results from these custom post types will be included when querying a field with type <code>%s</code> (such as <code>%s</code>)<br/>Press <code>ctrl</code> or <code>shift</code> keys to select more than one', 'graphql-api'),
-                    GenericCustomPostTypeResolver::NAME,
+                    $this->genericCustomPostTypeResolver->getTypeName(),
                     'genericCustomPosts'
                 ),
                 Properties::TYPE => Properties::TYPE_ARRAY,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/SystemServices/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/SystemServices/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -25,6 +25,7 @@ use GraphQLAPI\GraphQLAPI\SystemServices\ModuleResolvers\AbstractSchemaTypeModul
 use PoPSchema\GenericCustomPosts\TypeResolvers\GenericCustomPostTypeResolver;
 use GraphQLAPI\GraphQLAPI\SystemServices\ModuleResolvers\EndpointFunctionalityModuleResolver;
 use GraphQLAPI\GraphQLAPI\SystemServices\ModuleResolvers\OperationalFunctionalityModuleResolver;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 
 class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
 {
@@ -62,36 +63,39 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
      */
     public const HOOK_GENERIC_CUSTOMPOST_TYPES = __CLASS__ . ':generic-custompost-types';
 
-    protected CommentTypeResolver $commentTypeResolver;
-    protected CustomPostUnionTypeResolver $customPostUnionTypeResolver;
-    protected GenericCustomPostTypeResolver $genericCustomPostTypeResolver;
-    protected MediaTypeResolver $mediaTypeResolver;
-    protected PageTypeResolver $pageTypeResolver;
-    protected PostTagTypeResolver $postTagTypeResolver;
-    protected PostTypeResolver $postTypeResolver;
-    protected UserRoleTypeResolver $userRoleTypeResolver;
-    protected UserTypeResolver $userTypeResolver;
+    protected ?CommentTypeResolver $commentTypeResolver = null;
+    protected ?CustomPostUnionTypeResolver $customPostUnionTypeResolver = null;
+    protected ?GenericCustomPostTypeResolver $genericCustomPostTypeResolver = null;
+    protected ?MediaTypeResolver $mediaTypeResolver = null;
+    protected ?PageTypeResolver $pageTypeResolver = null;
+    protected ?PostTagTypeResolver $postTagTypeResolver = null;
+    protected ?PostTypeResolver $postTypeResolver = null;
+    protected ?UserRoleTypeResolver $userRoleTypeResolver = null;
+    protected ?UserTypeResolver $userTypeResolver = null;
 
-    public function __construct(
-        CommentTypeResolver $commentTypeResolver,
-        CustomPostUnionTypeResolver $customPostUnionTypeResolver,
-        GenericCustomPostTypeResolver $genericCustomPostTypeResolver,
-        MediaTypeResolver $mediaTypeResolver,
-        PageTypeResolver $pageTypeResolver,
-        PostTagTypeResolver $postTagTypeResolver,
-        PostTypeResolver $postTypeResolver,
-        UserRoleTypeResolver $userRoleTypeResolver,
-        UserTypeResolver $userTypeResolver
-    ) {
-        $this->commentTypeResolver = $commentTypeResolver;
-        $this->customPostUnionTypeResolver = $customPostUnionTypeResolver;
-        $this->genericCustomPostTypeResolver = $genericCustomPostTypeResolver;
-        $this->mediaTypeResolver = $mediaTypeResolver;
-        $this->pageTypeResolver = $pageTypeResolver;
-        $this->postTagTypeResolver = $postTagTypeResolver;
-        $this->postTypeResolver = $postTypeResolver;
-        $this->userRoleTypeResolver = $userRoleTypeResolver;
-        $this->userTypeResolver = $userTypeResolver;
+    /**
+     * Temporary Hack! We can't inject the variables through dependency
+     * injection, because the ModuleResolver is defined in the
+     * SystemContainer, while all TypeResolvers are defined in the
+     * ApplicationContainer.
+     *
+     * Then, lazily get the instance from that container.
+     */
+    protected function initializeState(): void
+    {
+        if ($this->commentTypeResolver !== null) {
+            return;
+        }
+        $instanceManager = InstanceManagerFacade::getInstance();
+        $this->commentTypeResolver = $instanceManager->getInstance(CommentTypeResolver::class);
+        $this->customPostUnionTypeResolver = $instanceManager->getInstance(CustomPostUnionTypeResolver::class);
+        $this->genericCustomPostTypeResolver = $instanceManager->getInstance(GenericCustomPostTypeResolver::class);
+        $this->mediaTypeResolver = $instanceManager->getInstance(MediaTypeResolver::class);
+        $this->pageTypeResolver = $instanceManager->getInstance(PageTypeResolver::class);
+        $this->postTagTypeResolver = $instanceManager->getInstance(PostTagTypeResolver::class);
+        $this->postTypeResolver = $instanceManager->getInstance(PostTypeResolver::class);
+        $this->userRoleTypeResolver = $instanceManager->getInstance(UserRoleTypeResolver::class);
+        $this->userTypeResolver = $instanceManager->getInstance(UserTypeResolver::class);
     }
 
     /**
@@ -229,6 +233,10 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
 
     public function getDescription(string $module): string
     {
+        /**
+         * Temporary hack
+         */
+        $this->initializeState();
         switch ($module) {
             case self::SCHEMA_GENERIC_CUSTOMPOSTS:
                 return sprintf(
@@ -407,6 +415,10 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
      */
     public function getSettings(string $module): array
     {
+        /**
+         * Temporary hack
+         */
+        $this->initializeState();
         $moduleSettings = parent::getSettings($module);
         // Common variables to set the limit on the schema types
         $limitArg = 'limit';

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Enums/DirectiveLocationEnum.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Enums/DirectiveLocationEnum.php
@@ -9,11 +9,9 @@ use GraphQLByPoP\GraphQLServer\ObjectModels\DirectiveLocations;
 
 class DirectiveLocationEnum extends AbstractEnum
 {
-    public const NAME = 'DirectiveLocation';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'DirectiveLocation';
     }
     public function getValues(): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Enums/DirectiveTypeEnum.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Enums/DirectiveTypeEnum.php
@@ -9,11 +9,9 @@ use PoP\ComponentModel\Directives\DirectiveTypes;
 
 class DirectiveTypeEnum extends AbstractEnum
 {
-    public const NAME = 'DirectiveType';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'DirectiveType';
     }
     public function getValues(): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Enums/TypeKindEnum.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Enums/TypeKindEnum.php
@@ -9,11 +9,9 @@ use GraphQLByPoP\GraphQLServer\ObjectModels\TypeKinds;
 
 class TypeKindEnum extends AbstractEnum
 {
-    public const NAME = 'TypeKind';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'TypeKind';
     }
     public function getValues(): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/DirectiveTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/DirectiveTypeResolver.php
@@ -10,11 +10,9 @@ use GraphQLByPoP\GraphQLServer\TypeResolvers\AbstractIntrospectionTypeResolver;
 
 class DirectiveTypeResolver extends AbstractIntrospectionTypeResolver
 {
-    public const NAME = '__Directive';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return '__Directive';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/EnumValueTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/EnumValueTypeResolver.php
@@ -10,11 +10,9 @@ use GraphQLByPoP\GraphQLServer\TypeDataLoaders\SchemaDefinitionReferenceTypeData
 
 class EnumValueTypeResolver extends AbstractIntrospectionTypeResolver
 {
-    public const NAME = '__EnumValue';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return '__EnumValue';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/FieldTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/FieldTypeResolver.php
@@ -10,11 +10,9 @@ use GraphQLByPoP\GraphQLServer\TypeDataLoaders\SchemaDefinitionReferenceTypeData
 
 class FieldTypeResolver extends AbstractIntrospectionTypeResolver
 {
-    public const NAME = '__Field';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return '__Field';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/InputValueTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/InputValueTypeResolver.php
@@ -10,11 +10,9 @@ use GraphQLByPoP\GraphQLServer\TypeResolvers\AbstractIntrospectionTypeResolver;
 
 class InputValueTypeResolver extends AbstractIntrospectionTypeResolver
 {
-    public const NAME = '__InputValue';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return '__InputValue';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/MutationRootTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/MutationRootTypeResolver.php
@@ -14,11 +14,9 @@ class MutationRootTypeResolver extends AbstractUseRootAsSourceForSchemaTypeResol
 {
     use ReservedNameTypeResolverTrait;
 
-    public const NAME = 'MutationRoot';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'MutationRoot';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/QueryRootTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/QueryRootTypeResolver.php
@@ -14,11 +14,9 @@ class QueryRootTypeResolver extends AbstractUseRootAsSourceForSchemaTypeResolver
 {
     use ReservedNameTypeResolverTrait;
 
-    public const NAME = 'QueryRoot';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'QueryRoot';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/SchemaTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/SchemaTypeResolver.php
@@ -10,11 +10,9 @@ use GraphQLByPoP\GraphQLServer\TypeResolvers\AbstractIntrospectionTypeResolver;
 
 class SchemaTypeResolver extends AbstractIntrospectionTypeResolver
 {
-    public const NAME = '__Schema';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return '__Schema';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/TypeTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/TypeTypeResolver.php
@@ -10,11 +10,9 @@ use GraphQLByPoP\GraphQLServer\TypeDataLoaders\SchemaDefinitionReferenceTypeData
 
 class TypeTypeResolver extends AbstractIntrospectionTypeResolver
 {
-    public const NAME = '__Type';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return '__Type';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/basic-directives/src/Enums/DefaultConditionEnum.php
+++ b/layers/Schema/packages/basic-directives/src/Enums/DefaultConditionEnum.php
@@ -8,14 +8,12 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class DefaultConditionEnum extends AbstractEnum
 {
-    public const NAME = 'DefaultCondition';
-
     public const IS_NULL = 'IS_NULL';
     public const IS_EMPTY = 'IS_EMPTY';
 
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'DefaultCondition';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/categories/src/TypeResolvers/CategoryTypeResolver.php
+++ b/layers/Schema/packages/categories/src/TypeResolvers/CategoryTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class CategoryTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Category';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Category';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -13,10 +13,9 @@ use PoP\ComponentModel\FieldInterfaceResolvers\AbstractQueryableSchemaFieldInter
 
 class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInterfaceResolver
 {
-    public const NAME = 'Commentable';
     public function getInterfaceName(): string
     {
-        return self::NAME;
+        return 'Commentable';
     }
 
     public function getSchemaInterfaceDescription(): ?string

--- a/layers/Schema/packages/comments/src/TypeResolvers/CommentTypeResolver.php
+++ b/layers/Schema/packages/comments/src/TypeResolvers/CommentTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class CommentTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Comment';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Comment';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -17,6 +17,13 @@ use PoPSchema\CustomPostMediaMutations\MutationResolvers\RemoveFeaturedImageOnCu
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
+    protected MediaTypeResolver $mediaTypeResolver;
+
+    function __construct(MediaTypeResolver $mediaTypeResolver)
+    {
+        $this->mediaTypeResolver = $mediaTypeResolver;
+    }
+
     public static function getClassesToAttachTo(): array
     {
         return array(IsCustomPostFieldInterfaceResolver::class);
@@ -72,7 +79,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                             $translationAPI->__('The ID of the featured image, of type \'%s\'', 'custompostmedia-mutations'),
-                            MediaTypeResolver::NAME
+                            $this->mediaTypeResolver->getTypeName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
                     ],

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -18,6 +18,13 @@ use PoP\Engine\ComponentConfiguration as EngineComponentConfiguration;
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
+    protected MediaTypeResolver $mediaTypeResolver;
+
+    function __construct(MediaTypeResolver $mediaTypeResolver)
+    {
+        $this->mediaTypeResolver = $mediaTypeResolver;
+    }
+
     public static function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
@@ -74,7 +81,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                                 $translationAPI->__('The ID of the featured image, of type \'%s\'', 'custompostmedia-mutations'),
-                                MediaTypeResolver::NAME
+                                $this->mediaTypeResolver->getTypeName()
                             ),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],

--- a/layers/Schema/packages/custompostmedia-mutations/src/Hooks/CustomPostMutationResolverHooks.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/Hooks/CustomPostMutationResolverHooks.php
@@ -4,17 +4,30 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMediaMutations\Hooks;
 
-use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPostMutations\Schema\SchemaDefinitionHelpers;
+use PoP\Hooks\AbstractHookSet;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\Translation\TranslationAPIInterface;
 use PoPSchema\CustomPostMediaMutations\Facades\CustomPostMediaTypeAPIFacade;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\MutationInputProperties;
 use PoPSchema\CustomPostMutations\MutationResolvers\AbstractCreateUpdateCustomPostMutationResolver;
+use PoPSchema\CustomPostMutations\Schema\SchemaDefinitionHelpers;
+use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 
 class CustomPostMutationResolverHooks extends AbstractHookSet
 {
+    protected MediaTypeResolver $mediaTypeResolver;
+
+    public function __construct(
+        HooksAPIInterface $hooksAPI,
+        TranslationAPIInterface $translationAPI,
+        MediaTypeResolver $mediaTypeResolver
+    ) {
+        parent::__construct($hooksAPI, $translationAPI);
+        $this->mediaTypeResolver = $mediaTypeResolver;
+    }
+
     protected function init()
     {
         $this->hooksAPI->addFilter(
@@ -41,7 +54,7 @@ class CustomPostMutationResolverHooks extends AbstractHookSet
             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                 $this->translationAPI->__('The ID of the featured image (of type %s)', 'custompost-mutations'),
-                MediaTypeResolver::NAME
+                $this->mediaTypeResolver->getTypeName()
             ),
         ];
         return $fieldArgs;

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -11,10 +11,9 @@ use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResol
 
 class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
-    public const NAME = 'SupportingFeaturedImage';
     public function getInterfaceName(): string
     {
-        return self::NAME;
+        return 'SupportingFeaturedImage';
     }
 
     public function getSchemaInterfaceDescription(): ?string

--- a/layers/Schema/packages/customposts/src/Enums/CustomPostContentFormatEnum.php
+++ b/layers/Schema/packages/customposts/src/Enums/CustomPostContentFormatEnum.php
@@ -8,14 +8,12 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class CustomPostContentFormatEnum extends AbstractEnum
 {
-    public const NAME = 'CustomPostContentFormat';
-
     public const HTML = 'HTML';
     public const PLAIN_TEXT = 'PLAIN_TEXT';
 
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'CustomPostContentFormat';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/customposts/src/Enums/CustomPostStatusEnum.php
+++ b/layers/Schema/packages/customposts/src/Enums/CustomPostStatusEnum.php
@@ -9,11 +9,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class CustomPostStatusEnum extends AbstractEnum
 {
-    public const NAME = 'CustomPostStatus';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'CustomPostStatus';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -19,11 +19,9 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
 {
     use EnumTypeFieldInterfaceSchemaDefinitionResolverTrait;
 
-    public const NAME = 'IsCustomPost';
-
     public function getInterfaceName(): string
     {
-        return self::NAME;
+        return 'IsCustomPost';
     }
 
     public static function getImplementedInterfaceClasses(): array

--- a/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostTypeResolver.php
@@ -16,11 +16,9 @@ use PoPSchema\CustomPosts\TypeResolvers\AbstractCustomPostTypeResolver;
  */
 class CustomPostTypeResolver extends AbstractCustomPostTypeResolver
 {
-    public const NAME = 'CustomPost';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'CustomPost';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostUnionTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostUnionTypeResolver.php
@@ -11,11 +11,9 @@ use PoPSchema\CustomPosts\TypeDataLoaders\CustomPostUnionTypeDataLoader;
 
 class CustomPostUnionTypeResolver extends AbstractUnionTypeResolver
 {
-    public const NAME = 'CustomPostUnion';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'CustomPostUnion';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/events/src/Enums/EventScopeEnum.php
+++ b/layers/Schema/packages/events/src/Enums/EventScopeEnum.php
@@ -8,11 +8,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class EventScopeEnum extends AbstractEnum
 {
-    public const NAME = 'EventScope';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'EventScope';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/events/src/TypeResolvers/EventTypeResolver.php
+++ b/layers/Schema/packages/events/src/TypeResolvers/EventTypeResolver.php
@@ -11,11 +11,9 @@ use PoPSchema\CustomPosts\TypeResolvers\AbstractCustomPostTypeResolver;
 
 class EventTypeResolver extends AbstractCustomPostTypeResolver
 {
-    public const NAME = 'Event';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Event';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/everythingelse/src/Enums/CustomPostModeratedStatusEnum.php
+++ b/layers/Schema/packages/everythingelse/src/Enums/CustomPostModeratedStatusEnum.php
@@ -8,11 +8,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class CustomPostModeratedStatusEnum extends AbstractEnum
 {
-    public const NAME = 'CustomPostModeratedStatus';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'CustomPostModeratedStatus';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/everythingelse/src/Enums/CustomPostUnmoderatedStatusEnum.php
+++ b/layers/Schema/packages/everythingelse/src/Enums/CustomPostUnmoderatedStatusEnum.php
@@ -8,11 +8,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class CustomPostUnmoderatedStatusEnum extends AbstractEnum
 {
-    public const NAME = 'CustomPostUnmoderatedStatus';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'CustomPostUnmoderatedStatus';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/everythingelse/src/Enums/MemberPrivilegeEnum.php
+++ b/layers/Schema/packages/everythingelse/src/Enums/MemberPrivilegeEnum.php
@@ -8,11 +8,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class MemberPrivilegeEnum extends AbstractEnum
 {
-    public const NAME = 'MemberPrivilege';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'MemberPrivilege';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/everythingelse/src/Enums/MemberStatusEnum.php
+++ b/layers/Schema/packages/everythingelse/src/Enums/MemberStatusEnum.php
@@ -8,11 +8,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class MemberStatusEnum extends AbstractEnum
 {
-    public const NAME = 'MemberStatus';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'MemberStatus';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/everythingelse/src/Enums/MemberTagEnum.php
+++ b/layers/Schema/packages/everythingelse/src/Enums/MemberTagEnum.php
@@ -8,11 +8,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class MemberTagEnum extends AbstractEnum
 {
-    public const NAME = 'MemberTag';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'MemberTag';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/everythingelse/src/Enums/SocialMediaProviderEnum.php
+++ b/layers/Schema/packages/everythingelse/src/Enums/SocialMediaProviderEnum.php
@@ -8,11 +8,9 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class SocialMediaProviderEnum extends AbstractEnum
 {
-    public const NAME = 'SocialMediaProvider';
-
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'SocialMediaProvider';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/generic-customposts/src/TypeResolvers/GenericCustomPostTypeResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/TypeResolvers/GenericCustomPostTypeResolver.php
@@ -10,11 +10,9 @@ use PoPSchema\GenericCustomPosts\TypeDataLoaders\GenericCustomPostTypeDataLoader
 
 class GenericCustomPostTypeResolver extends AbstractCustomPostTypeResolver
 {
-    public const NAME = 'GenericCustomPost';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'GenericCustomPost';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/highlights/src/TypeResolvers/HighlightTypeResolver.php
+++ b/layers/Schema/packages/highlights/src/TypeResolvers/HighlightTypeResolver.php
@@ -11,11 +11,9 @@ use PoPSchema\Highlights\TypeDataLoaders\HighlightTypeDataLoader;
 
 class HighlightTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Highlight';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Highlight';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/locations/src/TypeResolvers/LocationTypeResolver.php
+++ b/layers/Schema/packages/locations/src/TypeResolvers/LocationTypeResolver.php
@@ -11,11 +11,9 @@ use PoPSchema\Locations\Facades\LocationTypeAPIFacade;
 
 class LocationTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Location';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Location';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/media/src/Enums/MediaDeviceEnum.php
+++ b/layers/Schema/packages/media/src/Enums/MediaDeviceEnum.php
@@ -8,15 +8,13 @@ use PoP\ComponentModel\Enums\AbstractEnum;
 
 class MediaDeviceEnum extends AbstractEnum
 {
-    public const NAME = 'MediaDevice';
-
     public const MOBILE = 'MOBILE';
     public const DESKTOP = 'DESKTOP';
     public const AUTOMATIC = 'AUTOMATIC';
 
     protected function getEnumName(): string
     {
-        return self::NAME;
+        return 'MediaDevice';
     }
     public function getValues(): array
     {

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -11,14 +11,18 @@ use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\Media\MutationResolvers\MutationInputProperties;
 use PoPSchema\CustomPosts\TypeResolvers\CustomPostTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
-use PoPSchema\Media\MutationResolvers\SetFeaturedImageOnCustomPostMutationResolver;
-use PoPSchema\Media\MutationResolvers\RemoveFeaturedImageOnCustomPostMutationResolver;
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
+    protected CustomPostTypeResolver $customPostTypeResolver;
+
+    function __construct(CustomPostTypeResolver $customPostTypeResolver)
+    {
+        $this->customPostTypeResolver = $customPostTypeResolver;
+    }
+
     public static function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
@@ -62,7 +66,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                             $translationAPI->__('The ID of the media element, of type \'%s\'', 'media'),
-                            CustomPostTypeResolver::NAME
+                            $this->customPostTypeResolver->getTypeName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
                     ],

--- a/layers/Schema/packages/media/src/TypeResolvers/MediaTypeResolver.php
+++ b/layers/Schema/packages/media/src/TypeResolvers/MediaTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class MediaTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Media';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Media';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/menus/src/TypeResolvers/MenuItemTypeResolver.php
+++ b/layers/Schema/packages/menus/src/TypeResolvers/MenuItemTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class MenuItemTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'MenuItem';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'MenuItem';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/menus/src/TypeResolvers/MenuTypeResolver.php
+++ b/layers/Schema/packages/menus/src/TypeResolvers/MenuTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class MenuTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Menu';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Menu';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,5 +1,8 @@
 <?php
+
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Highlights\TypeResolvers\HighlightTypeResolver;
 
 class PoP_AddHighlights_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
@@ -13,11 +16,14 @@ class PoP_AddHighlights_Multilayout_Processor extends PoP_Application_Multilayou
                 case POP_MULTILAYOUT_HANDLE_POSTCONTENT:
                 case POP_MULTILAYOUT_HANDLE_AUTHORPOSTCONTENT:
                 case POP_MULTILAYOUT_HANDLE_SINGLEPOSTCONTENT:
+                    $instanceManager = InstanceManagerFacade::getInstance();
+                    /** @var TypeResolverInterface */
+                    $highlightTypeResolver = $instanceManager->getInstance(HighlightTypeResolver::class);
                     $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                     $field = $fieldQueryInterpreter->getField(
                         'isType',
                         [
-                            'type' => HighlightTypeResolver::NAME,
+                            'type' => $highlightTypeResolver->getTypeName(),
                         ]
                     );
                     $layouts[$field] = [PoP_Module_Processor_CustomPreviewPostLayouts::class, PoP_Module_Processor_CustomPreviewPostLayouts::MODULE_LAYOUT_PREVIEWPOST_HIGHLIGHT_CONTENT];

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/plugins/pop-events/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/plugins/pop-events/library/multilayout-processors/multilayout-processors.php
@@ -1,7 +1,9 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoPSchema\Events\TypeResolvers\EventTypeResolver;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Events\Facades\EventTypeAPIFacade;
+use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 
 class PoP_CommonAutomatedEmails_Events_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
 {
@@ -23,11 +25,14 @@ class PoP_CommonAutomatedEmails_Events_Multilayout_Processor extends PoP_Applica
                         POP_FORMAT_FULLVIEW => [PoPTheme_Wassup_EM_AE_Module_Processor_FullViewLayouts::class, PoPTheme_Wassup_EM_AE_Module_Processor_FullViewLayouts::MODULE_LAYOUT_AUTOMATEDEMAILS_FULLVIEW_EVENT],
                     );
                     if ($layout = $event_layouts[$format] ?? null) {
+                        $instanceManager = InstanceManagerFacade::getInstance();
+                        /** @var TypeResolverInterface */
+                        $eventTypeResolver = $instanceManager->getInstance(EventTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
                             'isType',
                             [
-                                'type' => EventTypeResolver::NAME,
+                                'type' => $eventTypeResolver->getTypeName(),
                             ]
                         );
                         $layouts[$field] = $layout;

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/library/mentions/mentions.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/library/mentions/mentions.php
@@ -1,9 +1,11 @@
 <?php
-use PoP\Hooks\Facades\HooksAPIFacade;
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Misc\RequestUtils;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Hooks\Facades\HooksAPIFacade;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 /**
  * Copied from plugin `hashtagger` (https://wordpress.org/plugins/hashtagger/)
@@ -248,9 +250,12 @@ class PoP_Mentions
             $content = $match[0];
         } else {
             // Allow for the popover by adding data-popover-id
+            $instanceManager = InstanceManagerFacade::getInstance();
+            /** @var TypeResolverInterface */
+            $userTypeResolver = $instanceManager->getInstance(UserTypeResolver::class);
             $content = sprintf(
                 '<a class="pop-mentions-user" data-popover-target="%s" href="%s">%s</a>',
-                '#popover-'.RequestUtils::getDomainId($cmsengineapi->getSiteURL()).'-'.UserTypeResolver::NAME.'-'.$cmsusersresolver->getUserId($user),
+                '#popover-' . RequestUtils::getDomainId($cmsengineapi->getSiteURL()) . '-' . $userTypeResolver->getTypeName() . '-' . $cmsusersresolver->getUserId($user),
                 $cmsusersapi->getUserURL($cmsusersresolver->getUserId($user)),
                 $cmsusersresolver->getUserDisplayName($user)
             );

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/appendcomment-base.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/appendcomment-base.php
@@ -1,4 +1,6 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 
 abstract class PoP_Module_Processor_AppendCommentLayoutsBase extends PoPEngine_QueryDataModuleProcessorBase
@@ -22,7 +24,10 @@ abstract class PoP_Module_Processor_AppendCommentLayoutsBase extends PoPEngine_Q
     {
         $ret = parent::getImmutableConfiguration($module, $props);
 
-        $ret['post-dbkey'] = PostTypeResolver::NAME;
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var TypeResolverInterface */
+        $postTypeResolver = $instanceManager->getInstance(PostTypeResolver::class);
+        $ret['post-dbkey'] = $postTypeResolver->getTypeName();
         $ret[GD_JS_CLASSES][GD_JS_APPENDABLE] = 'comments';
 
         return $ret;

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/plugins/pop-application-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/plugins/pop-application-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,8 +1,10 @@
 <?php
-use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoPSchema\Events\TypeResolvers\EventTypeResolver;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Hooks\Facades\HooksAPIFacade;
 use PoPSchema\Events\Facades\EventTypeAPIFacade;
+use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 
 class PoP_Events_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
 {
@@ -19,10 +21,13 @@ class PoP_Events_Multilayout_Processor extends PoP_Application_Multilayout_Proce
         $eventTypeAPI = EventTypeAPIFacade::getInstance();
         $event_post_type = $eventTypeAPI->getEventCustomPostType();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var TypeResolverInterface */
+        $eventTypeResolver = $instanceManager->getInstance(EventTypeResolver::class);
         $field = $fieldQueryInterpreter->getField(
             'isType',
             [
-                'type' => EventTypeResolver::NAME,
+                'type' => $eventTypeResolver->getTypeName(),
             ]
         );
 

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,7 +1,9 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoPSchema\Events\TypeResolvers\EventTypeResolver;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Events\Facades\EventTypeAPIFacade;
+use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 
 class PoP_EventsCreation_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
 {
@@ -28,11 +30,14 @@ class PoP_EventsCreation_Multilayout_Processor extends PoP_Application_Multilayo
                     //     $layouts[$event_post_type.'-'.POP_EVENTS_SCOPE_PAST] = $layout;
                     // }
                     if ($layout = $defaults[$format] ?? null) {
+                        $instanceManager = InstanceManagerFacade::getInstance();
+                        /** @var TypeResolverInterface */
+                        $eventTypeResolver = $instanceManager->getInstance(EventTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
                             'isType',
                             [
-                                'type' => EventTypeResolver::NAME,
+                                'type' => $eventTypeResolver->getTypeName(),
                             ]
                         );
                         $layouts[$field] = $layout;

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostcategorylayouts-processors/library/dataload-hooks/layouts.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostcategorylayouts-processors/library/dataload-hooks/layouts.php
@@ -1,7 +1,9 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Hooks\Facades\HooksAPIFacade;
-use PoPSchema\LocationPosts\TypeResolvers\LocationPostTypeResolver;
 use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
+use PoPSchema\LocationPosts\TypeResolvers\LocationPostTypeResolver;
 
 class PoP_LocationPostCategoryLayouts_LayoutDataloadHooks
 {
@@ -29,7 +31,10 @@ class PoP_LocationPostCategoryLayouts_LayoutDataloadHooks
             }
             if ($add_layout) {
                 // Priority: place it before the 'postType' layout key
-                array_unshift($keys, LocationPostTypeResolver::NAME.'-map');
+                $instanceManager = InstanceManagerFacade::getInstance();
+                /** @var TypeResolverInterface */
+                $locationPostTypeResolver = $instanceManager->getInstance(LocationPostTypeResolver::class);
+                array_unshift($keys, $locationPostTypeResolver->getTypeName() . '-map');
             }
         }
         return $keys;

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,5 +1,7 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\LocationPosts\TypeResolvers\LocationPostTypeResolver;
 
 class PoP_LocationPostCategoryLayouts_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
@@ -9,11 +11,14 @@ class PoP_LocationPostCategoryLayouts_Multilayout_Processor extends PoP_Applicat
         switch ($handle) {
             case POP_MULTILAYOUT_HANDLE_POSTABOVECONTENT:
                 if (POP_POSTCATEGORYLAYOUTS_CATEGORIES_LAYOUTFEATUREIMAGE) {
+                    $instanceManager = InstanceManagerFacade::getInstance();
+                    /** @var TypeResolverInterface */
+                    $locationPostTypeResolver = $instanceManager->getInstance(LocationPostTypeResolver::class);
                     $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                     $field = $fieldQueryInterpreter->getField(
                         'isType',
                         [
-                            'type' => LocationPostTypeResolver::NAME,
+                            'type' => $locationPostTypeResolver->getTypeName(),
                         ]
                     );
                     $layouts[$field] = [PoP_LocationPostCategoryLayouts_Module_Processor_MultipleComponents::class, PoP_LocationPostCategoryLayouts_Module_Processor_MultipleComponents::MODULE_MULTICOMPONENT_LOCATIONMAP];

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,6 +1,8 @@
 <?php
-use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Hooks\Facades\HooksAPIFacade;
 use PoPSchema\LocationPosts\TypeResolvers\LocationPostTypeResolver;
 
 class PoP_LocationPosts_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
@@ -15,11 +17,14 @@ class PoP_LocationPosts_Multilayout_Processor extends PoP_Application_Multilayou
 
     public function addLayoutModules(&$layouts, $handle, $format = '')
     {
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var TypeResolverInterface */
+        $locationPostTypeResolver = $instanceManager->getInstance(LocationPostTypeResolver::class);
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
         $field = $fieldQueryInterpreter->getField(
             'isType',
             [
-                'type' => LocationPostTypeResolver::NAME,
+                'type' => $locationPostTypeResolver->getTypeName(),
             ]
         );
         switch ($handle) {

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,5 +1,7 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\LocationPosts\TypeResolvers\LocationPostTypeResolver;
 
 class PoP_LocationPostsCreation_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
@@ -16,11 +18,14 @@ class PoP_LocationPostsCreation_Multilayout_Processor extends PoP_Application_Mu
                 }
 
                 if ($layout = $location_modules[$format] ?? null) {
+                    $instanceManager = InstanceManagerFacade::getInstance();
+                    /** @var TypeResolverInterface */
+                    $locationPostTypeResolver = $instanceManager->getInstance(LocationPostTypeResolver::class);
                     $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                     $field = $fieldQueryInterpreter->getField(
                         'isType',
                         [
-                            'type' => LocationPostTypeResolver::NAME,
+                            'type' => $locationPostTypeResolver->getTypeName(),
                         ]
                     );
                     $layouts[$field] = $layout;

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,5 +1,7 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 
 class PoP_PostCategoryLayouts_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
@@ -15,11 +17,14 @@ class PoP_PostCategoryLayouts_Multilayout_Processor extends PoP_Application_Mult
                 );
                 if ($layout = $extra_layouts[$format] ?? null) {
                     if (POP_POSTCATEGORYLAYOUTS_CATEGORIES_LAYOUTFEATUREIMAGE) {
+                        $instanceManager = InstanceManagerFacade::getInstance();
+                        /** @var TypeResolverInterface */
+                        $postTypeResolver = $instanceManager->getInstance(PostTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
                             'isType',
                             [
-                                'type' => PostTypeResolver::NAME,
+                                'type' => $postTypeResolver->getTypeName(),
                             ]
                         );
                         $layouts[$field] = $layout;

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/multilayout-processors/multilayout-processors.php
@@ -1,5 +1,7 @@
 <?php
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Stances\TypeResolvers\StanceTypeResolver;
 
 class PoP_UserStance_Multilayout_Processor extends PoP_Application_Multilayout_ProcessorBase
@@ -34,11 +36,14 @@ class PoP_UserStance_Multilayout_Processor extends PoP_Application_Multilayout_P
                     }
 
                     if ($layout = $stance_layouts[$format] ?? null) {
+                        $instanceManager = InstanceManagerFacade::getInstance();
+                        /** @var TypeResolverInterface */
+                        $stanceTypeResolver = $instanceManager->getInstance(StanceTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
                             'isType',
                             [
-                                'type' => StanceTypeResolver::NAME,
+                                'type' => $stanceTypeResolver->getTypeName(),
                             ]
                         );
                         $layouts[$field] = $layout;

--- a/layers/Schema/packages/notifications/src/TypeResolvers/NotificationTypeResolver.php
+++ b/layers/Schema/packages/notifications/src/TypeResolvers/NotificationTypeResolver.php
@@ -10,11 +10,9 @@ use PoPSchema\Notifications\TypeDataLoaders\NotificationTypeDataLoader;
 
 class NotificationTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Notification';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Notification';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/pages/src/TypeResolvers/PageTypeResolver.php
+++ b/layers/Schema/packages/pages/src/TypeResolvers/PageTypeResolver.php
@@ -10,11 +10,9 @@ use PoPSchema\CustomPosts\TypeResolvers\AbstractCustomPostTypeResolver;
 
 class PageTypeResolver extends AbstractCustomPostTypeResolver
 {
-    public const NAME = 'Page';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Page';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/post-tags/src/TypeResolvers/PostTagTypeResolver.php
+++ b/layers/Schema/packages/post-tags/src/TypeResolvers/PostTagTypeResolver.php
@@ -13,11 +13,9 @@ class PostTagTypeResolver extends AbstractTagTypeResolver
 {
     use PostTagAPISatisfiedContractTrait;
 
-    public const NAME = 'PostTag';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'PostTag';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/posts/src/TypeResolvers/PostTypeResolver.php
+++ b/layers/Schema/packages/posts/src/TypeResolvers/PostTypeResolver.php
@@ -10,11 +10,9 @@ use PoPSchema\CustomPosts\TypeResolvers\AbstractCustomPostTypeResolver;
 
 class PostTypeResolver extends AbstractCustomPostTypeResolver
 {
-    public const NAME = 'Post';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Post';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResol
 
 class QueryableFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
-    public const NAME = 'Queryable';
-
     public function getInterfaceName(): string
     {
-        return self::NAME;
+        return 'Queryable';
     }
 
     public function getSchemaInterfaceDescription(): ?string

--- a/layers/Schema/packages/stances/src/TypeResolvers/StanceTypeResolver.php
+++ b/layers/Schema/packages/stances/src/TypeResolvers/StanceTypeResolver.php
@@ -11,11 +11,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class StanceTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Stance';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Stance';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/user-roles-wp/src/TypeResolvers/UserRoleTypeResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/TypeResolvers/UserRoleTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class UserRoleTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'UserRole';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'UserRole';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -11,11 +11,9 @@ use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResol
 
 class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
-    public const NAME = 'WithAuthor';
-
     public function getInterfaceName(): string
     {
-        return self::NAME;
+        return 'WithAuthor';
     }
 
     public function getSchemaInterfaceDescription(): ?string

--- a/layers/Schema/packages/users/src/TypeResolvers/UserTypeResolver.php
+++ b/layers/Schema/packages/users/src/TypeResolvers/UserTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class UserTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'User';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'User';
     }
 
     public function getSchemaTypeDescription(): ?string

--- a/layers/SiteBuilder/packages/multisite/src/TypeResolvers/SiteTypeResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/TypeResolvers/SiteTypeResolver.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 
 class SiteTypeResolver extends AbstractTypeResolver
 {
-    public const NAME = 'Site';
-
     public function getTypeName(): string
     {
-        return self::NAME;
+        return 'Site';
     }
 
     public function getSchemaTypeDescription(): ?string


### PR DESCRIPTION
For all classes of type `TypeResolver`, `InterfaceResolver` and `Enum`, do not store/return their name under a static property `NAME`. That's because this const should not be accessed directly, just in case that the service is overridden via dependency injection.