### PR TITLE
Skip loading components with ModuleProcessor not-yet defined as services

### DIFF
--- a/layers/Wassup/packages/wassup/src/Component.php
+++ b/layers/Wassup/packages/wassup/src/Component.php
@@ -18,67 +18,83 @@ class Component extends AbstractComponent
      */
     public static function getDependedComponentClasses(): array
     {
-        return [
-            \GraphQLByPoP\GraphQLServer\Component::class,
-            \PoP\FunctionFields\Component::class,
-            \PoP\RESTAPI\Component::class,
-            \PoP\TraceTools\Component::class,
+        /**
+         * Comment Leo 17/03/2021:
+         * All the ModuleProcessors for all the migrate-* packages
+         * must be defined as services, otherwise we get a
+         * "service not-defined" Exception, in
+         * layers/Engine/packages/component-model/src/ItemProcessors/ItemProcessorManagerTrait.php:
+         *   $instanceManager = InstanceManagerFacade::getInstance();
+         *   $processorInstance = $instanceManager->getInstance($itemProcessorClass);
+         *
+         * Until we can do the migration, added a flag to not register
+         * the components with issues, so the the webserver doesn't fail.
+         */
+        $skipLoadingUnmigratedComponents = true;
+        return array_merge(
+            [
+                // These ones are working OK
+                \GraphQLByPoP\GraphQLServer\Component::class,
+                \PoP\FunctionFields\Component::class,
+                \PoP\RESTAPI\Component::class,
+                \PoP\TraceTools\Component::class,
+                \PoPSchema\BlockMetadataWP\Component::class,
+                \PoPSchema\CDNDirective\Component::class,
+                \PoPSchema\CommentMetaWP\Component::class,
+                \PoPSchema\ConvertCaseDirectives\Component::class,
+                \PoPSchema\CustomPostMediaWP\Component::class,
+                \PoPSchema\CustomPostMetaWP\Component::class,
+                \PoPSchema\GoogleTranslateDirectiveForCustomPosts\Component::class,
+                \PoPSchema\PagesWP\Component::class,
+                \PoPSchema\PostsWP\Component::class,
+                \PoPSchema\PostTagsWP\Component::class,
+                \PoPSchema\TaxonomyQueryWP\Component::class,
+                \PoPSchema\UserMetaWP\Component::class,
+                \PoPSchema\UserRolesACL\Component::class,
+                \PoPSchema\UserRolesWP\Component::class,
+                \PoPSchema\UserStateWP\Component::class,
+                \PoPSchema\PostMutations\Component::class,
+                \PoPSchema\CustomPostMediaMutationsWP\Component::class,
+                \PoPSchema\CommentMutationsWP\Component::class,
+                \PoPSchema\UserStateMutationsWP\Component::class,
 
-            \PoP\SiteWP\Component::class,
-            \PoP\SPA\Component::class,
-
-            \PoPSchema\BlockMetadataWP\Component::class,
-            \PoPSchema\CDNDirective\Component::class,
-            \PoPSchema\CommentMetaWP\Component::class,
-            \PoPSchema\ConvertCaseDirectives\Component::class,
-            \PoPSchema\CustomPostMediaWP\Component::class,
-            \PoPSchema\CustomPostMetaWP\Component::class,
-            \PoPSchema\GoogleTranslateDirectiveForCustomPosts\Component::class,
-            \PoPSchema\PagesWP\Component::class,
-            \PoPSchema\PostsWP\Component::class,
-            \PoPSchema\PostTagsWP\Component::class,
-            \PoPSchema\TaxonomyQueryWP\Component::class,
-            \PoPSchema\UserMetaWP\Component::class,
-            \PoPSchema\UserRolesACL\Component::class,
-            \PoPSchema\UserRolesWP\Component::class,
-            \PoPSchema\UserStateWP\Component::class,
-            \PoPSchema\PostMutations\Component::class,
-            \PoPSchema\CustomPostMediaMutationsWP\Component::class,
-            \PoPSchema\CommentMutationsWP\Component::class,
-            \PoPSchema\UserStateMutationsWP\Component::class,
-
-            \PoPSchema\CategoriesWP\Component::class,
-            \PoPSchema\NotificationsWP\Component::class,
-            \PoPSchema\MenusWP\Component::class,
-            \PoPSchema\EventMutationsWPEM\Component::class,
-            \PoPSchema\EverythingElseWP\Component::class,
-            \PoPSchema\HighlightsWP\Component::class,
-            \PoPSchema\LocationPostsWP\Component::class,
-            \PoPSchema\StancesWP\Component::class,
-
-            \PoPSitesWassup\PostMutations\Component::class,
-            \PoPSitesWassup\HighlightMutations\Component::class,
-            \PoPSitesWassup\StanceMutations\Component::class,
-            \PoPSitesWassup\CommentMutations\Component::class,
-            \PoPSitesWassup\SystemMutations\Component::class,
-            \PoPSitesWassup\GravityFormsMutations\Component::class,
-            \PoPSitesWassup\ContactUsMutations\Component::class,
-            \PoPSitesWassup\ContactUserMutations\Component::class,
-            \PoPSitesWassup\NewsletterMutations\Component::class,
-            \PoPSitesWassup\FlagMutations\Component::class,
-            \PoPSitesWassup\ShareMutations\Component::class,
-            \PoPSitesWassup\VolunteerMutations\Component::class,
-            \PoPSitesWassup\EventMutations\Component::class,
-            \PoPSitesWassup\LocationMutations\Component::class,
-            \PoPSitesWassup\LocationPostMutations\Component::class,
-            \PoPSitesWassup\PostLinkMutations\Component::class,
-            \PoPSitesWassup\EventLinkMutations\Component::class,
-            \PoPSitesWassup\LocationPostLinkMutations\Component::class,
-            \PoPSitesWassup\NotificationMutations\Component::class,
-            \PoPSitesWassup\SocialNetworkMutations\Component::class,
-            \PoPSitesWassup\UserStateMutations\Component::class,
-            \PoPSitesWassup\EverythingElseMutations\Component::class,
-        ];
+                \PoPSchema\CategoriesWP\Component::class,
+                \PoPSchema\NotificationsWP\Component::class,
+                \PoPSchema\MenusWP\Component::class,
+                \PoPSchema\HighlightsWP\Component::class,
+                \PoPSchema\LocationPostsWP\Component::class,
+                \PoPSchema\StancesWP\Component::class,
+            ],
+            $skipLoadingUnmigratedComponents ? [] : [
+                // These ones must have their ModuleProcessors defined as services
+                \PoPSchema\EventMutationsWPEM\Component::class,
+                \PoPSchema\EverythingElseWP\Component::class,
+                \PoP\SiteWP\Component::class,
+                \PoP\SPA\Component::class,
+                \PoPSitesWassup\PostMutations\Component::class,
+                \PoPSitesWassup\HighlightMutations\Component::class,
+                \PoPSitesWassup\StanceMutations\Component::class,
+                \PoPSitesWassup\CommentMutations\Component::class,
+                \PoPSitesWassup\SystemMutations\Component::class,
+                \PoPSitesWassup\GravityFormsMutations\Component::class,
+                \PoPSitesWassup\ContactUsMutations\Component::class,
+                \PoPSitesWassup\ContactUserMutations\Component::class,
+                \PoPSitesWassup\NewsletterMutations\Component::class,
+                \PoPSitesWassup\FlagMutations\Component::class,
+                \PoPSitesWassup\ShareMutations\Component::class,
+                \PoPSitesWassup\VolunteerMutations\Component::class,
+                \PoPSitesWassup\EventMutations\Component::class,
+                \PoPSitesWassup\LocationMutations\Component::class,
+                \PoPSitesWassup\LocationPostMutations\Component::class,
+                \PoPSitesWassup\PostLinkMutations\Component::class,
+                \PoPSitesWassup\EventLinkMutations\Component::class,
+                \PoPSitesWassup\LocationPostLinkMutations\Component::class,
+                \PoPSitesWassup\NotificationMutations\Component::class,
+                \PoPSitesWassup\SocialNetworkMutations\Component::class,
+                \PoPSitesWassup\UserStateMutations\Component::class,
+                \PoPSitesWassup\EverythingElseMutations\Component::class,
+            ]
+        );
     }
 
     /**

--- a/layers/Wassup/packages/wassup/src/Component.php
+++ b/layers/Wassup/packages/wassup/src/Component.php
@@ -30,7 +30,7 @@ class Component extends AbstractComponent
          * Until we can do the migration, added a flag to not register
          * the components with issues, so the the webserver doesn't fail.
          */
