### PR TITLE
Deal with instances, not classes: Convert getExtensionClasses to getAttachableExtensions

### DIFF
--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
@@ -12,7 +12,7 @@ final class CacheControlDirectiveResolver extends AbstractCacheControlDirectiveR
     /**
      * It must execute after everyone else!
      */
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         return 0;
     }

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
@@ -12,7 +12,7 @@ final class CacheControlDirectiveResolver extends AbstractCacheControlDirectiveR
     /**
      * It must execute after everyone else!
      */
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         return 0;
     }

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
@@ -32,7 +32,7 @@ class NestedFieldCacheControlDirectiveResolver extends AbstractCacheControlDirec
     /**
      * It must execute before anyone else!
      */
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         return PHP_INT_MAX;
     }

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
@@ -32,7 +32,7 @@ class NestedFieldCacheControlDirectiveResolver extends AbstractCacheControlDirec
     /**
      * It must execute before anyone else!
      */
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         return PHP_INT_MAX;
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -14,7 +14,7 @@ interface AttachableExtensionInterface
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
      */
-    public function getPriorityToAttachClasses(): int;
+    public function getPriorityToAttachToClasses(): int;
 
     /**
      * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -20,5 +20,5 @@ interface AttachableExtensionInterface
      * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself
      * The priority in the class has priority (pun intended ;))
      */
-    public function attach(string $group, int $priority = 10): void;
+    public function attach(string $group): void;
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionInterface.php
@@ -14,7 +14,7 @@ interface AttachableExtensionInterface
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
      */
-    public function getPriorityToAttachClasses(): ?int;
+    public function getPriorityToAttachClasses(): int;
 
     /**
      * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
@@ -13,7 +13,7 @@ class AttachableExtensionManager implements AttachableExtensionManagerInterface
      */
     protected array $attachableExtensions = [];
 
-    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $attachableExtension): void
+    public function attachExtensionToClass(string $attachableClass, string $group, AttachableExtensionInterface $attachableExtension): void
     {
         $this->attachableExtensions[$attachableClass][$group][] = $attachableExtension;
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
@@ -11,11 +11,11 @@ class AttachableExtensionManager implements AttachableExtensionManagerInterface
     /**
      * @var array<string, array<string, AttachableExtensionInterface[]>
      */
-    protected array $extensionClasses = [];
+    protected array $attachableExtensions = [];
 
     public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $attachableExtension): void
     {
-        $this->extensionClasses[$attachableClass][$group][] = $attachableExtension;
+        $this->attachableExtensions[$attachableClass][$group][] = $attachableExtension;
     }
 
     /**
@@ -23,6 +23,6 @@ class AttachableExtensionManager implements AttachableExtensionManagerInterface
      */
     public function getAttachedExtensions(string $attachableClass, string $group): array
     {
-        return $this->extensionClasses[$attachableClass][$group] ?? [];
+        return $this->attachableExtensions[$attachableClass][$group] ?? [];
     }
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
@@ -21,7 +21,7 @@ class AttachableExtensionManager implements AttachableExtensionManagerInterface
     /**
      * @return array<string, array<string, AttachableExtensionInterface[]>
      */
