### PR TITLE
Removed "aligncenter" class when viewing source

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractBlock.php
@@ -190,7 +190,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
      */
     public function getAlignClass(): string
     {
-        return 'aligncenter';
+        return '';
     }
 
     /**


### PR DESCRIPTION
The blocks have class `aligncenter`, making it messy when viewing the persisted query's source:

![Screenshot_2021-03-18 Latest posts for mobile app – GraphQL API](https://user-images.githubusercontent.com/1981996/111588373-6e7c1280-87fe-11eb-8f32-5b4afab01df2.png)

Removed now.