### PR TITLE
Activate extension plugin on its main file, since AbstractExtension is hosted on main plugin

### DIFF
--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
@@ -92,7 +92,7 @@ abstract class AbstractExtension extends AbstractPlugin
                     [$this, 'boot']
                 );
             },
-            100
+            PluginLifecyclePriorities::SETUP_EXTENSIONS
         );
     }
 

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
@@ -231,18 +231,4 @@ abstract class AbstractExtension extends AbstractPlugin
     {
         // Function to override
     }
-
-    /**
-     * Remove permalinks when deactivating the plugin
-     *
-     * @see https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/
-     */
-    public function deactivate(): void
-    {
-        if (!$this->isGraphQLAPIPluginActive()) {
-            return;
-        }
-
-        parent::deactivate();
-    }
 }

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
@@ -57,7 +57,7 @@ abstract class AbstractExtension extends AbstractPlugin
         parent::setup();
 
         /**
-         * Priority 0: before the GraphQL API plugin is initialized
+         * Priority 100: before the GraphQL API plugin is initialized
          */
         \add_action(
             'plugins_loaded',
@@ -92,7 +92,7 @@ abstract class AbstractExtension extends AbstractPlugin
                     [$this, 'boot']
                 );
             },
-            0
+            100
         );
     }
 

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
@@ -7,6 +7,21 @@ namespace GraphQLAPI\PluginSkeleton;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\SystemModuleRegistryFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
 