-    public function getExtensionClasses(string $attachableClass, string $group): array
+    public function getAttachedExtensions(string $attachableClass, string $group): array
     {
         return $this->extensionClasses[$attachableClass][$group] ?? [];
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
@@ -11,9 +11,9 @@ class AttachableExtensionManager implements AttachableExtensionManagerInterface
      */
     protected array $extensionClasses = [];
 
-    public function setExtensionClass(string $attachableClass, string $group, string $extensionClass, int $priority = 10): void
+    public function setExtensionClass(string $attachableClass, string $group, string $extensionClass): void
     {
-        $this->extensionClasses[$attachableClass][$group][$extensionClass] = $priority;
+        $this->extensionClasses[$attachableClass][$group][] = $extensionClass;
     }
 
     public function getExtensionClasses(string $attachableClass, string $group): array

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
@@ -4,18 +4,23 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\AttachableExtensions;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
+
 class AttachableExtensionManager implements AttachableExtensionManagerInterface
 {
     /**
-     * @var array<string, array>
+     * @var array<string, array<string, AttachableExtensionInterface[]>
      */
     protected array $extensionClasses = [];
 
-    public function setExtensionClass(string $attachableClass, string $group, string $extensionClass): void
+    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $extensionClass): void
     {
         $this->extensionClasses[$attachableClass][$group][] = $extensionClass;
     }
 
+    /**
+     * @return array<string, array<string, AttachableExtensionInterface[]>
+     */
     public function getExtensionClasses(string $attachableClass, string $group): array
     {
         return $this->extensionClasses[$attachableClass][$group] ?? [];

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManager.php
@@ -13,9 +13,9 @@ class AttachableExtensionManager implements AttachableExtensionManagerInterface
      */
     protected array $extensionClasses = [];
 
-    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $extensionClass): void
+    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $attachableExtension): void
     {
-        $this->extensionClasses[$attachableClass][$group][] = $extensionClass;
+        $this->extensionClasses[$attachableClass][$group][] = $attachableExtension;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
@@ -6,6 +6,6 @@ namespace PoP\ComponentModel\AttachableExtensions;
 
 interface AttachableExtensionManagerInterface
 {
-    public function setExtensionClass(string $attachableClass, string $group, string $extensionClass, int $priority = 10);
+    public function setExtensionClass(string $attachableClass, string $group, string $extensionClass);
     public function getExtensionClasses(string $attachableClass, string $group): array;
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
@@ -8,7 +8,7 @@ use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 
 interface AttachableExtensionManagerInterface
 {
-    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $extensionClass): void;
+    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $attachableExtension): void;
     /**
      * @return array<string, array<string, AttachableExtensionInterface[]>
      */

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
@@ -12,5 +12,5 @@ interface AttachableExtensionManagerInterface
     /**
      * @return array<string, array<string, AttachableExtensionInterface[]>
      */
-    public function getExtensionClasses(string $attachableClass, string $group): array;
+    public function getAttachedExtensions(string $attachableClass, string $group): array;
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\AttachableExtensions;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
+
 interface AttachableExtensionManagerInterface
 {
-    public function setExtensionClass(string $attachableClass, string $group, string $extensionClass);
+    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $extensionClass): void;
+    /**
+     * @return array<string, array<string, AttachableExtensionInterface[]>
+     */
     public function getExtensionClasses(string $attachableClass, string $group): array;
 }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionManagerInterface.php
