### PR TITLE
Made DirectiveResolver's constructor final

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -59,7 +59,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      *   $instanceManager->getInstance(...)
      *
      * DirectiveResolvers must still be added to schema-services.yml, though.
-     * Thsi is because they need to be registered, so that all directives
+     * This is because they need to be registered, so that all directives
      * can be displayed in the GraphQL API's Access Control Lists
      */
     final public function __construct(?string $directive = null)

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -47,7 +47,22 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      */
     protected array $nestedDirectivePipelineData = [];
 
-    public function __construct(?string $directive = null)
+    /**
+     * The directiveResolvers are NOT instantiated through the service container!
+     * Instead, the directive will be instantiated in AbstractTypeResolver:
+     *   new $directiveClass($fieldDirective)
+     * Then, the constructor is made final, to avoid creating inheriting classes
+     * whose properties are expected to be injected via dependency injection.
+     *
+     * Whenever having depended-upon services,
+     * these must be obtained from the container by doing:
+     *   $instanceManager->getInstance(...)
+     *
+     * DirectiveResolvers must still be added to schema-services.yml, though.
+     * Thsi is because they need to be registered, so that all directives
+     * can be displayed in the GraphQL API's Access Control Lists
+     */
+    final public function __construct(?string $directive = null)
     {
         // If the directive is not provided, then it directly the directive name
         // This allows to instantiate the directive through the DependencyInjection component


### PR DESCRIPTION
The `DirectiveResolver`s are NOT instantiated through the service container! Instead, the directive will be instantiated in `AbstractTypeResolver`:

```php
new $directiveClass($fieldDirective)
```

Then, the constructor is made final:

```php
final public function __construct(?string $directive = null)
```

This way, we do not allow to create inheriting classes whose properties are expected to be injected via dependency injection.

Whenever having depended-upon services, these must be obtained from the container by doing:

```php
$instanceManager->getInstance(...)
```

DirectiveResolvers must still be added to `schema-services.yml`, though. This is because they need to be registered, so that all directives can be displayed in the GraphQL API's Access Control Lists.
