### PR TITLE
Flush rewrite rules after installing extension

### DIFF
--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
@@ -231,7 +231,7 @@ abstract class AbstractExtension extends AbstractPlugin
         parent::activate();
 
         // Tell the main Plugin to flush the rewrite rules (for if the extension contains CPTs)
-        \update_option(self::OPTION_ACTIVATED_EXTENSION, $this->getPluginName());
+        \update_option(PluginOptions::ACTIVATED_EXTENSION, $this->getPluginName());
     }
 
     /**

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
@@ -228,12 +228,10 @@ abstract class AbstractExtension extends AbstractPlugin
             return;
         }
 
-        // Flush rewrite rules: needed if the extension registers CPTs
-        if ($this->getPluginCustomPostTypes() !== []) {
-            \flush_rewrite_rules();
-        }
-
         parent::activate();
+
+        // Tell the main Plugin to flush the rewrite rules (for if the extension contains CPTs)
+        \update_option(self::OPTION_ACTIVATED_EXTENSION, $this->getPluginName());
     }
 
     /**

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -90,7 +90,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin
             'admin_init',
             function (): void {
                 // If the flag is true, it's the first screen after activating an extension
-                $justActivatedExtension = \get_option(PluginOptions::ACTIVATED_EXTENSION) !== false;
+                $justActivatedExtension = \get_option(PluginOptions::ACTIVATED_EXTENSION);
                 if (!$justActivatedExtension) {
                     return;
                 }

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\PluginSkeleton;
 
+use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\PluginSkeleton\AbstractPlugin;
 
 abstract class AbstractMainPlugin extends AbstractPlugin
@@ -24,6 +25,28 @@ abstract class AbstractMainPlugin extends AbstractPlugin
         // By removing the option (in case it already exists from a previously-installed version),
         // the next request will know the plugin was just installed
         \update_option(self::OPTION_PLUGIN_VERSION, false);
+    }
+
+    /**
+     * Remove permalinks when deactivating the plugin
+     *
+     * @see https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/
+     */
+    public function deactivate(): void
+    {
+        parent::deactivate();
+
+        // Remove the timestamp
+        $this->removeTimestamp();
+    }
+
+    /**
+     * Regenerate the timestamp
+     */
+    protected function removeTimestamp(): void
+    {
+        $userSettingsManager = UserSettingsManagerFacade::getInstance();
+        $userSettingsManager->removeTimestamp();
     }
 
     /**

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -95,6 +95,23 @@ abstract class AbstractMainPlugin extends AbstractPlugin
         \add_action(
             'admin_init',
             function (): void {
+                // If the flag is true, it's the first screen after activating an extension
+                $justActivatedExtension = \get_option(self::OPTION_ACTIVATED_EXTENSION) !== false;
+                if (!$justActivatedExtension) {
+                    return;
+                }
+                // Remove the entry
+                \delete_option(self::OPTION_ACTIVATED_EXTENSION);
+                // Required logic after extension is activated
+                \flush_rewrite_rules();
+
+                $this->extensionJustActivated((string) $justActivatedExtension);
+            }
+        );
+
+        \add_action(
+            'admin_init',
+            function (): void {
                 // Do not execute when doing Ajax, since we can't show the one-time
                 // admin notice to the user then
                 if (\wp_doing_ajax()) {
@@ -140,6 +157,13 @@ abstract class AbstractMainPlugin extends AbstractPlugin
      * Execute logic after the plugin has just been activated
      */
     protected function pluginJustActivated(): void
