### PR TITLE
Fix configure plugin

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -108,14 +108,6 @@ abstract class AbstractExtension extends AbstractPlugin
     }
 
     /**
-     * Plugin's booting
-     */
-    public function boot(): void
-    {
-        // Function to override
-    }
-
-    /**
      * Plugin set-up
      */
     protected function doSetup(): void

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtension.php
@@ -108,14 +108,6 @@ abstract class AbstractExtension extends AbstractPlugin
     }
 
     /**
-     * Plugin's configuration
-     */
-    public function configure(): void
-    {
-        // Function to override
-    }
-
-    /**
      * Plugin's booting
      */
     public function boot(): void

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -211,11 +211,6 @@ abstract class AbstractMainPlugin extends AbstractPlugin
      */
     abstract public function bootSystem(): void;
 
-    public function boot(): void
-    {
-        // Doing nothing yet
-    }
-
     /**
      * Boot the application
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -95,6 +95,14 @@ abstract class AbstractPlugin
     }
 
     /**
+     * Plugin's booting
+     */
+    public function boot(): void
+    {
+        // Function to override
+    }
+
+    /**
      * Add configuration for the Component classes
      *
      * @return array<string, mixed> [key]: Component class, [value]: Configuration


### PR DESCRIPTION
Function `configure` in `AbstractExtension` was overriding the parent one. Fixed now.