### PR TITLE
Remove parent::initializeContainerServices

### DIFF
--- a/layers/API/packages/api-endpoints-for-wp/src/Component.php
+++ b/layers/API/packages/api-endpoints-for-wp/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
     }

--- a/layers/API/packages/api-graphql/src/Component.php
+++ b/layers/API/packages/api-graphql/src/Component.php
@@ -48,7 +48,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             self::initServices(dirname(__DIR__));
         }
     }

--- a/layers/API/packages/api-mirrorquery/src/Component.php
+++ b/layers/API/packages/api-mirrorquery/src/Component.php
@@ -33,7 +33,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/API/packages/api-rest/src/Component.php
+++ b/layers/API/packages/api-rest/src/Component.php
@@ -39,7 +39,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             self::initServices(dirname(__DIR__));
         }
     }

--- a/layers/API/packages/api/src/Component.php
+++ b/layers/API/packages/api/src/Component.php
@@ -79,7 +79,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
             self::initServices(dirname(__DIR__));
             self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Engine/packages/access-control/src/Component.php
+++ b/layers/Engine/packages/access-control/src/Component.php
@@ -40,7 +40,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
             self::initServices(dirname(__DIR__));
             self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Engine/packages/cache-control/src/Component.php
+++ b/layers/Engine/packages/cache-control/src/Component.php
@@ -38,7 +38,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             self::initServices(dirname(__DIR__));
             self::initSchemaServices(dirname(__DIR__), $skipSchema);
         }

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -48,7 +48,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -58,7 +58,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__));
     }
 

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -61,11 +61,6 @@ class Component extends AbstractComponent
         self::initSystemServices(dirname(__DIR__));
     }
 
-    /**
-     * Boot component
-     *
-     * @return void
-     */
     public static function beforeBoot(): void
     {
         // Initialize the Component Configuration
@@ -75,11 +70,6 @@ class Component extends AbstractComponent
         $attachExtensionService->attachExtensions(ApplicationEvents::BEFORE_BOOT);
     }
 
-    /**
-     * Boot component
-     *
-     * @return void
-     */
     public static function afterBoot(): void
     {
         $attachExtensionService = AttachExtensionServiceFacade::getInstance();

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -68,12 +68,9 @@ class Component extends AbstractComponent
      */
     public static function beforeBoot(): void
     {
-        parent::beforeBoot();
-
         // Initialize the Component Configuration
         ComponentConfiguration::init();
 
-        // Attach class extensions
         $attachExtensionService = AttachExtensionServiceFacade::getInstance();
         $attachExtensionService->attachExtensions(ApplicationEvents::BEFORE_BOOT);
     }
@@ -85,9 +82,6 @@ class Component extends AbstractComponent
      */
     public static function afterBoot(): void
     {
-        parent::afterBoot();
-
-        // Attach class extensions
         $attachExtensionService = AttachExtensionServiceFacade::getInstance();
         $attachExtensionService->attachExtensions(ApplicationEvents::AFTER_BOOT);
     }

--- a/layers/Engine/packages/configurable-schema-feedback/src/Component.php
+++ b/layers/Engine/packages/configurable-schema-feedback/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Engine/packages/definitions/src/Component.php
+++ b/layers/Engine/packages/definitions/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/engine-wp/src/Component.php
+++ b/layers/Engine/packages/engine-wp/src/Component.php
@@ -51,7 +51,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/engine/src/Component.php
+++ b/layers/Engine/packages/engine/src/Component.php
@@ -51,7 +51,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initServices(dirname(__DIR__), '/Overrides');

--- a/layers/Engine/packages/field-query/src/Component.php
+++ b/layers/Engine/packages/field-query/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/filestore/src/Component.php
+++ b/layers/Engine/packages/filestore/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/function-fields/src/Component.php
+++ b/layers/Engine/packages/function-fields/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Engine/packages/hooks-wp/src/Component.php
+++ b/layers/Engine/packages/hooks-wp/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 

--- a/layers/Engine/packages/hooks-wp/src/Component.php
+++ b/layers/Engine/packages/hooks-wp/src/Component.php
@@ -42,7 +42,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         // The same services injected into the application are injected into the system container
         self::initSystemServices(dirname(__DIR__), '', 'services.yaml');
     }