+/**
+ * This class is hosted within the graphql-api-for-wp plugin, and not
+ * within the extension plugin. That means that the main plugin
+ * must be installed, for any extension to work.
+ *
+ * This class doesn't have an `activate` function, because `activate`
+ * can't be executed within "plugins_loaded", on which we find out if the
+ * main plugin is installed and activated.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_activation_hook/#more-information
+ *
+ * Then, the activation must be done on the extension's main file.
+ *
+ * @see
+ */
 abstract class AbstractExtension extends AbstractPlugin
 {
     /**
@@ -215,23 +230,6 @@ abstract class AbstractExtension extends AbstractPlugin
     protected function doConfigure(): void
     {
         // Function to override
-    }
-
-    /**
-     * Get permalinks to work when activating the plugin
-     *
-     * @see https://codex.wordpress.org/Function_Reference/register_post_type#Flushing_Rewrite_on_Activation
-     */
-    public function activate(): void
-    {
-        if (!$this->isGraphQLAPIPluginActive()) {
-            return;
-        }
-
-        parent::activate();
-
-        // Tell the main Plugin to flush the rewrite rules (for if the extension contains CPTs)
-        \update_option(PluginOptions::ACTIVATED_EXTENSION, $this->getPluginName());
     }
 
     /**

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -58,6 +58,8 @@ abstract class AbstractMainPlugin extends AbstractPlugin
         parent::setup();
 
         /**
+         * Logic to check if the plugin has just been activated or updated.
+         *
          * Regenerate the container here, and not in the `activate` function,
          * because `activate` doesn't get called within the "plugins_loaded" hook.
          * This is not an issue to register the main plugin, but it is for extensions,
@@ -92,6 +94,9 @@ abstract class AbstractMainPlugin extends AbstractPlugin
             }
         );
 
+        /**
+         * Logic to check if an extension has just been activated.
+         */
         \add_action(
             'admin_init',
             function (): void {

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -52,18 +52,8 @@ abstract class AbstractMainPlugin extends AbstractPlugin
      * - The plugin must execute its logic before the extensions
      * - The services can't be booted before all services have been initialized
      *
-     * To attain the needed order, we execute them using hook "plugins_loaded":
-     *
-     * 1. GraphQL API => setup(): immediately
-     * 2. GraphQL API extensions => setup(): priority 100
-     * 3. GraphQL API => initialize(): priority 110
-     * 4. GraphQL API extensions => initialize(): priority 120
-     * 5. GraphQL API => bootSystem(): priority 130
-     * 3. GraphQL API => configure(): priority 140
-     * 4. GraphQL API extensions => configure(): priority 150
-     * 5. GraphQL API => bootApplication(): priority 160
-     * 6. GraphQL API => boot(): priority 170
-     * 7. GraphQL API extensions => boot(): priority 180
+     * To attain the needed order, we execute them using hook "plugins_loaded",
+     * with all the priorities defined in PluginLifecyclePriorities
      */
     public function setup(): void
     {
@@ -125,6 +115,23 @@ abstract class AbstractMainPlugin extends AbstractPlugin
             }
         );
 
+        $this->executeSetupProcedure();
+    }
+
+    /**
+     * There are three stages for the main plugin, and for each extension plugin:
+     * `setup`, `initialize` and `boot`.
+     *
+     * This is because:
+     *
+     * - The plugin must execute its logic before the extensions
+     * - The services can't be booted before all services have been initialized
+     *
+     * To attain the needed order, we execute them using hook "plugins_loaded",
+     * with all the priorities defined in PluginLifecyclePriorities
+     */
+    final protected function executeSetupProcedure(): void
+    {
         /**
          * Wait until "plugins_loaded" to initialize the plugin, because:
          *

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -131,20 +131,20 @@ abstract class AbstractMainPlugin extends AbstractPlugin
          * - ModuleListTableAction requires `wp_verify_nonce`, loaded in pluggable.php
          * - Allow other plugins to inject their own functionality
          */
-        \add_action('plugins_loaded', [$this, 'initialize'], 110);
+        \add_action('plugins_loaded', [$this, 'initialize'], PluginLifecyclePriorities::INITIALIZE_PLUGIN);
         \add_action('plugins_loaded', function () {
             \do_action(PluginLifecycleHooks::INITIALIZE_EXTENSION);
-        }, 120);
-        \add_action('plugins_loaded', [$this, 'bootSystem'], 130);
-        \add_action('plugins_loaded', [$this, 'configure'], 140);
+        }, PluginLifecyclePriorities::INITIALIZE_EXTENSIONS);
+        \add_action('plugins_loaded', [$this, 'bootSystem'], PluginLifecyclePriorities::BOOT_SYSTEM);
+        \add_action('plugins_loaded', [$this, 'configure'], PluginLifecyclePriorities::CONFIGURE_PLUGIN);
         \add_action('plugins_loaded', function () {
             \do_action(PluginLifecycleHooks::CONFIGURE_EXTENSION);
-        }, 150);
-        \add_action('plugins_loaded', [$this, 'bootApplication'], 160);
-        \add_action('plugins_loaded', [$this, 'boot'], 170);
+        }, PluginLifecyclePriorities::CONFIGURE_EXTENSIONS);
+        \add_action('plugins_loaded', [$this, 'bootApplication'], PluginLifecyclePriorities::BOOT_APPLICATION);
+        \add_action('plugins_loaded', [$this, 'boot'], PluginLifecyclePriorities::BOOT_PLUGIN);
         \add_action('plugins_loaded', function () {
             \do_action(PluginLifecycleHooks::BOOT_EXTENSION);
-        }, 180);
+        }, PluginLifecyclePriorities::BOOT_EXTENSIONS);
     }
 
     /**

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractMainPlugin.php
@@ -55,15 +55,15 @@ abstract class AbstractMainPlugin extends AbstractPlugin
      * To attain the needed order, we execute them using hook "plugins_loaded":
      *
      * 1. GraphQL API => setup(): immediately
-     * 2. GraphQL API extensions => setup(): priority 0
-     * 3. GraphQL API => initialize(): priority 10
-     * 4. GraphQL API extensions => initialize(): priority 20
-     * 5. GraphQL API => bootSystem(): priority 30
-     * 3. GraphQL API => configure(): priority 40
-     * 4. GraphQL API extensions => configure(): priority 50
-     * 5. GraphQL API => bootApplication(): priority 60
-     * 6. GraphQL API => boot(): priority 70
-     * 7. GraphQL API extensions => boot(): priority 80
+     * 2. GraphQL API extensions => setup(): priority 100
+     * 3. GraphQL API => initialize(): priority 110
+     * 4. GraphQL API extensions => initialize(): priority 120
+     * 5. GraphQL API => bootSystem(): priority 130
+     * 3. GraphQL API => configure(): priority 140
+     * 4. GraphQL API extensions => configure(): priority 150
+     * 5. GraphQL API => bootApplication(): priority 160
+     * 6. GraphQL API => boot(): priority 170
+     * 7. GraphQL API extensions => boot(): priority 180
      */
     public function setup(): void
     {
@@ -131,20 +131,20 @@ abstract class AbstractMainPlugin extends AbstractPlugin
          * - ModuleListTableAction requires `wp_verify_nonce`, loaded in pluggable.php
          * - Allow other plugins to inject their own functionality
          */
-        \add_action('plugins_loaded', [$this, 'initialize'], 10);
+        \add_action('plugins_loaded', [$this, 'initialize'], 110);
         \add_action('plugins_loaded', function () {
             \do_action(PluginLifecycleHooks::INITIALIZE_EXTENSION);
-        }, 20);
-        \add_action('plugins_loaded', [$this, 'bootSystem'], 30);
-        \add_action('plugins_loaded', [$this, 'configure'], 40);
+        }, 120);
+        \add_action('plugins_loaded', [$this, 'bootSystem'], 130);
+        \add_action('plugins_loaded', [$this, 'configure'], 140);
         \add_action('plugins_loaded', function () {
             \do_action(PluginLifecycleHooks::CONFIGURE_EXTENSION);
-        }, 50);
-        \add_action('plugins_loaded', [$this, 'bootApplication'], 60);
-        \add_action('plugins_loaded', [$this, 'boot'], 70);
+        }, 150);
+        \add_action('plugins_loaded', [$this, 'bootApplication'], 160);
+        \add_action('plugins_loaded', [$this, 'boot'], 170);
         \add_action('plugins_loaded', function () {
             \do_action(PluginLifecycleHooks::BOOT_EXTENSION);
-        }, 80);
+        }, 180);
     }
 
     /**

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractPlugin.php
@@ -200,15 +200,6 @@ abstract class AbstractPlugin
     }
 
     /**
-     * Activate the plugin
-     */
-    public function activate(): void
-    {
-        // Initialize the timestamp
-        $this->regenerateTimestamp();
-    }
-
-    /**
      * Remove permalinks when deactivating the plugin
      *
      * @see https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginLifecyclePriorities.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginLifecyclePriorities.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\PluginSkeleton;
+
+/**
+ * There are three stages for the main plugin, and for each extension plugin:
+ * `setup`, `initialize` and `boot`.
+ *
+ * This is because:
+ *
+ * - The plugin must execute its logic before the extensions
+ * - The services can't be booted before all services have been initialized
+ *
+ * To attain the needed order, we execute them using hook "plugins_loaded":
+ *
+ * 1. GraphQL API => setup(): immediately (not on "plugins_loaded")
+ * 2. GraphQL API extensions => setup(): priority 100
+ * 3. GraphQL API => initialize(): priority 110
+ * 4. GraphQL API extensions => initialize(): priority 120
+ * 5. GraphQL API => bootSystem(): priority 130
+ * 3. GraphQL API => configure(): priority 140
+ * 4. GraphQL API extensions => configure(): priority 150
+ * 5. GraphQL API => bootApplication(): priority 160
+ * 6. GraphQL API => boot(): priority 170
+ * 7. GraphQL API extensions => boot(): priority 180
+ */
+class PluginLifecyclePriorities
+{
+    public const SETUP_EXTENSIONS = 100;
+    public const INITIALIZE_PLUGIN = 110;
+    public const INITIALIZE_EXTENSIONS = 120;
+    public const BOOT_SYSTEM = 130;
+    public const CONFIGURE_PLUGIN = 140;
+    public const CONFIGURE_EXTENSIONS = 150;
+    public const BOOT_APPLICATION = 160;
+    public const BOOT_PLUGIN = 170;
+    public const BOOT_EXTENSIONS = 180;
+}

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginLifecyclePriorities.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginLifecyclePriorities.php
@@ -16,18 +16,20 @@ namespace GraphQLAPI\PluginSkeleton;
  * To attain the needed order, we execute them using hook "plugins_loaded":
  *
  * 1. GraphQL API => setup(): immediately (not on "plugins_loaded")