-        $skipLoadingUnmigratedComponents = true;
+        $skipLoadingUnmigratedComponents = false;
         return array_merge(
             [
                 // These ones are working OK


### PR DESCRIPTION
All the `ModuleProcessor`s for all the `migrate-*` packages must be defined as services, otherwise we get the "service not-defined" Exception:

```
Fatal error: Uncaught Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "PoP_Module_Processor_Entries". in /app/vendor/symfony/dependency-injection/ContainerBuilder.php:982 Stack trace: 
#0 /app/vendor/symfony/dependency-injection/ContainerBuilder.php(579): Symfony\Component\DependencyInjection\ContainerBuilder->getDefinition('PoP_Module_Proc...') 
#1 /app/vendor/symfony/dependency-injection/ContainerBuilder.php(542): Symfony\Component\DependencyInjection\ContainerBuilder->doGet('PoP_Module_Proc...', 1) 
#2 /layers/Engine/packages/component-model/src/Instances/InstanceManagerTrait.php(19): Symfony\Component\DependencyInjection\ContainerBuilder->get('PoP_Module_Proc...') 
#3 /layers/Engine/packages/component-model/src/ItemProcessors/ItemProcessorManagerTrait.php(68): PoP\ComponentModel\Instances\InstanceManager->getInstance('PoP_Module_Proc...') 
#4 /layers/Engine/packages/component-model/src/ItemProcessors/ItemProcessorManagerTrait.php(81): PoP\ComponentModel\It in /app/vendor/symfony/dependency-injection/ContainerBuilder.php on line 982 
```

The root happens in `layers/Engine/packages/component-model/src/ItemProcessors/ItemProcessorManagerTrait.php`:

```php
$instanceManager = InstanceManagerFacade::getInstance();
$processorInstance = $instanceManager->getInstance($itemProcessorClass);
```

Until we can do the migration, added a flag `$skipLoadingUnmigratedComponents` to allow to not register the components with issues, so the the webserver doesn't fail.