### PR TITLE
Order modules by priority

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/HybridServices/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/HybridServices/ModuleResolvers/SchemaModuleResolver.php
@@ -47,6 +47,15 @@ class SchemaModuleResolver extends AbstractSchemaTypeModuleResolver
         ];
     }
 
+    /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 90;
+    }
+
     public function getDependedModuleLists(string $module): array
     {
         switch ($module) {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/AbstractModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/AbstractModuleResolver.php
@@ -17,6 +17,16 @@ abstract class AbstractModuleResolver implements ModuleResolverInterface
     {
         $this->moduleRegistry = $moduleRegistry;
     }
+
+    /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 10;
+    }
+
     /**
      * @return array<array> List of entries that must be satisfied, each entry is an array where at least 1 module must be satisfied
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/AccessControlFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/AccessControlFunctionalityModuleResolver.php
@@ -36,6 +36,15 @@ class AccessControlFunctionalityModuleResolver extends AbstractFunctionalityModu
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 170;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/CacheFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/CacheFunctionalityModuleResolver.php
@@ -35,6 +35,15 @@ class CacheFunctionalityModuleResolver extends AbstractCacheFunctionalityModuleR
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 130;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/ClientFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/ClientFunctionalityModuleResolver.php
@@ -48,6 +48,15 @@ class ClientFunctionalityModuleResolver extends AbstractFunctionalityModuleResol
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 110;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/EndpointFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/EndpointFunctionalityModuleResolver.php
@@ -38,6 +38,15 @@ class EndpointFunctionalityModuleResolver extends AbstractFunctionalityModuleRes
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 190;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/ModuleResolverInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/ModuleResolverInterface.php
@@ -11,6 +11,11 @@ interface ModuleResolverInterface
      */
     public function getModulesToResolve(): array;
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int;
+    /**
      * This is a list of lists of modules, as to model both OR and AND conditions
      * The innermost list is an OR: if any module is enabled, then the condition succeeds
      * The outermost list is an AND: all list must succeed for this module to be enabled

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/OperationalFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/OperationalFunctionalityModuleResolver.php
@@ -45,6 +45,15 @@ class OperationalFunctionalityModuleResolver extends AbstractFunctionalityModule
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 120;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/PerformanceFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/PerformanceFunctionalityModuleResolver.php
@@ -39,6 +39,15 @@ class PerformanceFunctionalityModuleResolver extends AbstractFunctionalityModule
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 140;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/PluginManagementFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/PluginManagementFunctionalityModuleResolver.php
@@ -35,6 +35,15 @@ class PluginManagementFunctionalityModuleResolver extends AbstractFunctionalityM
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 200;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
@@ -47,6 +47,15 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 180;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -127,6 +127,15 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 100;
+    }
+
+    /**
      * @return array<array> List of entries that must be satisfied, each entry is an array where at least 1 module must be satisfied
      */
     public function getDependedModuleLists(string $module): array

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/UserInterfaceFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/UserInterfaceFunctionalityModuleResolver.php
@@ -29,6 +29,15 @@ class UserInterfaceFunctionalityModuleResolver extends AbstractFunctionalityModu
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 150;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/VersioningFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/HybridServices/ModuleResolvers/VersioningFunctionalityModuleResolver.php
@@ -26,6 +26,15 @@ class VersioningFunctionalityModuleResolver extends AbstractFunctionalityModuleR
     }
 
     /**
+     * The priority to display the modules from this resolver in the Modules page.
+     * The higher the number, the earlier it shows
+     */
+    public function getPriority(): int
+    {
+        return 160;
+    }
+
+    /**
      * Enable to customize a specific UI for the module
      */
     public function getModuleType(string $module): string


### PR DESCRIPTION
In the Modules page, show modules according to some priority given through function `getPriority`. The higher the number, the earlier it displays.