### PR TITLE
Migrate static names from module filters

### DIFF
--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -43,7 +43,6 @@ services:
 
     PoP\ComponentModel\ModuleFilters\:
         resource: '../src/ModuleFilters/*'
-        public: false
 
     PoP\ComponentModel\ModulePath\ModulePathManagerInterface:
         class: \PoP\ComponentModel\ModulePath\ModulePathManager

--- a/layers/Engine/packages/component-model/src/ModuleFilters/ModulePaths.php
+++ b/layers/Engine/packages/component-model/src/ModuleFilters/ModulePaths.php
@@ -9,7 +9,6 @@ use PoP\ComponentModel\ModulePath\ModulePathUtils;
 
 class ModulePaths extends AbstractModuleFilter
 {
-    public const NAME = 'modulepaths';
     public const URLPARAM_MODULEPATHS = 'modulepaths';
 
     /**
@@ -40,7 +39,7 @@ class ModulePaths extends AbstractModuleFilter
 
     public function getName()
     {
-        return self::NAME;
+        return 'modulepaths';
     }
 
     public function excludeModule(array $module, array &$props)

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
@@ -1032,11 +1032,14 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
 
     public function getDataloadSource(array $module, array &$props): string
     {
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var ModulePaths */
+        $modulePaths = $instanceManager->getInstance(ModulePaths::class);
         // Because a component can interact with itself by adding ?modulepaths=...,
         // then, by default, we simply set the dataload source to point to itself!
         $stringified_module_propagation_current_path = ModulePathHelpersFacade::getInstance()->getStringifiedModulePropagationCurrentPath($module);
         $ret = GeneralUtils::addQueryArgs([
-            ModuleFilterManager::URLPARAM_MODULEFILTER => ModulePaths::NAME,
+            ModuleFilterManager::URLPARAM_MODULEFILTER => $modulePaths->getName(),
             ModulePaths::URLPARAM_MODULEPATHS . '[]' => $stringified_module_propagation_current_path,
         ], RequestUtils::getCurrentUrl());
 

--- a/layers/Engine/packages/engine/config/services.yaml
+++ b/layers/Engine/packages/engine/config/services.yaml
@@ -24,7 +24,6 @@ services:
 
     PoP\Engine\ModuleFilters\:
         resource: '../src/ModuleFilters/*'
-        public: false
 
     PoP\Engine\RouteModuleProcessors\:
         resource: '../src/RouteModuleProcessors/*'

--- a/layers/Engine/packages/engine/src/Hooks/Misc/URLHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/Misc/URLHookSet.php
@@ -6,25 +6,9 @@ namespace PoP\Engine\Hooks\Misc;
 
 use PoP\Engine\ModuleFilters\HeadModule;
 use PoP\Hooks\AbstractHookSet;
-use PoP\Hooks\HooksAPIInterface;
-use PoP\Translation\TranslationAPIInterface;
 
 class URLHookSet extends AbstractHookSet
 {
-    protected HeadModule $headModule;
-
-    public function __construct(
-        HooksAPIInterface $hooksAPI,
-        TranslationAPIInterface $translationAPI,
-        HeadModule $headModule
-    ) {
-        parent::__construct(
-            $hooksAPI,
-            $translationAPI
-        );
-        $this->headModule = $headModule;
-    }
-
     protected function init()
     {
         $this->hooksAPI->addFilter(
@@ -34,7 +18,7 @@ class URLHookSet extends AbstractHookSet
     }
     public function getParamsToRemoveFromURL($params)
     {
-        $params[] = $this->headModule::URLPARAM_HEADMODULE;
+        $params[] = HeadModule::URLPARAM_HEADMODULE;
         return $params;
     }
 }

--- a/layers/Engine/packages/engine/src/Hooks/Misc/URLHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/Misc/URLHookSet.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace PoP\Engine\Hooks\Misc;
 
-use PoP\Hooks\AbstractHookSet;
 use PoP\Engine\ModuleFilters\HeadModule;
+use PoP\Hooks\AbstractHookSet;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\Translation\TranslationAPIInterface;
 
 class URLHookSet extends AbstractHookSet
 {
+    protected HeadModule $headModule;
+
+    public function __construct(
+        HooksAPIInterface $hooksAPI,
+        TranslationAPIInterface $translationAPI,
+        HeadModule $headModule
+    ) {
+        parent::__construct(
+            $hooksAPI,
+            $translationAPI
+        );
+        $this->headModule = $headModule;
+    }
+
     protected function init()
     {
         $this->hooksAPI->addFilter(
@@ -18,7 +34,7 @@ class URLHookSet extends AbstractHookSet
     }
     public function getParamsToRemoveFromURL($params)
     {
-        $params[] = HeadModule::URLPARAM_HEADMODULE;
+        $params[] = $this->headModule::URLPARAM_HEADMODULE;
         return $params;
     }
 }

--- a/layers/Engine/packages/engine/src/Hooks/ModuleFilters/HeadModuleHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/ModuleFilters/HeadModuleHookSet.php
@@ -4,14 +4,30 @@ declare(strict_types=1);
 
 namespace PoP\Engine\Hooks\ModuleFilters;
 
-use PoP\Engine\ModuleFilters\Constants;
-use PoP\ComponentModel\Modules\ModuleUtils;
-use PoP\Hooks\AbstractHookSet;
 use PoP\ComponentModel\ModelInstance\ModelInstance;
+use PoP\ComponentModel\Modules\ModuleUtils;
 use PoP\ComponentModel\State\ApplicationState;
+use PoP\Engine\ModuleFilters\HeadModule;
+use PoP\Hooks\AbstractHookSet;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\Translation\TranslationAPIInterface;
 
-class HeadModule extends AbstractHookSet
+class HeadModuleHookSet extends AbstractHookSet
 {
+    protected HeadModule $headModule;
+
+    public function __construct(
+        HooksAPIInterface $hooksAPI,
+        TranslationAPIInterface $translationAPI,
+        HeadModule $headModule
+    ) {
+        parent::__construct(
+            $hooksAPI,
+            $translationAPI
+        );
+        $this->headModule = $headModule;
+    }
+
     protected function init()
     {
         $this->hooksAPI->addFilter(
@@ -31,8 +47,8 @@ class HeadModule extends AbstractHookSet
     public function addVars(array $vars_in_array): void
     {
         [&$vars] = $vars_in_array;
-        if (isset($vars['modulefilter']) && $vars['modulefilter'] == \PoP\Engine\ModuleFilters\HeadModule::NAME) {
-            if ($headmodule = $_REQUEST[Constants::URLPARAM_HEADMODULE] ?? null) {
+        if (isset($vars['modulefilter']) && $vars['modulefilter'] == $this->headModule->getName()) {
+            if ($headmodule = $_REQUEST[$this->headModule::URLPARAM_HEADMODULE] ?? null) {
                 $vars['headmodule'] = ModuleUtils::getModuleFromOutputName($headmodule);
             }
         }
@@ -40,7 +56,7 @@ class HeadModule extends AbstractHookSet
     public function maybeAddComponent($components)
     {
         $vars = ApplicationState::getVars();
-        if (isset($vars['modulefilter']) && $vars['modulefilter'] == \PoP\Engine\ModuleFilters\HeadModule::NAME) {
+        if (isset($vars['modulefilter']) && $vars['modulefilter'] == $this->headModule->getName()) {
             if ($headmodule = $vars['headmodule']) {
                 $components[] = $this->translationAPI->__('head module:', 'engine') . ModuleUtils::getModuleFullName($headmodule);
             }

--- a/layers/Engine/packages/engine/src/Hooks/ModuleFilters/HeadModuleHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/ModuleFilters/HeadModuleHookSet.php
@@ -48,7 +48,7 @@ class HeadModuleHookSet extends AbstractHookSet
     {
         [&$vars] = $vars_in_array;
         if (isset($vars['modulefilter']) && $vars['modulefilter'] == $this->headModule->getName()) {
-            if ($headmodule = $_REQUEST[$this->headModule::URLPARAM_HEADMODULE] ?? null) {
+            if ($headmodule = $_REQUEST[HeadModule::URLPARAM_HEADMODULE] ?? null) {
                 $vars['headmodule'] = ModuleUtils::getModuleFromOutputName($headmodule);
             }
         }

--- a/layers/Engine/packages/engine/src/Hooks/ModuleFilters/MainContentModuleHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/ModuleFilters/MainContentModuleHookSet.php
@@ -4,11 +4,28 @@ declare(strict_types=1);
 
 namespace PoP\Engine\Hooks\ModuleFilters;
 
+use PoP\Engine\ModuleFilters\MainContentModule;
 use PoP\Hooks\AbstractHookSet;
+use PoP\Hooks\HooksAPIInterface;
 use PoP\ModuleRouting\Facades\RouteModuleProcessorManagerFacade;
+use PoP\Translation\TranslationAPIInterface;
 
-class MainContentModule extends AbstractHookSet
+class MainContentModuleHookSet extends AbstractHookSet
 {
+    protected MainContentModule $mainContentModule;
+
+    public function __construct(
+        HooksAPIInterface $hooksAPI,
+        TranslationAPIInterface $translationAPI,
+        MainContentModule $mainContentModule
+    ) {
+        parent::__construct(
+            $hooksAPI,
+            $translationAPI
+        );
+        $this->mainContentModule = $mainContentModule;
+    }
+
     protected function init()
     {
         $this->hooksAPI->addAction(
@@ -28,7 +45,7 @@ class MainContentModule extends AbstractHookSet
         // Function `getRouteModuleByMostAllmatchingVarsProperties` actually needs to access all values in $vars
         // Hence, calculate only at the very end
         // If filtering module by "maincontent", then calculate which is the main content module
-        if (isset($vars['modulefilter']) && $vars['modulefilter'] == \PoP\Engine\ModuleFilters\MainContentModule::NAME) {
+        if (isset($vars['modulefilter']) && $vars['modulefilter'] == $this->mainContentModule->getName()) {
             $vars['maincontentmodule'] = RouteModuleProcessorManagerFacade::getInstance()->getRouteModuleByMostAllmatchingVarsProperties(POP_PAGEMODULEGROUPPLACEHOLDER_MAINCONTENTMODULE);
         }
     }

--- a/layers/Engine/packages/engine/src/Hooks/ModuleFilters/ModulePathsHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/ModuleFilters/ModulePathsHookSet.php
@@ -4,14 +4,31 @@ declare(strict_types=1);
 
 namespace PoP\Engine\Hooks\ModuleFilters;
 
-use PoP\Hooks\AbstractHookSet;
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\ComponentModel\ModulePath\ModulePathUtils;
 use PoP\ComponentModel\Facades\ModulePath\ModulePathHelpersFacade;
 use PoP\ComponentModel\ModelInstance\ModelInstance;
+use PoP\ComponentModel\ModuleFilters\ModulePaths;
+use PoP\ComponentModel\ModulePath\ModulePathUtils;
+use PoP\ComponentModel\State\ApplicationState;
+use PoP\Hooks\AbstractHookSet;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\Translation\TranslationAPIInterface;
 
-class ModulePaths extends AbstractHookSet
+class ModulePathsHookSet extends AbstractHookSet
 {
+    protected ModulePaths $modulePaths;
+
+    public function __construct(
+        HooksAPIInterface $hooksAPI,
+        TranslationAPIInterface $translationAPI,
+        ModulePaths $modulePaths
+    ) {
+        parent::__construct(
+            $hooksAPI,
+            $translationAPI
+        );
+        $this->modulePaths = $modulePaths;
+    }
+
     protected function init()
     {
         $this->hooksAPI->addFilter(
@@ -31,14 +48,14 @@ class ModulePaths extends AbstractHookSet
     public function addVars(array $vars_in_array): void
     {
         [&$vars] = $vars_in_array;
-        if (isset($vars['modulefilter']) && $vars['modulefilter'] == \PoP\ComponentModel\ModuleFilters\ModulePaths::NAME) {
+        if (isset($vars['modulefilter']) && $vars['modulefilter'] == $this->modulePaths->getName()) {
             $vars['modulepaths'] = ModulePathUtils::getModulePaths();
         }
     }
     public function maybeAddComponent($components)
     {
         $vars = ApplicationState::getVars();
-        if (isset($vars['modulefilter']) && $vars['modulefilter'] == \PoP\ComponentModel\ModuleFilters\ModulePaths::NAME) {
+        if (isset($vars['modulefilter']) && $vars['modulefilter'] == $this->modulePaths->getName()) {
             if ($modulepaths = $vars['modulepaths']) {
                 $modulePathHelpers = ModulePathHelpersFacade::getInstance();
                 $paths = array_map(

--- a/layers/Engine/packages/engine/src/ModuleFilters/HeadModule.php
+++ b/layers/Engine/packages/engine/src/ModuleFilters/HeadModule.php
@@ -9,12 +9,11 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class HeadModule extends AbstractModuleFilter
 {
-    public const NAME = 'headmodule';
     public const URLPARAM_HEADMODULE = 'headmodule';
 
     public function getName()
     {
-        return self::NAME;
+        return 'headmodule';
     }
 
     public function excludeModule(array $module, array &$props)

--- a/layers/Engine/packages/engine/src/ModuleFilters/MainContentModule.php
+++ b/layers/Engine/packages/engine/src/ModuleFilters/MainContentModule.php
@@ -9,11 +9,9 @@ use PoP\ComponentModel\State\ApplicationState;
 
 class MainContentModule extends AbstractModuleFilter
 {
-    public const NAME = 'maincontentmodule';
-
     public function getName()
     {
-        return self::NAME;
+        return 'maincontentmodule';
     }
 
     public function excludeModule(array $module, array &$props)

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/pop-engine-utils.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/pop-engine-utils.php
@@ -4,6 +4,7 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\ModuleFiltering\ModuleFilterManager;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\Engine\DataStructureFormatters\DBItemListDataStructureFormatter;
+use PoP\Engine\ModuleFilters\MainContentModule;
 
 class PoPCore_ModuleManager_Utils
 {
@@ -15,10 +16,12 @@ class PoPCore_ModuleManager_Utils
         $instanceManager = InstanceManagerFacade::getInstance();
         /** @var DBItemListDataStructureFormatter */
         $dbItemListDataStructureFormatter = $instanceManager->getInstance(DBItemListDataStructureFormatter::class);
+        /** @var MainContentModule */
+        $mainContentModule = $instanceManager->getInstance(MainContentModule::class);
         $args = [
             \PoP\ComponentModel\Constants\Params::VERSION => $vars['version'],
             \PoP\ComponentModel\Constants\Params::OUTPUT => \PoP\ComponentModel\Constants\Outputs::JSON,
-            ModuleFilterManager::URLPARAM_MODULEFILTER => \PoP\Engine\ModuleFilters\MainContentModule::NAME,
+            ModuleFilterManager::URLPARAM_MODULEFILTER => $mainContentModule->getName(),
             \PoP\ComponentModel\Constants\Params::DATA_OUTPUT_ITEMS => [
                 \PoP\ComponentModel\Constants\DataOutputItems::DATABASES,
             ],

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/abstract-classes/structures/forms/delegatorfilters-base.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/abstract-classes/structures/forms/delegatorfilters-base.php
@@ -1,6 +1,8 @@
 <?php
-use PoP\ComponentModel\ModuleFiltering\ModuleFilterManager;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Misc\RequestUtils;
+use PoP\ComponentModel\ModuleFiltering\ModuleFilterManager;
+use PoP\Engine\ModuleFilters\MainContentModule;
 
 define('GD_SUBMITFORMTYPE_DELEGATE', 'delegate');
 
@@ -14,12 +16,15 @@ abstract class PoP_Module_Processor_DelegatorFiltersBase extends PoP_Module_Proc
 
     public function initWebPlatformModelProps(array $module, array &$props)
     {
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var MainContentModule */
+        $mainContentModule = $instanceManager->getInstance(MainContentModule::class);
         $this->mergeImmutableJsconfigurationProp(
             $module,
             $props,
             array(
                 'fetchparams' => array(
-                    ModuleFilterManager::URLPARAM_MODULEFILTER => \PoP\Engine\ModuleFilters\MainContentModule::NAME,
+                    ModuleFilterManager::URLPARAM_MODULEFILTER => $mainContentModule->getName(),
                 ),
             )
         );

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-spa-webplatform/library/functions/configuration-utils.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-spa-webplatform/library/functions/configuration-utils.php
@@ -1,7 +1,9 @@
 <?php
-use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\Engine\Route\RouteUtils;
+use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\SPA\ModuleFilters\Page;
 
 class PoP_SPAWebPlatform_ConfigurationUtils
 {
@@ -13,9 +15,13 @@ class PoP_SPAWebPlatform_ConfigurationUtils
 
             // If preloading (eg: INITIALFRAMES) then add the action=preload and modulefilter=page URL parameters
             if ($configuration['preload'] ?? null) {
+                $instanceManager = InstanceManagerFacade::getInstance();
+                /** @var Page */
+                $page = $instanceManager->getInstance(Page::class);
+
                 $url = GeneralUtils::addQueryArgs([
-                    \PoP\ComponentModel\ModuleFiltering\ModuleFilterManager::URLPARAM_MODULEFILTER => \PoP\SPA\ModuleFilters\Page::NAME,
-                    \PoP\ComponentModel\Constants\Params::ACTIONS.'[]' => GD_URLPARAM_ACTION_PRELOAD,
+                    \PoP\ComponentModel\ModuleFiltering\ModuleFilterManager::URLPARAM_MODULEFILTER => $page->getName(),
+                    \PoP\ComponentModel\Constants\Params::ACTIONS . '[]' => GD_URLPARAM_ACTION_PRELOAD,
                 ], $url);
             }
             $url_targets[$url] = $configuration['targets'];

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sparesourceloader/kernel/resourceloaders/config/implementations/resourceloader-config-resources-base.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sparesourceloader/kernel/resourceloaders/config/implementations/resourceloader-config-resources-base.php
@@ -1,5 +1,8 @@
 <?php
 
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\SPA\ModuleFilters\Page;
+
 abstract class PoP_SPAResourceLoader_FileReproduction_ResourcesConfigBase extends \PoP\FileStore\File\AbstractRenderableFileFragment
 {
     protected function getOptions()
@@ -32,10 +35,17 @@ abstract class PoP_SPAResourceLoader_FileReproduction_ResourcesConfigBase extend
         // Domain
         $configuration['$domain'] = $cmsengineapi->getSiteURL();
 
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var Page */
+        $page = $instanceManager->getInstance(Page::class);
+
         // Get all the resources, for the different natures
         // Notice that we get the callback to filter results from the instantiating class
         $options = $this->getOptions();
-        $resource_mapping = PoP_ResourceLoader_FileReproduction_Utils::getResourceMapping(\PoP\SPA\ModuleFilters\Page::NAME, $options);
+        $resource_mapping = PoP_ResourceLoader_FileReproduction_Utils::getResourceMapping(
+            $page->getName(),
+            $options
+        );
 
         // Print the resource mapping information into the config file's configuration
         $configuration['$matchPaths'] = $this->matchPaths();

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/library/functions/utils.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/library/functions/utils.php
@@ -1,9 +1,11 @@
 <?php
-use PoP\ComponentModel\Modules\ModuleUtils;
-use PoP\Hooks\Facades\HooksAPIFacade;
-use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 use PoP\ComponentModel\Facades\Engine\EngineFacade;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
+use PoP\ComponentModel\ModuleFilters\ModulePaths;
+use PoP\ComponentModel\Modules\ModuleUtils;
 use PoP\ComponentModel\State\ApplicationState;
+use PoP\Hooks\Facades\HooksAPIFacade;
 
 class PoPThemeWassup_Utils
 {
@@ -11,13 +13,15 @@ class PoPThemeWassup_Utils
     public static function checkLoadingPagesectionModule()
     {
         if (is_null(self::$checkLoadingPagesectionModule)) {
-
             $vars = ApplicationState::getVars();
+            $instanceManager = InstanceManagerFacade::getInstance();
+            /** @var ModulePaths */
+            $modulePaths = $instanceManager->getInstance(ModulePaths::class);
 
             // If we are targeting specific module paths, then no need to validate. Otherwise, we must check that the module is under only 1 pageSection, or it may be repeated here and there
             self::$checkLoadingPagesectionModule = HooksAPIFacade::getInstance()->applyFilters(
                 'PoPThemeWassup_Utils:checkLoadingPagesectionModule',
-                $vars['modulefilter'] !== \PoP\ComponentModel\ModuleFilters\ModulePaths::NAME
+                $vars['modulefilter'] !== $modulePaths->getName()
             );
         }
 
@@ -26,9 +30,8 @@ class PoPThemeWassup_Utils
 
     public static function getFrontendId($frontend_id, $group)
     {
-
         // As defined in helper generateId in helpers.handlebars.js
-        return $frontend_id.POP_CONSTANT_ID_SEPARATOR.$group;
+        return $frontend_id . POP_CONSTANT_ID_SEPARATOR . $group;
     }
 
     // Return all the classes to make the pageSections active inside the pageSectionGroup
@@ -36,7 +39,6 @@ class PoPThemeWassup_Utils
     // for javascript to execute to have content visible
     public static function getPagesectiongroupActivePagesectionClasses($active_classes = array())
     {
-
         // If PoP SSR is not defined, then there is no PoP_SSR_ServerUtils
         if (defined('POP_SSR_INITIALIZED')) {
             if (!PoP_SSR_ServerUtils::disableServerSideRendering()) {

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/plugins/pop-spa/library/processors/pagesectiongroups.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/plugins/pop-spa/library/processors/pagesectiongroups.php
@@ -1,16 +1,20 @@
 <?php
 
-use PoP\ModuleRouting\Facades\RouteModuleProcessorManagerFacade;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\State\ApplicationState;
+use PoP\ModuleRouting\Facades\RouteModuleProcessorManagerFacade;
+use PoP\SPA\ModuleFilters\Page;
 
 class PoP_SPA_Module_Processor_Entries extends PoP_Module_Processor_Entries
 {
     public function getSubmodules(array $module): array
     {
-
         // If fetching a page, then load only the required pageSection modules and nothing else
         $vars = ApplicationState::getVars();
-        if (isset($vars['modulefilter']) && $vars['modulefilter'] == \PoP\SPA\ModuleFilters\Page::NAME) {
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var Page */
+        $page = $instanceManager->getInstance(Page::class);
+        if (isset($vars['modulefilter']) && $vars['modulefilter'] == $page->getName()) {
             $ret = array();
 
             switch ($module[1]) {

--- a/layers/SiteBuilder/packages/application/config/services.yaml
+++ b/layers/SiteBuilder/packages/application/config/services.yaml
@@ -5,7 +5,6 @@ services:
 
     PoP\Application\ModuleFilters\:
         resource: '../src/ModuleFilters/*'
-        public: false
 
     PoP\Application\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/SiteBuilder/packages/application/src/Hooks/LazyLoadHookSet.php
+++ b/layers/SiteBuilder/packages/application/src/Hooks/LazyLoadHookSet.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace PoP\Application\Hooks;
 
-use PoP\ComponentModel\Constants\Params;
-use PoP\ComponentModel\Constants\DataOutputItems;
-use PoP\ComponentModel\Constants\Targets;
-use PoP\ComponentModel\ModuleFiltering\ModuleFilterManager;
-use PoP\Application\ModuleProcessors\DataloadingConstants;
-use PoP\ComponentModel\Misc\GeneralUtils;
-use PoP\Hooks\AbstractHookSet;
 use PoP\Application\Constants\Actions;
 use PoP\Application\ModuleFilters\Lazy;
+use PoP\Application\ModuleProcessors\DataloadingConstants;
+use PoP\ComponentModel\Constants\DataOutputItems;
+use PoP\ComponentModel\Constants\Params;
+use PoP\ComponentModel\Constants\Targets;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Misc\RequestUtils;
+use PoP\ComponentModel\ModuleFiltering\ModuleFilterManager;
+use PoP\Hooks\AbstractHookSet;
 
 class LazyLoadHookSet extends AbstractHookSet
 {
@@ -58,6 +59,9 @@ class LazyLoadHookSet extends AbstractHookSet
     public function end($root_module, $root_model_props_in_array, $root_props_in_array, $helperCalculations_in_array, $engine)
     {
         $helperCalculations = &$helperCalculations_in_array[0];
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var Lazy */
+        $lazy = $instanceManager->getInstance(Lazy::class);
 
         // Fetch the lazy-loaded data using the Background URL load
         if ($helperCalculations['has-lazy-load'] ?? null) {
@@ -67,7 +71,7 @@ class LazyLoadHookSet extends AbstractHookSet
                     DataOutputItems::MODULE_DATA,
                     DataOutputItems::DATABASES,
                 ],
-                ModuleFilterManager::URLPARAM_MODULEFILTER => Lazy::NAME,
+                ModuleFilterManager::URLPARAM_MODULEFILTER => $lazy->getName(),
                 Params::ACTIONS . '[]' => Actions::LOADLAZY,
             ], RequestUtils::getCurrentUrl());
             $engine->addBackgroundUrl($url, array(Targets::MAIN));

--- a/layers/SiteBuilder/packages/application/src/ModuleFilters/Lazy.php
+++ b/layers/SiteBuilder/packages/application/src/ModuleFilters/Lazy.php
@@ -9,11 +9,9 @@ use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 
 class Lazy extends AbstractModuleFilter
 {
-    public const NAME = 'lazy';
-
     public function getName()
     {
-        return self::NAME;
+        return 'lazy';
     }
 
     public function excludeModule(array $module, array &$props)

--- a/layers/SiteBuilder/packages/spa/config/services.yaml
+++ b/layers/SiteBuilder/packages/spa/config/services.yaml
@@ -5,4 +5,3 @@ services:
 
     PoP\SPA\ModuleFilters\:
         resource: '../src/ModuleFilters/*'
-        public: false

--- a/layers/SiteBuilder/packages/spa/src/ModuleFilters/Page.php
+++ b/layers/SiteBuilder/packages/spa/src/ModuleFilters/Page.php
@@ -10,11 +10,9 @@ use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 
 class Page extends AbstractModuleFilter
 {
-    public const NAME = 'page';
-
     public function getName()
     {
-        return self::NAME;
+        return 'page';
     }
 
     public function excludeModule(array $module, array &$props)


### PR DESCRIPTION
In all the `ModuleFilter`s, do not use a public const to reference their name, as `self::NAME`, because then it can be accessed directly, and this can create bugs if overriding the class as service in the dependency injection container.