### PR TITLE
Avoid leak for scoping compiler pass

### DIFF
--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
@@ -6,12 +6,12 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 
 use PoP\ComponentModel\AttachableExtensions\AttachExtensionServiceInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractAttachExtensionCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $event = $this->getAttachExtensionEvent();
         $attachableClassGroups = $this->getAttachableClassGroups();

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
@@ -11,12 +11,12 @@ use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractAttachExtensionCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         $event = $this->getAttachExtensionEvent();
         $attachableClassGroups = $this->getAttachableClassGroups();
-        $attachExtensionServiceDefinition = $containerBuilder->getDefinition(AttachExtensionServiceInterface::class);
-        $definitions = $containerBuilder->getDefinitions();
+        $attachExtensionServiceDefinition = $containerBuilderWrapper->getDefinition(AttachExtensionServiceInterface::class);
+        $definitions = $containerBuilderWrapper->getDefinitions();
         foreach ($definitions as $definitionID => $definition) {
             $definitionClass = $definition->getClass();
             if ($definitionClass === null) {

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
@@ -6,12 +6,12 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 
 use PoP\ComponentModel\AttachableExtensions\AttachExtensionServiceInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractAttachExtensionCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $event = $this->getAttachExtensionEvent();
         $attachableClassGroups = $this->getAttachableClassGroups();

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
@@ -7,7 +7,6 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 use PoP\ComponentModel\AttachableExtensions\AttachExtensionServiceInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Root\Container\ContainerBuilderWrapperInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractAttachExtensionCompilerPass extends AbstractCompilerPass
 {
@@ -38,7 +37,7 @@ abstract class AbstractAttachExtensionCompilerPass extends AbstractCompilerPass
                 if ($definition->isAutoconfigured()) {
                     $attachExtensionServiceDefinition->addMethodCall(
                         'enqueueExtension',
-                        [$event, $attachableGroup, new Reference($definitionID)]
+                        [$event, $attachableGroup, $this->createReference($definitionID)]
                     );
                 }
                 // A service won't be of 2 attachable classes, so can skip checking

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/AbstractAttachExtensionCompilerPass.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Container\CompilerPasses;
 
 use PoP\ComponentModel\AttachableExtensions\AttachExtensionServiceInterface;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-abstract class AbstractAttachExtensionCompilerPass implements CompilerPassInterface
+abstract class AbstractAttachExtensionCompilerPass extends AbstractCompilerPass
 {
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $event = $this->getAttachExtensionEvent();
         $attachableClassGroups = $this->getAttachableClassGroups();

--- a/layers/Engine/packages/root/src/Container/CompilerPassContainerInterface.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPassContainerInterface.php
@@ -11,4 +11,8 @@ interface CompilerPassContainerInterface
 {
     public function getContainerBuilder(): ContainerBuilder;
     public function getDefinition(string $id): Definition;
+    /**
+     * @return Definition[] An array of Definition instances
+     */
+    public function getDefinitions(): array;
 }

--- a/layers/Engine/packages/root/src/Container/CompilerPassContainerInterface.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPassContainerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Container;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+interface CompilerPassContainerInterface
+{
+    public function getContainerBuilder(): ContainerBuilder;
+    public function getDefinition(string $id): Definition;
+}

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
-use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoP\Root\Container\ContainerBuilderWrapper;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * This class enables to leak the implementation of Compiler Passes to the application.
@@ -32,5 +33,10 @@ abstract class AbstractCompilerPass implements CompilerPassInterface
     protected function enabled(): bool
     {
         return true;
+    }
+
+    protected function createReference(string $id): Reference
+    {
+        return new Reference($id);
     }
 }

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoP\Root\Container\ContainerBuilderWrapper;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,7 +27,7 @@ abstract class AbstractCompilerPass implements CompilerPassInterface
     /**
      * Compiler passes must implement the logic in this function, not in `process`
      */
-    abstract protected function doProcess(CompilerPassContainerInterface $containerBuilder): void;
+    abstract protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void;
 
     protected function enabled(): bool
     {

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
@@ -9,6 +9,7 @@ use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * This class enables to leak the implementation of Compiler Passes to the application.
@@ -38,5 +39,10 @@ abstract class AbstractCompilerPass implements CompilerPassInterface
     protected function createReference(string $id): Reference
     {
         return new Reference($id);
+    }
+
+    protected function createExpression(string $expression): Expression
+    {
+        return new Expression($expression);
     }
 }

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
+use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapper;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -19,13 +21,13 @@ abstract class AbstractCompilerPass implements CompilerPassInterface
         if (!$this->enabled()) {
             return;
         }
-        $this->doProcess($containerBuilder);
+        $this->doProcess(new ContainerBuilderWrapper($containerBuilder));
     }
 
     /**
      * Compiler passes must implement the logic in this function, not in `process`
      */
-    abstract protected function doProcess(ContainerBuilder $containerBuilder): void;
+    abstract protected function doProcess(CompilerPassContainerInterface $containerBuilder): void;
 
     protected function enabled(): bool
     {

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Container\CompilerPasses;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+abstract class AbstractCompilerPass implements CompilerPassInterface
+{
+    final public function process(ContainerBuilder $containerBuilder): void
+    {
+        if (!$this->enabled()) {
+            return;
+        }
+        $this->doProcess($containerBuilder);
+    }
+
+    abstract protected function doProcess(ContainerBuilder $containerBuilder): void;
+
+    protected function enabled(): bool
+    {
+        return true;
+    }
+}

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
@@ -27,7 +27,7 @@ abstract class AbstractCompilerPass implements CompilerPassInterface
     /**
      * Compiler passes must implement the logic in this function, not in `process`
      */
-    abstract protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void;
+    abstract protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void;
 
     protected function enabled(): bool
     {

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractCompilerPass.php
@@ -7,6 +7,11 @@ namespace PoP\Root\Container\CompilerPasses;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * This class enables to leak the implementation of Compiler Passes to the application.
+ * This is needed to add compiler passes on "-wp" packages, which are not scoped
+ * with PHP-Scoper. Then, in these packages we can't reference Symfony (or any 3rd party)
+ */
 abstract class AbstractCompilerPass implements CompilerPassInterface
 {
     final public function process(ContainerBuilder $containerBuilder): void
@@ -17,6 +22,9 @@ abstract class AbstractCompilerPass implements CompilerPassInterface
         $this->doProcess($containerBuilder);
     }
 
+    /**
+     * Compiler passes must implement the logic in this function, not in `process`
+     */
     abstract protected function doProcess(ContainerBuilder $containerBuilder): void;
 
     protected function enabled(): bool

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-abstract class AbstractInjectServiceIntoRegistryCompilerPass implements CompilerPassInterface
+abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCompilerPass
 {
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
-        if (!$this->enabled()) {
-            return;
-        }
         $registryDefinition = $containerBuilder->getDefinition($this->getRegistryServiceDefinition());
         $definitions = $containerBuilder->getDefinitions();
         $serviceClass = $this->getServiceClass();
@@ -42,9 +38,4 @@ abstract class AbstractInjectServiceIntoRegistryCompilerPass implements Compiler
     abstract protected function getRegistryServiceDefinition(): string;
     abstract protected function getServiceClass(): string;
     abstract protected function getRegistryMethodCallName(): string;
-
-    protected function enabled(): bool
-    {
-        return true;
-    }
 }

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $registryDefinition = $containerBuilder->getDefinition($this->getRegistryServiceDefinition());
         $definitions = $containerBuilder->getDefinitions();

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -9,10 +9,10 @@ use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $registryDefinition = $containerBuilder->getDefinition($this->getRegistryServiceDefinition());
-        $definitions = $containerBuilder->getDefinitions();
+        $registryDefinition = $containerBuilderWrapper->getDefinition($this->getRegistryServiceDefinition());
+        $definitions = $containerBuilderWrapper->getDefinitions();
         $serviceClass = $this->getServiceClass();
         foreach ($definitions as $definitionID => $definition) {
             $definitionClass = $definition->getClass();

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $registryDefinition = $containerBuilder->getDefinition($this->getRegistryServiceDefinition());
         $definitions = $containerBuilder->getDefinitions();

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoP\Root\Container\CompilerPasses;
 
 use PoP\Root\Container\ContainerBuilderWrapperInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCompilerPass
 {
@@ -30,7 +29,7 @@ abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCom
             // Register the service in the corresponding registry
             $registryDefinition->addMethodCall(
                 $this->getRegistryMethodCallName(),
-                [new Reference($definitionID)]
+                [$this->createReference($definitionID)]
             );
         }
     }

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoP\Root\Container\ServiceInstantiatorInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $serviceInstantiatorDefinition = $containerBuilder->getDefinition(ServiceInstantiatorInterface::class);
         $serviceClass = $this->getServiceClass();

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\CompilerPasses;
 
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoP\Root\Container\ServiceInstantiatorInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $serviceInstantiatorDefinition = $containerBuilder->getDefinition(ServiceInstantiatorInterface::class);
         $serviceClass = $this->getServiceClass();

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
@@ -6,7 +6,6 @@ namespace PoP\Root\Container\CompilerPasses;
 
 use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoP\Root\Container\ServiceInstantiatorInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPass
 {
@@ -23,7 +22,7 @@ abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPa
 
             $serviceInstantiatorDefinition->addMethodCall(
                 'addService',
-                [new Reference($definitionID)]
+                [$this->createReference($definitionID)]
             );
         }
     }

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace PoP\Root\Container\CompilerPasses;
 
 use PoP\Root\Container\ServiceInstantiatorInterface;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-abstract class AbstractInstantiateServiceCompilerPass implements CompilerPassInterface
+abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPass
 {
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $serviceInstantiatorDefinition = $containerBuilder->getDefinition(ServiceInstantiatorInterface::class);
         $serviceClass = $this->getServiceClass();

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
@@ -10,11 +10,11 @@ use Symfony\Component\DependencyInjection\Reference;
 
 abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $serviceInstantiatorDefinition = $containerBuilder->getDefinition(ServiceInstantiatorInterface::class);
+        $serviceInstantiatorDefinition = $containerBuilderWrapper->getDefinition(ServiceInstantiatorInterface::class);
         $serviceClass = $this->getServiceClass();
-        $definitions = $containerBuilder->getDefinitions();
+        $definitions = $containerBuilderWrapper->getDefinitions();
         foreach ($definitions as $definitionID => $definition) {
             $definitionClass = $definition->getClass();
             if ($definitionClass === null || !is_a($definitionClass, $serviceClass, true)) {

--- a/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
+++ b/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
@@ -25,4 +25,12 @@ final class ContainerBuilderWrapper implements CompilerPassContainerInterface
     {
         return $this->containerBuilder->getDefinition($id);
     }
+
+    /**
+     * @return Definition[] An array of Definition instances
+     */
+    final public function getDefinitions(): array
+    {
+        return $this->containerBuilder->getDefinitions();
+    }
 }

--- a/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
+++ b/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
@@ -7,7 +7,7 @@ namespace PoP\Root\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-final class ContainerBuilderWrapper implements CompilerPassContainerInterface
+final class ContainerBuilderWrapper implements ContainerBuilderWrapperInterface
 {
     private ContainerBuilder $containerBuilder;
 

--- a/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
+++ b/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Container;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class ContainerBuilderWrapper implements CompilerPassContainerInterface
+{
+    private ContainerBuilder $containerBuilder;
+
+    final public function __construct(ContainerBuilder $containerBuilder)
+    {
+        $this->containerBuilder = $containerBuilder;
+    }
+
+    final public function getContainerBuilder(): ContainerBuilder
+    {
+        return $this->containerBuilder;
+    }
+
+    final public function getDefinition(string $id): Definition
+    {
+        return $this->containerBuilder->getDefinition($id);
+    }
+}

--- a/layers/Engine/packages/root/src/Container/ContainerBuilderWrapperInterface.php
+++ b/layers/Engine/packages/root/src/Container/ContainerBuilderWrapperInterface.php
@@ -7,7 +7,7 @@ namespace PoP\Root\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-interface CompilerPassContainerInterface
+interface ContainerBuilderWrapperInterface
 {
     public function getContainerBuilder(): ContainerBuilder;
     public function getDefinition(string $id): Definition;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -8,13 +8,13 @@ use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
 use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         // Obtain the capabilities from another service

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -10,7 +10,6 @@ use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
-use Symfony\Component\ExpressionLanguage\Expression;
 
 class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
@@ -20,7 +19,7 @@ class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
         // Obtain the capabilities from another service
         $userAuthorizationDefinitionService = str_replace('\\', '\\\\', UserAuthorizationInterface::class);
         $capabilities = [
-            new Expression(sprintf(
+            $this->createExpression(sprintf(
                 'service("%s").getSchemaEditorAccessCapability()',
                 $userAuthorizationDefinitionService
             ))

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Container\CompilerPasses;
 
-use PoP\AccessControl\Services\AccessControlManagerInterface;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
 use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
+use PoP\AccessControl\Services\AccessControlManagerInterface;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ExpressionLanguage\Expression;
 
-class ConfigureAccessControlCompilerPass implements CompilerPassInterface
+class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         // Obtain the capabilities from another service

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -14,9 +14,9 @@ use Symfony\Component\ExpressionLanguage\Expression;
 
 class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
+        $accessControlManagerDefinition = $containerBuilderWrapper->getDefinition(AccessControlManagerInterface::class);
         // Obtain the capabilities from another service
         $userAuthorizationDefinitionService = str_replace('\\', '\\\\', UserAuthorizationInterface::class);
         $capabilities = [

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -8,13 +8,13 @@ use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
 use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         // Obtain the capabilities from another service

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\Container\CompilerPasses;
 
-use GraphQLByPoP\GraphQLServer\Environment;
 use GraphQLByPoP\GraphQLRequest\PersistedQueries\GraphQLPersistedQueryManagerInterface;
+use GraphQLByPoP\GraphQLServer\Environment;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ConfigureGraphQLPersistedQueryCompilerPass implements CompilerPassInterface
+class ConfigureGraphQLPersistedQueryCompilerPass extends AbstractCompilerPass
 {
+    protected function enabled(): bool
+    {
+        return Environment::addGraphQLIntrospectionPersistedQuery();
+    }
+
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
-        if (!Environment::addGraphQLIntrospectionPersistedQuery()) {
-            return;
-        }
-
         $introspectionPersistedQuery = <<<EOT
         query IntrospectionQuery {
             __schema {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
@@ -7,8 +7,8 @@ namespace GraphQLByPoP\GraphQLServer\Container\CompilerPasses;
 use GraphQLByPoP\GraphQLRequest\PersistedQueries\GraphQLPersistedQueryManagerInterface;
 use GraphQLByPoP\GraphQLServer\Environment;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConfigureGraphQLPersistedQueryCompilerPass extends AbstractCompilerPass
 {
@@ -20,7 +20,7 @@ class ConfigureGraphQLPersistedQueryCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $introspectionPersistedQuery = <<<EOT
         query IntrospectionQuery {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
@@ -20,7 +20,7 @@ class ConfigureGraphQLPersistedQueryCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         $introspectionPersistedQuery = <<<EOT
         query IntrospectionQuery {
@@ -129,7 +129,7 @@ class ConfigureGraphQLPersistedQueryCompilerPass extends AbstractCompilerPass
          */
         $translationAPI = SystemTranslationAPIFacade::getInstance();
         $description = $translationAPI->__('GraphQL introspection query', 'examples-for-pop');
-        $graphQLPersistedQueryManagerDefinition = $containerBuilder->getDefinition(GraphQLPersistedQueryManagerInterface::class);
+        $graphQLPersistedQueryManagerDefinition = $containerBuilderWrapper->getDefinition(GraphQLPersistedQueryManagerInterface::class);
         $graphQLPersistedQueryManagerDefinition->addMethodCall(
             'addPersistedQuery',
             [

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Container/CompilerPasses/ConfigureGraphQLPersistedQueryCompilerPass.php
@@ -7,7 +7,7 @@ namespace GraphQLByPoP\GraphQLServer\Container\CompilerPasses;
 use GraphQLByPoP\GraphQLRequest\PersistedQueries\GraphQLPersistedQueryManagerInterface;
 use GraphQLByPoP\GraphQLServer\Environment;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
 
 class ConfigureGraphQLPersistedQueryCompilerPass extends AbstractCompilerPass
@@ -20,7 +20,7 @@ class ConfigureGraphQLPersistedQueryCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $introspectionPersistedQuery = <<<EOT
         query IntrospectionQuery {

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
@@ -7,15 +7,15 @@ namespace Leoloso\ExamplesForPoP\Container\CompilerPasses;
 use PoP\API\PersistedQueries\PersistedFragmentManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryUtils;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConfigurePersistedFragmentCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         // 'contentMesh' persisted fragments
         // Initialization of parameters

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
@@ -15,7 +15,7 @@ class ConfigurePersistedFragmentCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         // 'contentMesh' persisted fragments
         // Initialization of parameters
@@ -66,7 +66,7 @@ EOT;
 EOT;
         // Inject the values into the service
         $translationAPI = SystemTranslationAPIFacade::getInstance();
-        $persistedFragmentManagerDefinition = $containerBuilder->getDefinition(PersistedFragmentManagerInterface::class);
+        $persistedFragmentManagerDefinition = $containerBuilderWrapper->getDefinition(PersistedFragmentManagerInterface::class);
         $persistedFragmentManagerDefinition->addMethodCall(
             'addPersistedFragment',
             [

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
@@ -7,7 +7,7 @@ namespace Leoloso\ExamplesForPoP\Container\CompilerPasses;
 use PoP\API\PersistedQueries\PersistedFragmentManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryUtils;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
 
 class ConfigurePersistedFragmentCompilerPass extends AbstractCompilerPass
@@ -15,7 +15,7 @@ class ConfigurePersistedFragmentCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         // 'contentMesh' persisted fragments
         // Initialization of parameters

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedFragmentCompilerPass.php
@@ -6,16 +6,16 @@ namespace Leoloso\ExamplesForPoP\Container\CompilerPasses;
 
 use PoP\API\PersistedQueries\PersistedFragmentManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryUtils;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ConfigurePersistedFragmentCompilerPass implements CompilerPassInterface
+class ConfigurePersistedFragmentCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         // 'contentMesh' persisted fragments
         // Initialization of parameters

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
@@ -7,15 +7,15 @@ namespace Leoloso\ExamplesForPoP\Container\CompilerPasses;
 use PoP\API\PersistedQueries\PersistedQueryManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryUtils;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConfigurePersistedQueryCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         // Persisted queries
         $contentMeshPersistedQuery = <<<EOT

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
@@ -15,7 +15,7 @@ class ConfigurePersistedQueryCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         // Persisted queries
         $contentMeshPersistedQuery = <<<EOT
@@ -33,7 +33,7 @@ EOT;
 EOT;
         // Inject the values into the service
         $translationAPI = SystemTranslationAPIFacade::getInstance();
-        $persistedQueryManagerDefinition = $containerBuilder->getDefinition(PersistedQueryManagerInterface::class);
+        $persistedQueryManagerDefinition = $containerBuilderWrapper->getDefinition(PersistedQueryManagerInterface::class);
         $persistedQueryManagerDefinition->addMethodCall(
             'addPersistedQuery',
             [

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
@@ -7,7 +7,7 @@ namespace Leoloso\ExamplesForPoP\Container\CompilerPasses;
 use PoP\API\PersistedQueries\PersistedQueryManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryUtils;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
 
 class ConfigurePersistedQueryCompilerPass extends AbstractCompilerPass
@@ -15,7 +15,7 @@ class ConfigurePersistedQueryCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         // Persisted queries
         $contentMeshPersistedQuery = <<<EOT

--- a/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
+++ b/layers/Misc/packages/examples-for-pop/src/Container/CompilerPasses/ConfigurePersistedQueryCompilerPass.php
@@ -6,16 +6,16 @@ namespace Leoloso\ExamplesForPoP\Container\CompilerPasses;
 
 use PoP\API\PersistedQueries\PersistedQueryManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryUtils;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Translation\Facades\SystemTranslationAPIFacade;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ConfigurePersistedQueryCompilerPass implements CompilerPassInterface
+class ConfigurePersistedQueryCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         // Persisted queries
         $contentMeshPersistedQuery = <<<EOT

--- a/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -6,20 +6,19 @@ namespace PoPSchema\TranslateDirectiveACL\Container\CompilerPasses;
 
 use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoPSchema\TranslateDirective\DirectiveResolvers\AbstractTranslateDirectiveResolver;
 use PoPSchema\TranslateDirectiveACL\Environment;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
 use PoPSchema\UserStateAccessControl\ConfigurationEntries\UserStates;
 use PoPSchema\UserStateAccessControl\Services\AccessControlGroups as UserStateAccessControlGroups;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         if (Environment::userMustBeLoggedInToAccessTranslateDirective()) {

--- a/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace PoPSchema\TranslateDirectiveACL\Container\CompilerPasses;
 
+use PoP\AccessControl\Services\AccessControlManagerInterface;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoPSchema\TranslateDirective\DirectiveResolvers\AbstractTranslateDirectiveResolver;
+use PoPSchema\TranslateDirectiveACL\Environment;
+use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
+use PoPSchema\UserStateAccessControl\ConfigurationEntries\UserStates;
+use PoPSchema\UserStateAccessControl\Services\AccessControlGroups as UserStateAccessControlGroups;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use PoPSchema\TranslateDirectiveACL\Environment;
-use PoP\AccessControl\Services\AccessControlManagerInterface;
-use PoPSchema\UserStateAccessControl\ConfigurationEntries\UserStates;
-use PoPSchema\TranslateDirective\DirectiveResolvers\AbstractTranslateDirectiveResolver;
-use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
-use PoPSchema\UserStateAccessControl\Services\AccessControlGroups as UserStateAccessControlGroups;
 
-class ConfigureAccessControlCompilerPass implements CompilerPassInterface
+class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         if (Environment::userMustBeLoggedInToAccessTranslateDirective()) {

--- a/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -18,9 +18,9 @@ class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
+        $accessControlManagerDefinition = $containerBuilderWrapper->getDefinition(AccessControlManagerInterface::class);
         if (Environment::userMustBeLoggedInToAccessTranslateDirective()) {
             $accessControlManagerDefinition->addMethodCall(
                 'addEntriesForDirectives',

--- a/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/translate-directive-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -6,7 +6,7 @@ namespace PoPSchema\TranslateDirectiveACL\Container\CompilerPasses;
 
 use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoPSchema\TranslateDirective\DirectiveResolvers\AbstractTranslateDirectiveResolver;
 use PoPSchema\TranslateDirectiveACL\Environment;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
@@ -18,7 +18,7 @@ class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         if (Environment::userMustBeLoggedInToAccessTranslateDirective()) {

--- a/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
+++ b/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PoPSchema\TranslateDirective\Container\CompilerPasses;
 
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoPSchema\TranslateDirective\Environment;
 use PoPSchema\TranslateDirective\Translation\TranslationServiceInterface;
 
@@ -14,7 +14,7 @@ class ConfigureTranslationServiceCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         // If there is a default translation provider, inject it into the service
         if ($defaultTranslationProvider = Environment::getDefaultTranslationProvider()) {

--- a/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
+++ b/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\TranslateDirective\Container\CompilerPasses;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoPSchema\TranslateDirective\Environment;
 use PoPSchema\TranslateDirective\Translation\TranslationServiceInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ConfigureTranslationServiceCompilerPass implements CompilerPassInterface
+class ConfigureTranslationServiceCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         // If there is a default translation provider, inject it into the service
         if ($defaultTranslationProvider = Environment::getDefaultTranslationProvider()) {

--- a/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
+++ b/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
@@ -14,11 +14,11 @@ class ConfigureTranslationServiceCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         // If there is a default translation provider, inject it into the service
         if ($defaultTranslationProvider = Environment::getDefaultTranslationProvider()) {
-            $translationServiceDefinition = $containerBuilder->getDefinition(TranslationServiceInterface::class);
+            $translationServiceDefinition = $containerBuilderWrapper->getDefinition(TranslationServiceInterface::class);
             $translationServiceDefinition->addMethodCall(
                 'setDefaultProvider',
                 [

--- a/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
+++ b/layers/Schema/packages/translate-directive/src/Container/CompilerPasses/ConfigureTranslationServiceCompilerPass.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace PoPSchema\TranslateDirective\Container\CompilerPasses;
 
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoPSchema\TranslateDirective\Environment;
 use PoPSchema\TranslateDirective\Translation\TranslationServiceInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConfigureTranslationServiceCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         // If there is a default translation provider, inject it into the service
         if ($defaultTranslationProvider = Environment::getDefaultTranslationProvider()) {

--- a/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -8,19 +8,19 @@ use PoP\AccessControl\Services\AccessControlGroups as AccessControlGroups;
 use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
 use PoPSchema\UserRolesACL\Environment;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 use PoPSchema\UserStateAccessControl\ConfigurationEntries\UserStates;
 use PoPSchema\UserStateAccessControl\Services\AccessControlGroups as UserStateAccessControlGroups;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         // Inject the access control entries

--- a/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRolesACL\Container\CompilerPasses;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use PoPSchema\UserRolesACL\Environment;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
-use PoP\AccessControl\Services\AccessControlManagerInterface;
-use PoPSchema\UserStateAccessControl\ConfigurationEntries\UserStates;
 use PoP\AccessControl\Services\AccessControlGroups as AccessControlGroups;
+use PoP\AccessControl\Services\AccessControlManagerInterface;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
+use PoPSchema\UserRolesACL\Environment;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
+use PoPSchema\UserStateAccessControl\ConfigurationEntries\UserStates;
 use PoPSchema\UserStateAccessControl\Services\AccessControlGroups as UserStateAccessControlGroups;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class ConfigureAccessControlCompilerPass implements CompilerPassInterface
+class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         // Inject the access control entries

--- a/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -20,9 +20,9 @@ class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
+        $accessControlManagerDefinition = $containerBuilderWrapper->getDefinition(AccessControlManagerInterface::class);
         // Inject the access control entries
         if (Environment::disableRolesFields()) {
             $accessControlManagerDefinition->addMethodCall(

--- a/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
+++ b/layers/Schema/packages/user-roles-acl/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php
@@ -8,7 +8,7 @@ use PoP\AccessControl\Services\AccessControlGroups as AccessControlGroups;
 use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use PoPSchema\UserRolesAccessControl\Services\AccessControlGroups as UserRolesAccessControlGroups;
 use PoPSchema\UserRolesACL\Environment;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
@@ -20,7 +20,7 @@ class ConfigureAccessControlCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $accessControlManagerDefinition = $containerBuilder->getDefinition(AccessControlManagerInterface::class);
         // Inject the access control entries

--- a/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace PoP\Application\Container\CompilerPasses;
 
-use PoP\Definitions\DefinitionManagerInterface;
 use PoP\ComponentModel\Modules\DefinitionGroups;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use PoP\Definitions\DefinitionManagerInterface;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfigureDefinitionCompilerPass implements CompilerPassInterface
+class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -7,7 +7,7 @@ namespace PoP\Application\Container\CompilerPasses;
 use PoP\ComponentModel\Modules\DefinitionGroups;
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
@@ -15,7 +15,7 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -15,9 +15,9 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
+        $definitionManagerDefinition = $containerBuilderWrapper->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(
             'setDefinitionResolver',
             [

--- a/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -8,7 +8,6 @@ use PoP\ComponentModel\Modules\DefinitionGroups;
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Root\Container\ContainerBuilderWrapperInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
 {
@@ -21,7 +20,7 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
         $definitionManagerDefinition->addMethodCall(
             'setDefinitionResolver',
             [
-                new Reference('emoji_definition_resolver'),
+                $this->createReference('emoji_definition_resolver'),
                 DefinitionGroups::MODULES
             ]
         );

--- a/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/application/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -7,7 +7,7 @@ namespace PoP\Application\Container\CompilerPasses;
 use PoP\ComponentModel\Modules\DefinitionGroups;
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
@@ -15,7 +15,7 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
@@ -6,7 +6,7 @@ namespace PoP\DefinitionPersistence\Container\CompilerPasses;
 
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
@@ -14,7 +14,7 @@ class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
@@ -6,7 +6,7 @@ namespace PoP\DefinitionPersistence\Container\CompilerPasses;
 
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
@@ -14,7 +14,7 @@ class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
@@ -7,7 +7,6 @@ namespace PoP\DefinitionPersistence\Container\CompilerPasses;
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Root\Container\ContainerBuilderWrapperInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
 {
@@ -20,7 +19,7 @@ class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
         $definitionManagerDefinition->addMethodCall(
             'setDefinitionPersistence',
             [
-                new Reference('file_definition_persistence')
+                $this->createReference('file_definition_persistence')
             ]
         );
     }

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace PoP\DefinitionPersistence\Container\CompilerPasses;
 
 use PoP\Definitions\DefinitionManagerInterface;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfigureDefinitionPersistenceCompilerPass implements CompilerPassInterface
+class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/Container/CompilerPasses/ConfigureDefinitionPersistenceCompilerPass.php
@@ -14,9 +14,9 @@ class ConfigureDefinitionPersistenceCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
+        $definitionManagerDefinition = $containerBuilderWrapper->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(
             'setDefinitionPersistence',
             [

--- a/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -7,7 +7,7 @@ namespace PoP\Site\Container\CompilerPasses;
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Resources\DefinitionGroups;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use PoP\Root\Container\CompilerPassContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
@@ -15,7 +15,7 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilder $containerBuilder): void
+    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -8,7 +8,6 @@ use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Resources\DefinitionGroups;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use PoP\Root\Container\ContainerBuilderWrapperInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
 {
@@ -21,7 +20,7 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
         $definitionManagerDefinition->addMethodCall(
             'setDefinitionResolver',
             [
-                new Reference('base36_definition_resolver'),
+                $this->createReference('base36_definition_resolver'),
                 DefinitionGroups::RESOURCES
             ]
         );

--- a/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -15,9 +15,9 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
-        $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
+        $definitionManagerDefinition = $containerBuilderWrapper->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(
             'setDefinitionResolver',
             [

--- a/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -7,7 +7,7 @@ namespace PoP\Site\Container\CompilerPasses;
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Resources\DefinitionGroups;
 use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
-use PoP\Root\Container\CompilerPassContainerInterface;
+use PoP\Root\Container\ContainerBuilderWrapperInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
@@ -15,7 +15,7 @@ class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
     /**
      * GraphQL persisted query for Introspection query
      */
-    protected function doProcess(CompilerPassContainerInterface $containerBuilder): void
+    protected function doProcess(ContainerBuilderWrapperInterface $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(

--- a/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
+++ b/layers/SiteBuilder/packages/site/src/Container/CompilerPasses/ConfigureDefinitionCompilerPass.php
@@ -6,16 +6,16 @@ namespace PoP\Site\Container\CompilerPasses;
 
 use PoP\Definitions\DefinitionManagerInterface;
 use PoP\Resources\DefinitionGroups;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use PoP\Root\Container\CompilerPasses\AbstractCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfigureDefinitionCompilerPass implements CompilerPassInterface
+class ConfigureDefinitionCompilerPass extends AbstractCompilerPass
 {
     /**
      * GraphQL persisted query for Introspection query
      */
-    public function process(ContainerBuilder $containerBuilder): void
+    protected function doProcess(ContainerBuilder $containerBuilder): void
     {
         $definitionManagerDefinition = $containerBuilder->getDefinition(DefinitionManagerInterface::class);
         $definitionManagerDefinition->addMethodCall(


### PR DESCRIPTION
Create a `ContainerBuilderWrapper` to wrap the class from Symfony, so we don't need to reference it.

This way, we can add Compiler Passes in the `-wp` packages, which are not scoped with PHP-Scoper (since WordPress logic cannot be scoped).

The example is [`ConfigureAccessControlCompilerPass`](https://github.com/leoloso/PoP/blob/f36e8ea01b64f3921e5fbbccb98852b01bcf1d96/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Container/CompilerPasses/ConfigureAccessControlCompilerPass.php#L26), from the GraphQL API for WordPress plugin.