### PR TITLE
Force autoconfigure for schema services

### DIFF
--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
@@ -27,10 +27,19 @@ abstract class AbstractAttachExtensionCompilerPass implements CompilerPassInterf
                     continue;
                 }
 
-                $attachExtensionServiceDefinition->addMethodCall(
-                    'enqueueExtension',
-                    [$event, $definitionClass, $attachableGroup]
-                );
+                /**
+                 * Only attach the extension when autoconfigure => true
+                 * Then, if autoconfigure => false, the service is registered in the container,
+                 * but the class is not attached.
+                 * This is used for disabling the Schema services,
+                 * together with ForceAutoconfigureYamlFileLoader
+                 */
+                if ($definition->isAutoconfigured()) {
+                    $attachExtensionServiceDefinition->addMethodCall(
+                        'enqueueExtension',
+                        [$event, $definitionClass, $attachableGroup]
+                    );
+                }
                 // A service won't be of 2 attachable classes, so can skip checking
                 continue(2);
             }

--- a/layers/Engine/packages/root/src/Container/Loader/ForceAutoconfigureYamlFileLoader.php
+++ b/layers/Engine/packages/root/src/Container/Loader/ForceAutoconfigureYamlFileLoader.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Container\Loader;
+
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class ForceAutoconfigureYamlFileLoader extends YamlFileLoader
+{
+    protected bool $autoconfigure;
+
+    public function __construct(
+        ContainerBuilder $container,
+        FileLocatorInterface $locator,
+        ?bool $autoconfigure = true
+    ) {
+        parent::__construct($container, $locator);
+        $this->autoconfigure = $autoconfigure;
+    }
+
+    /**
+     * Override the Symfony class, to always inject the
+     * "autoconfigure" property
+     */
+    protected function loadFile($file)
+    {
+        $content = parent::loadFile($file);
+        $content['services']['_defaults']['autoconfigure'] = $this->autoconfigure;
+        return $content;
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/HybridServices/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/HybridServices/ModuleResolvers/SchemaModuleResolver.php
@@ -33,10 +33,9 @@ class SchemaModuleResolver extends AbstractSchemaTypeModuleResolver
         ?LowerCaseStringDirectiveResolver $lowerCaseStringDirectiveResolver,
         ?TitleCaseStringDirectiveResolver $titleCaseStringDirectiveResolver
     ) {
-        // Hack: Temporarily instantiate new class
-        $this->upperCaseStringDirectiveResolver = $upperCaseStringDirectiveResolver ?? new UpperCaseStringDirectiveResolver();
-        $this->lowerCaseStringDirectiveResolver = $lowerCaseStringDirectiveResolver ?? new LowerCaseStringDirectiveResolver();
-        $this->titleCaseStringDirectiveResolver = $titleCaseStringDirectiveResolver ?? new TitleCaseStringDirectiveResolver();
+        $this->upperCaseStringDirectiveResolver = $upperCaseStringDirectiveResolver;
+        $this->lowerCaseStringDirectiveResolver = $lowerCaseStringDirectiveResolver;
+        $this->titleCaseStringDirectiveResolver = $titleCaseStringDirectiveResolver;
     }
 
     public static function getModulesToResolve(): array

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/HybridServices/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/HybridServices/ModuleResolvers/SchemaModuleResolver.php
@@ -19,11 +19,13 @@ class SchemaModuleResolver extends AbstractSchemaTypeModuleResolver
     public const CONVERT_CASE_DIRECTIVES = Plugin::NAMESPACE . '\convert-case-directives';
 
     /**
-    * Make all properties nullable, becase the ModuleRegistry is registered
-    * in the SystemContainer, where there are no typeResolvers so it will be null,
-    * and in the ApplicationContainer, from where the "Modules" page is resolved
-    * and which does have all the typeResolvers
-    */
+     * Make all properties nullable, becase the ModuleRegistry is registered
+     * in the SystemContainer, where there are no typeResolvers so it will be null,
+     * and in the ApplicationContainer, from where the "Modules" page is resolved
+     * and which does have all the typeResolvers.
+     * Function `getDescription` will only be accessed from the Application Container,
+     * so the properties will not be null in that situation.
+     */
     protected ?UpperCaseStringDirectiveResolver $upperCaseStringDirectiveResolver;
     protected ?LowerCaseStringDirectiveResolver $lowerCaseStringDirectiveResolver;
     protected ?TitleCaseStringDirectiveResolver $titleCaseStringDirectiveResolver;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -66,7 +66,9 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
      * Make all properties nullable, becase the ModuleRegistry is registered
      * in the SystemContainer, where there are no typeResolvers so it will be null,
      * and in the ApplicationContainer, from where the "Modules" page is resolved
-     * and which does have all the typeResolvers
+     * and which does have all the typeResolvers.
+     * Function `getDescription` will only be accessed from the Application Container,
+     * so the properties will not be null in that situation.
      */
     protected ?CommentTypeResolver $commentTypeResolver;
     protected ?CustomPostUnionTypeResolver $customPostUnionTypeResolver;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -89,16 +89,15 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
         ?UserRoleTypeResolver $userRoleTypeResolver,
         ?UserTypeResolver $userTypeResolver
     ) {
-        // Hack: Temporarily instantiate new class
-        $this->commentTypeResolver = $commentTypeResolver ?? new CommentTypeResolver();
-        $this->customPostUnionTypeResolver = $customPostUnionTypeResolver ?? new CustomPostUnionTypeResolver();
-        $this->genericCustomPostTypeResolver = $genericCustomPostTypeResolver ?? new GenericCustomPostTypeResolver();
-        $this->mediaTypeResolver = $mediaTypeResolver ?? new MediaTypeResolver();
-        $this->pageTypeResolver = $pageTypeResolver ?? new PageTypeResolver();
-        $this->postTagTypeResolver = $postTagTypeResolver ?? new PostTagTypeResolver();
-        $this->postTypeResolver = $postTypeResolver ?? new PostTypeResolver();
-        $this->userRoleTypeResolver = $userRoleTypeResolver ?? new UserRoleTypeResolver();
-        $this->userTypeResolver = $userTypeResolver ?? new UserTypeResolver();
+        $this->commentTypeResolver = $commentTypeResolver;
+        $this->customPostUnionTypeResolver = $customPostUnionTypeResolver;
+        $this->genericCustomPostTypeResolver = $genericCustomPostTypeResolver;
+        $this->mediaTypeResolver = $mediaTypeResolver;
+        $this->pageTypeResolver = $pageTypeResolver;
+        $this->postTagTypeResolver = $postTagTypeResolver;
+        $this->postTypeResolver = $postTypeResolver;
+        $this->userRoleTypeResolver = $userRoleTypeResolver;
+        $this->userTypeResolver = $userTypeResolver;
     }
 
     /**


### PR DESCRIPTION
Before, if `$skipSchema` is `true`, then schema services would not be registered in the container.

That created a problem: the `ModuleResolver` needs to show the name for those services in the Modules page, but since a disabled module was not registered in the container, we couldn't access its name.

This PR changes the procedure:

- Schema services are always registered in the container
- But, if `$skipSchema` is `true`, they are just not initialized

Schema services are all of the `AttachExtension` type. Hence, "not initialized" means that they do not execute their `attach` method.

To do this, we created a new `ForceAutoconfigureYamlFileLoader` class which will always set the default `autoconfigure` option in the container, with value `!$skipSchema`.

And then, in the `CompilerPass` to register all `AttachExtension` objects in the registry, we only register those objects with `autoconfigure => true` (i.e. `$skipSchema => false`)