--- a/layers/Engine/packages/loosecontracts/src/Component.php
+++ b/layers/Engine/packages/loosecontracts/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/modulerouting/src/Component.php
+++ b/layers/Engine/packages/modulerouting/src/Component.php
@@ -28,7 +28,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/query-parsing/src/Component.php
+++ b/layers/Engine/packages/query-parsing/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -42,9 +42,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
-
-        // Only after initializing the containerBuilder, can inject a service
         self::initSystemServices(dirname(__DIR__));
     }
 

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -59,9 +59,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
-
-        // Only after initializing the containerBuilder, can inject a service
         self::initServices(dirname(__DIR__));
     }
 

--- a/layers/Engine/packages/routing-wp/src/Component.php
+++ b/layers/Engine/packages/routing-wp/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 

--- a/layers/Engine/packages/routing-wp/src/Component.php
+++ b/layers/Engine/packages/routing-wp/src/Component.php
@@ -38,11 +38,6 @@ class Component extends AbstractComponent
         self::initServices(dirname(__DIR__));
     }
 
-    /**
-     * Boot component
-     *
-     * @return void
-     */
     public static function beforeBoot(): void
     {
         Cortex::boot();

--- a/layers/Engine/packages/routing-wp/src/Component.php
+++ b/layers/Engine/packages/routing-wp/src/Component.php
@@ -45,9 +45,6 @@ class Component extends AbstractComponent
      */
     public static function beforeBoot(): void
     {
-        parent::beforeBoot();
-
-        // Boot Cortex
         Cortex::boot();
     }
 }

--- a/layers/Engine/packages/routing/src/Component.php
+++ b/layers/Engine/packages/routing/src/Component.php
@@ -24,11 +24,6 @@ class Component extends AbstractComponent
         ];
     }
 
-    /**
-     * Boot component
-     *
-     * @return void
-     */
     public static function beforeBoot(): void
     {
         Routes::init();

--- a/layers/Engine/packages/routing/src/Component.php
+++ b/layers/Engine/packages/routing/src/Component.php
@@ -31,9 +31,6 @@ class Component extends AbstractComponent
      */
     public static function beforeBoot(): void
     {
-        parent::beforeBoot();
-
-        // Initialize classes
         Routes::init();
     }
 }

--- a/layers/Engine/packages/trace-tools/src/Component.php
+++ b/layers/Engine/packages/trace-tools/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Engine/packages/translation-wp/src/Component.php
+++ b/layers/Engine/packages/translation-wp/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 

--- a/layers/Engine/packages/translation-wp/src/Component.php
+++ b/layers/Engine/packages/translation-wp/src/Component.php
@@ -42,7 +42,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         // The same services injected into the application are injected into the system container
         self::initSystemServices(dirname(__DIR__), '', 'services.yaml');
     }

--- a/layers/GraphQLAPIForWP/packages/markdown-convertor/src/Component.php
+++ b/layers/GraphQLAPIForWP/packages/markdown-convertor/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -23,7 +23,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__), '', 'hybrid-services.yaml');
     }
 

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -38,7 +38,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__), '', 'hybrid-services.yaml');
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -86,7 +86,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__), '', 'hybrid-services.yaml');
         self::initServices(dirname(__DIR__));
         self::initComponentConfiguration();

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -70,7 +70,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__), '', 'hybrid-services.yaml');
         self::initSystemServices(dirname(__DIR__));
     }

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Component.php
@@ -41,7 +41,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
             self::initServices(dirname(__DIR__));
             if (ComponentConfiguration::useGraphiQLExplorer()) {

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
     }

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Component.php
@@ -40,7 +40,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
             self::initServices(dirname(__DIR__));
         }

--- a/layers/GraphQLByPoP/packages/graphql-request/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-request/src/Component.php
@@ -39,7 +39,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
             self::initServices(dirname(__DIR__));
         }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -89,7 +89,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             ComponentConfiguration::setConfiguration($configuration);
             self::initServices(dirname(__DIR__));
             self::initServices(dirname(__DIR__), '/Overrides');

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -130,8 +130,7 @@ class Component extends AbstractComponent
     protected static function initializeSystemContainerServices(): void
     {
         if (self::isEnabled()) {
-            parent::initializeSystemContainerServices();
-            self::initSystemServices(dirname(__DIR__));
+                self::initSystemServices(dirname(__DIR__));
         }
     }
 

