### PR TITLE
Make leftover functions non static

### DIFF
--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -202,7 +202,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
                             SchemaDefinition::ARGNAME_ENUM_VALUES => SchemaHelpers::convertToSchemaFieldArgEnumValueDefinitions(
                                 $customPostContentFormatEnum->getValues()
                             ),
-                            SchemaDefinition::ARGNAME_DEFAULT_VALUE => self::getDefaultContentFormatValue(),
+                            SchemaDefinition::ARGNAME_DEFAULT_VALUE => $this->getDefaultContentFormatValue(),
                         ],
                     ]
                 );
@@ -211,7 +211,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
         return $schemaFieldArgs;
     }
 
-    public static function getDefaultContentFormatValue(): string
+    public function getDefaultContentFormatValue(): string
     {
         return CustomPostContentFormatEnum::HTML;
     }

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -18,7 +18,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
         return array(UserRoleTypeResolver::class);
     }
 
-    protected static function getTypeClass(): string
+    protected function getTypeClass(): string
     {
         return \WP_Role::class;
     }


### PR DESCRIPTION
Convert the last remaining static functions in any resolver to non-static:

- `getDefaultContentFormatValue`
- Everything in `AbstractReflectionPropertyFieldResolver`