### PR TITLE
Added isGlobal to DirectiveResolverInterface

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -176,4 +176,8 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
      * @return string|null
      */
     public function getSchemaDirectiveVersion(TypeResolverInterface $typeResolver): ?string;
+    /**
+     * Indicate if the directive is global (i.e. it can be applied to all fields, for all typeResolvers)
+     */
+    public function isGlobal(TypeResolverInterface $typeResolver): bool;
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
@@ -60,9 +60,6 @@ interface SchemaDirectiveResolverInterface
     public function getSchemaDirectiveDeprecationDescription(TypeResolverInterface $typeResolver): ?string;
     /**
      * Indicate if the directive is global (i.e. it can be applied to all fields, for all typeResolvers)
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return bool
      */
     public function isGlobal(TypeResolverInterface $typeResolver): bool;
 }


### PR DESCRIPTION
`AbstractTypeResolver` is [invoking `isGlobal` on `DirectiveResolverInterface`](https://github.com/leoloso/PoP/blob/7e5699ddbb600f6cb7cd794b75490966330cddd1/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php#L1648), but this function was not there (it was taken from another interface implemented by `AbstractDirectiveResolver`: `SchemaDirectiveResolverInterface`).

This PR adds it.