### PR TITLE
Have modules in extensions provide their own documentation

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/docs/en/modules/convert-case-directives.md
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/docs/en/modules/convert-case-directives.md
@@ -1,1 +1,59 @@
 # Convert Case Directives
+
+Set of directives to manipulate strings:
+
+- `@upperCase`: converts the text to uppercase => `"HELLO FRIENDS"`
+- `@lowerCase`: converts the text to lowercase => `"hello friends"`
+- `@titleCase`: converts the text to title case => `"Hello Friends"`
+
+## Usage
+
+For instance, if these query produces the results below:
+
+```graphql
+{
+  posts {
+    title
+  }
+}
+```
+
+```json
+{
+  "data": {
+    "posts": [
+      {
+        "title": "Hello world!"
+      },
+      {
+        "title": "lovely weather"
+      }
+    ]
+  }
+}
+```
+
+Then, the following query will produce the following response:
+
+```graphql
+{
+  posts {
+    title @upperCase
+  }
+}
+```
+
+```json
+{
+  "data": {
+    "posts": [
+      {
+        "title": "HELLO WORLD!"
+      },
+      {
+        "title": "LOVELY WEATHER"
+      }
+    ]
+  }
+}
+```

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/graphql-api-convert-case-directives.php
@@ -21,6 +21,8 @@ if (!defined('ABSPATH')) {
 
 define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_PLUGIN_FILE', __FILE__);
 define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_VERSION', '0.7.13');
+define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_DIR', dirname(__FILE__));
+define('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_URL', plugin_dir_url(__FILE__));
 
 // Load Composer’s autoloader
 require_once(__DIR__ . '/vendor/autoload.php');

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/ModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/ModuleResolverTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\ConvertCaseDirectives\ModuleResolvers;
+
+use GraphQLAPI\GraphQLAPI\ModuleResolvers\HasMarkdownDocumentationModuleResolverTrait;
+
+trait ModuleResolverTrait
+{
+    use HasMarkdownDocumentationModuleResolverTrait;
+
+    /**
+     * Get the dir where to look for the documentation.
+     */
+    protected function getBaseDir(): string
+    {
+        return constant('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_DIR');
+    }
+
+    /**
+     * Get the URL where to look for the documentation.
+     */
+    protected function getBaseURL(): string
+    {
+        return constant('GRAPHQL_API_CONVERT_CASE_DIRECTIVES_DIR');
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GraphQLAPI\ConvertCaseDirectives\ModuleResolvers;
 
 use GraphQLAPI\ConvertCaseDirectives\GraphQLAPIExtension;
-use GraphQLAPI\GraphQLAPI\ModuleResolvers\ModuleResolverTrait;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\EndpointFunctionalityModuleResolver;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\AbstractSchemaTypeModuleResolver;
 use PoPSchema\ConvertCaseDirectives\DirectiveResolvers\LowerCaseStringDirectiveResolver;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/AbstractContentParser.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/AbstractContentParser.php
@@ -15,6 +15,37 @@ abstract class AbstractContentParser implements ContentParserInterface
 {
     public const PATH_URL_TO_DOCS = 'pathURLToDocs';
 
+    protected string $baseDir;
+    protected string $baseURL;
+
+    /**
+     * @param string|null $baseDir Where to look for the documentation
+     * @param string|null $baseURL URL for the documentation
+     */
+    public function __construct(?string $baseDir = null, ?string $baseURL = null)
+    {
+        $this->setBaseDir($baseDir);
+        $this->setBaseURL($baseURL);
+    }
+
+    /**
+     * Inject the dir where to look for the documentation.
+     * If null, it uses the default value from the main plugin.
+     */
+    public function setBaseDir(?string $baseDir = null): void
+    {
+        $this->baseDir = $baseDir ?? constant('GRAPHQL_API_DIR');
+    }
+
+    /**
+     * Inject the URL where to look for the documentation.
+     * If null, it uses the default value from the main plugin.
+     */
+    public function setBaseURL(?string $baseURL = null): void
+    {
+        $this->baseURL = $baseURL ?? constant('GRAPHQL_API_URL');
+    }
+
     /**
      * Parse the file's Markdown into HTML Content
      *
@@ -92,7 +123,7 @@ abstract class AbstractContentParser implements ContentParserInterface
      */
     protected function getFileDir(string $lang): string
     {
-        return constant('GRAPHQL_API_DIR') . "/docs/${lang}";
+        return $this->baseDir . "/docs/${lang}";
     }
 
     /**
@@ -101,7 +132,7 @@ abstract class AbstractContentParser implements ContentParserInterface
     protected function getDefaultFileURL(): string
     {
         $lang = $this->getDefaultDocsLanguage();
-        return constant('GRAPHQL_API_URL') . "docs/${lang}";
+        return $this->baseURL . "docs/${lang}";
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/ContentParserInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/ContentParserInterface.php
@@ -7,6 +7,18 @@ namespace GraphQLAPI\GraphQLAPI\ContentProcessors;
 interface ContentParserInterface
 {
     /**
+     * Inject the dir where to look for the documentation.
+     * If null, it uses the default value from the main plugin.
+     */
+    public function setBaseDir(?string $baseDir = null): void;
+
+    /**
+     * Inject the URL where to look for the documentation.
+     * If null, it uses the default value from the main plugin.
+     */
+    public function setBaseURL(?string $baseDir = null): void;
+
+    /**
      * Parse the file's Markdown into HTML Content
      *
      * @param string $relativePathDir Dir relative to the docs/en/ folder

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
@@ -48,6 +48,9 @@ trait HasMarkdownDocumentationModuleResolverTrait
     {
         if ($markdownFilename = $this->getMarkdownFilename($module)) {
             $markdownContentParser = MarkdownContentParserFacade::getInstance();
+            // Inject the place to look for the documentation
+            $markdownContentParser->setBaseDir($this->getBaseDir());
+            $markdownContentParser->setBaseURL($this->getBaseURL());
             try {
                 return $markdownContentParser->getContent(
                     'modules/' . $markdownFilename,
@@ -65,4 +68,14 @@ trait HasMarkdownDocumentationModuleResolverTrait
         }
         return null;
     }
+
+    /**
+     * Get the dir where to look for the documentation.
+     */
+    abstract protected function getBaseDir(): string;
+
+    /**
+     * Get the URL where to look for the documentation.
+     */
+    abstract protected function getBaseURL(): string;
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverTrait.php
@@ -9,4 +9,20 @@ use GraphQLAPI\GraphQLAPI\ModuleResolvers\HasMarkdownDocumentationModuleResolver
 trait ModuleResolverTrait
 {
     use HasMarkdownDocumentationModuleResolverTrait;
+
+    /**
+     * Get the dir where to look for the documentation.
+     */
+    protected function getBaseDir(): string
+    {
+        return constant('GRAPHQL_API_DIR');
+    }
+
+    /**
+     * Get the URL where to look for the documentation.
+     */
+    protected function getBaseURL(): string
+    {
+        return constant('GRAPHQL_API_DIR');
+    }
 }

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/src/ModuleResolvers/FunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/src/ModuleResolvers/FunctionalityModuleResolver.php
@@ -7,6 +7,7 @@ namespace GraphQLAPI\SchemaFeedback\ModuleResolvers;
 use GraphQLAPI\SchemaFeedback\GraphQLAPIExtension;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\ModuleResolverTrait;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\AbstractFunctionalityModuleResolver;
+use GraphQLAPI\GraphQLAPI\ModuleResolvers\SchemaConfigurationFunctionalityModuleResolver;
 
 class FunctionalityModuleResolver extends AbstractFunctionalityModuleResolver
 {
@@ -27,7 +28,7 @@ class FunctionalityModuleResolver extends AbstractFunctionalityModuleResolver
             case self::SCHEMA_FEEDBACK:
                 return [
                     [
-                        \GraphQLAPI\GraphQLAPI\ModuleResolvers\FunctionalityModuleResolver::SCHEMA_CONFIGURATION,
+                        SchemaConfigurationFunctionalityModuleResolver::SCHEMA_CONFIGURATION,
                     ],
                 ];
         }


### PR DESCRIPTION
The module documentation was always fetched from constant `GRAPHQL_API_DIR`, so extensions could not use it.

Now, extensions can inject the base dir/URL into the parsing service.

Implemented for extension "Convert Case Directives"