### PR TITLE
Pass branch "master" to Monorepo Split

### DIFF
--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -197,6 +197,7 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
+                    branch: 'master'
                     package-directory: 'build/downgraded-graphql-api-for-wp'
                     split-repository-organization: 'GraphQLAPI'
                     split-repository-name: 'graphql-api-for-wp-dist'

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -73,6 +73,7 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
+                    branch: 'master'
                     package-directory: '${{ matrix.package.path }}'
                     split-repository-organization: '${{ matrix.package.organization }}'
                     split-repository-name: '${{ matrix.package.name }}'

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -67,6 +67,7 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
+                    branch: 'master'
                     package-directory: '${{ matrix.package.path }}'
                     split-repository-organization: '${{ matrix.package.organization }}'
                     split-repository-name: '${{ matrix.package.name }}'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/disabled-workflows/generate_plugin.yml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/.github/disabled-workflows/generate_plugin.yml
@@ -150,6 +150,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
+          branch: 'master'
           package-directory: 'build/downgraded-code'
           split-repository-organization: 'GraphQLAPI'
           split-repository-name: 'graphql-api-for-wp-dist'


### PR DESCRIPTION
The [default branch went from being `master` to `main`](https://github.com/symplify/monorepo-split-github-action/commit/79457b1adc49693646ffbd3a284c220ba8a52d07#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL20), so must pass the `master` value to the GitHub Action