- * 2. GraphQL API extensions => setup(): priority 100
- * 3. GraphQL API => initialize(): priority 110
- * 4. GraphQL API extensions => initialize(): priority 120
- * 5. GraphQL API => bootSystem(): priority 130
- * 3. GraphQL API => configure(): priority 140
- * 4. GraphQL API extensions => configure(): priority 150
- * 5. GraphQL API => bootApplication(): priority 160
- * 6. GraphQL API => boot(): priority 170
- * 7. GraphQL API extensions => boot(): priority 180
+ * 2. System => handleNewActivations(): priority 0
+ * 3. GraphQL API extensions => setup(): priority 100
+ * 4. GraphQL API => initialize(): priority 110
+ * 5. GraphQL API extensions => initialize(): priority 120
+ * 6. GraphQL API => bootSystem(): priority 130
+ * 7. GraphQL API => configure(): priority 140
+ * 8. GraphQL API extensions => configure(): priority 150
+ * 9. GraphQL API => bootApplication(): priority 160
+ * 10. GraphQL API => boot(): priority 170
+ * 11. GraphQL API extensions => boot(): priority 180
  */
 class PluginLifecyclePriorities
 {
+    public const HANDLE_NEW_ACTIVATIONS = 0;
     public const SETUP_EXTENSIONS = 100;
     public const INITIALIZE_PLUGIN = 110;
     public const INITIALIZE_EXTENSIONS = 120;

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginOptions.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/PluginOptions.php
@@ -14,7 +14,11 @@ class PluginOptions
 
     /**
      * Store when an extension is activated in the Options table,
-     * to flush the rewrite rules
+     * to flush the rewrite rules.
+     *
+     * Watch out: when registering a new extension,
+     * this value will be added manually, not via the const.
+     * Then, do NOT change this value!
      */
-    public const ACTIVATED_EXTENSION = 'graphql-api-activated-extension';
+    public const ACTIVATED_EXTENSION = 'graphql-api-extension';
 }

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
@@ -14,8 +14,6 @@ Text Domain: graphql-api-convert-case-directives
 Domain Path: /languages
 */
 