+    {
+    }
+
+    /**
+     * Execute logic after the plugin has just been activated
+     */
+    protected function extensionJustActivated(string $extension): void
     {
     }
 

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -10,12 +10,6 @@ use GraphQLAPI\PluginSkeleton\AbstractPlugin;
 abstract class AbstractMainPlugin extends AbstractPlugin
 {
     /**
-     * Store the plugin version in the Options table, to track when
-     * the plugin is installed/updated
-     */
-    public const OPTION_PLUGIN_VERSION = 'graphql-api-plugin-version';
-
-    /**
      * Activate the plugin
      */
     public function activate(): void
@@ -24,7 +18,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin
 
         // By removing the option (in case it already exists from a previously-installed version),
         // the next request will know the plugin was just installed
-        \update_option(self::OPTION_PLUGIN_VERSION, false);
+        \update_option(PluginOptions::PLUGIN_VERSION, false);
     }
 
     /**
@@ -79,12 +73,12 @@ abstract class AbstractMainPlugin extends AbstractPlugin
             'admin_init',
             function (): void {
                 // If there is no version stored, it's the first screen after activating the plugin
-                $isPluginJustActivated = \get_option(self::OPTION_PLUGIN_VERSION) === false;
+                $isPluginJustActivated = \get_option(PluginOptions::PLUGIN_VERSION) === false;
                 if (!$isPluginJustActivated) {
                     return;
                 }
                 // Update to the current version
-                \update_option(self::OPTION_PLUGIN_VERSION, \GRAPHQL_API_VERSION);
+                \update_option(PluginOptions::PLUGIN_VERSION, \GRAPHQL_API_VERSION);
                 // Required logic after plugin is activated
                 \flush_rewrite_rules();
 
@@ -96,12 +90,12 @@ abstract class AbstractMainPlugin extends AbstractPlugin
             'admin_init',
             function (): void {
                 // If the flag is true, it's the first screen after activating an extension
-                $justActivatedExtension = \get_option(self::OPTION_ACTIVATED_EXTENSION) !== false;
+                $justActivatedExtension = \get_option(PluginOptions::ACTIVATED_EXTENSION) !== false;
                 if (!$justActivatedExtension) {
                     return;
                 }
                 // Remove the entry
-                \delete_option(self::OPTION_ACTIVATED_EXTENSION);
+                \delete_option(PluginOptions::ACTIVATED_EXTENSION);
                 // Required logic after extension is activated
                 \flush_rewrite_rules();
 
@@ -120,12 +114,12 @@ abstract class AbstractMainPlugin extends AbstractPlugin
                 // Check if the plugin has been updated: if the stored version in the DB
                 // and the current plugin's version are different
                 // It could also be false from the first time we install the plugin
-                $storedVersion = \get_option(self::OPTION_PLUGIN_VERSION, \GRAPHQL_API_VERSION);
+                $storedVersion = \get_option(PluginOptions::PLUGIN_VERSION, \GRAPHQL_API_VERSION);
                 if (!$storedVersion || $storedVersion == \GRAPHQL_API_VERSION) {
                     return;
                 }
                 // Update to the current version
-                \update_option(self::OPTION_PLUGIN_VERSION, \GRAPHQL_API_VERSION);
+                \update_option(PluginOptions::PLUGIN_VERSION, \GRAPHQL_API_VERSION);
 
                 $this->pluginJustUpdated($storedVersion);
             }

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractPlugin.php
@@ -12,12 +12,6 @@ use PoP\Engine\AppLoader;
 abstract class AbstractPlugin
 {
     /**
-     * Store when an extension is activated in the Options table,
-     * to flush the rewrite rules
-     */
-    public const OPTION_ACTIVATED_EXTENSION = 'graphql-api-activated-extension';
-
-    /**
      * The main plugin file
      */
     protected string $pluginFile;

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractPlugin.php
@@ -12,6 +12,12 @@ use PoP\Engine\AppLoader;
 abstract class AbstractPlugin
 {
     /**
+     * Store when an extension is activated in the Options table,
+     * to flush the rewrite rules
+     */
+    public const OPTION_ACTIVATED_EXTENSION = 'graphql-api-activated-extension';
+
+    /**
      * The main plugin file
      */
     protected string $pluginFile;

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginOptions.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginOptions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\PluginSkeleton;
+
+class PluginOptions
+{
+    /**
+     * Store the plugin version in the Options table, to track when
+     * the plugin is installed/updated
+     */
+    public const PLUGIN_VERSION = 'graphql-api-plugin-version';
+
+    /**
+     * Store when an extension is activated in the Options table,
+     * to flush the rewrite rules
+     */
+    public const ACTIVATED_EXTENSION = 'graphql-api-activated-extension';
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -30,24 +30,6 @@ class Plugin extends AbstractMainPlugin
     public const NAMESPACE = __NAMESPACE__;
 
     /**
-     * Store the plugin version in the Options table, to track when
-     * the plugin is installed/updated
-     */
-    public const OPTION_PLUGIN_VERSION = 'graphql-api-plugin-version';
-
-    /**
-     * Activate the plugin
-     */
-    public function activate(): void
-    {
-        parent::activate();
-
-        // By removing the option (in case it already exists from a previously-installed version),
-        // the next request will know the plugin was just installed
-        \update_option(self::OPTION_PLUGIN_VERSION, false);
-    }
-
-    /**
      * Remove permalinks when deactivating the plugin
      *
      * @see https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/
@@ -61,66 +43,28 @@ class Plugin extends AbstractMainPlugin
     }
 
     /**
-     * Plugin set-up, executed immediately when loading the plugin.
+     * Show an admin notice with a link to the latest release notes
      */
-    public function setup(): void
+    protected function pluginJustUpdated(string $storedVersion): void
     {
-        parent::setup();
-
-        \add_action(
-            'admin_init',
-            function (): void {
-                // If there is no version stored, it's the first screen after activating the plugin
-                $isPluginJustActivated = \get_option(self::OPTION_PLUGIN_VERSION) === false;
-                if (!$isPluginJustActivated) {
-                    return;
-                }
-                // Update to the current version
-                \update_option(self::OPTION_PLUGIN_VERSION, \GRAPHQL_API_VERSION);
-                // Required logic after plugin is activated
-                \flush_rewrite_rules();
-            }
-        );
-        /**
-         * Show an admin notice with a link to the latest release notes
-         */
-        \add_action(
-            'admin_init',
-            function (): void {
-                // Do not execute when doing Ajax, since we can't show the one-time
-                // admin notice to the user then
-                if (\wp_doing_ajax()) {
-                    return;
-                }
-                // Check if the plugin has been updated: if the stored version in the DB
-                // and the current plugin's version are different
-                // It could also be false from the first time we install the plugin
-                $storedVersion = \get_option(self::OPTION_PLUGIN_VERSION, \GRAPHQL_API_VERSION);
-                if (!$storedVersion || $storedVersion == \GRAPHQL_API_VERSION) {
-                    return;
-                }
-                // Update to the current version
-                \update_option(self::OPTION_PLUGIN_VERSION, \GRAPHQL_API_VERSION);
-                // Admin notice: Check if it is enabled
-                $userSettingsManager = UserSettingsManagerFacade::getInstance();
-                if (
-                    !$userSettingsManager->getSetting(
-                        PluginManagementFunctionalityModuleResolver::GENERAL,
-                        PluginManagementFunctionalityModuleResolver::OPTION_ADD_RELEASE_NOTES_ADMIN_NOTICE
-                    )
-                ) {
-                    return;
-                }
-                // Show admin notice only when updating MAJOR or MINOR versions. No need for PATCH versions
-                $currentMinorReleaseVersion = $this->getMinorReleaseVersion(\GRAPHQL_API_VERSION);
-                $previousMinorReleaseVersion = $this->getMinorReleaseVersion($storedVersion);
-                if ($currentMinorReleaseVersion == $previousMinorReleaseVersion) {
-                    return;
-                }
-                // All checks passed, show the release notes
-                $this->showReleaseNotesInAdminNotice();
-            }
-        );
+        // Admin notice: Check if it is enabled
+        $userSettingsManager = UserSettingsManagerFacade::getInstance();
+        if (
+            !$userSettingsManager->getSetting(
+                PluginManagementFunctionalityModuleResolver::GENERAL,
+                PluginManagementFunctionalityModuleResolver::OPTION_ADD_RELEASE_NOTES_ADMIN_NOTICE
+            )
+        ) {
+            return;
+        }
+        // Show admin notice only when updating MAJOR or MINOR versions. No need for PATCH versions
+        $currentMinorReleaseVersion = $this->getMinorReleaseVersion(\GRAPHQL_API_VERSION);
+        $previousMinorReleaseVersion = $this->getMinorReleaseVersion($storedVersion);
+        if ($currentMinorReleaseVersion == $previousMinorReleaseVersion) {
+            return;
+        }
+        // All checks passed, show the release notes
+        $this->showReleaseNotesInAdminNotice();
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -30,19 +30,6 @@ class Plugin extends AbstractMainPlugin
     public const NAMESPACE = __NAMESPACE__;
 
     /**
-     * Remove permalinks when deactivating the plugin
-     *
-     * @see https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/
-     */
-    public function deactivate(): void
-    {
-        parent::deactivate();
-
-        // Remove the timestamp
-        $this->removeTimestamp();
-    }
-
-    /**
      * Show an admin notice with a link to the latest release notes
      */
     protected function pluginJustUpdated(string $storedVersion): void
@@ -252,14 +239,5 @@ class Plugin extends AbstractMainPlugin
         AppLoader::bootApplication(
             ...PluginConfiguration::getContainerCacheConfiguration()
         );
-    }
-
-    /**
-     * Regenerate the timestamp
-     */
-    protected function removeTimestamp(): void
-    {
-        $userSettingsManager = UserSettingsManagerFacade::getInstance();
-        $userSettingsManager->removeTimestamp();
     }
 }


### PR DESCRIPTION
Store a flag in the DB after activating an extension, so we can call `flush_rewrite_rules` immediately after.

This is needed if the extension contains CPTs with `addRewriteEndpoints` which must be set by a service, and only after must be flushed.

(Container services from the activated extension are not loaded by the time WordPress calls `activate`, that's why the `flush_rewrite_rules` is executed on the following screen)