@@ -8,7 +8,7 @@ use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 
 interface AttachableExtensionManagerInterface
 {
-    public function setExtensionClass(string $attachableClass, string $group, AttachableExtensionInterface $attachableExtension): void;
+    public function attachExtensionToClass(string $attachableClass, string $group, AttachableExtensionInterface $attachableExtension): void;
     /**
      * @return array<string, array<string, AttachableExtensionInterface[]>
      */

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -32,7 +32,7 @@ trait AttachableExtensionTrait
     {
         $attachableExtensionManager = AttachableExtensionManagerFacade::getInstance();
         foreach ($this->getClassesToAttachTo() as $attachableClass) {
-            $attachableExtensionManager->setExtensionClass(
+            $attachableExtensionManager->attachExtensionToClass(
                 $attachableClass,
                 $group,
                 $this

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -19,7 +19,7 @@ trait AttachableExtensionTrait
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
      */
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         return 10;
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -19,9 +19,9 @@ trait AttachableExtensionTrait
     /**
      * The priority with which to attach to the class. The higher the priority, the sooner it will be processed
      */
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
-        return null;
+        return 10;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -31,12 +31,11 @@ trait AttachableExtensionTrait
     public function attach(string $group): void
     {
         $attachableExtensionManager = AttachableExtensionManagerFacade::getInstance();
-        $extensionClass = get_called_class();
         foreach ($this->getClassesToAttachTo() as $attachableClass) {
             $attachableExtensionManager->setExtensionClass(
                 $attachableClass,
                 $group,
-                $extensionClass
+                $this
             );
         }
     }

--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachableExtensionTrait.php
@@ -28,7 +28,7 @@ trait AttachableExtensionTrait
      * There are 2 ways of setting a priority: either by configuration through parameter, or explicity defined in the class itself
      * The priority in the class has priority (pun intended ;))
      */
-    public function attach(string $group, int $priority = 10): void
+    public function attach(string $group): void
     {
         $attachableExtensionManager = AttachableExtensionManagerFacade::getInstance();
         $extensionClass = get_called_class();
@@ -36,8 +36,7 @@ trait AttachableExtensionTrait
             $attachableExtensionManager->setExtensionClass(
                 $attachableClass,
                 $group,
-                $extensionClass,
-                $this->getPriorityToAttachClasses() ?? $priority
+                $extensionClass
             );
         }
     }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -7,7 +7,6 @@ namespace PoP\ComponentModel\DirectiveResolvers;
 use Composer\Semver\Semver;
 use Exception;
 use League\Pipeline\StageInterface;
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 use PoP\ComponentModel\DirectivePipeline\DirectivePipelineUtils;
 use PoP\ComponentModel\Directives\DirectiveTypes;
@@ -25,7 +24,7 @@ use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\FieldQuery\QueryHelpers;
 use PoP\Translation\Facades\TranslationAPIFacade;
 
-abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, SchemaDirectiveResolverInterface, StageInterface, AttachableExtensionInterface
+abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, SchemaDirectiveResolverInterface, StageInterface
 {
     use AttachableExtensionTrait;
     use RemoveIDsDataFieldsDirectiveResolverTrait;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\DirectiveResolvers;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
-interface DirectiveResolverInterface
+interface DirectiveResolverInterface extends AttachableExtensionInterface
 {
     public static function getDirectiveName(): string;
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -6,7 +6,6 @@ namespace PoP\ComponentModel\FieldResolvers;
 
 use Composer\Semver\Semver;
 use Exception;
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 use PoP\ComponentModel\CheckpointSets\CheckpointSets;
 use PoP\ComponentModel\Environment;
@@ -29,7 +28,7 @@ use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\Translation\Facades\TranslationAPIFacade;
 
-abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSchemaDefinitionResolverInterface, AttachableExtensionInterface
+abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSchemaDefinitionResolverInterface
 {
     /**
      * This class is attached to a TypeResolver

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 
-interface FieldResolverInterface
+interface FieldResolverInterface extends AttachableExtensionInterface
 {
     /**
      * Get an array with the fieldNames that this fieldResolver resolves

--- a/layers/Engine/packages/component-model/src/TypeResolverDecorators/AbstractTypeResolverDecorator.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverDecorators/AbstractTypeResolverDecorator.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolverDecorators;
 
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 use PoP\ComponentModel\TypeResolverDecorators\TypeResolverDecoratorInterface;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
-abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInterface, AttachableExtensionInterface
+abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInterface
 {
     /**
      * This class is attached to a TypeResolver

--- a/layers/Engine/packages/component-model/src/TypeResolverDecorators/TypeResolverDecoratorInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverDecorators/TypeResolverDecoratorInterface.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolverDecorators;
 
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
-interface TypeResolverDecoratorInterface
+interface TypeResolverDecoratorInterface extends AttachableExtensionInterface
 {
     /**
      * Allow to disable the functionality

--- a/layers/Engine/packages/component-model/src/TypeResolverPickers/AbstractTypeResolverPicker.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverPickers/AbstractTypeResolverPicker.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolverPickers;
 
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 
-abstract class AbstractTypeResolverPicker implements TypeResolverPickerInterface, AttachableExtensionInterface
+abstract class AbstractTypeResolverPicker implements TypeResolverPickerInterface
 {
     use AttachableExtensionTrait;
 

--- a/layers/Engine/packages/component-model/src/TypeResolverPickers/TypeResolverPickerInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverPickers/TypeResolverPickerInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolverPickers;
 
-interface TypeResolverPickerInterface
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
+
+interface TypeResolverPickerInterface extends AttachableExtensionInterface
 {
     public function getTypeResolverClass(): string;
     public function isIDOfType($resultItemID): bool;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1820,7 +1820,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             // Iterate classes from the current class towards the parent classes until finding typeResolver that satisfies processing this field
             do {
                 /** @var FieldResolverInterface[] */
-                $fieldResolvers = $attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::FIELDRESOLVERS);
+                $fieldResolvers = $attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::FIELDRESOLVERS);
                 foreach ($fieldResolvers as $fieldResolver) {
                     // Process the fields which have not been processed yet
                     $extensionClassFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
@@ -1962,7 +1962,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         do {
             // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
             /** @var TypeResolverDecoratorInterface[] */
-            $extensionTypeResolverDecorators = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::TYPERESOLVERDECORATORS));
+            $extensionTypeResolverDecorators = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::TYPERESOLVERDECORATORS));
             // Order them by priority: higher priority are evaluated first
             $extensionPriorities = array_map(
                 fn (TypeResolverDecoratorInterface $typeResolverDecorator) => $typeResolverDecorator->getPriorityToAttachClasses(),
@@ -2078,7 +2078,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
 
                 // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
                 /** @var FieldResolverInterface[] */
-                $extensionFieldResolvers = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::FIELDRESOLVERS));
+                $extensionFieldResolvers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::FIELDRESOLVERS));
                 foreach ($extensionFieldResolvers as $fieldResolver) {
                     $extensionClassFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
                     if (in_array($fieldName, $extensionClassFieldNames)) {
@@ -2127,7 +2127,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             do {
                 // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
                 /** @var DirectiveResolverInterface[] */
-                $directiveResolvers = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::DIRECTIVERESOLVERS));
+                $directiveResolvers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::DIRECTIVERESOLVERS));
                 // Order them by priority: higher priority are evaluated first
                 $extensionPriorities = array_map(
                     fn (DirectiveResolverInterface $directiveResolver) => $directiveResolver->getPriorityToAttachClasses(),
@@ -2159,7 +2159,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         $class = $this->getTypeResolverClassToCalculateSchema();
         do {
             /** @var FieldResolverInterface[] */
-            $fieldResolvers = $attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::FIELDRESOLVERS);
+            $fieldResolvers = $attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::FIELDRESOLVERS);
             foreach ($fieldResolvers as $fieldResolver) {
                 $extensionClassFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
                 $ret = array_merge(

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1822,8 +1822,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $fieldResolvers = $attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::FIELDRESOLVERS);
                 foreach ($fieldResolvers as $fieldResolver) {
                     // Process the fields which have not been processed yet
-                    $extensionClassFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
-                    foreach (array_diff($extensionClassFieldNames, array_keys($schemaFieldResolvers)) as $fieldName) {
+                    $extensionFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
+                    foreach (array_diff($extensionFieldNames, array_keys($schemaFieldResolvers)) as $fieldName) {
                         // Watch out here: no fieldArgs!!!! So this deals with the base case (static), not with all cases (runtime)
                         // If using an ACL to remove a field from an interface,
                         // getting the fieldResolvers for that field will be empty
@@ -2079,8 +2079,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 /** @var FieldResolverInterface[] */
                 $extensionFieldResolvers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::FIELDRESOLVERS));
                 foreach ($extensionFieldResolvers as $fieldResolver) {
-                    $extensionClassFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
-                    if (in_array($fieldName, $extensionClassFieldNames)) {
+                    $extensionFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
+                    if (in_array($fieldName, $extensionFieldNames)) {
                         // Check that the fieldResolver can handle the field based on other parameters (eg: "version" in the fieldArgs)
                         if ($fieldResolver->resolveCanProcess($this, $fieldName, $fieldArgs)) {
                             $extensionPriority = $fieldResolver->getPriorityToAttachClasses();
@@ -2160,10 +2160,10 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             /** @var FieldResolverInterface[] */
             $fieldResolvers = $attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::FIELDRESOLVERS);
             foreach ($fieldResolvers as $fieldResolver) {
-                $extensionClassFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
+                $extensionFieldNames = $this->getFieldNamesResolvedByFieldResolver($fieldResolver);
                 $ret = array_merge(
                     $ret,
-                    $extensionClassFieldNames
+                    $extensionFieldNames
                 );
             }
             // Continue iterating for the class parents

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1964,7 +1964,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             $attachedTypeResolverDecorators = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::TYPERESOLVERDECORATORS));
             // Order them by priority: higher priority are evaluated first
             $extensionPriorities = array_map(
-                fn (TypeResolverDecoratorInterface $typeResolverDecorator) => $typeResolverDecorator->getPriorityToAttachClasses(),
+                fn (TypeResolverDecoratorInterface $typeResolverDecorator) => $typeResolverDecorator->getPriorityToAttachToClasses(),
                 $attachedTypeResolverDecorators
             );
             array_multisort($extensionPriorities, SORT_DESC, SORT_NUMERIC, $attachedTypeResolverDecorators);
@@ -2083,7 +2083,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                     if (in_array($fieldName, $extensionFieldNames)) {
                         // Check that the fieldResolver can handle the field based on other parameters (eg: "version" in the fieldArgs)
                         if ($fieldResolver->resolveCanProcess($this, $fieldName, $fieldArgs)) {
-                            $extensionPriority = $fieldResolver->getPriorityToAttachClasses();
+                            $extensionPriority = $fieldResolver->getPriorityToAttachToClasses();
                             $classTypeResolverPriorities[] = $extensionPriority;
                             $classFieldResolvers[] = $fieldResolver;
                         }
@@ -2129,7 +2129,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $attachedDirectiveResolvers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::DIRECTIVERESOLVERS));
                 // Order them by priority: higher priority are evaluated first
                 $extensionPriorities = array_map(
-                    fn (DirectiveResolverInterface $directiveResolver) => $directiveResolver->getPriorityToAttachClasses(),
+                    fn (DirectiveResolverInterface $directiveResolver) => $directiveResolver->getPriorityToAttachToClasses(),
                     $attachedDirectiveResolvers
                 );
                 array_multisort($extensionPriorities, SORT_DESC, SORT_NUMERIC, $attachedDirectiveResolvers);

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1768,8 +1768,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     /**
      * Return the fieldNames resolved by the fieldResolverClass, adding a hook to disable each of them (eg: to implement a private schema)
      *
-     * @param string $extensionClass
-     * @return array
+     * @return string[]
      */
     protected function getFieldNamesResolvedByFieldResolver(FieldResolverInterface $fieldResolver): array
     {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -206,7 +206,7 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
             // All the pickers and their priorities for this class level
             // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
             /** @var TypeResolverPickerInterface[] */
-            $classPickers = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
+            $classPickers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
             // Order them by priority: higher priority are evaluated first
             $classPickerPriorities = array_map(
                 fn (TypeResolverPickerInterface $typeResolverPicker) => $typeResolverPicker->getPriorityToAttachClasses(),

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -209,7 +209,7 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
             $attachedTypeResolverPickers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
             // Order them by priority: higher priority are evaluated first
             $extensionPriorities = array_map(
-                fn (TypeResolverPickerInterface $typeResolverPicker) => $typeResolverPicker->getPriorityToAttachClasses(),
+                fn (TypeResolverPickerInterface $typeResolverPicker) => $typeResolverPicker->getPriorityToAttachToClasses(),
                 $attachedTypeResolverPickers
             );
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -206,19 +206,19 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
             // All the pickers and their priorities for this class level
             // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
             /** @var TypeResolverPickerInterface[] */
-            $classPickers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
+            $attachedTypeResolverPickers = array_reverse($attachableExtensionManager->getAttachedExtensions($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
             // Order them by priority: higher priority are evaluated first
-            $classPickerPriorities = array_map(
+            $extensionPriorities = array_map(
                 fn (TypeResolverPickerInterface $typeResolverPicker) => $typeResolverPicker->getPriorityToAttachClasses(),
-                $classPickers
+                $attachedTypeResolverPickers
             );
 
             // Sort the found pickers by their priority, and then add to the stack of all pickers, for all classes
             // Higher priority means they execute first!
-            array_multisort($classPickerPriorities, SORT_DESC, SORT_NUMERIC, $classPickers);
+            array_multisort($extensionPriorities, SORT_DESC, SORT_NUMERIC, $attachedTypeResolverPickers);
             $typeResolverPickers = array_merge(
                 $typeResolverPickers,
-                $classPickers
+                $attachedTypeResolverPickers
             );
             // Continue iterating for the class parents
         } while ($class = get_parent_class($class));

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -205,19 +205,13 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
         do {
             // All the pickers and their priorities for this class level
             // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
-            $classPickerClasses = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
+            /** @var TypeResolverPickerInterface[] */
+            $classPickers = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
             // Order them by priority: higher priority are evaluated first
             $classPickerPriorities = array_map(
-                function ($extensionClass) use ($instanceManager): int {
-                    /** @var AttachableExtensionInterface */
-                    $attachableExtension = $instanceManager->getInstance($extensionClass);
-                    return $attachableExtension->getPriorityToAttachClasses();
-                },
-                $classPickerClasses
+                fn (TypeResolverPickerInterface $typeResolverPicker) => $typeResolverPicker->getPriorityToAttachClasses(),
+                $classPickers
             );
-            $classPickers = array_map(function ($extensionClass) use ($instanceManager) {
-                return $instanceManager->getInstance($extensionClass);
-            }, $classPickerClasses);
 
             // Sort the found pickers by their priority, and then add to the stack of all pickers, for all classes
             // Higher priority means they execute first!

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -205,9 +205,16 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
         do {
             // All the pickers and their priorities for this class level
             // Important: do array_reverse to enable more specific hooks, which are initialized later on in the project, to be the chosen ones (if their priority is the same)
-            $extensionPickerClassPriorities = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
-            $classPickerPriorities = array_values($extensionPickerClassPriorities);
-            $classPickerClasses = array_keys($extensionPickerClassPriorities);
+            $classPickerClasses = array_reverse($attachableExtensionManager->getExtensionClasses($class, AttachableExtensionGroups::TYPERESOLVERPICKERS));
+            // Order them by priority: higher priority are evaluated first
+            $classPickerPriorities = array_map(
+                function ($extensionClass) use ($instanceManager): int {
+                    /** @var AttachableExtensionInterface */
+                    $attachableExtension = $instanceManager->getInstance($extensionClass);
+                    return $attachableExtension->getPriorityToAttachClasses();
+                },
+                $classPickerClasses
+            );
             $classPickers = array_map(function ($extensionClass) use ($instanceManager) {
                 return $instanceManager->getInstance($extensionClass);
             }, $classPickerClasses);

--- a/layers/Engine/packages/component-model/src/TypeResolvers/TypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/TypeResolverInterface.php
@@ -26,7 +26,10 @@ interface TypeResolverInterface
     public function getAllImplementedInterfaceResolverInstances(): array;
     public function getQualifiedDBObjectIDOrIDs($dbObjectIDOrIDs);
     public function getIdFieldTypeResolverClass(): string;
-    public function getDirectiveNameClasses(): array;
+    /**
+     * @return array<string,DirectiveResolverInterface[]>
+     */
+    public function getDirectiveNameResolvers(): array;
     public function validateFieldArgumentsForSchema(string $field, array $fieldArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array;
     public function enqueueFillingResultItemsFromIDs(array $ids_data_fields);
     public function fillResultItems(

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
@@ -28,7 +28,7 @@ class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
     //  * so this one gets registered (otherwise, since `ADD_GLOBAL_FIELDS_TO_SCHEMA`
     //  * is false, the field would be removed)
     //  */
-    // public function getPriorityToAttachClasses(): int
+    // public function getPriorityToAttachToClasses(): int
     // {
     //     return 20;
     // }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
@@ -28,7 +28,7 @@ class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
     //  * so this one gets registered (otherwise, since `ADD_GLOBAL_FIELDS_TO_SCHEMA`
     //  * is false, the field would be removed)
     //  */
-    // public function getPriorityToAttachClasses(): ?int
+    // public function getPriorityToAttachClasses(): int
     // {
     //     return 20;
     // }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -31,7 +31,7 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
         ];
     }
 
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         // Higher priority => Process first
         return 100;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -31,7 +31,7 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
         ];
     }
 
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         // Higher priority => Process first
         return 100;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -20,7 +20,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return array(TypeTypeResolver::class);
     }
 
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         // Higher priority => Process first
         return 100;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -20,7 +20,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return array(TypeTypeResolver::class);
     }
 
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         // Higher priority => Process first
         return 100;

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class MakeTitleDirectiveResolver extends MakeTitleVersion010DirectiveResolver
 {
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         return null;
     }

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class MakeTitleDirectiveResolver extends MakeTitleVersion010DirectiveResolver
 {
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         return null;
     }

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
@@ -17,7 +17,7 @@ class MakeTitleVersion010DirectiveResolver extends AbstractGlobalDirectiveResolv
         return self::DIRECTIVE_NAME;
     }
 
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 20;

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
@@ -17,7 +17,7 @@ class MakeTitleVersion010DirectiveResolver extends AbstractGlobalDirectiveResolv
         return self::DIRECTIVE_NAME;
     }
 
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 20;

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion020DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion020DirectiveResolver.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 class MakeTitleVersion020DirectiveResolver extends MakeTitleVersion010DirectiveResolver
 {
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 30;

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion020DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion020DirectiveResolver.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 class MakeTitleVersion020DirectiveResolver extends MakeTitleVersion010DirectiveResolver
 {
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 30;

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
@@ -20,7 +20,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return array(RootTypeResolver::class);
     }
 
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 20;

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
@@ -20,7 +20,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return array(RootTypeResolver::class);
     }
 
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         // Higher priority => Process before the latest version fieldResolver
         return 20;

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_2_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_2_0/RootFieldResolver.php
@@ -13,7 +13,7 @@ class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Ve
     {
         return '0.2.0';
     }
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         return 30;
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_2_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_2_0/RootFieldResolver.php
@@ -13,7 +13,7 @@ class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Ve
     {
         return '0.2.0';
     }
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         return 30;
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Version_0_1_0\RootFieldResolver
 {
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         return null;
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Version_0_1_0\RootFieldResolver
 {
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         return null;
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
@@ -30,7 +30,7 @@ class ExperimentalBranchFieldResolver extends CustomPostFieldResolver
      *
      * @return integer|null
      */
-    public function getPriorityToAttachClasses(): ?int
+    public function getPriorityToAttachClasses(): int
     {
         return 20;
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
@@ -30,7 +30,7 @@ class ExperimentalBranchFieldResolver extends CustomPostFieldResolver
      *
      * @return integer|null
      */
-    public function getPriorityToAttachClasses(): int
+    public function getPriorityToAttachToClasses(): int
     {
         return 20;
     }


### PR DESCRIPTION
Instead of operating with classnames, directly operate with the instance retrieved from the service container.

To simplify logic, don't allot wo inject the priority, but always retrieve it through `getPriorityToAttachToClasses` from the instance itself.