-use GraphQLAPI\ConvertCaseDirectives\GraphQLAPIExtension;
-
 // Exit if accessed directly
 if (!defined('ABSPATH')) {
     exit;
@@ -36,5 +34,5 @@ add_action('plugins_loaded', function (): void {
     if (!class_exists('\GraphQLAPI\GraphQLAPI\Plugin')) {
         return;
     }
-    (new GraphQLAPIExtension(__FILE__))->setup();
+    (new \GraphQLAPI\ConvertCaseDirectives\GraphQLAPIExtension(__FILE__))->setup();
 });

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
@@ -27,5 +27,14 @@ define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_VERSION', '0.7.13');
 // Load Composer’s autoloader
 require_once(__DIR__ . '/vendor/autoload.php');
 
-// Create and set-up the plugin instance
-(new GraphQLAPIExtension(__FILE__))->setup();
+register_activation_hook(__FILE__, function (): void {
+    \update_option('graphql-api-extension', true);
+});
+
+// If the GraphQL API plugin is active => Create and set-up the extension
+add_action('plugins_loaded', function (): void {
+    if (!class_exists('\GraphQLAPI\GraphQLAPI\Plugin')) {
+        return;
+    }
+    (new GraphQLAPIExtension(__FILE__))->setup();
+});

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -34,6 +34,12 @@ class Plugin extends AbstractMainPlugin
      */
     protected function pluginJustUpdated(string $storedVersion): void
     {
+        // Do not execute when doing Ajax, since we can't show the one-time
+        // admin notice to the user then
+        if (\wp_doing_ajax()) {
+            return;
+        }
+
         // Admin notice: Check if it is enabled
         $userSettingsManager = UserSettingsManagerFacade::getInstance();
         if (


### PR DESCRIPTION
Moved the `activate` method out from `AbstractExtension` and into the extension's main file.

That's because `activate` [can't be called within hook `"plugins_loaded"`](https://developer.wordpress.org/reference/functions/register_activation_hook/#more-information), on which we depend to see if the main plugin is installed and activated (if it is not, `AbstractExtension` will not exist).

Added method `handleNewActivations` to be executed on `"plugins_loaded"` with priority 0 (i.e. at the beginning of the lifecycle), and not on `"admin_init", because the latter one is executed after, so by then the services are initialized, and if an extension is installed it throws an exception, since it's accessing the container from the previous state (it wasn't dumped yet).