### PR TITLE
Make getDirectiveName non static

### DIFF
--- a/layers/API/packages/api/src/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema/SchemaServices/DirectiveResolvers/SchemaNoCacheCacheControlDirectiveResolver.php
+++ b/layers/API/packages/api/src/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema/SchemaServices/DirectiveResolvers/SchemaNoCacheCacheControlDirectiveResolver.php
@@ -11,7 +11,7 @@ use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
  */
 class SchemaNoCacheCacheControlDirectiveResolver extends AbstractCacheControlDirectiveResolver
 {
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'fullSchema',

--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -17,10 +17,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 
 class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'copyRelationalResults';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'copyRelationalResults';
     }
 
     /**

--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -18,7 +18,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     const DIRECTIVE_NAME = 'copyRelationalResults';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
@@ -14,10 +14,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 
 class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'duplicateProperty';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'duplicateProperty';
     }
 
     /**

--- a/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     const DIRECTIVE_NAME = 'duplicateProperty';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 class RenamePropertyDirectiveResolver extends DuplicatePropertyDirectiveResolver
 {
     const DIRECTIVE_NAME = 'renameProperty';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
@@ -11,10 +11,9 @@ use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 class RenamePropertyDirectiveResolver extends DuplicatePropertyDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'renameProperty';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'renameProperty';
     }
 
     /**

--- a/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     const DIRECTIVE_NAME = 'setPropertiesAsExpressions';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
@@ -14,10 +14,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 
 class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'setPropertiesAsExpressions';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'setPropertiesAsExpressions';
     }
 
     /**

--- a/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
@@ -19,10 +19,9 @@ use PoP\Translation\Facades\TranslationAPIFacade;
 class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolver
 {
     protected const PROPERTY_SEPARATOR = ':';
-    public const DIRECTIVE_NAME = 'transformArrayItems';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'transformArrayItems';
     }
 
     /**

--- a/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
@@ -20,7 +20,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
 {
     protected const PROPERTY_SEPARATOR = ':';
     public const DIRECTIVE_NAME = 'transformArrayItems';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace PoP\API\DirectiveResolvers;
 
-use PoP\FieldQuery\QuerySyntax;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Directives\DirectiveTypes;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\Misc\GeneralUtils;
-use PoP\ComponentModel\Directives\DirectiveTypes;
-use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\Engine\DirectiveResolvers\ForEachDirectiveResolver;
 use PoP\Engine\DirectiveResolvers\ApplyFunctionDirectiveResolver;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\Engine\DirectiveResolvers\ForEachDirectiveResolver;
+use PoP\FieldQuery\QuerySyntax;
+use PoP\Translation\Facades\TranslationAPIFacade;
 
 class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolver
 {
@@ -43,15 +45,20 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
         $translationAPI = TranslationAPIFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $forEachDirectiveResolver = $instanceManager->getInstance(ForEachDirectiveResolver::class);
+        /** @var DirectiveResolverInterface */
+        $applyFunctionDirectiveResolver = $instanceManager->getInstance(ApplyFunctionDirectiveResolver::class);
         return sprintf(
             $translationAPI->__('Use %s instead', 'component-model'),
             $fieldQueryInterpreter->getFieldDirectivesAsString([
                 [
-                    ForEachDirectiveResolver::getDirectiveName(),
+                    $forEachDirectiveResolver->getDirectiveName(),
                     '',
                     $fieldQueryInterpreter->getFieldDirectivesAsString([
                         [
-                            ApplyFunctionDirectiveResolver::getDirectiveName(),
+                            $applyFunctionDirectiveResolver->getDirectiveName(),
                         ],
                     ]),
                 ],

--- a/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessDirectiveResolver.php
+++ b/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessDirectiveResolver.php
@@ -10,10 +10,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateConditionDirectiveReso
 
 class DisableAccessDirectiveResolver extends AbstractValidateConditionDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'disableAccess';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'disableAccess';
     }
 
     protected function validateCondition(TypeResolverInterface $typeResolver): bool

--- a/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessDirectiveResolver.php
+++ b/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessDirectiveResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateConditionDirectiveReso
 class DisableAccessDirectiveResolver extends AbstractValidateConditionDirectiveResolver
 {
     const DIRECTIVE_NAME = 'disableAccess';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessForDirectivesDirectiveResolver.php
+++ b/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessForDirectivesDirectiveResolver.php
@@ -7,7 +7,7 @@ namespace PoP\AccessControl\DirectiveResolvers;
 class DisableAccessForDirectivesDirectiveResolver extends DisableAccessDirectiveResolver
 {
     const DIRECTIVE_NAME = 'disableAccessForDirectives';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessForDirectivesDirectiveResolver.php
+++ b/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessForDirectivesDirectiveResolver.php
@@ -6,10 +6,9 @@ namespace PoP\AccessControl\DirectiveResolvers;
 
 class DisableAccessForDirectivesDirectiveResolver extends DisableAccessDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'disableAccessForDirectives';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'disableAccessForDirectives';
     }
 
     protected function isValidatingDirective(): bool

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\TypeResolvers\HookHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\FieldResolverInterface;
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 
 abstract class AbstractAccessControlForDirectivesHookSet extends AbstractCMSBootHookSet
 {
@@ -20,10 +21,10 @@ abstract class AbstractAccessControlForDirectivesHookSet extends AbstractCMSBoot
         // If no directiveNames defined, apply to all of them
         if (
             $directiveNames = array_map(
-                function ($directiveResolverClass) {
-                    return $directiveResolverClass::getDirectiveName();
+                function ($directiveResolver) {
+                    return $directiveResolver->getDirectiveName();
                 },
-                $this->getDirectiveResolverClasses()
+                $this->getDirectiveResolvers()
             )
         ) {
             foreach ($directiveNames as $directiveName) {
@@ -65,13 +66,20 @@ abstract class AbstractAccessControlForDirectivesHookSet extends AbstractCMSBoot
     }
     /**
      * Affected directives
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param FieldResolverInterface $directiveResolver
-     * @param string $directiveName
-     * @return boolean
      */
     abstract protected function getDirectiveResolverClasses(): array;
+    /**
+     * Affected directives
+     * @return DirectiveResolverInterface[]
+     */
+    protected function getDirectiveResolvers(): array
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+        return array_map(
+            fn (string $directiveResolverClass) => $instanceManager->getInstance($directiveResolverClass),
+            $this->getDirectiveResolverClasses()
+        );
+    }
     /**
      * Decide if to remove the directiveNames
      *

--- a/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractDisableAccessConfigurableAccessControlForDirectivesInPublicSchemaTypeResolverDecorator.php
+++ b/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractDisableAccessConfigurableAccessControlForDirectivesInPublicSchemaTypeResolverDecorator.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace PoP\AccessControl\TypeResolverDecorators;
 
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\AccessControl\DirectiveResolvers\DisableAccessForDirectivesDirectiveResolver;
 use PoP\AccessControl\TypeResolverDecorators\AbstractConfigurableAccessControlForDirectivesInPublicSchemaTypeResolverDecorator;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 abstract class AbstractDisableAccessConfigurableAccessControlForDirectivesInPublicSchemaTypeResolverDecorator extends AbstractConfigurableAccessControlForDirectivesInPublicSchemaTypeResolverDecorator
 {
     protected function getMandatoryDirectives($entryValue = null): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $disableAccessForDirectivesDirectiveResolver = $instanceManager->getInstance(DisableAccessForDirectivesDirectiveResolver::class);
         $disableAccessDirective = $fieldQueryInterpreter->getDirective(
-            DisableAccessForDirectivesDirectiveResolver::getDirectiveName()
+            $disableAccessForDirectivesDirectiveResolver->getDirectiveName()
         );
         return [
             $disableAccessDirective,

--- a/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractDisableAccessConfigurableAccessControlForFieldsInPublicSchemaTypeResolverDecorator.php
+++ b/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractDisableAccessConfigurableAccessControlForFieldsInPublicSchemaTypeResolverDecorator.php
@@ -5,16 +5,21 @@ declare(strict_types=1);
 namespace PoP\AccessControl\TypeResolverDecorators;
 
 use PoP\AccessControl\DirectiveResolvers\DisableAccessDirectiveResolver;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\AccessControl\TypeResolverDecorators\AbstractConfigurableAccessControlForFieldsInPublicSchemaTypeResolverDecorator;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 abstract class AbstractDisableAccessConfigurableAccessControlForFieldsInPublicSchemaTypeResolverDecorator extends AbstractConfigurableAccessControlForFieldsInPublicSchemaTypeResolverDecorator
 {
     protected function getMandatoryDirectives($entryValue = null): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $disableAccessDirectiveResolver = $instanceManager->getInstance(DisableAccessDirectiveResolver::class);
         $disableAccessDirective = $fieldQueryInterpreter->getDirective(
-            DisableAccessDirectiveResolver::getDirectiveName()
+            $disableAccessDirectiveResolver->getDirectiveName()
         );
         return [
             $disableAccessDirective,

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
@@ -13,10 +13,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 
 abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirectiveResolver implements CacheControlDirectiveResolverInterface
 {
-    const DIRECTIVE_NAME = 'cacheControl';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'cacheControl';
     }
 
     /**

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
@@ -14,7 +14,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirectiveResolver implements CacheControlDirectiveResolverInterface
 {
     const DIRECTIVE_NAME = 'cacheControl';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/cache-control/src/Helpers/CacheControlHelper.php
+++ b/layers/Engine/packages/cache-control/src/Helpers/CacheControlHelper.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace PoP\CacheControl\Helpers;
 
+use PoP\CacheControl\DirectiveResolvers\CacheControlDirectiveResolver;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
 
 class CacheControlHelper
 {
     public static function getNoCacheDirective(): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $cacheControlDirectiveResolver = $instanceManager->getInstance(CacheControlDirectiveResolver::class);
         return $fieldQueryInterpreter->getDirective(
-            AbstractCacheControlDirectiveResolver::getDirectiveName(),
+            $cacheControlDirectiveResolver->getDirectiveName(),
             [
                 'maxAge' => 0,
             ]

--- a/layers/Engine/packages/cache-control/src/TypeResolverDecorators/ConfigurableCacheControlTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/cache-control/src/TypeResolverDecorators/ConfigurableCacheControlTypeResolverDecoratorTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\CacheControl\TypeResolverDecorators;
 
 use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
+use PoP\CacheControl\DirectiveResolvers\CacheControlDirectiveResolver;
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;

--- a/layers/Engine/packages/cache-control/src/TypeResolverDecorators/ConfigurableCacheControlTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/cache-control/src/TypeResolverDecorators/ConfigurableCacheControlTypeResolverDecoratorTrait.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace PoP\CacheControl\TypeResolverDecorators;
 
 use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait ConfigurableCacheControlTypeResolverDecoratorTrait
 {
@@ -20,9 +22,11 @@ trait ConfigurableCacheControlTypeResolverDecoratorTrait
     {
         $maxAge = $entryValue;
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $directiveName = AbstractCacheControlDirectiveResolver::getDirectiveName();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $cacheControlDirectiveResolver = $instanceManager->getInstance(CacheControlDirectiveResolver::class);
         $cacheControlDirective = $fieldQueryInterpreter->getDirective(
-            $directiveName,
+            $cacheControlDirectiveResolver->getDirectiveName(),
             [
                 'maxAge' => $maxAge,
             ]

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -368,7 +368,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                  */
                 $versionConstraint =
                     $directiveArgs[SchemaDefinition::ARGNAME_VERSION_CONSTRAINT]
-                    ?? VersioningHelpers::getVersionConstraintsForDirective(static::getDirectiveName())
+                    ?? VersioningHelpers::getVersionConstraintsForDirective($this->getDirectiveName())
                     ?? $vars['version-constraint'];
                 /**
                  * If the query doesn't restrict the version, then do not process

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -318,7 +318,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      *
      * @return array
      */
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         // By default, apply to all fieldNames
         return [];
@@ -905,7 +905,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
             SchemaDefinition::ARGNAME_DIRECTIVE_IS_REPEATABLE => $this->isRepeatable(),
             SchemaDefinition::ARGNAME_DIRECTIVE_NEEDS_DATA_TO_EXECUTE => $this->needsIDsDataFieldsToExecute(),
         ];
-        if ($limitedToFields = $this::getFieldNamesToApplyTo()) {
+        if ($limitedToFields = $this->getFieldNamesToApplyTo()) {
             $schemaDefinition[SchemaDefinition::ARGNAME_DIRECTIVE_LIMITED_TO_FIELDS] = $limitedToFields;
         }
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
@@ -27,7 +27,7 @@ trait AliasSchemaDirectiveResolverTrait
     /**
      * The specific `DirectiveResolver` class that is being aliased
      */
-    abstract protected static function getAliasedDirectiveResolverClass(): string;
+    abstract protected function getAliasedDirectiveResolverClass(): string;
 
     /**
      * Aliased `DirectiveResolver` instance
@@ -36,7 +36,7 @@ trait AliasSchemaDirectiveResolverTrait
     {
         $instanceManager = InstanceManagerFacade::getInstance();
         return $instanceManager->getInstance(
-            static::getAliasedDirectiveResolverClass()
+            $this->getAliasedDirectiveResolverClass()
         );
     }
 
@@ -131,10 +131,10 @@ trait AliasSchemaDirectiveResolverTrait
     /**
      * Proxy pattern: execute same function on the aliased DirectiveResolver
      */
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
-        $aliasedDirectiveResolverClass = static::getAliasedDirectiveResolverClass();
-        return $aliasedDirectiveResolverClass::getFieldNamesToApplyTo();
+        $aliasedDirectiveResolver = $this->getAliasedDirectiveResolverInstance();
+        return $aliasedDirectiveResolver->getFieldNamesToApplyTo();
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -16,7 +16,7 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
      *
      * @return array
      */
-    public static function getFieldNamesToApplyTo(): array;
+    public function getFieldNamesToApplyTo(): array;
     /**
      * Directives can be either of type "Schema" or "Query" and,
      * depending on one case or the other, might be exposed to the user.

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 interface DirectiveResolverInterface extends AttachableExtensionInterface
 {
-    public static function getDirectiveName(): string;
+    public function getDirectiveName(): string;
     /**
      * Indicate to what fieldNames this directive can be applied.
      * Returning an empty array means all of them

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -16,11 +16,9 @@ use PoP\Translation\Facades\TranslationAPIFacade;
 
 final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiveResolver implements MandatoryDirectiveServiceTagInterface
 {
-    public const DIRECTIVE_NAME = 'resolveValueAndMerge';
-
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'resolveValueAndMerge';
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -18,7 +18,7 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
 {
     public const DIRECTIVE_NAME = 'resolveValueAndMerge';
 
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -13,11 +13,9 @@ use PoP\Translation\Facades\TranslationAPIFacade;
 
 final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver implements MandatoryDirectiveServiceTagInterface
 {
-    public const DIRECTIVE_NAME = 'validate';
-
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validate';
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -15,7 +15,7 @@ final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver 
 {
     public const DIRECTIVE_NAME = 'validate';
 
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -669,7 +669,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             // Check that at least one class which deals with this directiveName can satisfy the directive (for instance, validating that a required directiveArg is present)
             $fieldName = $fieldQueryInterpreter->getFieldName($field);
             foreach ($directiveResolvers as $directiveResolver) {
-                $directiveSupportedFieldNames = $directiveResolver::getFieldNamesToApplyTo();
+                $directiveSupportedFieldNames = $directiveResolver->getFieldNamesToApplyTo();
                 // If this field is not supported by the directive, skip
                 if ($directiveSupportedFieldNames && !in_array($fieldName, $directiveSupportedFieldNames)) {
                     continue;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -185,7 +185,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         $dataloadingEngine = DataloadingEngineFacade::getInstance();
         return array_map(
             function ($directiveResolver) use ($fieldQueryInterpreter) {
-                return $fieldQueryInterpreter->listFieldDirective($directiveResolver::getDirectiveName());
+                return $fieldQueryInterpreter->listFieldDirective($directiveResolver->getDirectiveName());
             },
             $dataloadingEngine->getMandatoryDirectiveResolvers()
         );
@@ -2102,7 +2102,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 array_multisort($extensionPriorities, SORT_DESC, SORT_NUMERIC, $attachedDirectiveResolvers);
                 // Add them to the results. We keep the list of all resolvers, so that if the first one cannot process the directive (eg: through `resolveCanProcess`, the next one can do it)
                 foreach ($attachedDirectiveResolvers as $directiveResolver) {
-                    $directiveName = $directiveResolver::getDirectiveName();
+                    $directiveName = $directiveResolver->getDirectiveName();
                     $directiveNameResolvers[$directiveName][] = $directiveResolver;
                 }
                 // Continue iterating for the class parents

--- a/layers/Engine/packages/configurable-schema-feedback/src/TypeResolverDecorators/ConfigurableSchemaFeedbackForFieldsTypeResolverDecorator.php
+++ b/layers/Engine/packages/configurable-schema-feedback/src/TypeResolverDecorators/ConfigurableSchemaFeedbackForFieldsTypeResolverDecorator.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\ConfigurableSchemaFeedback\TypeResolverDecorators;
 
-use PoP\Engine\Enums\FieldFeedbackTypeEnum;
-use PoP\Engine\Enums\FieldFeedbackTargetEnum;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoP\Engine\DirectiveResolvers\AddFeedbackForFieldDirectiveResolver;
 use PoP\ConfigurableSchemaFeedback\Facades\SchemaFeedbackManagerFacade;
+use PoP\Engine\DirectiveResolvers\AddFeedbackForFieldDirectiveResolver;
+use PoP\Engine\Enums\FieldFeedbackTargetEnum;
+use PoP\Engine\Enums\FieldFeedbackTypeEnum;
 use PoP\MandatoryDirectivesByConfiguration\TypeResolverDecorators\AbstractMandatoryDirectivesForFieldsTypeResolverDecorator;
 
 class ConfigurableSchemaFeedbackForFieldsTypeResolverDecorator extends AbstractMandatoryDirectivesForFieldsTypeResolverDecorator
@@ -23,7 +25,10 @@ class ConfigurableSchemaFeedbackForFieldsTypeResolverDecorator extends AbstractM
     {
         $message = $entryValue;
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $directiveName = AddFeedbackForFieldDirectiveResolver::getDirectiveName();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $addFeedbackForFieldDirectiveResolver = $instanceManager->getInstance(AddFeedbackForFieldDirectiveResolver::class);
+        $directiveName = $addFeedbackForFieldDirectiveResolver->getDirectiveName();
         $schemaFeedbackDirective = $fieldQueryInterpreter->getDirective(
             $directiveName,
             [

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/Guzzle/SchemaServices/DirectiveResolvers/NoCacheCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/Guzzle/SchemaServices/DirectiveResolvers/NoCacheCacheControlDirectiveResolver.php
@@ -8,7 +8,7 @@ use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
 
 class NoCacheCacheControlDirectiveResolver extends AbstractCacheControlDirectiveResolver
 {
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'getJSON',

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
@@ -27,10 +27,9 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
     use CacheDirectiveResolverTrait;
     use RemoveIDsDataFieldsDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'loadCache';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'loadCache';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace PoP\Engine\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\DirectiveResolvers;
 
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\TypeResolvers\PipelinePositions;
+use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\DirectiveResolvers\RemoveIDsDataFieldsDirectiveResolverTrait;
 use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FeedbackMessageStoreFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
-use PoP\ComponentModel\DirectiveResolvers\RemoveIDsDataFieldsDirectiveResolverTrait;
+use PoP\ComponentModel\TypeResolvers\PipelinePositions;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\Cache\CacheTypes;
+use PoP\Translation\Facades\TranslationAPIFacade;
 
 /**
  * Load the field value from the cache. This directive is executed before `@resolveAndMerge`,
@@ -117,9 +119,13 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
             // Find the position of the @cache directive. Compare by name and not by class, just in case the directive class was overriden
             $pos = 0;
             $found = false;
+            $instanceManager = InstanceManagerFacade::getInstance();
+            /** @var DirectiveResolverInterface */
+            $saveCacheDirectiveResolver = $instanceManager->getInstance(SaveCacheDirectiveResolver::class);
+            $directiveName = $saveCacheDirectiveResolver->getDirectiveName();
             while (!$found && $pos < count($succeedingPipelineDirectiveResolverInstances)) {
                 $directiveResolverInstance = $succeedingPipelineDirectiveResolverInstances[$pos];
-                if ($directiveResolverInstance->getDirectiveName() == SaveCacheDirectiveResolver::getDirectiveName()) {
+                if ($directiveResolverInstance->getDirectiveName() == $directiveName) {
                     $found = true;
                 } else {
                     $pos++;

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
@@ -28,7 +28,7 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
     use RemoveIDsDataFieldsDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'loadCache';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
@@ -41,7 +41,7 @@ class SaveCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
      * is added as a mandatory directive on directive
      */
     const DIRECTIVE_NAME = 'cache';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
@@ -40,10 +40,9 @@ class SaveCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
      * and because "cache" involves both "loadCache" and "saveCache", where "loadCache"
      * is added as a mandatory directive on directive
      */
-    const DIRECTIVE_NAME = 'cache';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'cache';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/CacheTypeResolverDecorator.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/CacheTypeResolverDecorator.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\Engine\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\TypeResolverDecorators;
 
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolverDecorators\AbstractTypeResolverDecorator;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\DirectiveResolvers\LoadCacheDirectiveResolver;
 use PoP\Engine\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\DirectiveResolvers\SaveCacheDirectiveResolver;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoP\ComponentModel\TypeResolverDecorators\AbstractTypeResolverDecorator;
 
 class CacheTypeResolverDecorator extends AbstractTypeResolverDecorator
 {
@@ -29,11 +31,16 @@ class CacheTypeResolverDecorator extends AbstractTypeResolverDecorator
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $loadCacheDirectiveResolver = $instanceManager->getInstance(LoadCacheDirectiveResolver::class);
+        /** @var DirectiveResolverInterface */
+        $saveCacheDirectiveResolver = $instanceManager->getInstance(SaveCacheDirectiveResolver::class);
         $loadCacheDirective = $fieldQueryInterpreter->getDirective(
-            LoadCacheDirectiveResolver::getDirectiveName()
+            $loadCacheDirectiveResolver->getDirectiveName()
         );
         return [
-            SaveCacheDirectiveResolver::getDirectiveName() => [
+            $saveCacheDirectiveResolver->getDirectiveName() => [
                 $loadCacheDirective,
             ],
         ];

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
@@ -18,7 +18,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     const DIRECTIVE_NAME = 'addFeedbackForField';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
@@ -17,10 +17,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 
 class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'addFeedbackForField';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'addFeedbackForField';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
@@ -14,10 +14,9 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver
 {
-    public const DIRECTIVE_NAME = 'advancePointerInArray';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'advancePointerInArray';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver
 {
     public const DIRECTIVE_NAME = 'advancePointerInArray';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -21,7 +21,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     public const DIRECTIVE_NAME = 'applyFunction';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -20,10 +20,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 
 class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    public const DIRECTIVE_NAME = 'applyFunction';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'applyFunction';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
@@ -17,10 +17,9 @@ use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver
 {
-    public const DIRECTIVE_NAME = 'forEach';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'forEach';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
@@ -18,7 +18,7 @@ use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver
 {
     public const DIRECTIVE_NAME = 'forEach';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
@@ -14,10 +14,9 @@ class IncludeDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     use FilterIDsSatisfyingConditionDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'include';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'include';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
@@ -15,7 +15,7 @@ class IncludeDirectiveResolver extends AbstractGlobalDirectiveResolver
     use FilterIDsSatisfyingConditionDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'include';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/NoCacheCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/NoCacheCacheControlDirectiveResolver.php
@@ -8,7 +8,7 @@ use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
 
 class NoCacheCacheControlDirectiveResolver extends AbstractCacheControlDirectiveResolver
 {
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'var',

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/OneYearCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/OneYearCacheControlDirectiveResolver.php
@@ -8,7 +8,7 @@ use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
 
 class OneYearCacheControlDirectiveResolver extends AbstractCacheControlDirectiveResolver
 {
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'id',

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
@@ -15,11 +15,9 @@ use PoP\Translation\Facades\TranslationAPIFacade;
 
 final class SetSelfAsExpressionDirectiveResolver extends AbstractGlobalDirectiveResolver implements MandatoryDirectiveServiceTagInterface
 {
-    public const DIRECTIVE_NAME = 'setSelfAsExpression';
-
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'setSelfAsExpression';
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
@@ -17,7 +17,7 @@ final class SetSelfAsExpressionDirectiveResolver extends AbstractGlobalDirective
 {
     public const DIRECTIVE_NAME = 'setSelfAsExpression';
 
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
@@ -15,7 +15,7 @@ class SkipDirectiveResolver extends AbstractGlobalDirectiveResolver
     use FilterIDsSatisfyingConditionDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'skip';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
@@ -14,10 +14,9 @@ class SkipDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     use FilterIDsSatisfyingConditionDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'skip';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'skip';
     }
 
     /**

--- a/layers/Engine/packages/function-fields/src/DirectiveResolvers/OneYearCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/function-fields/src/DirectiveResolvers/OneYearCacheControlDirectiveResolver.php
@@ -8,7 +8,7 @@ use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
 
 class OneYearCacheControlDirectiveResolver extends AbstractCacheControlDirectiveResolver
 {
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'sprintf',

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/ConfigurableMandatoryDirectivesForDirectivesTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/ConfigurableMandatoryDirectivesForDirectivesTypeResolverDecoratorTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\MandatoryDirectivesByConfiguration\TypeResolverDecorators;
 
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\MandatoryDirectivesByConfiguration\ConfigurationEntries\ConfigurableMandatoryDirectivesForDirectivesTrait;
 
@@ -15,11 +17,14 @@ trait ConfigurableMandatoryDirectivesForDirectivesTypeResolverDecoratorTrait
 
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {
+        $instanceManager = InstanceManagerFacade::getInstance();
         $mandatoryDirectivesForDirectives = [];
         foreach ($this->getEntries() as $entry) {
             $directiveResolverClass = $entry[0];
             $entryValue = $entry[1] ?? null; // this might be any value (string, array, etc) or, if not defined, null
-            $directiveName = $directiveResolverClass::getDirectiveName();
+            /** @var DirectiveResolverInterface */
+            $directiveResolver = $instanceManager->getInstance($directiveResolverClass);
+            $directiveName = $directiveResolver->getDirectiveName();
             $mandatoryDirectivesForDirectives[$directiveName] = $this->getMandatoryDirectives($entryValue);
         }
         return $mandatoryDirectivesForDirectives;

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
@@ -29,10 +29,9 @@ class EndTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveReso
      * and because "traceExecutionTime" involves both "startTraceExecutionTime" and "endTraceExecutionTime",
      * where "startTraceExecutionTime" is added as a mandatory directive on directive
      */
-    const DIRECTIVE_NAME = 'traceExecutionTime';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'traceExecutionTime';
     }
 
     /**

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
@@ -30,7 +30,7 @@ class EndTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveReso
      * where "startTraceExecutionTime" is added as a mandatory directive on directive
      */
     const DIRECTIVE_NAME = 'traceExecutionTime';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
@@ -107,7 +107,7 @@ class EndTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveReso
         // Add the traces
         $schemaTraces[] = [
             Tokens::PATH => [$this->directive],
-            Tokens::NAME => static::getDirectiveName(),
+            Tokens::NAME => $this->getDirectiveName(),
             Tokens::EXTENSIONS => [
                 Tokens::ID_FIELDS => array_map(
                     function ($dataFields) {

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
@@ -18,10 +18,9 @@ class StartTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveRe
 {
     use TraceDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'startTraceExecutionTime';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'startTraceExecutionTime';
     }
 
     /**

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
@@ -19,7 +19,7 @@ class StartTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveRe
     use TraceDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'startTraceExecutionTime';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Engine/packages/trace-tools/src/TypeResolverDecorators/TraceTypeResolverDecorator.php
+++ b/layers/Engine/packages/trace-tools/src/TypeResolverDecorators/TraceTypeResolverDecorator.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\TraceTools\TypeResolverDecorators;
 
-use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\ComponentModel\TypeResolverDecorators\AbstractTypeResolverDecorator;
+use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\TraceTools\DirectiveResolvers\EndTraceExecutionTimeDirectiveResolver;
 use PoP\TraceTools\DirectiveResolvers\StartTraceExecutionTimeDirectiveResolver;
 
@@ -30,11 +32,16 @@ class TraceTypeResolverDecorator extends AbstractTypeResolverDecorator
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $startTraceExecutionTimeDirectiveResolver = $instanceManager->getInstance(StartTraceExecutionTimeDirectiveResolver::class);
+        /** @var DirectiveResolverInterface */
+        $endTraceExecutionTimeDirectiveResolver = $instanceManager->getInstance(EndTraceExecutionTimeDirectiveResolver::class);
         $startTraceExecutionTimeDirective = $fieldQueryInterpreter->getDirective(
-            StartTraceExecutionTimeDirectiveResolver::getDirectiveName()
+            $startTraceExecutionTimeDirectiveResolver->getDirectiveName()
         );
         return [
-            EndTraceExecutionTimeDirectiveResolver::getDirectiveName() => [
+            $endTraceExecutionTimeDirectiveResolver->getDirectiveName() => [
                 $startTraceExecutionTimeDirective,
             ],
         ];

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
@@ -5,29 +5,31 @@ declare(strict_types=1);
 namespace GraphQLByPoP\GraphQLQuery\Schema;
 
 use Exception;
-use InvalidArgumentException;
-use PoP\FieldQuery\QuerySyntax;
-use PoP\FieldQuery\QueryHelpers;
-use GraphQLByPoP\GraphQLParser\Parser\Parser;
-use GraphQLByPoP\GraphQLParser\Parser\Ast\Field;
-use GraphQLByPoP\GraphQLParser\Parser\Ast\Query;
-use GraphQLByPoP\GraphQLParser\Execution\Request;
-use PoP\Translation\TranslationAPIInterface;
-use GraphQLByPoP\GraphQLParser\Parser\Ast\FragmentReference;
-use GraphQLByPoP\GraphQLParser\Parser\Ast\TypedFragmentReference;
-use GraphQLByPoP\GraphQLParser\Parser\Ast\Interfaces\FieldInterface;
-use PoP\Engine\DirectiveResolvers\IncludeDirectiveResolver;
-use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
-use GraphQLByPoP\GraphQLParser\Validator\RequestValidator\RequestValidator;
 use GraphQLByPoP\GraphQLParser\Exception\Interfaces\LocationableExceptionInterface;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use GraphQLByPoP\GraphQLQuery\ComponentConfiguration;
-use GraphQLByPoP\GraphQLQuery\Schema\QuerySymbols;
-use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\VariableReference;
-use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\Variable;
+use GraphQLByPoP\GraphQLParser\Execution\Request;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\InputList;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\InputObject;
 use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\Literal;
+use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\Variable;
+use GraphQLByPoP\GraphQLParser\Parser\Ast\ArgumentValue\VariableReference;
+use GraphQLByPoP\GraphQLParser\Parser\Ast\Field;
+use GraphQLByPoP\GraphQLParser\Parser\Ast\FragmentReference;
+use GraphQLByPoP\GraphQLParser\Parser\Ast\Interfaces\FieldInterface;
+use GraphQLByPoP\GraphQLParser\Parser\Ast\Query;
+use GraphQLByPoP\GraphQLParser\Parser\Ast\TypedFragmentReference;
+use GraphQLByPoP\GraphQLParser\Parser\Parser;
+use GraphQLByPoP\GraphQLParser\Validator\RequestValidator\RequestValidator;
+use GraphQLByPoP\GraphQLQuery\ComponentConfiguration;
+use GraphQLByPoP\GraphQLQuery\Schema\QuerySymbols;
+use InvalidArgumentException;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
+use PoP\Engine\DirectiveResolvers\IncludeDirectiveResolver;
+use PoP\FieldQuery\QueryHelpers;
+use PoP\FieldQuery\QuerySyntax;
+use PoP\Translation\TranslationAPIInterface;
 
 class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
 {
@@ -313,9 +315,12 @@ class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
     protected function restrainFieldsByTypeOrInterface(array $fragmentFieldPaths, string $fragmentModel): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $includeDirectiveResolver = $instanceManager->getInstance(IncludeDirectiveResolver::class);
         // Create the <include> directive, if the fragment references the type or interface
         $includeDirective = $fieldQueryInterpreter->composeFieldDirective(
-            IncludeDirectiveResolver::getDirectiveName(),
+            $includeDirectiveResolver->getDirectiveName(),
             $fieldQueryInterpreter->getFieldArgsAsString([
                 'if' => $fieldQueryInterpreter->getField(
                     'or',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema/SchemaServices/DirectiveResolvers/SchemaNoCacheCacheControlDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Conditional/CacheControl/Conditional/AccessControl/ConditionalOnEnvironment/PrivateSchema/SchemaServices/DirectiveResolvers/SchemaNoCacheCacheControlDirectiveResolver.php
@@ -11,7 +11,7 @@ use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
  */
 class SchemaNoCacheCacheControlDirectiveResolver extends AbstractCacheControlDirectiveResolver
 {
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             '__schema',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
@@ -65,7 +65,7 @@ class ExportDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     public const DIRECTIVE_NAME = 'export';
 
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
@@ -63,11 +63,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
  */
 class ExportDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    public const DIRECTIVE_NAME = 'export';
-
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'export';
     }
 
     /**

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
@@ -181,11 +181,9 @@ class RemoveIfNullDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     use RemoveIDsDataFieldsDirectiveResolverTrait;
 
-    public const DIRECTIVE_NAME = 'removeIfNull';
-
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'removeIfNull';
     }
 
     public function resolveDirective(

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
@@ -183,7 +183,7 @@ class RemoveIfNullDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     public const DIRECTIVE_NAME = 'removeIfNull';
 
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\ConditionalOnEnvironment\VariablesAsExpressions\SchemaServices\FieldResolvers;
 
-use PoP\Engine\TypeResolvers\RootTypeResolver;
+use GraphQLByPoP\GraphQLQuery\Facades\GraphQLQueryConvertorFacade;
+use GraphQLByPoP\GraphQLServer\ConditionalOnEnvironment\MultipleQueryExecution\SchemaServices\DirectiveResolvers\ExportDirectiveResolver;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use GraphQLByPoP\GraphQLServer\ConditionalOnEnvironment\MultipleQueryExecution\SchemaServices\DirectiveResolvers\ExportDirectiveResolver;
-use GraphQLByPoP\GraphQLQuery\Facades\GraphQLQueryConvertorFacade;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoP\Translation\Facades\TranslationAPIFacade;
 
 class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -53,7 +55,10 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
         $translationAPI = TranslationAPIFacade::getInstance();
-        $exportDirectiveName = ExportDirectiveResolver::getDirectiveName();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $exportDirectiveResolver = $instanceManager->getInstance(ExportDirectiveResolver::class);
+        $exportDirectiveName = $exportDirectiveResolver->getDirectiveName();
         $descriptions = [
             'exportedVariables' => sprintf(
                 $translationAPI->__('Returns a dictionary with the values for all variables exported through the `%s` directive', 'graphql-server'),

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -126,7 +126,7 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
                         $ofTypes
                     );
                     $directiveRegistry = DirectiveRegistryFacade::getInstance();
-                    $ofTypeDirectiveResolverClasses = array_filter(
+                    $ofTypeDirectiveResolvers = array_filter(
                         $directiveRegistry->getDirectiveResolvers(),
                         function ($directiveResolver) use ($ofTypes) {
                             return in_array($directiveResolver->getDirectiveType(), $ofTypes);
@@ -134,17 +134,17 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
                     );
                     // Calculate the directive IDs
                     $ofTypeDirectiveIDs = array_map(
-                        function ($directiveResolverClass) {
+                        function ($directiveResolver) {
                             // To retrieve the ID, use the same method to calculate the ID
                             // used when creating a new Directive instance
                             // (which we can't do here, since it has side-effects)
                             $directiveSchemaDefinitionPath = [
                                 SchemaDefinition::ARGNAME_GLOBAL_DIRECTIVES,
-                                $directiveResolverClass::getDirectiveName(),
+                                $directiveResolver->getDirectiveName(),
                             ];
                             return SchemaDefinitionHelpers::getID($directiveSchemaDefinitionPath);
                         },
-                        $ofTypeDirectiveResolverClasses
+                        $ofTypeDirectiveResolvers
                     );
                     return array_intersect(
                         $directiveIDs,

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/AbstractCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/AbstractCacheTypeResolverDecorator.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Leoloso\ExamplesForPoP\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\TypeResolverDecorators;
 
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoP\Engine\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\DirectiveResolvers\SaveCacheDirectiveResolver;
 use PoP\AccessControl\TypeResolverDecorators\AbstractPublicSchemaTypeResolverDecorator;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\DirectiveResolvers\SaveCacheDirectiveResolver;
 
 /**
  * Add directive @cache to fields expensive to calculate
@@ -54,8 +56,11 @@ abstract class AbstractCacheTypeResolverDecorator extends AbstractPublicSchemaTy
     protected function getCacheDirective(): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $saveCacheDirectiveResolver = $instanceManager->getInstance(SaveCacheDirectiveResolver::class);
         return $fieldQueryInterpreter->getDirective(
-            SaveCacheDirectiveResolver::getDirectiveName(),
+            $saveCacheDirectiveResolver->getDirectiveName(),
             [
                 'time' => $this->getTime(),
             ]

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/TranslateCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/TranslateCacheTypeResolverDecorator.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Leoloso\ExamplesForPoP\ConditionalOnEnvironment\UseComponentModelCache\SchemaServices\TypeResolverDecorators;
 
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
+use PoPSchema\GoogleTranslateDirective\DirectiveResolvers\GlobalGoogleTranslateDirectiveResolver;
 use PoPSchema\TranslateDirective\DirectiveResolvers\AbstractTranslateDirectiveResolver;
 
 /**
@@ -33,8 +36,11 @@ class TranslateCacheTypeResolverDecorator extends AbstractCacheTypeResolverDecor
          */
         $enabled = false;
         if ($enabled) {
+            $instanceManager = InstanceManagerFacade::getInstance();
+            /** @var DirectiveResolverInterface */
+            $globalGoogleTranslateDirectiveResolver = $instanceManager->getInstance(GlobalGoogleTranslateDirectiveResolver::class);
             return [
-                AbstractTranslateDirectiveResolver::getDirectiveName(),
+                $globalGoogleTranslateDirectiveResolver->getDirectiveName(),
             ];
         }
         return [];

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleAliasDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleAliasDirectiveResolver.php
@@ -16,7 +16,7 @@ class MakeTitleAliasDirectiveResolver extends AbstractGlobalDirectiveResolver
         return 'unambiguousMakeTitle';
     }
 
-    protected static function getAliasedDirectiveResolverClass(): string
+    protected function getAliasedDirectiveResolverClass(): string
     {
         return MakeTitleDirectiveResolver::class;
     }

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleAliasDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleAliasDirectiveResolver.php
@@ -12,7 +12,7 @@ class MakeTitleAliasDirectiveResolver extends AbstractGlobalDirectiveResolver
     use AliasSchemaDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'unambiguousMakeTitle';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleAliasDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleAliasDirectiveResolver.php
@@ -11,10 +11,9 @@ class MakeTitleAliasDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     use AliasSchemaDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'unambiguousMakeTitle';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'unambiguousMakeTitle';
     }
 
     protected static function getAliasedDirectiveResolverClass(): string

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
@@ -11,10 +11,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 
 class MakeTitleVersion010DirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    public const DIRECTIVE_NAME = 'makeTitle';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'makeTitle';
     }
 
     public function getPriorityToAttachToClasses(): int

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 class MakeTitleVersion010DirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     public const DIRECTIVE_NAME = 'makeTitle';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/SendByEmailDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/SendByEmailDirectiveResolver.php
@@ -12,10 +12,9 @@ use PoP\ComponentModel\Feedback\Tokens;
 
 class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
-    public const DIRECTIVE_NAME = 'sendByEmail';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'sendByEmail';
     }
 
     // public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/SendByEmailDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/SendByEmailDirectiveResolver.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\Feedback\Tokens;
 class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
     public const DIRECTIVE_NAME = 'sendByEmail';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Misc/packages/examples-for-pop/src/TypeResolverDecorators/CDNTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/TypeResolverDecorators/CDNTypeResolverDecorator.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Leoloso\ExamplesForPoP\TypeResolverDecorators;
 
-use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CDNDirective\DirectiveResolvers\CDNDirectiveResolver;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoPSchema\CDNDirective\ComponentConfiguration as CDNComponentConfiguration;
 use PoP\AccessControl\TypeResolverDecorators\AbstractPublicSchemaTypeResolverDecorator;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\CDNDirective\ComponentConfiguration as CDNComponentConfiguration;
+use PoPSchema\CDNDirective\DirectiveResolvers\CDNDirectiveResolver;
+use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 
 class CDNTypeResolverDecorator extends AbstractPublicSchemaTypeResolverDecorator
 {
@@ -36,8 +38,11 @@ class CDNTypeResolverDecorator extends AbstractPublicSchemaTypeResolverDecorator
         ) {
             // Add the mapping
             $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+            $instanceManager = InstanceManagerFacade::getInstance();
+            /** @var DirectiveResolverInterface */
+            $cdnDirectiveResolver = $instanceManager->getInstance(CDNDirectiveResolver::class);
             $cdnDirective = $fieldQueryInterpreter->getDirective(
-                CDNDirectiveResolver::getDirectiveName()
+                $cdnDirectiveResolver->getDirectiveName()
             );
             $mandatoryDirectivesForFields['src'] = [
                 $cdnDirective,

--- a/layers/Schema/packages/basic-directives/src/DirectiveResolvers/UseDefaultValueIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/basic-directives/src/DirectiveResolvers/UseDefaultValueIfConditionDirectiveResolver.php
@@ -11,9 +11,8 @@ class UseDefaultValueIfConditionDirectiveResolver extends AbstractUseDefaultValu
 {
     use GlobalDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'default';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'default';
     }
 }

--- a/layers/Schema/packages/basic-directives/src/DirectiveResolvers/UseDefaultValueIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/basic-directives/src/DirectiveResolvers/UseDefaultValueIfConditionDirectiveResolver.php
@@ -12,7 +12,7 @@ class UseDefaultValueIfConditionDirectiveResolver extends AbstractUseDefaultValu
     use GlobalDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'default';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/CDNDirectiveResolver.php
+++ b/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/CDNDirectiveResolver.php
@@ -15,7 +15,7 @@ use PoPSchema\CDNDirective\ComponentConfiguration;
 class CDNDirectiveResolver extends ModifyURLDirectiveResolver
 {
     const DIRECTIVE_NAME = 'cdn';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/CDNDirectiveResolver.php
+++ b/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/CDNDirectiveResolver.php
@@ -14,10 +14,9 @@ use PoPSchema\CDNDirective\ComponentConfiguration;
  */
 class CDNDirectiveResolver extends ModifyURLDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'cdn';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'cdn';
     }
 
     protected function getFromURLSection(): ?string

--- a/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/ModifyURLDirectiveResolver.php
+++ b/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/ModifyURLDirectiveResolver.php
@@ -17,10 +17,9 @@ class ModifyURLDirectiveResolver extends AbstractTransformFieldStringValueDirect
 {
     use GlobalDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'modifyURL';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'modifyURL';
     }
 
     protected function transformValue($value, $id, string $field, string $fieldOutputKey, TypeResolverInterface $typeResolver, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)

--- a/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/ModifyURLDirectiveResolver.php
+++ b/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/ModifyURLDirectiveResolver.php
@@ -18,7 +18,7 @@ class ModifyURLDirectiveResolver extends AbstractTransformFieldStringValueDirect
     use GlobalDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'modifyURL';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/LowerCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/LowerCaseStringDirectiveResolver.php
@@ -17,7 +17,7 @@ class LowerCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
     use GlobalDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'lowerCase';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/LowerCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/LowerCaseStringDirectiveResolver.php
@@ -16,10 +16,9 @@ class LowerCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
 {
     use GlobalDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'lowerCase';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'lowerCase';
     }
 
     protected function transformValue($value, $id, string $field, string $fieldOutputKey, TypeResolverInterface $typeResolver, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/TitleCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/TitleCaseStringDirectiveResolver.php
@@ -17,7 +17,7 @@ class TitleCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
     use GlobalDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'titleCase';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/TitleCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/TitleCaseStringDirectiveResolver.php
@@ -16,10 +16,9 @@ class TitleCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
 {
     use GlobalDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'titleCase';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'titleCase';
     }
 
     protected function transformValue($value, $id, string $field, string $fieldOutputKey, TypeResolverInterface $typeResolver, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/UpperCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/UpperCaseStringDirectiveResolver.php
@@ -17,7 +17,7 @@ class UpperCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
     use GlobalDirectiveResolverTrait;
 
     const DIRECTIVE_NAME = 'upperCase';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/UpperCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/UpperCaseStringDirectiveResolver.php
@@ -16,10 +16,9 @@ class UpperCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
 {
     use GlobalDirectiveResolverTrait;
 
-    const DIRECTIVE_NAME = 'upperCase';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'upperCase';
     }
 
     protected function transformValue($value, $id, string $field, string $fieldOutputKey, TypeResolverInterface $typeResolver, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)

--- a/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
@@ -11,7 +11,7 @@ use PoPSchema\BasicDirectives\DirectiveResolvers\AbstractUseDefaultValueIfCondit
 class UseDefaultFeaturedImageIDIfConditionDirectiveResolver extends AbstractUseDefaultValueIfConditionDirectiveResolver
 {
     const DIRECTIVE_NAME = 'defaultFeaturedImage';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
@@ -21,7 +21,7 @@ class UseDefaultFeaturedImageIDIfConditionDirectiveResolver extends AbstractUseD
             IsCustomPostFieldInterfaceResolver::class,
         ];
     }
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'featuredImage',

--- a/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/DirectiveResolvers/UseDefaultFeaturedImageIDIfConditionDirectiveResolver.php
@@ -10,10 +10,9 @@ use PoPSchema\BasicDirectives\DirectiveResolvers\AbstractUseDefaultValueIfCondit
 
 class UseDefaultFeaturedImageIDIfConditionDirectiveResolver extends AbstractUseDefaultValueIfConditionDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'defaultFeaturedImage';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'defaultFeaturedImage';
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/google-translate-directive-for-customposts/src/DirectiveResolvers/CustomPostGoogleTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/src/DirectiveResolvers/CustomPostGoogleTranslateDirectiveResolver.php
@@ -15,7 +15,7 @@ class CustomPostGoogleTranslateDirectiveResolver extends AbstractGoogleTranslate
             IsCustomPostFieldInterfaceResolver::class,
         ];
     }
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'title',

--- a/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
@@ -19,10 +19,9 @@ use PoP\ComponentModel\Feedback\Tokens;
 
 abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'translate';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'translate';
     }
 
         /**

--- a/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
@@ -20,7 +20,7 @@ use PoP\ComponentModel\Feedback\Tokens;
 abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiveResolver
 {
     const DIRECTIVE_NAME = 'translate';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateConditionDirectiveReso
 class ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver extends AbstractValidateConditionDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyCapability';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver.php
@@ -14,10 +14,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateConditionDirectiveReso
 
 class ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver extends AbstractValidateConditionDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyCapability';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateDoesLoggedInUserHaveAnyCapability';
     }
 
     protected function validateCondition(TypeResolverInterface $typeResolver): bool

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityForDirectivesDirectiveResolver.php
@@ -7,7 +7,7 @@ namespace PoPSchema\UserRolesAccessControl\DirectiveResolvers;
 class ValidateDoesLoggedInUserHaveAnyCapabilityForDirectivesDirectiveResolver extends ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyCapabilityForDirectives';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityForDirectivesDirectiveResolver.php
@@ -6,10 +6,9 @@ namespace PoPSchema\UserRolesAccessControl\DirectiveResolvers;
 
 class ValidateDoesLoggedInUserHaveAnyCapabilityForDirectivesDirectiveResolver extends ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyCapabilityForDirectives';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateDoesLoggedInUserHaveAnyCapabilityForDirectives';
     }
 
     protected function isValidatingDirective(): bool

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver.php
@@ -14,10 +14,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateConditionDirectiveReso
 
 class ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver extends AbstractValidateConditionDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyRole';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateDoesLoggedInUserHaveAnyRole';
     }
 
     protected function validateCondition(TypeResolverInterface $typeResolver): bool

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver.php
@@ -15,7 +15,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateConditionDirectiveReso
 class ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver extends AbstractValidateConditionDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyRole';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleForDirectivesDirectiveResolver.php
@@ -7,7 +7,7 @@ namespace PoPSchema\UserRolesAccessControl\DirectiveResolvers;
 class ValidateDoesLoggedInUserHaveAnyRoleForDirectivesDirectiveResolver extends ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyRoleForDirectives';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleForDirectivesDirectiveResolver.php
@@ -6,10 +6,9 @@ namespace PoPSchema\UserRolesAccessControl\DirectiveResolvers;
 
 class ValidateDoesLoggedInUserHaveAnyRoleForDirectivesDirectiveResolver extends ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateDoesLoggedInUserHaveAnyRoleForDirectives';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateDoesLoggedInUserHaveAnyRoleForDirectives';
     }
 
     protected function isValidatingDirective(): bool

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveCapabilityPublicSchemaTypeResolverDecoratorTrait.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveCapabilityPublicSchemaTypeResolverDecoratorTrait.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRolesAccessControl\TypeResolverDecorators;
 
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait ValidateDoesLoggedInUserHaveCapabilityPublicSchemaTypeResolverDecoratorTrait
 {
@@ -19,8 +21,11 @@ trait ValidateDoesLoggedInUserHaveCapabilityPublicSchemaTypeResolverDecoratorTra
     {
         $capabilities = $entryValue;
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $directiveResoverClass = $this->getValidateCapabilityDirectiveResolverClass();
-        $directiveName = $directiveResoverClass::getDirectiveName();
+        $directiveResolverClass = $this->getValidateCapabilityDirectiveResolverClass();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $directiveResolver = $instanceManager->getInstance($directiveResolverClass);
+        $directiveName = $directiveResolver->getDirectiveName();
         $validateDoesLoggedInUserHaveAnyCapabilityDirective = $fieldQueryInterpreter->getDirective(
             $directiveName,
             [

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveRolePublicSchemaTypeResolverDecoratorTrait.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveRolePublicSchemaTypeResolverDecoratorTrait.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRolesAccessControl\TypeResolverDecorators;
 
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\UserRolesAccessControl\DirectiveResolvers\ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver;
 
 trait ValidateDoesLoggedInUserHaveRolePublicSchemaTypeResolverDecoratorTrait
@@ -20,8 +22,11 @@ trait ValidateDoesLoggedInUserHaveRolePublicSchemaTypeResolverDecoratorTrait
     {
         $roles = $entryValue;
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $directiveResoverClass = $this->getValidateRoleDirectiveResolverClass();
-        $directiveName = $directiveResoverClass::getDirectiveName();
+        $directiveResolverClass = $this->getValidateRoleDirectiveResolverClass();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $directiveResolver = $instanceManager->getInstance($directiveResolverClass);
+        $directiveName = $directiveResolver->getDirectiveName();
         $validateDoesLoggedInUserHaveAnyRoleDirective = $fieldQueryInterpreter->getDirective(
             $directiveName,
             [

--- a/layers/Schema/packages/user-state-access-control/src/Conditional/CacheControl/TypeResolverDecorators/NoCacheUserStateTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-state-access-control/src/Conditional/CacheControl/TypeResolverDecorators/NoCacheUserStateTypeResolverDecorator.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserStateAccessControl\Conditional\CacheControl\TypeResolverDecorators;
 
+use PoP\CacheControl\Helpers\CacheControlHelper;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\TypeResolverDecorators\AbstractTypeResolverDecorator;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\TypeResolverDecorators\AbstractTypeResolverDecorator;
-use PoP\CacheControl\Helpers\CacheControlHelper;
 use PoPSchema\UserStateAccessControl\DirectiveResolvers\ValidateIsUserLoggedInDirectiveResolver;
 use PoPSchema\UserStateAccessControl\DirectiveResolvers\ValidateIsUserLoggedInForDirectivesDirectiveResolver;
 use PoPSchema\UserStateAccessControl\DirectiveResolvers\ValidateIsUserNotLoggedInDirectiveResolver;
@@ -31,17 +33,26 @@ class NoCacheUserStateTypeResolverDecorator extends AbstractTypeResolverDecorato
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {
         $noCacheControlDirective = CacheControlHelper::getNoCacheDirective();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $validateIsUserLoggedInDirectiveResolver = $instanceManager->getInstance(ValidateIsUserLoggedInDirectiveResolver::class);
+        /** @var DirectiveResolverInterface */
+        $validateIsUserLoggedInForDirectivesDirectiveResolver = $instanceManager->getInstance(ValidateIsUserLoggedInForDirectivesDirectiveResolver::class);
+        /** @var DirectiveResolverInterface */
+        $validateIsUserNotLoggedInDirectiveResolver = $instanceManager->getInstance(ValidateIsUserNotLoggedInDirectiveResolver::class);
+        /** @var DirectiveResolverInterface */
+        $validateIsUserNotLoggedInForDirectivesDirectiveResolver = $instanceManager->getInstance(ValidateIsUserNotLoggedInForDirectivesDirectiveResolver::class);
         return [
-            ValidateIsUserLoggedInDirectiveResolver::getDirectiveName() => [
+            $validateIsUserLoggedInDirectiveResolver->getDirectiveName() => [
                 $noCacheControlDirective,
             ],
-            ValidateIsUserLoggedInForDirectivesDirectiveResolver::getDirectiveName() => [
+            $validateIsUserLoggedInForDirectivesDirectiveResolver->getDirectiveName() => [
                 $noCacheControlDirective,
             ],
-            ValidateIsUserNotLoggedInDirectiveResolver::getDirectiveName() => [
+            $validateIsUserNotLoggedInDirectiveResolver->getDirectiveName() => [
                 $noCacheControlDirective,
             ],
-            ValidateIsUserNotLoggedInForDirectivesDirectiveResolver::getDirectiveName() => [
+            $validateIsUserNotLoggedInForDirectivesDirectiveResolver->getDirectiveName() => [
                 $noCacheControlDirective,
             ],
         ];

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInDirectiveResolver.php
@@ -11,10 +11,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateCheckpointDirectiveRes
 
 class ValidateIsUserLoggedInDirectiveResolver extends AbstractValidateCheckpointDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateIsUserLoggedIn';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateIsUserLoggedIn';
     }
 
     protected function getValidationCheckpointSet(TypeResolverInterface $typeResolver): array

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInDirectiveResolver.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateCheckpointDirectiveRes
 class ValidateIsUserLoggedInDirectiveResolver extends AbstractValidateCheckpointDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateIsUserLoggedIn';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInForDirectivesDirectiveResolver.php
@@ -6,10 +6,9 @@ namespace PoPSchema\UserStateAccessControl\DirectiveResolvers;
 
 class ValidateIsUserLoggedInForDirectivesDirectiveResolver extends ValidateIsUserLoggedInDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateIsUserLoggedInForDirectives';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateIsUserLoggedInForDirectives';
     }
 
     protected function isValidatingDirective(): bool

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInForDirectivesDirectiveResolver.php
@@ -7,7 +7,7 @@ namespace PoPSchema\UserStateAccessControl\DirectiveResolvers;
 class ValidateIsUserLoggedInForDirectivesDirectiveResolver extends ValidateIsUserLoggedInDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateIsUserLoggedInForDirectives';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInDirectiveResolver.php
@@ -12,7 +12,7 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateCheckpointDirectiveRes
 class ValidateIsUserNotLoggedInDirectiveResolver extends AbstractValidateCheckpointDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateIsUserNotLoggedIn';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInDirectiveResolver.php
@@ -11,10 +11,9 @@ use PoP\ComponentModel\DirectiveResolvers\AbstractValidateCheckpointDirectiveRes
 
 class ValidateIsUserNotLoggedInDirectiveResolver extends AbstractValidateCheckpointDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateIsUserNotLoggedIn';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateIsUserNotLoggedIn';
     }
 
     protected function getValidationCheckpointSet(TypeResolverInterface $typeResolver): array

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInForDirectivesDirectiveResolver.php
@@ -7,7 +7,7 @@ namespace PoPSchema\UserStateAccessControl\DirectiveResolvers;
 class ValidateIsUserNotLoggedInForDirectivesDirectiveResolver extends ValidateIsUserNotLoggedInDirectiveResolver
 {
     const DIRECTIVE_NAME = 'validateIsUserNotLoggedInForDirectives';
-    public static function getDirectiveName(): string
+    public function getDirectiveName(): string
     {
         return self::DIRECTIVE_NAME;
     }

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInForDirectivesDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInForDirectivesDirectiveResolver.php
@@ -6,10 +6,9 @@ namespace PoPSchema\UserStateAccessControl\DirectiveResolvers;
 
 class ValidateIsUserNotLoggedInForDirectivesDirectiveResolver extends ValidateIsUserNotLoggedInDirectiveResolver
 {
-    const DIRECTIVE_NAME = 'validateIsUserNotLoggedInForDirectives';
     public function getDirectiveName(): string
     {
-        return self::DIRECTIVE_NAME;
+        return 'validateIsUserNotLoggedInForDirectives';
     }
 
     protected function isValidatingDirective(): bool

--- a/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserStateAccessControl\TypeResolverDecorators;
 
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\AccessControl\TypeResolverDecorators\AbstractPublicSchemaTypeResolverDecorator;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\UserStateAccessControl\DirectiveResolvers\ValidateIsUserLoggedInForDirectivesDirectiveResolver;
 
 abstract class AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator extends AbstractPublicSchemaTypeResolverDecorator
@@ -21,13 +23,18 @@ abstract class AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolv
     {
         $mandatoryDirectivesForDirectives = [];
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var DirectiveResolverInterface */
+        $validateIsUserLoggedInForDirectivesDirectiveResolver = $instanceManager->getInstance(ValidateIsUserLoggedInForDirectivesDirectiveResolver::class);
         // This is the required "validateIsUserLoggedIn" directive
         $validateIsUserLoggedInDirective = $fieldQueryInterpreter->getDirective(
-            ValidateIsUserLoggedInForDirectivesDirectiveResolver::getDirectiveName()
+            $validateIsUserLoggedInForDirectivesDirectiveResolver->getDirectiveName()
         );
         // Add the mapping
-        foreach ($this->getDirectiveResolverClasses() as $needValidateIsUserLoggedInDirective) {
-            $mandatoryDirectivesForDirectives[$needValidateIsUserLoggedInDirective::getDirectiveName()] = [
+        foreach ($this->getDirectiveResolverClasses() as $needValidateIsUserLoggedInDirectiveResolverClass) {
+            /** @var DirectiveResolverInterface */
+            $needValidateIsUserLoggedInDirectiveResolver = $instanceManager->getInstance($needValidateIsUserLoggedInDirectiveResolverClass);
+            $mandatoryDirectivesForDirectives[$needValidateIsUserLoggedInDirectiveResolver->getDirectiveName()] = [
                 $validateIsUserLoggedInDirective,
             ];
         }
@@ -36,7 +43,7 @@ abstract class AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolv
     /**
      * Provide the classes for all the directiveResolverClasses that need the "validateIsUserLoggedIn" directive
      *
-     * @return array
+     * @return string[]
      */
     abstract protected function getDirectiveResolverClasses(): array;
 }

--- a/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserStateAccessControl\TypeResolverDecorators;
 
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\AccessControl\TypeResolverDecorators\AbstractPublicSchemaTypeResolverDecorator;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\UserStateAccessControl\DirectiveResolvers\ValidateIsUserLoggedInDirectiveResolver;
 
 abstract class AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator extends AbstractPublicSchemaTypeResolverDecorator
@@ -22,13 +24,18 @@ abstract class AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDe
         $mandatoryDirectivesForDirectives = [];
         if ($directiveResolverClasses = $this->getDirectiveResolverClasses()) {
             $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+            $instanceManager = InstanceManagerFacade::getInstance();
+            /** @var DirectiveResolverInterface */
+            $validateIsUserLoggedInDirectiveResolver = $instanceManager->getInstance(ValidateIsUserLoggedInDirectiveResolver::class);
             // This is the required "validateIsUserLoggedIn" directive
             $validateIsUserLoggedInDirective = $fieldQueryInterpreter->getDirective(
-                ValidateIsUserLoggedInDirectiveResolver::getDirectiveName()
+                $validateIsUserLoggedInDirectiveResolver->getDirectiveName()
             );
             // Add the mapping
-            foreach ($directiveResolverClasses as $needValidateIsUserLoggedInDirective) {
-                $mandatoryDirectivesForDirectives[$needValidateIsUserLoggedInDirective::getDirectiveName()] = [
+            foreach ($directiveResolverClasses as $needValidateIsUserLoggedInDirectiveResolverClass) {
+                /** @var DirectiveResolverInterface */
+                $needValidateIsUserLoggedInDirectiveResolver = $instanceManager->getInstance($needValidateIsUserLoggedInDirectiveResolverClass);
+                $mandatoryDirectivesForDirectives[$needValidateIsUserLoggedInDirectiveResolver->getDirectiveName()] = [
                     $validateIsUserLoggedInDirective,
                 ];
             }
@@ -56,9 +63,12 @@ abstract class AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDe
         $mandatoryDirectivesForFields = [];
         if ($fieldNames = $this->getFieldNames()) {
             $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
+            $instanceManager = InstanceManagerFacade::getInstance();
+            /** @var DirectiveResolverInterface */
+            $validateIsUserLoggedInDirectiveResolver = $instanceManager->getInstance(ValidateIsUserLoggedInDirectiveResolver::class);
             // This is the required "validateIsUserLoggedIn" directive
             $validateIsUserLoggedInDirective = $fieldQueryInterpreter->getDirective(
-                ValidateIsUserLoggedInDirectiveResolver::getDirectiveName()
+                $validateIsUserLoggedInDirectiveResolver->getDirectiveName()
             );
             // Add the mapping
             foreach ($fieldNames as $fieldName) {

--- a/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/UserStateConfigurableAccessControlInPublicSchemaTypeResolverDecoratorTrait.php
+++ b/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/UserStateConfigurableAccessControlInPublicSchemaTypeResolverDecoratorTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserStateAccessControl\TypeResolverDecorators;
 
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 
 trait UserStateConfigurableAccessControlInPublicSchemaTypeResolverDecoratorTrait
@@ -11,8 +13,11 @@ trait UserStateConfigurableAccessControlInPublicSchemaTypeResolverDecoratorTrait
     protected function getMandatoryDirectives($entryValue = null): array
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $validateUserStateDirectiveClass = $this->getValidateUserStateDirectiveResolverClass();
-        $validateUserStateDirectiveName = $validateUserStateDirectiveClass::getDirectiveName();
+        $instanceManager = InstanceManagerFacade::getInstance();
+        $validateUserStateDirectiveResolverClass = $this->getValidateUserStateDirectiveResolverClass();
+        /** @var DirectiveResolverInterface */
+        $validateUserStateDirectiveResolver = $instanceManager->getInstance($validateUserStateDirectiveResolverClass);
+        $validateUserStateDirectiveName = $validateUserStateDirectiveResolver->getDirectiveName();
         $validateUserStateDirective = $fieldQueryInterpreter->getDirective(
             $validateUserStateDirectiveName
         );

--- a/layers/Schema/packages/user-state/src/DirectiveResolvers/NoCacheCacheControlDirectiveResolver.php
+++ b/layers/Schema/packages/user-state/src/DirectiveResolvers/NoCacheCacheControlDirectiveResolver.php
@@ -8,7 +8,7 @@ use PoP\CacheControl\DirectiveResolvers\AbstractCacheControlDirectiveResolver;
 
 class NoCacheCacheControlDirectiveResolver extends AbstractCacheControlDirectiveResolver
 {
-    public static function getFieldNamesToApplyTo(): array
+    public function getFieldNamesToApplyTo(): array
     {
         return [
             'me',


### PR DESCRIPTION
In the `DirectiveResolver`, the following methods have been made non-static:

- `getDirectiveName`
- `getAliasedDirectiveResolverClass`
- `getFieldNamesToApplyTo`


This PR fixes the leftover stuff from #461.