### PR TITLE
AttachExtensionRegistry: deal with service, not definitionID

### DIFF
--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -22,7 +22,7 @@ use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Engine/packages/access-control/src/TypeResolverDecorators/ConfigurableAccessControlForDirectivesTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/access-control/src/TypeResolverDecorators/ConfigurableAccessControlForDirectivesTypeResolverDecoratorTrait.php
@@ -26,7 +26,7 @@ trait ConfigurableAccessControlForDirectivesTypeResolverDecoratorTrait
      *
      * @return array
      */
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             AbstractTypeResolver::class,

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
@@ -12,7 +12,7 @@ final class CacheControlDirectiveResolver extends AbstractCacheControlDirectiveR
     /**
      * It must execute after everyone else!
      */
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         return 0;
     }

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
@@ -32,7 +32,7 @@ class NestedFieldCacheControlDirectiveResolver extends AbstractCacheControlDirec
     /**
      * It must execute before anyone else!
      */
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         return PHP_INT_MAX;
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionService.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionService.php
@@ -4,21 +4,25 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\AttachableExtensions;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
+
 class AttachExtensionService implements AttachExtensionServiceInterface
 {
     /**
-     * @var array<string,array<string,string>>
+     * @var array<string,array<string,AttachableExtensionInterface[]>>
      */
     protected array $classGroups = [];
 
-    public function enqueueExtension(string $event, string $class, string $group): void
+    public function enqueueExtension(string $event, string $group, AttachableExtensionInterface $extension): void
     {
-        $this->classGroups[$event][$class] = $group;
+        $this->classGroups[$event][$group][] = $extension;
     }
     public function attachExtensions(string $event): void
     {
-        foreach ($this->classGroups[$event] as $class => $group) {
-            $class::attach($group);
+        foreach ($this->classGroups[$event] as $group => $extensions) {
+            foreach ($extensions as $extension) {
+                $extension::attach($group);
+            }
         }
     }
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionService.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionService.php
@@ -21,7 +21,7 @@ class AttachExtensionService implements AttachExtensionServiceInterface
     {
         foreach ($this->classGroups[$event] as $group => $extensions) {
             foreach ($extensions as $extension) {
-                $extension::attach($group);
+                $extension->attach($group);
             }
         }
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionServiceInterface.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\AttachableExtensions;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
+
 interface AttachExtensionServiceInterface
 {
-    public function enqueueExtension(string $event, string $class, string $group): void;
+    public function enqueueExtension(string $event, string $group, AttachableExtensionInterface $extension): void;
     public function attachExtensions(string $event): void;
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -14,7 +14,7 @@ interface AttachableExtensionInterface
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
      */
-    public static function getPriorityToAttachClasses(): ?int;
+    public function getPriorityToAttachClasses(): ?int;
 
     /**
      * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -13,18 +13,12 @@ interface AttachableExtensionInterface
 
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
-     *
-     * @return integer|null
      */
     public static function getPriorityToAttachClasses(): ?int;
 
     /**
      * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself
      * The priority in the class has priority (pun intended ;))
-     *
-     * @param string $group
-     * @param integer $priority
-     * @return void
      */
-    public static function attach(string $group, int $priority = 10): void;
+    public function attach(string $group, int $priority = 10): void;
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -9,7 +9,7 @@ interface AttachableExtensionInterface
     /**
      * It is represented through a static class, because the extensions work at class level, not object level
      */
-    public static function getClassesToAttachTo(): array;
+    public function getClassesToAttachTo(): array;
 
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\AttachableExtensions;
+
+interface AttachableExtensionInterface
+{
+    /**
+     * It is represented through a static class, because the extensions work at class level, not object level
+     */
+    public static function getClassesToAttachTo(): array;
+
+    /**
+     * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
+     *
+     * @return integer|null
+     */
+    public static function getPriorityToAttachClasses(): ?int;
+
+    /**
+     * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself
+     * The priority in the class has priority (pun intended ;))
+     *
+     * @param string $group
+     * @param integer $priority
+     * @return void
+     */
+    public static function attach(string $group, int $priority = 10);
+}

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -26,5 +26,5 @@ interface AttachableExtensionInterface
      * @param integer $priority
      * @return void
      */
-    public static function attach(string $group, int $priority = 10);
+    public static function attach(string $group, int $priority = 10): void;
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -34,7 +34,7 @@ trait AttachableExtensionTrait
      * @param integer $priority
      * @return void
      */
-    public static function attach(string $group, int $priority = 10): void
+    public function attach(string $group, int $priority = 10): void
     {
         $attachableExtensionManager = AttachableExtensionManagerFacade::getInstance();
         $extensionClass = get_called_class();

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -21,7 +21,7 @@ trait AttachableExtensionTrait
      *
      * @return integer|null
      */
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         return null;
     }
@@ -43,7 +43,7 @@ trait AttachableExtensionTrait
                 $attachableClass,
                 $group,
                 $extensionClass,
-                $extensionClass::getPriorityToAttachClasses() ?? $priority
+                $this->getPriorityToAttachClasses() ?? $priority
             );
         }
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -18,8 +18,6 @@ trait AttachableExtensionTrait
 
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
-     *
-     * @return integer|null
      */
     public function getPriorityToAttachClasses(): ?int
     {
@@ -29,10 +27,6 @@ trait AttachableExtensionTrait
     /**
      * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself
      * The priority in the class has priority (pun intended ;))
-     *
-     * @param string $group
-     * @param integer $priority
-     * @return void
      */
     public function attach(string $group, int $priority = 10): void
     {

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -11,7 +11,7 @@ trait AttachableExtensionTrait
     /**
      * It is represented through a static class, because the extensions work at class level, not object level
      */
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [];
     }
@@ -38,7 +38,7 @@ trait AttachableExtensionTrait
     {
         $attachableExtensionManager = AttachableExtensionManagerFacade::getInstance();
         $extensionClass = get_called_class();
-        foreach ($extensionClass::getClassesToAttachTo() as $attachableClass) {
+        foreach ($this->getClassesToAttachTo() as $attachableClass) {
             $attachableExtensionManager->setExtensionClass(
                 $attachableClass,
                 $group,

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -34,7 +34,7 @@ trait AttachableExtensionTrait
      * @param integer $priority
      * @return void
      */
-    public static function attach(string $group, int $priority = 10)
+    public static function attach(string $group, int $priority = 10): void
     {
         $attachableExtensionManager = AttachableExtensionManagerFacade::getInstance();
         $extensionClass = get_called_class();

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
@@ -7,6 +7,7 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 use PoP\ComponentModel\AttachableExtensions\AttachExtensionServiceInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractAttachExtensionCompilerPass implements CompilerPassInterface
 {
@@ -16,7 +17,7 @@ abstract class AbstractAttachExtensionCompilerPass implements CompilerPassInterf
         $attachableClassGroups = $this->getAttachableClassGroups();
         $attachExtensionServiceDefinition = $containerBuilder->getDefinition(AttachExtensionServiceInterface::class);
         $definitions = $containerBuilder->getDefinitions();
-        foreach ($definitions as $definition) {
+        foreach ($definitions as $definitionID => $definition) {
             $definitionClass = $definition->getClass();
             if ($definitionClass === null) {
                 continue;
@@ -37,7 +38,7 @@ abstract class AbstractAttachExtensionCompilerPass implements CompilerPassInterf
                 if ($definition->isAutoconfigured()) {
                     $attachExtensionServiceDefinition->addMethodCall(
                         'enqueueExtension',
-                        [$event, $definitionClass, $attachableGroup]
+                        [$event, $attachableGroup, new Reference($definitionID)]
                     );
                 }
                 // A service won't be of 2 attachable classes, so can skip checking

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -4,27 +4,28 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\DirectiveResolvers;
 
-use Exception;
 use Composer\Semver\Semver;
-use PoP\FieldQuery\QueryHelpers;
+use Exception;
 use League\Pipeline\StageInterface;
-use PoP\ComponentModel\Environment;
-use PoP\ComponentModel\Feedback\Tokens;
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
+use PoP\ComponentModel\DirectivePipeline\DirectivePipelineUtils;
 use PoP\ComponentModel\Directives\DirectiveTypes;
-use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\ComponentModel\Environment;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\Feedback\Tokens;
+use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\Resolvers\ResolverTypes;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\FieldSymbols;
-use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\ComponentModel\TypeResolvers\PipelinePositions;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
-use PoP\ComponentModel\DirectivePipeline\DirectivePipelineUtils;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
-use PoP\ComponentModel\Resolvers\ResolverTypes;
+use PoP\ComponentModel\Versioning\VersioningHelpers;
+use PoP\FieldQuery\QueryHelpers;
+use PoP\Translation\Facades\TranslationAPIFacade;
 
-abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, SchemaDirectiveResolverInterface, StageInterface
+abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, SchemaDirectiveResolverInterface, StageInterface, AttachableExtensionInterface
 {
     use AttachableExtensionTrait;
     use RemoveIDsDataFieldsDirectiveResolverTrait;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/GlobalDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/GlobalDirectiveResolverTrait.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait GlobalDirectiveResolverTrait
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         // Be attached to all typeResolvers
         return [

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -4,30 +4,31 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
-use Exception;
 use Composer\Semver\Semver;
-use PoP\ComponentModel\Environment;
-use PoP\Hooks\Facades\HooksAPIFacade;
-use PoP\ComponentModel\Misc\GeneralUtils;
-use PoP\ComponentModel\Schema\HookHelpers;
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\ComponentModel\Resolvers\ResolverTypes;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Facades\Engine\EngineFacade;
-use PoP\ComponentModel\Versioning\VersioningHelpers;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
-use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
-use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+use Exception;
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 use PoP\ComponentModel\CheckpointSets\CheckpointSets;
-use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverTrait;
-use PoP\ComponentModel\Resolvers\InterfaceSchemaDefinitionResolverAdapter;
-use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
+use PoP\ComponentModel\Environment;
 use PoP\ComponentModel\ErrorHandling\Error;
+use PoP\ComponentModel\Facades\Engine\EngineFacade;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
+use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\Resolvers\InterfaceSchemaDefinitionResolverAdapter;
+use PoP\ComponentModel\Resolvers\ResolverTypes;
+use PoP\ComponentModel\Schema\HookHelpers;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Versioning\VersioningHelpers;
+use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\Translation\Facades\TranslationAPIFacade;
 
-abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSchemaDefinitionResolverInterface
+abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSchemaDefinitionResolverInterface, AttachableExtensionInterface
 {
     /**
      * This class is attached to a TypeResolver

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\FieldInterfaceResolvers\ElementalFieldInterfaceResolver;
 
 class ElementalFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             AbstractTypeResolver::class,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/GlobalFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/GlobalFieldResolverTrait.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait GlobalFieldResolverTrait
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             AbstractTypeResolver::class,

--- a/layers/Engine/packages/component-model/src/TypeResolverDecorators/AbstractTypeResolverDecorator.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverDecorators/AbstractTypeResolverDecorator.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolverDecorators;
 
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 use PoP\ComponentModel\TypeResolverDecorators\TypeResolverDecoratorInterface;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
-abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInterface
+abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInterface, AttachableExtensionInterface
 {
     /**
      * This class is attached to a TypeResolver

--- a/layers/Engine/packages/component-model/src/TypeResolverPickers/AbstractTypeResolverPicker.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverPickers/AbstractTypeResolverPicker.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolverPickers;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 
-abstract class AbstractTypeResolverPicker implements TypeResolverPickerInterface
+abstract class AbstractTypeResolverPicker implements TypeResolverPickerInterface, AttachableExtensionInterface
 {
     use AttachableExtensionTrait;
 

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/CacheTypeResolverDecorator.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/CacheTypeResolverDecorator.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\TypeResolverDecorators\AbstractTypeResolverDecorator;
 
 class CacheTypeResolverDecorator extends AbstractTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             AbstractTypeResolver::class,

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/AbstractMandatoryDirectivesForDirectivesTypeResolverDecorator.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/AbstractMandatoryDirectivesForDirectivesTypeResolverDecorator.php
@@ -17,7 +17,7 @@ abstract class AbstractMandatoryDirectivesForDirectivesTypeResolverDecorator ext
      *
      * @return array
      */
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             AbstractTypeResolver::class,

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/ConfigurableMandatoryDirectivesForFieldsTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/ConfigurableMandatoryDirectivesForFieldsTypeResolverDecoratorTrait.php
@@ -11,7 +11,7 @@ trait ConfigurableMandatoryDirectivesForFieldsTypeResolverDecoratorTrait
 {
     use ConfigurableMandatoryDirectivesForFieldsTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array_map(
             function ($entry) {

--- a/layers/Engine/packages/trace-tools/src/TypeResolverDecorators/TraceTypeResolverDecorator.php
+++ b/layers/Engine/packages/trace-tools/src/TypeResolverDecorators/TraceTypeResolverDecorator.php
@@ -13,7 +13,7 @@ use PoP\TraceTools\DirectiveResolvers\StartTraceExecutionTimeDirectiveResolver;
 
 class TraceTypeResolverDecorator extends AbstractTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             AbstractTypeResolver::class,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/SchemaServices/FieldResolvers/CPTFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/SchemaServices/FieldResolvers/CPTFieldResolver.php
@@ -32,7 +32,7 @@ class CPTFieldResolver extends AbstractQueryableFieldResolver
     /**
      * @return string[]
      */
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             RootTypeResolver::class,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
@@ -28,7 +28,7 @@ class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
     //  * so this one gets registered (otherwise, since `ADD_GLOBAL_FIELDS_TO_SCHEMA`
     //  * is false, the field would be removed)
     //  */
-    // public static function getPriorityToAttachClasses(): ?int
+    // public function getPriorityToAttachClasses(): ?int
     // {
     //     return 20;
     // }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -19,7 +19,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
 {
     use EnumTypeFieldSchemaDefinitionResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(DirectiveTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class EnumValueFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(EnumValueTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -19,7 +19,7 @@ use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 
 class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(SchemaTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -31,7 +31,7 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
         ];
     }
 
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         // Higher priority => Process first
         return 100;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -20,7 +20,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return array(TypeTypeResolver::class);
     }
 
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         // Higher priority => Process first
         return 100;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -15,7 +15,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
 {
     use EnumTypeFieldSchemaDefinitionResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(TypeTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class FieldFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(FieldTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class InputValueFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(InputValueTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
@@ -20,7 +20,7 @@ use PoP\API\ComponentConfiguration as APIComponentConfiguration;
  */
 class RegisterQueryAndMutationRootsRootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -19,7 +19,7 @@ use GraphQLByPoP\GraphQLServer\TypeDataLoaders\SchemaTypeDataLoader;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class SchemaFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(SchemaTypeResolver::class);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -27,7 +27,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
 {
     use EnumTypeFieldSchemaDefinitionResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(TypeTypeResolver::class);
     }

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/GlobalCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/GlobalCacheTypeResolverDecorator.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
  */
 class GlobalCacheTypeResolverDecorator extends AbstractCacheTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             AbstractTypeResolver::class,

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/RootCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/RootCacheTypeResolverDecorator.php
@@ -11,7 +11,7 @@ use PoP\Engine\TypeResolvers\RootTypeResolver;
  */
 class RootCacheTypeResolverDecorator extends AbstractCacheTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             RootTypeResolver::class,

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/TranslateCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/TranslateCacheTypeResolverDecorator.php
@@ -12,7 +12,7 @@ use PoPSchema\TranslateDirective\DirectiveResolvers\AbstractTranslateDirectiveRe
  */
 class TranslateCacheTypeResolverDecorator extends AbstractCacheTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             AbstractTypeResolver::class,

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class MakeTitleDirectiveResolver extends MakeTitleVersion010DirectiveResolver
 {
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         return null;
     }

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
@@ -17,7 +17,7 @@ class MakeTitleVersion010DirectiveResolver extends AbstractGlobalDirectiveResolv
         return self::DIRECTIVE_NAME;
     }
 
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 20;

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion020DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion020DirectiveResolver.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 class MakeTitleVersion020DirectiveResolver extends MakeTitleVersion010DirectiveResolver
 {
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 30;

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
@@ -20,7 +20,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return array(RootTypeResolver::class);
     }
 
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 20;

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_2_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_2_0/RootFieldResolver.php
@@ -13,7 +13,7 @@ class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Ve
     {
         return '0.2.0';
     }
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         return 30;
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/MeshRootAliasFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/MeshRootAliasFieldResolver.php
@@ -18,7 +18,7 @@ class MeshRootAliasFieldResolver extends AbstractDBDataFieldResolver
 {
     use AliasSchemaFieldResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/MeshRootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/MeshRootFieldResolver.php
@@ -16,7 +16,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class MeshRootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Version_0_1_0\RootFieldResolver
 {
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         return null;
     }

--- a/layers/Misc/packages/examples-for-pop/src/TypeResolverDecorators/CDNTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/TypeResolverDecorators/CDNTypeResolverDecorator.php
@@ -13,7 +13,7 @@ use PoP\AccessControl\TypeResolverDecorators\AbstractPublicSchemaTypeResolverDec
 
 class CDNTypeResolverDecorator extends AbstractPublicSchemaTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             MediaTypeResolver::class,

--- a/layers/Schema/README.md
+++ b/layers/Schema/README.md
@@ -70,7 +70,7 @@ Adding fields to the type is done via a `FieldResolver`:
 ```php
 class UserFieldResolver extends AbstractDBDataFieldResolver
 {
-  public static function getClassesToAttachTo(): array
+  public function getClassesToAttachTo(): array
   {
     return [
       UserTypeResolver::class,

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -15,7 +15,7 @@ use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 
 class PostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             PostTypeResolver::class,

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 
 class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             PostTypeResolver::class,

--- a/layers/Schema/packages/categories/src/FieldResolvers/CategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/CategoryFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\QueriedObject\FieldInterfaceResolvers\QueryableFieldInterfaceResol
 
 class CategoryFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(CategoryTypeResolver::class);
     }

--- a/layers/Schema/packages/categories/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/CustomPostFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/categories/src/FieldResolvers/CustomPostListCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/CustomPostListCategoryFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\Categories\TypeResolvers\CategoryTypeResolver;
 
 class CustomPostListCategoryFieldResolver extends AbstractCustomPostListFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(CategoryTypeResolver::class);
     }

--- a/layers/Schema/packages/categories/src/FieldResolvers/CustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/CustomPostQueryableFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class CustomPostQueryableFieldResolver extends AbstractQueryableFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/categories/src/FieldResolvers/RootCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/RootCategoryFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class RootCategoryFieldResolver extends AbstractCategoryFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
@@ -15,7 +15,7 @@ use PoPSchema\CommentMutations\Schema\SchemaDefinitionHelpers;
 
 class CommentFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(CommentTypeResolver::class);
     }

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\CommentMutations\Schema\SchemaDefinitionHelpers;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(IsCustomPostFieldInterfaceResolver::class);
     }

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\CommentMutations\MutationResolvers\AddCommentToCustomPostMutationR
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/comments/src/Conditional/Users/FieldResolvers/CommentUserFieldResolver.php
+++ b/layers/Schema/packages/comments/src/Conditional/Users/FieldResolvers/CommentUserFieldResolver.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class CommentUserFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(CommentTypeResolver::class);
     }

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class CommentFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(CommentTypeResolver::class);
     }

--- a/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class CustomPostFieldResolver extends AbstractQueryableFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -24,7 +24,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         $this->mediaTypeResolver = $mediaTypeResolver;
     }
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(IsCustomPostFieldInterfaceResolver::class);
     }

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -25,7 +25,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         $this->mediaTypeResolver = $mediaTypeResolver;
     }
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
@@ -16,7 +16,7 @@ class UseDefaultFeaturedImageIDIfConditionDirectiveResolver extends AbstractUseD
         return self::DIRECTIVE_NAME;
     }
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/custompostmedia/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldResolvers/CustomPostFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\CustomPostMedia\FieldInterfaceResolvers\SupportingFeaturedImageFie
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/customposts/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/CustomPostFieldResolver.php
@@ -9,7 +9,7 @@ use PoPSchema\CustomPosts\FieldResolvers\AbstractCustomPostFieldResolver;
 
 class CustomPostFieldResolver extends AbstractCustomPostFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             AbstractCustomPostTypeResolver::class,

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -21,7 +21,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
  */
 class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/events/src/Conditional/Tags/FieldResolvers/EventTagFieldResolver.php
+++ b/layers/Schema/packages/events/src/Conditional/Tags/FieldResolvers/EventTagFieldResolver.php
@@ -18,7 +18,7 @@ use PoPSchema\Events\FieldResolvers\AbstractEventFieldResolver;
  */
 abstract class EventTagFieldResolver extends AbstractEventFieldResolver
 {
-    // public static function getClassesToAttachTo(): array
+    // public function getClassesToAttachTo(): array
     // {
     //     return array(EventTagTypeResolver::class);
     // }

--- a/layers/Schema/packages/events/src/Conditional/Users/FieldResolvers/EventUserFieldResolver.php
+++ b/layers/Schema/packages/events/src/Conditional/Users/FieldResolvers/EventUserFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class EventUserFieldResolver extends AbstractEventFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/events/src/ConditionalOnEnvironment/AddEventTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/EventCustomPostTypeResolverPicker.php
+++ b/layers/Schema/packages/events/src/ConditionalOnEnvironment/AddEventTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/EventCustomPostTypeResolverPicker.php
@@ -9,7 +9,7 @@ use PoPSchema\Events\TypeResolverPickers\AbstractEventTypeResolverPicker;
 
 class EventCustomPostTypeResolverPicker extends AbstractEventTypeResolverPicker
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             CustomPostUnionTypeResolver::class,

--- a/layers/Schema/packages/events/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/EventFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\Events\Facades\EventTypeAPIFacade;
 
 class EventFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(EventTypeResolver::class);
     }

--- a/layers/Schema/packages/events/src/FieldResolvers/EventFunctionalFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/EventFunctionalFieldResolver.php
@@ -20,7 +20,7 @@ class EventFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
     use EnumTypeFieldSchemaDefinitionResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(EventTypeResolver::class);
     }

--- a/layers/Schema/packages/events/src/FieldResolvers/RootEventFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/RootEventFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\Events\FieldResolvers\AbstractEventFieldResolver;
 
 class RootEventFieldResolver extends AbstractEventFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -15,7 +15,7 @@ use PoPSchema\Events\Facades\EventTypeAPIFacade;
 
 class CatEventFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(EventTypeResolver::class);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CommentsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CommentsCustomPostFieldResolver.php
@@ -12,7 +12,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class CommentsCustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/QueryableObjectPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/QueryableObjectPostFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\QueriedObject\FieldInterfaceResolvers\QueryableFieldInterfaceResol
 
 class QueryableObjectPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             QueryableFieldInterfaceResolver::class,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagFunctionalFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\EverythingElse\Misc\TagHelpers;
 
 class TagFunctionalFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(AbstractTagTypeResolver::class);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -24,7 +24,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
  */
 class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/google-translate-directive-for-customposts/src/DirectiveResolvers/CustomPostGoogleTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/src/DirectiveResolvers/CustomPostGoogleTranslateDirectiveResolver.php
@@ -9,7 +9,7 @@ use PoPSchema\GoogleTranslateDirective\DirectiveResolvers\AbstractGoogleTranslat
 
 class CustomPostGoogleTranslateDirectiveResolver extends AbstractGoogleTranslateDirectiveResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/highlights/src/ConditionalOnEnvironment/AddHighlightTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/HighlightCustomPostTypeResolverPicker.php
+++ b/layers/Schema/packages/highlights/src/ConditionalOnEnvironment/AddHighlightTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/HighlightCustomPostTypeResolverPicker.php
@@ -9,7 +9,7 @@ use PoPSchema\Highlights\TypeResolverPickers\AbstractHighlightTypeResolverPicker
 
 class HighlightCustomPostTypeResolverPicker extends AbstractHighlightTypeResolverPicker
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             CustomPostUnionTypeResolver::class,

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -18,7 +18,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -14,7 +14,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -16,7 +16,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class HighlightFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(HighlightTypeResolver::class);
     }

--- a/layers/Schema/packages/locationposts/src/Conditional/Tags/FieldResolvers/LocationPostTagFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/Conditional/Tags/FieldResolvers/LocationPostTagFieldResolver.php
@@ -18,7 +18,7 @@ use PoPSchema\LocationPosts\FieldResolvers\AbstractLocationPostFieldResolver;
  */
 abstract class LocationPostTagFieldResolver extends AbstractLocationPostFieldResolver
 {
-    // public static function getClassesToAttachTo(): array
+    // public function getClassesToAttachTo(): array
     // {
     //     return array(LocationTagTypeResolver::class);
     // }

--- a/layers/Schema/packages/locationposts/src/Conditional/Users/FieldResolvers/LocationPostUserFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/Conditional/Users/FieldResolvers/LocationPostUserFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class LocationPostUserFieldResolver extends AbstractLocationPostFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/locationposts/src/ConditionalOnEnvironment/AddLocationPostTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/LocationPostCustomPostTypeResolverPicker.php
+++ b/layers/Schema/packages/locationposts/src/ConditionalOnEnvironment/AddLocationPostTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/LocationPostCustomPostTypeResolverPicker.php
@@ -9,7 +9,7 @@ use PoPSchema\LocationPosts\TypeResolverPickers\AbstractLocationPostTypeResolver
 
 class LocationPostCustomPostTypeResolverPicker extends AbstractLocationPostTypeResolverPicker
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             CustomPostUnionTypeResolver::class,

--- a/layers/Schema/packages/locationposts/src/FieldResolvers/LocationPostFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/FieldResolvers/LocationPostFieldResolver.php
@@ -15,7 +15,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class LocationPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(LocationPostTypeResolver::class);
     }

--- a/layers/Schema/packages/locationposts/src/FieldResolvers/RootLocationPostFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/FieldResolvers/RootLocationPostFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\LocationPosts\FieldResolvers\AbstractLocationPostFieldResolver;
 
 class RootLocationPostFieldResolver extends AbstractLocationPostFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/locations/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -15,7 +15,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/locations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/locations/src/FieldResolvers/CustomPostLocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/CustomPostLocationFunctionalFieldResolver.php
@@ -9,7 +9,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class CustomPostLocationFunctionalFieldResolver extends AbstractLocationFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/locations/src/FieldResolvers/LocationFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/LocationFieldResolver.php
@@ -12,7 +12,7 @@ use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
 
 class LocationFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(LocationTypeResolver::class);
     }

--- a/layers/Schema/packages/locations/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
 
 class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             LocationTypeResolver::class,

--- a/layers/Schema/packages/locations/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/UserFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
 
 class UserFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             UserTypeResolver::class,

--- a/layers/Schema/packages/locations/src/FieldResolvers/UserLocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/UserLocationFunctionalFieldResolver.php
@@ -9,7 +9,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class UserLocationFunctionalFieldResolver extends AbstractLocationFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             UserTypeResolver::class,

--- a/layers/Schema/packages/media/src/Conditional/Users/FieldResolvers/MediaUserFieldResolver.php
+++ b/layers/Schema/packages/media/src/Conditional/Users/FieldResolvers/MediaUserFieldResolver.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class MediaUserFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(MediaTypeResolver::class);
     }

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -16,7 +16,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class MediaFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(MediaTypeResolver::class);
     }

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -23,7 +23,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         $this->customPostTypeResolver = $customPostTypeResolver;
     }
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -17,7 +17,7 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 
 class MenuFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(MenuTypeResolver::class);
     }

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\Menus\TypeResolvers\MenuItemTypeResolver;
 
 class MenuItemFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(MenuItemTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -9,7 +9,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class PS_POP_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -77,4 +77,4 @@ class PS_POP_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-PS_POP_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PS_POP_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -202,4 +202,4 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
 }
 
 // Static Initialization: Attach
-PoP_AddComments_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_AddComments_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -9,7 +9,7 @@ use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 
 class PoPTheme_Wassup_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -116,4 +116,4 @@ class PoPTheme_Wassup_AAL_PoP_DataLoad_FieldResolver_Notifications extends Abstr
 }
 
 // Static Initialization: Attach
-PoPTheme_Wassup_AAL_PoP_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoPTheme_Wassup_AAL_PoP_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -79,4 +79,4 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
 }
 
 // Static Initialization: Attach
-PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -7,7 +7,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -8,7 +8,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -89,4 +89,4 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
 }
 
 // Static Initialization: Attach
-PoP_AddPostLinks_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_AddPostLinks_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -71,4 +71,4 @@ class GD_ApplicationProcessors_DataLoad_FieldResolver_Posts extends AbstractDBDa
 }
 
 // Static Initialization: Attach
-GD_ApplicationProcessors_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_ApplicationProcessors_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -9,7 +9,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class GD_ApplicationProcessors_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -10,7 +10,7 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 
 class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(CommentTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -97,4 +97,4 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
 }
 
 // Static Initialization: Attach
-PoPGenericForms_DataLoad_FieldResolver_Comments::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoPGenericForms_DataLoad_FieldResolver_Comments())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 
 class PoP_Application_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -148,4 +148,4 @@ class PoP_Application_DataLoad_FieldResolver_FunctionalPosts extends AbstractFun
 }
 
 // Static Initialization: Attach
-PoP_Application_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Application_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -225,4 +225,4 @@ class PoP_Application_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldRe
 }
 
 // Static Initialization: Attach
-PoP_Application_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Application_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -13,7 +13,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class PoP_Application_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -8,7 +8,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class PoP_Application_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             UserTypeResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -96,4 +96,4 @@ class PoP_Application_DataLoad_FieldResolver_FunctionalUsers extends AbstractFun
 }
 
 // Static Initialization: Attach
-PoP_Application_DataLoad_FieldResolver_FunctionalUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Application_DataLoad_FieldResolver_FunctionalUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -7,7 +7,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class PoP_Application_UserAvatar_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -86,4 +86,4 @@ class PoP_Application_UserAvatar_DataLoad_FieldResolver_Users extends AbstractDB
 }
 
 // Static Initialization: Attach
-PoP_Application_UserAvatar_DataLoad_FieldResolver_Users::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Application_UserAvatar_DataLoad_FieldResolver_Users())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -7,7 +7,7 @@ use PoPSchema\Tags\TypeResolvers\AbstractTagTypeResolver;
 
 class PoP_Application_DataLoad_FieldResolver_Tags extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(AbstractTagTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -64,4 +64,4 @@ class PoP_Application_DataLoad_FieldResolver_Tags extends AbstractDBDataFieldRes
 }
 
 // Static Initialization: Attach
-PoP_Application_DataLoad_FieldResolver_Tags::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Application_DataLoad_FieldResolver_Tags())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -69,4 +69,4 @@ class PoP_Avatar_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolve
 }
 
 // Static Initialization: Attach
-PoP_Avatar_DataLoad_FieldResolver_Users::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Avatar_DataLoad_FieldResolver_Users())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -7,7 +7,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class PoP_Avatar_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
@@ -10,7 +10,7 @@ class GD_URE_Custom_DataLoad_FieldResolver_FunctionalIndividualUsers extends Abs
 {
     use IndividualFieldResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
@@ -71,4 +71,4 @@ class GD_URE_Custom_DataLoad_FieldResolver_FunctionalIndividualUsers extends Abs
 }
 
 // Static Initialization: Attach
-GD_URE_Custom_DataLoad_FieldResolver_FunctionalIndividualUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_URE_Custom_DataLoad_FieldResolver_FunctionalIndividualUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -10,7 +10,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
 {
     use IndividualFieldResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -83,4 +83,4 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-FieldResolver_IndividualUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new FieldResolver_IndividualUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
@@ -82,4 +82,4 @@ class GD_URE_Custom_DataLoad_FieldResolver_FunctionalOrganizationUsers extends A
 }
 
 // Static Initialization: Attach
-GD_URE_Custom_DataLoad_FieldResolver_FunctionalOrganizationUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_URE_Custom_DataLoad_FieldResolver_FunctionalOrganizationUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
@@ -10,7 +10,7 @@ class GD_URE_Custom_DataLoad_FieldResolver_FunctionalOrganizationUsers extends A
 {
     use OrganizationFieldResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -105,4 +105,4 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-FieldResolver_OrganizationUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new FieldResolver_OrganizationUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -10,7 +10,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
 {
     use OrganizationFieldResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -10,7 +10,7 @@ use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 
 class GD_ContentCreation_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -72,4 +72,4 @@ class GD_ContentCreation_DataLoad_FieldResolver_FunctionalPosts extends Abstract
 }
 
 // Static Initialization: Attach
-GD_ContentCreation_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_ContentCreation_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -133,4 +133,4 @@ class GD_ContentCreation_DataLoad_FieldResolver_Posts extends AbstractDBDataFiel
 }
 
 // Static Initialization: Attach
-GD_ContentCreation_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_ContentCreation_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class GD_ContentCreation_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -70,4 +70,4 @@ class GD_ContentCreation_Media_DataLoad_FieldResolver_FunctionalPosts extends Ab
 }
 
 // Static Initialization: Attach
-GD_ContentCreation_Media_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_ContentCreation_Media_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -8,7 +8,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class GD_ContentCreation_Media_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -216,4 +216,4 @@ class PoP_ContentCreation_DataLoad_FieldResolver_Notifications extends AbstractD
 }
 
 // Static Initialization: Attach
-PoP_ContentCreation_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_ContentCreation_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -10,7 +10,7 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class PoP_ContentCreation_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -11,7 +11,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
 {
     use EnumTypeFieldSchemaDefinitionResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -190,4 +190,4 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
 }
 
 // Static Initialization: Attach
-PoP_ContentPostLinks_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_ContentPostLinks_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -76,4 +76,4 @@ class GD_ContentPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts extends
 }
 
 // Static Initialization: Attach
-GD_ContentPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_ContentPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class GD_ContentPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class GD_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
@@ -76,4 +76,4 @@ class GD_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolve
 }
 
 // Static Initialization: Attach
-GD_DataLoad_FunctionalFieldResolver::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_DataLoad_FunctionalFieldResolver())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -7,7 +7,7 @@ use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 
 class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             EventTypeResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -101,4 +101,4 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-GD_EM_DataLoad_FieldResolver_Events::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new GD_EM_DataLoad_FieldResolver_Events())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -7,7 +7,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             EventTypeResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -101,4 +101,4 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-GD_EM_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new GD_EM_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -77,4 +77,4 @@ class PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver extends AbstractFu
 }
 
 // Static Initialization: Attach
-PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -77,4 +77,4 @@ class PoP_EventsCreation_DataLoad_FunctionalFieldResolver extends AbstractFuncti
 }
 
 // Static Initialization: Attach
-PoP_EventsCreation_DataLoad_FunctionalFieldResolver::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_EventsCreation_DataLoad_FunctionalFieldResolver())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class PoP_EventsCreation_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -100,4 +100,4 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
 }
 
 // Static Initialization: Attach
-GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -7,7 +7,7 @@ use PoPSchema\LocationPosts\TypeResolvers\LocationPostTypeResolver;
 
 class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(LocationPostTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class PoP_LocationPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -77,4 +77,4 @@ class PoP_LocationPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts exten
 }
 
 // Static Initialization: Attach
-PoP_LocationPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_LocationPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class PoP_LocationPostsCreation_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -77,4 +77,4 @@ class PoP_LocationPostsCreation_DataLoad_FieldResolver_FunctionalPosts extends A
 }
 
 // Static Initialization: Attach
-PoP_LocationPostsCreation_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_LocationPostsCreation_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -106,4 +106,4 @@ class PoP_Notifications_UserLogin_DataLoad_FieldResolver_Notifications extends A
 }
 
 // Static Initialization: Attach
-PoP_Notifications_UserLogin_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_Notifications_UserLogin_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -7,7 +7,7 @@ use PoPSchema\Notifications\TypeResolvers\NotificationTypeResolver;
 
 class PoP_Notifications_UserLogin_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -7,7 +7,7 @@ use PoPSchema\Notifications\TypeResolvers\NotificationTypeResolver;
 
 class PoP_Notifications_UserPlatform_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -132,4 +132,4 @@ class PoP_Notifications_UserPlatform_DataLoad_FieldResolver_Notifications extend
 }
 
 // Static Initialization: Attach
-PoP_Notifications_UserPlatform_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_Notifications_UserPlatform_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class GD_PostsCreation_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -77,4 +77,4 @@ class GD_PostsCreation_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
 }
 
 // Static Initialization: Attach
-GD_PostsCreation_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_PostsCreation_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -67,4 +67,4 @@ class PPPPoP_DataLoad_FieldResolver_FunctionalProfiles extends AbstractFunctiona
 }
 
 // Static Initialization: Attach
-PPPPoP_DataLoad_FieldResolver_FunctionalProfiles::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PPPPoP_DataLoad_FieldResolver_FunctionalProfiles())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -7,7 +7,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class PPPPoP_DataLoad_FieldResolver_FunctionalProfiles extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -122,4 +122,4 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
 }
 
 // Static Initialization: Attach
-PoP_RelatedPosts_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_RelatedPosts_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -11,7 +11,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -118,4 +118,4 @@ class PoP_RelatedPosts_AAL_PoP_DataLoad_FieldResolver_Notifications extends Abst
 }
 
 // Static Initialization: Attach
-PoP_RelatedPosts_AAL_PoP_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_RelatedPosts_AAL_PoP_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -9,7 +9,7 @@ use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 
 class PoP_RelatedPosts_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -8,7 +8,7 @@ use PoPSchema\Notifications\TypeResolvers\NotificationTypeResolver;
 
 class WSL_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -116,4 +116,4 @@ class WSL_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFie
 }
 
 // Static Initialization: Attach
-WSL_AAL_PoP_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new WSL_AAL_PoP_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
@@ -79,4 +79,4 @@ class GD_WSL_FieldResolver_Users extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-GD_WSL_FieldResolver_Users::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new GD_WSL_FieldResolver_Users())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
@@ -7,7 +7,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_WSL_FieldResolver_Users extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -4,7 +4,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_PostSocialMediaItems extends PoP_SocialMediaProviders_DataLoad_FieldResolver_FunctionalSocialMediaItems
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -18,4 +18,4 @@ class PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_PostSocialMediaI
 }
 
 // Static Initialization: Attach
-PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_PostSocialMediaItems::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_PostSocialMediaItems())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -17,4 +17,4 @@ class PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_TagSocialMediaIt
 }
 
 // Static Initialization: Attach
-PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_TagSocialMediaItems::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_TagSocialMediaItems())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -3,7 +3,7 @@ use PoPSchema\PostTags\TypeResolvers\PostTagTypeResolver;
 
 class PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_TagSocialMediaItems extends PoP_SocialMediaProviders_DataLoad_FieldResolver_FunctionalSocialMediaItems
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             PostTagTypeResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -15,6 +15,6 @@ class PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_UserSocialMediaI
         return 'displayName';
     }
 }
-    
+
 // Static Initialization: Attach
-PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_UserSocialMediaItems::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_UserSocialMediaItems())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -3,7 +3,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class PoP_SocialMediaProviders_DataLoad_FunctionalFieldResolver_UserSocialMediaItems extends PoP_SocialMediaProviders_DataLoad_FieldResolver_FunctionalSocialMediaItems
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             UserTypeResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -9,7 +9,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class PoPGenericForms_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -67,4 +67,4 @@ class PoPGenericForms_DataLoad_FieldResolver_FunctionalUsers extends AbstractFun
 }
 
 // Static Initialization: Attach
-PoPGenericForms_DataLoad_FieldResolver_FunctionalUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoPGenericForms_DataLoad_FieldResolver_FunctionalUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -264,4 +264,4 @@ class PoP_SocialNetwork_DataLoad_FieldResolver_Notifications extends AbstractDBD
 }
 
 // Static Initialization: Attach
-PoP_SocialNetwork_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_SocialNetwork_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -8,7 +8,7 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class PoP_SocialNetwork_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -87,4 +87,4 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-GD_DataLoad_FieldResolver_Comments::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_DataLoad_FieldResolver_Comments())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -9,7 +9,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(CommentTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class GD_SocialNetwork_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -136,4 +136,4 @@ class GD_SocialNetwork_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
 }
 
 // Static Initialization: Attach
-GD_SocialNetwork_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_SocialNetwork_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -10,7 +10,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -122,4 +122,4 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
 }
 
 // Static Initialization: Attach
-GD_SocialNetwork_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_SocialNetwork_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -75,4 +75,4 @@ class GD_DataLoad_FieldResolver_Tags extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-GD_DataLoad_FieldResolver_Tags::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_DataLoad_FieldResolver_Tags())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -9,7 +9,7 @@ use PoPSchema\PostTags\TypeResolvers\PostTagTypeResolver;
 
 class GD_DataLoad_FieldResolver_Tags extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(PostTagTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -75,4 +75,4 @@ class GD_SocialNetwork_DataLoad_FieldResolver_FunctionalUsers extends AbstractFu
 }
 
 // Static Initialization: Attach
-GD_SocialNetwork_DataLoad_FieldResolver_FunctionalUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_SocialNetwork_DataLoad_FieldResolver_FunctionalUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -9,7 +9,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_SocialNetwork_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -12,7 +12,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -122,4 +122,4 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
 }
 
 // Static Initialization: Attach
-GD_SocialNetwork_DataLoad_FieldResolver_Users::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_SocialNetwork_DataLoad_FieldResolver_Users())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -7,7 +7,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class PoP_UserAvatar_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             UserTypeResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -66,4 +66,4 @@ class PoP_UserAvatar_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunc
 }
 
 // Static Initialization: Attach
-PoP_UserAvatar_DataLoad_FieldResolver_FunctionalUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_UserAvatar_DataLoad_FieldResolver_FunctionalUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -8,7 +8,7 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class PoP_AAL_UserAvatar_DataLoad_FieldResolver_Notification extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -111,4 +111,4 @@ class PoP_AAL_UserAvatar_DataLoad_FieldResolver_Notification extends AbstractDBD
 }
 
 // Static Initialization: Attach
-PoP_AAL_UserAvatar_DataLoad_FieldResolver_Notification::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new PoP_AAL_UserAvatar_DataLoad_FieldResolver_Notification())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -94,4 +94,4 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-FieldResolver_CommunityUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new FieldResolver_CommunityUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -10,7 +10,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
 {
     use CommunityFieldResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -8,7 +8,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_UserCommunities_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -103,4 +103,4 @@ class GD_UserCommunities_DataLoad_FieldResolver_FunctionalUsers extends Abstract
 }
 
 // Static Initialization: Attach
-GD_UserCommunities_DataLoad_FieldResolver_FunctionalUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_UserCommunities_DataLoad_FieldResolver_FunctionalUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -15,7 +15,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
 {
     use EnumTypeFieldSchemaDefinitionResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -183,4 +183,4 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
 }
 
 // Static Initialization: Attach
-GD_UserCommunities_DataLoad_FieldResolver_Users::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_UserCommunities_DataLoad_FieldResolver_Users())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -18,7 +18,7 @@ class URE_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFie
 {
     use EnumTypeFieldSchemaDefinitionResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -274,4 +274,4 @@ class URE_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFie
 }
 
 // Static Initialization: Attach
-URE_AAL_PoP_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new URE_AAL_PoP_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -90,4 +90,4 @@ class GD_UserPlatform_DataLoad_FieldResolver_FunctionalUsers extends AbstractFun
 }
 
 // Static Initialization: Attach
-GD_UserPlatform_DataLoad_FieldResolver_FunctionalUsers::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_UserPlatform_DataLoad_FieldResolver_FunctionalUsers())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -8,7 +8,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_UserPlatform_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -213,4 +213,4 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
 }
 
 // Static Initialization: Attach
-GD_UserPlatform_DataLoad_FieldResolver_Users::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new GD_UserPlatform_DataLoad_FieldResolver_Users())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -7,7 +7,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class FieldResolver_Users extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -118,4 +118,4 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
 }
 
 // Static Initialization: Attach
-FieldResolver_Users::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new FieldResolver_Users())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -9,7 +9,7 @@ use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 
 class UserStance_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -116,4 +116,4 @@ class UserStance_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDB
 }
 
 // Static Initialization: Attach
-UserStance_AAL_PoP_DataLoad_FieldResolver_Notifications::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);
+(new UserStance_AAL_PoP_DataLoad_FieldResolver_Notifications())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS, 20);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -10,7 +10,7 @@ use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 
 class PoP_Volunteering_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -72,4 +72,4 @@ class PoP_Volunteering_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
 }
 
 // Static Initialization: Attach
-PoP_Volunteering_DataLoad_FieldResolver_FunctionalPosts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Volunteering_DataLoad_FieldResolver_FunctionalPosts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -7,7 +7,7 @@ use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceReso
 
 class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -76,4 +76,4 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
 }
 
 // Static Initialization: Attach
-PoP_Volunteering_DataLoad_FieldResolver_Posts::attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+(new PoP_Volunteering_DataLoad_FieldResolver_Posts())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -18,7 +18,7 @@ use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 
 class NotificationFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFunctionalFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\Notifications\TypeResolvers\NotificationTypeResolver;
 
 class NotificationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(NotificationTypeResolver::class);
     }

--- a/layers/Schema/packages/pages/src/ConditionalOnEnvironment/AddPageTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/PageCustomPostTypeResolverPicker.php
+++ b/layers/Schema/packages/pages/src/ConditionalOnEnvironment/AddPageTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/PageCustomPostTypeResolverPicker.php
@@ -9,7 +9,7 @@ use PoPSchema\Pages\TypeResolverPickers\AbstractPageTypeResolverPicker;
 
 class PageCustomPostTypeResolverPicker extends AbstractPageTypeResolverPicker
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             CustomPostUnionTypeResolver::class,

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -19,7 +19,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class RootPageFieldResolver extends AbstractQueryableFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/PostFieldResolver.php
@@ -12,7 +12,7 @@ use PoPSchema\CustomPostMutations\FieldResolvers\AbstractCustomPostFieldResolver
 
 class PostFieldResolver extends AbstractCustomPostFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(PostTypeResolver::class);
     }

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -17,7 +17,7 @@ use PoPSchema\PostMutations\MutationResolvers\UpdatePostMutationResolver;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/CustomPostListPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/CustomPostListPostTagFieldResolver.php
@@ -12,7 +12,7 @@ class CustomPostListPostTagFieldResolver extends AbstractCustomPostListTagFieldR
 {
     use PostTagAPISatisfiedContractTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(PostTagTypeResolver::class);
     }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/PostQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/PostQueryableFieldResolver.php
@@ -14,7 +14,7 @@ class PostQueryableFieldResolver extends AbstractCustomPostQueryableFieldResolve
 {
     use PostTagAPISatisfiedContractTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             PostTypeResolver::class,

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagFieldResolver.php
@@ -12,7 +12,7 @@ class PostTagFieldResolver extends AbstractTagFieldResolver
 {
     use PostTagAPISatisfiedContractTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(PostTagTypeResolver::class);
     }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagListFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagListFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\PostTags\TypeResolvers\PostTagTypeResolver;
 
 class PostTagListFieldResolver extends AbstractPostFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(PostTagTypeResolver::class);
     }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/posts/src/Conditional/Users/FieldResolvers/PostUserFieldResolver.php
+++ b/layers/Schema/packages/posts/src/Conditional/Users/FieldResolvers/PostUserFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class PostUserFieldResolver extends AbstractPostFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/posts/src/ConditionalOnEnvironment/AddPostTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/PostCustomPostTypeResolverPicker.php
+++ b/layers/Schema/packages/posts/src/ConditionalOnEnvironment/AddPostTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/PostCustomPostTypeResolverPicker.php
@@ -9,7 +9,7 @@ use PoPSchema\Posts\TypeResolverPickers\AbstractPostTypeResolverPicker;
 
 class PostCustomPostTypeResolverPicker extends AbstractPostTypeResolverPicker
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             CustomPostUnionTypeResolver::class,

--- a/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
@@ -30,7 +30,7 @@ class ExperimentalBranchFieldResolver extends CustomPostFieldResolver
      *
      * @return integer|null
      */
-    public static function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): ?int
     {
         return 20;
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
@@ -17,7 +17,7 @@ class ExperimentalBranchFieldResolver extends CustomPostFieldResolver
      *
      * @return array
      */
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             PostTypeResolver::class,

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\CustomPosts\Types\Status;
 
 class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             PostTypeResolver::class,

--- a/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class RootPostFieldResolver extends AbstractPostFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/stances/src/ConditionalOnEnvironment/AddStanceTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/StanceCustomPostTypeResolverPicker.php
+++ b/layers/Schema/packages/stances/src/ConditionalOnEnvironment/AddStanceTypeToCustomPostUnionTypes/SchemaServices/TypeResolverPickers/StanceCustomPostTypeResolverPicker.php
@@ -9,7 +9,7 @@ use PoPSchema\Stances\TypeResolverPickers\AbstractStanceTypeResolverPicker;
 
 class StanceCustomPostTypeResolverPicker extends AbstractStanceTypeResolverPicker
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             CustomPostUnionTypeResolver::class,

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -18,7 +18,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -19,7 +19,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -17,7 +17,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class StanceFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             StanceTypeResolver::class,

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
@@ -11,7 +11,7 @@ use PoPSchema\UserRolesAccessControl\DirectiveResolvers\ValidateDoesLoggedInUser
 
 class GlobalValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator extends AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             AbstractTypeResolver::class,

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
@@ -11,7 +11,7 @@ use PoPSchema\UserRolesAccessControl\DirectiveResolvers\ValidateDoesLoggedInUser
 
 class GlobalValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator extends AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             AbstractTypeResolver::class,

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractReflectionPropertyFieldResolver;
 
 class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserRoleTypeResolver::class);
     }

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/RootRolesFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/RootRolesFieldResolver.php
@@ -12,7 +12,7 @@ class RootRolesFieldResolver extends AbstractDBDataFieldResolver
 {
     use RolesFieldResolverTrait;
 
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             RootTypeResolver::class,

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -14,7 +14,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class UserFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             UserTypeResolver::class,

--- a/layers/Schema/packages/user-state-access-control/src/Conditional/CacheControl/TypeResolverDecorators/NoCacheUserStateTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-state-access-control/src/Conditional/CacheControl/TypeResolverDecorators/NoCacheUserStateTypeResolverDecorator.php
@@ -15,7 +15,7 @@ use PoPSchema\UserStateAccessControl\DirectiveResolvers\ValidateIsUserNotLoggedI
 
 class NoCacheUserStateTypeResolverDecorator extends AbstractTypeResolverDecorator
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(
             AbstractTypeResolver::class,

--- a/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -16,7 +16,7 @@ use PoPSchema\UserStateMutations\MutationResolvers\MutationInputProperties;
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
@@ -14,7 +14,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class RootMeFieldResolver extends AbstractUserStateFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/users/src/Conditional/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/Conditional/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return [
             IsCustomPostFieldInterfaceResolver::class,

--- a/layers/Schema/packages/users/src/Conditional/CustomPosts/FieldResolvers/CustomPostListUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/Conditional/CustomPosts/FieldResolvers/CustomPostListUserFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\CustomPosts\FieldResolvers\AbstractCustomPostListFieldResolver;
 
 class CustomPostListUserFieldResolver extends AbstractCustomPostListFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/users/src/Conditional/CustomPosts/FieldResolvers/CustomPostUserListFieldResolver.php
+++ b/layers/Schema/packages/users/src/Conditional/CustomPosts/FieldResolvers/CustomPostUserListFieldResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class CustomPostUserListFieldResolver extends AbstractCustomPostListFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
@@ -14,7 +14,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class RootUserFieldResolver extends AbstractUserFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/Schema/packages/users/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/UserFieldResolver.php
@@ -13,7 +13,7 @@ use PoPSchema\QueriedObject\FieldInterfaceResolvers\QueryableFieldInterfaceResol
 
 class UserFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(UserTypeResolver::class);
     }

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -14,7 +14,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(RootTypeResolver::class);
     }

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -12,7 +12,7 @@ use PoP\Multisite\TypeResolvers\SiteTypeResolver;
 
 class SiteFieldResolver extends AbstractDBDataFieldResolver
 {
-    public static function getClassesToAttachTo(): array
+    public function getClassesToAttachTo(): array
     {
         return array(SiteTypeResolver::class);
     }


### PR DESCRIPTION
Directly pass the service when enqueuing an attachable extension.

Also, implemented `AttachableExtensionInterface`, and made functions non-static:

- `getClassesToAttachTo`
- `getPriorityToAttachClasses`
- `attach`