### PR TITLE
Fix bug "ModuleListTable not defined as a service"

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/ModuleListTable.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/ModuleListTable.php
@@ -10,7 +10,7 @@ use GraphQLAPI\GraphQLAPI\Services\MenuPages\ModulesMenuPage;
 use GraphQLAPI\GraphQLAPI\Services\MenuPages\SettingsMenuPage;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleTypeRegistryFacade;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
-use GraphQLAPI\GraphQLAPI\Admin\TableActions\ModuleListTableAction;
+use GraphQLAPI\GraphQLAPI\Services\Admin\TableActions\ModuleListTableAction;
 
 /**
  * Module Table

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI;
 
-use GraphQLAPI\GraphQLAPI\Admin\TableActions\ModuleListTableAction;
+use GraphQLAPI\GraphQLAPI\Services\Admin\TableActions\ModuleListTableAction;
 use GraphQLAPI\GraphQLAPI\Constants\RequestParams;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/AbstractListTableAction.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/AbstractListTableAction.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\GraphQLAPI\Admin\TableActions;
-
-use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
+namespace GraphQLAPI\GraphQLAPI\Services\Admin\TableActions;
 
 /**
  * Table Action

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/ModuleListTableAction.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/ModuleListTableAction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\GraphQLAPI\Admin\TableActions;
+namespace GraphQLAPI\GraphQLAPI\Services\Admin\TableActions;
 
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractTableMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractTableMenuPage.php
@@ -6,7 +6,6 @@ namespace GraphQLAPI\GraphQLAPI\Services\MenuPages;
 
 use GraphQLAPI\GraphQLAPI\Services\MenuPages\AbstractMenuPage;
 use GraphQLAPI\GraphQLAPI\Admin\Tables\AbstractItemListTable;
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 
 /**
  * Table menu page
@@ -83,14 +82,12 @@ abstract class AbstractTableMenuPage extends AbstractMenuPage
         }
 
         /**
-         * Instantiate the table object
+         * Instantiate the table object.
+         * It inherits from \WP_List_Table, which is not available when defining services.
+         * Hence, cannot use the container.
          */
-        $instanceManager = InstanceManagerFacade::getInstance();
-        /**
-         * @var AbstractItemListTable
-         */
-        $tableObject = $instanceManager->getInstance($this->getTableClass());
-        $this->tableObject = $tableObject;
+        $tableClass = $this->getTableClass();
+        $this->tableObject = new $tableClass();
         /**
          * Set properties
          */


### PR DESCRIPTION
`ModuleListTable` inherits from `WP_List_Table`, which is not available by the time the services are initialized.

Hence, instantiate the class directly, not through the container.

Also, moved all `TableActions` under `Services/`