### PR TITLE
Move plugin skeleton back to main plugin

### DIFF
--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/src/AbstractExtension.php
@@ -20,7 +20,7 @@ use PoP\ComponentModel\Misc\GeneralUtils;
  *
  * Then, the activation must be done on the extension's main file.
  *
- * @see
+ * @see https://github.com/leoloso/PoP/blob/bdbe7c911f3a7919c42e19d42a1354de1a94806c/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php#L29
  */
 abstract class AbstractExtension extends AbstractPlugin
 {

--- a/layers/GraphQLAPIForWP/packages/plugin-skeleton/tests/Extension.php
+++ b/layers/GraphQLAPIForWP/packages/plugin-skeleton/tests/Extension.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace GraphQLAPI\PluginSkeleton;
-
-class Extension extends AbstractExtension
-{
-}

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
@@ -16,7 +16,6 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4|^8.0",
-        "graphql-api/plugin-skeleton": "^0.8",
         "pop-schema/convert-case-directives": "^0.8"
     },
     "require-dev": {

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json
@@ -19,6 +19,7 @@
         "pop-schema/convert-case-directives": "^0.8"
     },
     "require-dev": {
+        "graphql-api/graphql-api-for-wp": "^0.8",
         "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/Component.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\ConvertCaseDirectives;
 
-use GraphQLAPI\PluginSkeleton\AbstractExtensionComponent;
+use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractExtensionComponent;
 
 /**
  * Initialize component

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/GraphQLAPIExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/GraphQLAPIExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\ConvertCaseDirectives;
 
 use GraphQLAPI\ConvertCaseDirectives\HybridServices\ModuleResolvers\SchemaModuleResolver;
-use GraphQLAPI\PluginSkeleton\AbstractExtension;
+use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractExtension;
 
 class GraphQLAPIExtension extends AbstractExtension
 {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "^7.4|^8.0",
         "graphql-api/markdown-convertor": "^0.8",
-        "graphql-api/plugin-skeleton": "^0.8",
         "pop-schema/generic-customposts": "^0.8",
         "pop-schema/commentmeta-wp": "^0.8",
         "pop-schema/comments-wp": "^0.8",

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -9,7 +9,7 @@ use GraphQLAPI\GraphQLAPI\Facades\Registries\SystemModuleRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\GraphQLAPI\HybridServices\ModuleResolvers\ClientFunctionalityModuleResolver;
 use GraphQLAPI\GraphQLAPI\HybridServices\ModuleResolvers\PerformanceFunctionalityModuleResolver;
-use GraphQLAPI\PluginSkeleton\AbstractPluginComponent;
+use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractPluginComponent;
 
 /**
  * Initialize component

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -18,7 +18,7 @@ use GraphQLAPI\GraphQLAPI\Services\MenuPages\AboutMenuPage;
 use GraphQLAPI\GraphQLAPI\Services\MenuPages\ModulesMenuPage;
 use GraphQLAPI\GraphQLAPI\Services\MenuPages\SettingsMenuPage;
 use GraphQLAPI\GraphQLAPI\Services\Menus\Menu;
-use GraphQLAPI\PluginSkeleton\AbstractMainPlugin;
+use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractMainPlugin;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\Engine\AppLoader;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 use GraphQLAPI\GraphQLAPI\Facades\Registries\SystemModuleRegistryFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtensionComponent.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtensionComponent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 abstract class AbstractExtensionComponent extends AbstractPluginComponent
 {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
-use GraphQLAPI\PluginSkeleton\AbstractPlugin;
+use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractPlugin;
 
 abstract class AbstractMainPlugin extends AbstractPlugin
 {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 use GraphQLAPI\GraphQLAPI\Facades\Registries\CustomPostTypeRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\CustomPostTypeInterface;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPluginComponent.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPluginComponent.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 use PoP\Root\Component\AbstractComponent;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginLifecycleHooks.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginLifecycleHooks.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 class PluginLifecycleHooks
 {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginLifecyclePriorities.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginLifecyclePriorities.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 /**
  * There are three stages for the main plugin, and for each extension plugin:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginOptions.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginOptions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 class PluginOptions
 {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/tests/Extension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/tests/Extension.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GraphQLAPI\GraphQLAPI;
+
+use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractExtension;
+
+class Extension extends AbstractExtension
+{
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/tests/ExtensionTest.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/tests/ExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GraphQLAPI\PluginSkeleton;
+namespace GraphQLAPI\GraphQLAPI;
 
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +14,7 @@ class ExtensionTest extends TestCase
         $extension = new Extension('');
         $this->assertEquals(
             $extension->getPluginNamespace(),
-            'GraphQLAPI\PluginSkeleton'
+            'GraphQLAPI\GraphQLAPI'
         );
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/composer.json
@@ -16,8 +16,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4|^8.0",
-        "getpop/configurable-schema-feedback": "^0.8",
-        "graphql-api/plugin-skeleton": "^0.8"
+        "getpop/configurable-schema-feedback": "^0.8"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.76",

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/composer.json
@@ -19,6 +19,7 @@
         "getpop/configurable-schema-feedback": "^0.8"
     },
     "require-dev": {
+        "graphql-api/graphql-api-for-wp": "^0.8",
         "phpstan/phpstan": "^0.12.76",
         "phpunit/phpunit": ">=9.3",
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/src/GraphQLAPIExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/src/GraphQLAPIExtension.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\SchemaFeedback;
 
-use GraphQLAPI\PluginSkeleton\AbstractExtension;
+use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractExtension;
 
 class GraphQLAPIExtension extends AbstractExtension
 {


### PR DESCRIPTION
Moved `graphql-api/plugin-skeleton` back to the main plugin, as to avoid having to generate other packages (`packages/user-settings`, `packages/modules`, and `packages/custom-post-type-services`) from code existing in the main plugin.

Since `AbstractExtension` is hosted in the main plugin, and extensions need the main plugin to be installed anyway, then doing this is OK.