### PR TITLE
Remove isGraphQLAPIPluginActive

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/GraphQLAPIExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/GraphQLAPIExtension.php
@@ -15,14 +15,6 @@ class GraphQLAPIExtension extends AbstractExtension
     public const NAMESPACE = __NAMESPACE__;
 
     /**
-     * Plugin name
-     */
-    protected function getPluginName(): string
-    {
-        return \__('GraphQL API - Convert Case Directives', 'graphql-api-convert-case-directives');
-    }
-
-    /**
      * Add Component classes to be initialized
      *
      * @return string[] List of `Component` class to initialize

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -25,19 +25,6 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 abstract class AbstractExtension extends AbstractPlugin
 {
     /**
-     * The message to show in the admin notices, when the GraphQL API plugin
-     * is not installed or activated
-     */
-    protected function getGraphQLAPIPluginInactiveAdminNoticeErrorMessage(): ?string
-    {
-        return sprintf(
-            \__('Plugin <strong>%1$s</strong> is not installed or activated. Without it, plugin <strong>%2$s</strong> cannot be enabled.'),
-            \__('GraphQL API for WordPress'),
-            $this->getPluginName()
-        );
-    }
-
-    /**
      * Plugin set-up, executed after the GraphQL API plugin is loaded,
      * and before it is initialized
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -38,9 +38,6 @@ abstract class AbstractExtension extends AbstractPlugin
         \add_action(
             'plugins_loaded',
             function (): void {
-                // Execute the plugin's custom setup, if any
-                $this->doSetup();
-
                 /**
                  * Initialize/configure/boot this extension plugin
                  */
@@ -56,6 +53,9 @@ abstract class AbstractExtension extends AbstractPlugin
                     PluginLifecycleHooks::BOOT_EXTENSION,
                     [$this, 'boot']
                 );
+
+                // Execute the plugin's custom setup, if any
+                $this->doSetup();
             },
             PluginLifecyclePriorities::SETUP_EXTENSIONS
         );

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -108,28 +108,9 @@ abstract class AbstractExtension extends AbstractPlugin
     }
 
     /**
-     * Plugin's configuration
-     */
-    final public function configure(): void
-    {
-        parent::configure();
-
-        // Execute the plugin's custom config
-        $this->doConfigure();
-    }
-
-    /**
      * Plugin set-up
      */
     protected function doSetup(): void
-    {
-        // Function to override
-    }
-
-    /**
-     * Plugin configuration
-     */
-    protected function doConfigure(): void
     {
         // Function to override
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -25,24 +25,6 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 abstract class AbstractExtension extends AbstractPlugin
 {
     /**
-     * If the GraphQL API plugin is not installed and activated,
-     * show an error for the admin
-     */
-    protected function addAdminNoticeError(): void
-    {
-        if ($errorMessage = $this->getGraphQLAPIPluginInactiveAdminNoticeErrorMessage()) {
-            \add_action('admin_notices', function () use ($errorMessage) {
-                \_e(sprintf(
-                    '<div class="notice notice-error is-dismissible">' .
-                        '<p>%s</p>' .
-                    '</div>',
-                    $errorMessage
-                ));
-            });
-        }
-    }
-
-    /**
      * The message to show in the admin notices, when the GraphQL API plugin
      * is not installed or activated
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -25,14 +25,6 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 abstract class AbstractExtension extends AbstractPlugin
 {
     /**
-     * Indicate if the main plugin is installed and activated
-     */
-    final protected function isGraphQLAPIPluginActive(): bool
-    {
-        return class_exists('\GraphQLAPI\GraphQLAPI\Plugin');
-    }
-
-    /**
      * If the GraphQL API plugin is not installed and activated,
      * show an error for the admin
      */
@@ -77,17 +69,6 @@ abstract class AbstractExtension extends AbstractPlugin
         \add_action(
             'plugins_loaded',
             function (): void {
-                /**
-                 * Check that the GraphQL API plugin is installed and activated.
-                 * Otherwise show an error, and skip initializing the plugin.
-                 */
-                if (!$this->isGraphQLAPIPluginActive()) {
-                    // Show an error message to the admin
-                    $this->addAdminNoticeError();
-                    // Exit
-                    return;
-                }
-
                 // Execute the plugin's custom setup, if any
                 $this->doSetup();
 
@@ -158,34 +139,10 @@ abstract class AbstractExtension extends AbstractPlugin
     }
 
     /**
-     * Plugin's initialization
-     */
-    final public function initialize(): void
-    {
-        /**
-         * Check that the GraphQL API plugin is installed and activated.
-         */
-        if (!$this->isGraphQLAPIPluginActive()) {
-            // Exit
-            return;
-        }
-
-        parent::initialize();
-    }
-
-    /**
      * Plugin's configuration
      */
     final public function configure(): void
     {
-        /**
-         * Check that the GraphQL API plugin is installed and activated.
-         */
-        if (!$this->isGraphQLAPIPluginActive()) {
-            // Exit
-            return;
-        }
-
         parent::configure();
 
         // Execute the plugin's custom config
@@ -197,14 +154,6 @@ abstract class AbstractExtension extends AbstractPlugin
      */
     final public function boot(): void
     {
-        /**
-         * Check that the GraphQL API plugin is installed and activated.
-         */
-        if (!$this->isGraphQLAPIPluginActive()) {
-            // Exit
-            return;
-        }
-
         // Execute the plugin's custom setup
         $this->doBoot();
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -119,22 +119,6 @@ abstract class AbstractExtension extends AbstractPlugin
     }
 
     /**
-     * Plugin's booting
-     */
-    final public function boot(): void
-    {
-        // Execute the plugin's custom setup
-        $this->doBoot();
-    }
-
-    /**
-     * Initialize plugin. Function to override
-     */
-    protected function doBoot(): void
-    {
-    }
-
-    /**
      * Plugin set-up
      */
     protected function doSetup(): void

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -30,14 +30,6 @@ abstract class AbstractPlugin
     }
 
     /**
-     * The plugin name
-     */
-    protected function getPluginName(): string
-    {
-        return trim(substr($this->pluginFile, strlen(\WP_PLUGIN_DIR)), '/');
-    }
-
-    /**
      * Plugin's initialization
      */
     public function initialize(): void

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/src/GraphQLAPIExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/src/GraphQLAPIExtension.php
@@ -14,14 +14,6 @@ class GraphQLAPIExtension extends AbstractExtension
     public const NAMESPACE = __NAMESPACE__;
 
     /**
-     * Plugin name
-     */
-    protected function getPluginName(): string
-    {
-        return \__('GraphQL API - Schema Feedback', 'graphql-api-schema-feedback');
-    }
-
-    /**
      * Add Component classes to be initialized
      *
      * @return string[] List of `Component` class to initialize


### PR DESCRIPTION
Thanks to #504, we won't have an extension working, when the GraphQL API plugin is not activated.

For instance, `graphql-api-convert-case-directives.php` is initialized like this:

```php
// If the GraphQL API plugin is active => Create and set-up the extension
add_action('plugins_loaded', function (): void {
    if (!class_exists('\GraphQLAPI\GraphQLAPI\Plugin')) {
        return;
    }
    (new \GraphQLAPI\ConvertCaseDirectives\GraphQLAPIExtension(__FILE__))->setup();
});
```

Then, can remove `isGraphQLAPIPluginActive` from `AbstractExtension`.