--- a/layers/Misc/packages/examples-for-pop/src/Component.php
+++ b/layers/Misc/packages/examples-for-pop/src/Component.php
@@ -38,7 +38,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
         if (ComponentModelComponentConfiguration::useComponentModelCache()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/UseComponentModelCache');

--- a/layers/Misc/packages/examples-for-pop/src/Component.php
+++ b/layers/Misc/packages/examples-for-pop/src/Component.php
@@ -49,7 +49,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/basic-directives/src/Component.php
+++ b/layers/Schema/packages/basic-directives/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Schema/packages/block-metadata-for-wp/src/Component.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/categories-wp/src/Component.php
+++ b/layers/Schema/packages/categories-wp/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/categories/src/Component.php
+++ b/layers/Schema/packages/categories/src/Component.php
@@ -56,7 +56,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Schema/packages/cdn-directive/src/Component.php
+++ b/layers/Schema/packages/cdn-directive/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Schema/packages/comment-mutations-wp/src/Component.php
+++ b/layers/Schema/packages/comment-mutations-wp/src/Component.php
@@ -36,7 +36,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/comment-mutations/src/Component.php
+++ b/layers/Schema/packages/comment-mutations/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/comments-wp/src/Component.php
+++ b/layers/Schema/packages/comments-wp/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/comments/src/Component.php
+++ b/layers/Schema/packages/comments/src/Component.php
@@ -55,7 +55,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
 

--- a/layers/Schema/packages/convert-case-directives/src/Component.php
+++ b/layers/Schema/packages/convert-case-directives/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/custompost-mutations-wp/src/Component.php
+++ b/layers/Schema/packages/custompost-mutations-wp/src/Component.php
@@ -37,7 +37,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/custompost-mutations/src/Component.php
+++ b/layers/Schema/packages/custompost-mutations/src/Component.php
@@ -36,7 +36,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/custompostmedia-mutations-wp/src/Component.php
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/src/Component.php
@@ -37,7 +37,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/custompostmedia-mutations/src/Component.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Schema/packages/custompostmedia/src/Component.php
+++ b/layers/Schema/packages/custompostmedia/src/Component.php
@@ -45,7 +45,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/customposts-wp/src/Component.php
+++ b/layers/Schema/packages/customposts-wp/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initServices(dirname(__DIR__), '/Overrides');
         self::initSchemaServices(dirname(__DIR__), $skipSchema, '/Overrides');

--- a/layers/Schema/packages/customposts/src/Component.php
+++ b/layers/Schema/packages/customposts/src/Component.php
@@ -43,7 +43,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Schema/packages/event-mutations-wp-em/src/Component.php
+++ b/layers/Schema/packages/event-mutations-wp-em/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/events-wp-em/src/Component.php
+++ b/layers/Schema/packages/events-wp-em/src/Component.php
@@ -62,7 +62,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             self::initServices(dirname(__DIR__));
             if (Environment::addEventTypeToCustomPostUnionTypes()) {
                 self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddEventTypeToCustomPostUnionTypes/Overrides');

--- a/layers/Schema/packages/events/src/Component.php
+++ b/layers/Schema/packages/events/src/Component.php
@@ -57,7 +57,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Schema/packages/everythingelse-wp/src/Component.php
+++ b/layers/Schema/packages/everythingelse-wp/src/Component.php
@@ -47,7 +47,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         if (class_exists('\PoPSchema\CustomPosts\Component')) {
             self::initServices(dirname(__DIR__), '/Conditional/CustomPosts');
         }

--- a/layers/Schema/packages/everythingelse/src/Component.php
+++ b/layers/Schema/packages/everythingelse/src/Component.php
@@ -43,7 +43,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Schema/packages/generic-customposts/src/Component.php
+++ b/layers/Schema/packages/generic-customposts/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Schema/packages/google-translate-directive-for-customposts/src/Component.php
+++ b/layers/Schema/packages/google-translate-directive-for-customposts/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/google-translate-directive/src/Component.php
+++ b/layers/Schema/packages/google-translate-directive/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         if (Environment::enableGlobalGoogleTranslateDirective()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema);
         }

--- a/layers/Schema/packages/highlights-wp/src/Component.php
+++ b/layers/Schema/packages/highlights-wp/src/Component.php
@@ -36,7 +36,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         if (Environment::addHighlightTypeToCustomPostUnionTypes()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddHighlightTypeToCustomPostUnionTypes/Overrides');

--- a/layers/Schema/packages/highlights/src/Component.php
+++ b/layers/Schema/packages/highlights/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
         if (Environment::addHighlightTypeToCustomPostUnionTypes()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddHighlightTypeToCustomPostUnionTypes');

--- a/layers/Schema/packages/locationposts-wp/src/Component.php
+++ b/layers/Schema/packages/locationposts-wp/src/Component.php
@@ -36,7 +36,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         if (Environment::addLocationPostTypeToCustomPostUnionTypes()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddLocationPostTypeToCustomPostUnionTypes/Overrides');

--- a/layers/Schema/packages/locationposts/src/Component.php
+++ b/layers/Schema/packages/locationposts/src/Component.php
@@ -48,7 +48,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
 
         if (Environment::addLocationPostTypeToCustomPostUnionTypes()) {

--- a/layers/Schema/packages/locations-wp-em/src/Component.php
+++ b/layers/Schema/packages/locations-wp-em/src/Component.php
@@ -60,7 +60,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             self::initServices(dirname(__DIR__));
         }
     }

--- a/layers/Schema/packages/locations/src/Component.php
+++ b/layers/Schema/packages/locations/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Schema/packages/media-wp/src/Component.php
+++ b/layers/Schema/packages/media-wp/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/media/src/Component.php
+++ b/layers/Schema/packages/media/src/Component.php
@@ -56,7 +56,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
 

--- a/layers/Schema/packages/menus-wp/src/Component.php
+++ b/layers/Schema/packages/menus-wp/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/menus/src/Component.php
+++ b/layers/Schema/packages/menus/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/notifications/src/Component.php
+++ b/layers/Schema/packages/notifications/src/Component.php
@@ -47,7 +47,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/pages-wp/src/Component.php
+++ b/layers/Schema/packages/pages-wp/src/Component.php
@@ -45,7 +45,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         if (ComponentConfiguration::addPageTypeToCustomPostUnionTypes()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddPageTypeToCustomPostUnionTypes/Overrides');

--- a/layers/Schema/packages/pages/src/Component.php
+++ b/layers/Schema/packages/pages/src/Component.php
@@ -56,7 +56,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Schema/packages/post-mutations/src/Component.php
+++ b/layers/Schema/packages/post-mutations/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/post-tags-wp/src/Component.php
+++ b/layers/Schema/packages/post-tags-wp/src/Component.php
@@ -45,7 +45,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/post-tags/src/Component.php
+++ b/layers/Schema/packages/post-tags/src/Component.php
@@ -59,7 +59,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Schema/packages/posts-wp/src/Component.php
+++ b/layers/Schema/packages/posts-wp/src/Component.php
@@ -45,7 +45,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         if (ComponentConfiguration::addPostTypeToCustomPostUnionTypes()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddPostTypeToCustomPostUnionTypes/Overrides');

--- a/layers/Schema/packages/posts/src/Component.php
+++ b/layers/Schema/packages/posts/src/Component.php
@@ -59,7 +59,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/Schema/packages/queriedobject/src/Component.php
+++ b/layers/Schema/packages/queriedobject/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/schema-commons/src/Component.php
+++ b/layers/Schema/packages/schema-commons/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/stances-wp/src/Component.php
+++ b/layers/Schema/packages/stances-wp/src/Component.php
@@ -36,7 +36,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         if (Environment::addStanceTypeToCustomPostUnionTypes()) {
             self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnEnvironment/AddStanceTypeToCustomPostUnionTypes/Overrides');

--- a/layers/Schema/packages/stances/src/Component.php
+++ b/layers/Schema/packages/stances/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
         if (Environment::addStanceTypeToCustomPostUnionTypes()) {

--- a/layers/Schema/packages/tags-wp/src/Component.php
+++ b/layers/Schema/packages/tags-wp/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/tags/src/Component.php
+++ b/layers/Schema/packages/tags/src/Component.php
@@ -43,7 +43,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
     }

--- a/layers/Schema/packages/taxonomies-wp/src/Component.php
+++ b/layers/Schema/packages/taxonomies-wp/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/translate-directive-acl/src/Component.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Component.php
@@ -34,8 +34,7 @@ class Component extends AbstractComponent
     protected static function initializeSystemContainerServices(): void
     {
         if (self::isEnabled()) {
-            parent::initializeSystemContainerServices();
-            self::initSystemServices(dirname(__DIR__));
+                self::initSystemServices(dirname(__DIR__));
         }
     }
 

--- a/layers/Schema/packages/translate-directive/src/Component.php
+++ b/layers/Schema/packages/translate-directive/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 

--- a/layers/Schema/packages/translate-directive/src/Component.php
+++ b/layers/Schema/packages/translate-directive/src/Component.php
@@ -43,7 +43,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/user-roles-access-control/src/Component.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Component.php
@@ -52,7 +52,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             self::initServices(dirname(__DIR__));
             self::initSchemaServices(dirname(__DIR__), $skipSchema);
 

--- a/layers/Schema/packages/user-roles-acl/src/Component.php
+++ b/layers/Schema/packages/user-roles-acl/src/Component.php
@@ -38,8 +38,7 @@ class Component extends AbstractComponent
     protected static function initializeSystemContainerServices(): void
     {
         if (self::isEnabled()) {
-            parent::initializeSystemContainerServices();
-            self::initSystemServices(dirname(__DIR__));
+                self::initSystemServices(dirname(__DIR__));
         }
     }
 }

--- a/layers/Schema/packages/user-roles-wp/src/Component.php
+++ b/layers/Schema/packages/user-roles-wp/src/Component.php
@@ -47,7 +47,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
         self::initSchemaServices(dirname(__DIR__), $skipSchema, '/Overrides');

--- a/layers/Schema/packages/user-roles/src/Component.php
+++ b/layers/Schema/packages/user-roles/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Schema/packages/user-state-access-control/src/Component.php
+++ b/layers/Schema/packages/user-state-access-control/src/Component.php
@@ -52,7 +52,6 @@ class Component extends AbstractComponent
         array $skipSchemaComponentClasses = []
     ): void {
         if (self::isEnabled()) {
-            parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
             self::initServices(dirname(__DIR__));
             self::initSchemaServices(dirname(__DIR__), $skipSchema);
 

--- a/layers/Schema/packages/user-state-mutations-wp/src/Component.php
+++ b/layers/Schema/packages/user-state-mutations-wp/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/user-state-mutations/src/Component.php
+++ b/layers/Schema/packages/user-state-mutations/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/Schema/packages/user-state-wp/src/Component.php
+++ b/layers/Schema/packages/user-state-wp/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Schema/packages/user-state/src/Component.php
+++ b/layers/Schema/packages/user-state/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/Schema/packages/users-wp/src/Component.php
+++ b/layers/Schema/packages/users-wp/src/Component.php
@@ -56,7 +56,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         if (class_exists('\PoPSchema\CustomPosts\Component')) {
             self::initServices(dirname(__DIR__), '/Conditional/CustomPosts');

--- a/layers/Schema/packages/users/src/Component.php
+++ b/layers/Schema/packages/users/src/Component.php
@@ -59,7 +59,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         ComponentConfiguration::setConfiguration($configuration);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);

--- a/layers/SiteBuilder/packages/application-wp/src/Component.php
+++ b/layers/SiteBuilder/packages/application-wp/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/application/src/Component.php
+++ b/layers/SiteBuilder/packages/application/src/Component.php
@@ -37,7 +37,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initServices(dirname(__DIR__), '/Overrides');
     }

--- a/layers/SiteBuilder/packages/application/src/Component.php
+++ b/layers/SiteBuilder/packages/application/src/Component.php
@@ -46,7 +46,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/component-model-configuration/src/Component.php
+++ b/layers/SiteBuilder/packages/component-model-configuration/src/Component.php
@@ -43,7 +43,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initServices(dirname(__DIR__), '/Overrides');
     }

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
@@ -41,7 +41,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Component.php
@@ -49,7 +49,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/definitions-base36/src/Component.php
+++ b/layers/SiteBuilder/packages/definitions-base36/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/definitions-emoji/src/Component.php
+++ b/layers/SiteBuilder/packages/definitions-emoji/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/multisite/src/Component.php
+++ b/layers/SiteBuilder/packages/multisite/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }

--- a/layers/SiteBuilder/packages/site-wp/src/Component.php
+++ b/layers/SiteBuilder/packages/site-wp/src/Component.php
@@ -35,7 +35,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/site/src/Component.php
+++ b/layers/SiteBuilder/packages/site/src/Component.php
@@ -36,7 +36,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__), '/Overrides');
     }
 

--- a/layers/SiteBuilder/packages/site/src/Component.php
+++ b/layers/SiteBuilder/packages/site/src/Component.php
@@ -44,7 +44,6 @@ class Component extends AbstractComponent
      */
     protected static function initializeSystemContainerServices(): void
     {
-        parent::initializeSystemContainerServices();
         self::initSystemServices(dirname(__DIR__));
     }
 }

--- a/layers/SiteBuilder/packages/spa/src/Component.php
+++ b/layers/SiteBuilder/packages/spa/src/Component.php
@@ -34,7 +34,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
     }
 }

--- a/layers/Wassup/packages/wassup/src/Component.php
+++ b/layers/Wassup/packages/wassup/src/Component.php
@@ -92,7 +92,6 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
-        parent::initializeContainerServices($configuration, $skipSchema, $skipSchemaComponentClasses);
         self::initServices(dirname(__DIR__));
         self::initServices(dirname(__DIR__), '/Overrides');
     }


### PR DESCRIPTION
Function `initializeContainerServices` in the `AbstractComponent` is empty, so don't call it, as to simplify the logic