### PR TITLE
Use Rector to automatically upgrade code to PHP 8.0

### DIFF
--- a/layers/API/packages/api-clients/src/ClientTrait.php
+++ b/layers/API/packages/api-clients/src/ClientTrait.php
@@ -14,20 +14,14 @@ trait ClientTrait
 
     /**
      * Relative Path
-     *
-     * @return string
      */
     abstract protected function getClientRelativePath(): string;
     /**
      * JavaScript file name
-     *
-     * @return string
      */
     abstract protected function getJSFilename(): string;
     /**
      * HTML file name
-     *
-     * @return string
      */
     protected function getIndexFilename(): string
     {
@@ -42,14 +36,10 @@ trait ClientTrait
     }
     /**
      * Base dir
-     *
-     * @return string
      */
     abstract protected function getComponentBaseDir(): string;
     /**
      * Base URL
-     *
-     * @return string|null
      */
     protected function getComponentBaseURL(): ?string
     {
@@ -57,15 +47,11 @@ trait ClientTrait
     }
     /**
      * Endpoint URL
-     *
-     * @return string
      */
     abstract protected function getEndpointURL(): string;
 
     /**
      * HTML to print the client
-     *
-     * @return string
      */
     public function getClientHTML(): string
     {
@@ -125,8 +111,6 @@ trait ClientTrait
 
     /**
      * If the endpoint for the client is requested, print the client and exit
-     *
-     * @return void
      */
     protected function executeEndpoint(): void
     {

--- a/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/AbstractEndpointHandler.php
+++ b/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/AbstractEndpointHandler.php
@@ -8,8 +8,6 @@ abstract class AbstractEndpointHandler extends \PoP\APIEndpoints\AbstractEndpoin
 {
     /**
      * Initialize the client
-     *
-     * @return void
      */
     public function initialize(): void
     {
@@ -58,11 +56,8 @@ abstract class AbstractEndpointHandler extends \PoP\APIEndpoints\AbstractEndpoin
     //         ]
     //     );
     // }
-
     /**
      * If the endpoint for the client is requested, do something
-     *
-     * @return void
      */
     public function parseRequest(): void
     {
@@ -73,8 +68,6 @@ abstract class AbstractEndpointHandler extends \PoP\APIEndpoints\AbstractEndpoin
 
     /**
      * Execute the endpoint. Function to override
-     *
-     * @return void
      */
     protected function executeEndpoint(): void
     {

--- a/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/NativeAPIEndpointHandler.php
+++ b/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/NativeAPIEndpointHandler.php
@@ -14,8 +14,6 @@ class NativeAPIEndpointHandler extends AbstractEndpointHandler
 {
     /**
      * Initialize the endpoints
-     *
-     * @return void
      */
     public function initialize(): void
     {
@@ -36,8 +34,6 @@ class NativeAPIEndpointHandler extends AbstractEndpointHandler
 
     /**
      * Check if the PoP API has been enabled
-     *
-     * @return boolean
      */
     protected function isNativeAPIEnabled(): bool
     {
@@ -48,8 +44,6 @@ class NativeAPIEndpointHandler extends AbstractEndpointHandler
 
     /**
      * Indicate this is an API request
-     *
-     * @return void
      */
     protected function executeEndpoint(): void
     {

--- a/layers/API/packages/api-endpoints/src/AbstractEndpointHandler.php
+++ b/layers/API/packages/api-endpoints/src/AbstractEndpointHandler.php
@@ -33,8 +33,6 @@ abstract class AbstractEndpointHandler extends AbstractAutomaticallyInstantiated
     /**
      * If `true`, the endpoint must exactly match the URL
      * If `false`, the endpoint is triggered when it is contained at the end of the URL
-     *
-     * @return boolean
      */
     protected function doesEndpointMatchWholeURL(): bool
     {

--- a/layers/API/packages/api-endpoints/src/EndpointUtils.php
+++ b/layers/API/packages/api-endpoints/src/EndpointUtils.php
@@ -28,9 +28,6 @@ class EndpointUtils
 
     /**
      * Make sure the URI has "/" at both ends
-     *
-     * @param string $uri
-     * @return string
      */
     public static function slashURI(string $uri): string
     {
@@ -39,10 +36,6 @@ class EndpointUtils
 
     /**
      * Indicate if the URI ends with the given endpoint
-     *
-     * @param string $uri
-     * @param string $endpointURI
-     * @return boolean
      */
     public static function doesURIEndWith(string $uri, string $endpointURI): bool
     {

--- a/layers/API/packages/api-rest/src/RouteModuleProcessors/AbstractRESTEntryRouteModuleProcessor.php
+++ b/layers/API/packages/api-rest/src/RouteModuleProcessors/AbstractRESTEntryRouteModuleProcessor.php
@@ -9,10 +9,7 @@ use PoP\RESTAPI\DataStructureFormatters\RESTDataStructureFormatter;
 
 abstract class AbstractRESTEntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
 {
-    protected RESTDataStructureFormatter $restDataStructureFormatter;
-
-    function __construct(RESTDataStructureFormatter $restDataStructureFormatter)
+    function __construct(protected RESTDataStructureFormatter $restDataStructureFormatter)
     {
-        $this->restDataStructureFormatter = $restDataStructureFormatter;
     }
 }

--- a/layers/API/packages/api/src/Component.php
+++ b/layers/API/packages/api/src/Component.php
@@ -30,8 +30,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -24,8 +24,6 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -34,8 +32,6 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
 
     /**
      * Do not allow dynamic fields
-     *
-     * @return bool
      */
     protected function disableDynamicFieldsFromDirectiveArgs(): bool
     {
@@ -74,13 +70,6 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
 
     /**
      * Validate that the number of elements in the fields `copyToFields` and `copyFromFields` match one another
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $directiveArgs
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return array
      */
     public function validateDirectiveArgumentsForSchema(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array
     {
@@ -118,17 +107,6 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
 
     /**
      * Copy the data under the relational object into the current object
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
@@ -21,8 +21,6 @@ class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -31,8 +29,6 @@ class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     /**
      * Do not allow dynamic fields
-     *
-     * @return bool
      */
     protected function disableDynamicFieldsFromDirectiveArgs(): bool
     {
@@ -60,17 +56,6 @@ class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     /**
      * Duplicate a property from the current object
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
@@ -18,8 +18,6 @@ class RenamePropertyDirectiveResolver extends DuplicatePropertyDirectiveResolver
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -34,17 +32,6 @@ class RenamePropertyDirectiveResolver extends DuplicatePropertyDirectiveResolver
 
     /**
      * Rename a property from the current object
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
@@ -21,8 +21,6 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -31,8 +29,6 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
 
     /**
      * Do not allow dynamic fields
-     *
-     * @return bool
      */
     protected function disableDynamicFieldsFromDirectiveArgs(): bool
     {
@@ -71,13 +67,6 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
 
     /**
      * Validate that the number of elements in the fields `properties` and `expressions` match one another
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $directiveArgs
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return array
      */
     public function validateDirectiveArgumentsForSchema(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array
     {
@@ -115,17 +104,6 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
 
     /**
      * Copy the data under the relational object into the current object
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
@@ -26,8 +26,6 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -36,9 +34,6 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
 
     /**
      * No need to use this function anymore
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return string|null
      */
     public function getSchemaDirectiveDeprecationDescription(TypeResolverInterface $typeResolver): ?string
     {
@@ -71,20 +66,6 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
      * 1. Unpack the elements of the array into a temporary property for each, in the current object
      * 2. Execute <transformProperty> on each property
      * 3. Pack into the array, once again, and remove all temporary properties
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,
@@ -302,19 +283,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
     /**
      * Add the $key in addition to the $value
      *
-     * @param TypeResolverInterface $typeResolver
      * @param [type] $id
-     * @param string $field
-     * @param array $resultIDItems
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
      * @return void
      */
     protected function addExpressionsForResultItem(TypeResolverInterface $typeResolver, $id, string $field, array &$resultIDItems, array &$dbItems, array &$previousDBItems, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)

--- a/layers/API/packages/api/src/ModuleProcessors/AbstractRelationalFieldQueryDataModuleProcessor.php
+++ b/layers/API/packages/api/src/ModuleProcessors/AbstractRelationalFieldQueryDataModuleProcessor.php
@@ -24,9 +24,6 @@ abstract class AbstractRelationalFieldQueryDataModuleProcessor extends AbstractQ
 
     /**
      * Property fields: Those fields which have a numeric key only
-     *
-     * @param array $module
-     * @return array
      */
     protected function getPropertyFields(array $module): array
     {
@@ -44,9 +41,6 @@ abstract class AbstractRelationalFieldQueryDataModuleProcessor extends AbstractQ
 
     /**
      * Nested fields: Those fields which have a field as key and an array of submodules as value
-     *
-     * @param array $module
-     * @return array
      */
     protected function getFieldsWithNestedSubfields(array $module): array
     {

--- a/layers/API/packages/api/src/PersistedQueries/PersistedQueryUtils.php
+++ b/layers/API/packages/api/src/PersistedQueries/PersistedQueryUtils.php
@@ -10,9 +10,6 @@ class PersistedQueryUtils
 {
     /**
      * Trim, and remove tabs and new lines
-     *
-     * @param string $fragmentResolution
-     * @return string
      */
     public static function removeWhitespaces(string $fragmentResolution): string
     {
@@ -23,9 +20,6 @@ class PersistedQueryUtils
      * Symfony's DependencyInjection component uses format "%parameter%", and PoP API uses format "%expression%",
      * so when passing an expression like "%self%" it throws an exception, expecting this to be a parameter (which doesn't exist!)
      * To fix it, we add a space in all expressions like this: "% expression %", which works for the PoP API since the expression name is trimmed
-     *
-     * @param string $fragmentResolution
-     * @return string
      */
     public static function addSpacingToExpressions(string $fragmentResolution): string
     {
@@ -34,9 +28,6 @@ class PersistedQueryUtils
 
     /**
      * Retrieve the query name from the persisted query param, which starts with "!"
-     *
-     * @param string $query
-     * @return string
      */
     public static function maybeGetPersistedQuery(string $query): string
     {

--- a/layers/API/packages/api/src/Registries/SchemaDefinitionRegistry.php
+++ b/layers/API/packages/api/src/Registries/SchemaDefinitionRegistry.php
@@ -25,8 +25,6 @@ class SchemaDefinitionRegistry implements SchemaDefinitionRegistryInterface
      * Create a key from the arrays, to cache the results
      *
      * @param array<string, mixed> $fieldArgs
-     * @param array|null $options
-     * @return string
      */
     protected function getArgumentKey(?array $fieldArgs, ?array $options): string
     {
@@ -37,10 +35,6 @@ class SchemaDefinitionRegistry implements SchemaDefinitionRegistryInterface
      * Produce the schema definition. It can store the value in the cache.
      * Use cache with care: if the schema is dynamic, it should not be cached.
      * Public schema: can cache, Private schema: cannot cache.
-     *
-     * @param array|null $fieldArgs
-     * @param array|null $options
-     * @return array
      */
     public function &getSchemaDefinition(?array $fieldArgs = [], ?array $options = []): array
     {

--- a/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
+++ b/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
@@ -38,19 +38,11 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
      */
     private ?array $fragmentsFromRequestCache = null;
 
-    // Services
-    protected TranslationAPIInterface $translationAPI;
-    protected FeedbackMessageStoreInterface $feedbackMessageStore;
-    protected QueryParserInterface $queryParser;
-
     public function __construct(
-        TranslationAPIInterface $translationAPI,
-        FeedbackMessageStoreInterface $feedbackMessageStore,
-        QueryParserInterface $queryParser
+        protected TranslationAPIInterface $translationAPI,
+        protected FeedbackMessageStoreInterface $feedbackMessageStore,
+        protected QueryParserInterface $queryParser
     ) {
-        $this->translationAPI = $translationAPI;
-        $this->feedbackMessageStore = $feedbackMessageStore;
-        $this->queryParser = $queryParser;
     }
 
     public function convertAPIQuery(string $operationDotNotation, ?array $fragments = null): FieldQuerySet

--- a/layers/API/packages/api/src/Schema/FieldQuerySet.php
+++ b/layers/API/packages/api/src/Schema/FieldQuerySet.php
@@ -11,15 +11,10 @@ namespace PoP\API\Schema;
  */
 class FieldQuerySet
 {
-    protected array $requestedFieldQuery;
-    protected array $executableFieldQuery;
-
     public function __construct(
-        array $requestedFieldQuery,
-        array $executableFieldQuery
+        protected array $requestedFieldQuery,
+        protected array $executableFieldQuery
     ) {
-        $this->requestedFieldQuery = $requestedFieldQuery;
-        $this->executableFieldQuery = $executableFieldQuery;
     }
 
     public function getRequestedFieldQuery(): array

--- a/layers/API/packages/api/src/State/ApplicationStateUtils.php
+++ b/layers/API/packages/api/src/State/ApplicationStateUtils.php
@@ -22,10 +22,8 @@ class ApplicationStateUtils
      * The requested query is used to display the data, for instance for GraphQL.
      * It's saved under "requested-query" in $vars, and it's optional: if empty,
      * requested = executable => the executable query from $vars['query'] can be used
-     *
-     * @param array|string $query
      */
-    public static function maybeConvertQueryAndAddToVars(array &$vars, $query): void
+    public static function maybeConvertQueryAndAddToVars(array &$vars, array|string $query): void
     {
         // The fields param can either be an array or a string. Convert them to array
         if (is_array($query)) {

--- a/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForDirectivesTrait.php
+++ b/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForDirectivesTrait.php
@@ -18,10 +18,6 @@ trait AccessControlConfigurableMandatoryDirectivesForDirectivesTrait
 
     /**
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
-     *
-     * @param array $entryList
-     * @param string|null $value
-     * @return array
      */
     final protected function getMatchingEntries(array $entryList, ?string $value): array
     {

--- a/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForFieldsTrait.php
+++ b/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForFieldsTrait.php
@@ -20,9 +20,6 @@ trait AccessControlConfigurableMandatoryDirectivesForFieldsTrait
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
      *
      * @param boolean $include
-     * @param array $entryList
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
      * @return boolean
      */
     final protected function getMatchingEntries(

--- a/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForItemsTrait.php
+++ b/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForItemsTrait.php
@@ -13,8 +13,6 @@ trait AccessControlConfigurableMandatoryDirectivesForItemsTrait
      * Indicates if the entry having no schema mode set must also be processed
      * To decide, it gets the default schema mode and checks its the same with
      * the one from this object
-     *
-     * @return bool
      */
     protected function doesSchemaModeProcessNullControlEntry(): bool
     {

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
@@ -47,8 +47,6 @@ abstract class AbstractAccessControlForDirectivesHookSet extends AbstractCMSBoot
 
     /**
      * Return true if the directives must be disabled
-     *
-     * @return boolean
      */
     protected function enabled(): bool
     {
@@ -83,10 +81,7 @@ abstract class AbstractAccessControlForDirectivesHookSet extends AbstractCMSBoot
     /**
      * Decide if to remove the directiveNames
      *
-     * @param TypeResolverInterface $typeResolver
      * @param FieldResolverInterface $directiveResolver
-     * @param string $directiveName
-     * @return boolean
      */
     protected function removeDirective(TypeResolverInterface $typeResolver, DirectiveResolverInterface $directiveResolver, string $directiveName): bool
     {

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
@@ -13,8 +13,6 @@ abstract class AbstractAccessControlForFieldsHookSet extends AbstractCMSBootHook
 {
     /**
      * Indicate if this hook is enabled
-     *
-     * @return boolean
      */
     protected function enabled(): bool
     {
@@ -63,17 +61,10 @@ abstract class AbstractAccessControlForFieldsHookSet extends AbstractCMSBootHook
     }
     /**
      * Field names to remove
-     *
-     * @return array
      */
     abstract protected function getFieldNames(): array;
     /**
      * Decide if to remove the fieldNames
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param FieldResolverInterface $fieldResolver
-     * @param string $fieldName
-     * @return boolean
      */
     protected function removeFieldName(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -12,8 +12,6 @@ abstract class AbstractAccessControlForFieldsInPrivateSchemaHookSet extends Abst
 {
     /**
      * Indicate if this hook is enabled
-     *
-     * @return boolean
      */
     protected function enabled(): bool
     {

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -30,10 +30,6 @@ abstract class AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet 
      * Remove fieldName "roles" if the user is not logged in
      *
      * @param boolean $include
-     * @param TypeResolverInterface $typeResolver
-     * @param FieldResolverInterface $fieldResolver
-     * @param string $fieldName
-     * @return boolean
      */
     protected function removeFieldName(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/access-control/src/Hooks/DisableFieldConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/DisableFieldConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -12,8 +12,6 @@ class DisableFieldConfigurableAccessControlForFieldsInPrivateSchemaHookSet exten
 {
     /**
      * Configuration entries
-     *
-     * @return array
      */
     protected function getConfigurationEntries(): array
     {

--- a/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractPrivateSchemaTypeResolverDecorator.php
+++ b/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractPrivateSchemaTypeResolverDecorator.php
@@ -14,7 +14,6 @@ abstract class AbstractPrivateSchemaTypeResolverDecorator extends AbstractTypeRe
     /**
      * Enable only for private schema
      *
-     * @param TypeResolverInterface $typeResolver
      * @return array
      */
     public function enabled(TypeResolverInterface $typeResolver): bool

--- a/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractPublicSchemaTypeResolverDecorator.php
+++ b/layers/Engine/packages/access-control/src/TypeResolverDecorators/AbstractPublicSchemaTypeResolverDecorator.php
@@ -14,7 +14,6 @@ abstract class AbstractPublicSchemaTypeResolverDecorator extends AbstractTypeRes
     /**
      * Enable only for public schema
      *
-     * @param TypeResolverInterface $typeResolver
      * @return array
      */
     public function enabled(TypeResolverInterface $typeResolver): bool

--- a/layers/Engine/packages/access-control/src/TypeResolverDecorators/ConfigurableAccessControlForDirectivesTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/access-control/src/TypeResolverDecorators/ConfigurableAccessControlForDirectivesTypeResolverDecoratorTrait.php
@@ -23,8 +23,6 @@ trait ConfigurableAccessControlForDirectivesTypeResolverDecoratorTrait
 
     /**
      * Because the validation can be done on any directive applied to any typeResolver, then attach it to the base abstract class: AbstractTypeResolver::class
-     *
-     * @return array
      */
     public function getClassesToAttachTo(): array
     {

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
@@ -20,8 +20,6 @@ abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirec
 
     /**
      * Set the cache even when there are no elements: they might've been removed due to some validation, and this caching maxAge must be respected!
-     *
-     * @return boolean
      */
     public function needsIDsDataFieldsToExecute(): bool
     {
@@ -40,8 +38,6 @@ abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirec
 
     /**
      * This is a "Schema" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -50,8 +46,6 @@ abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirec
 
     /**
      * Allow it to execute multiple times
-     *
-     * @return boolean
      */
     public function isRepeatable(): bool
     {
@@ -83,12 +77,9 @@ abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirec
     //         $schemaDefinition[SchemaDefinition::ARGNAME_MAX_AGE] = $maxAge;
     //     }
     // }
-
     /**
      * Do not allow dynamic fields, or it may throw an exception
      * Eg: <cacheControl(maxAge:id())>
-     *
-     * @return bool
      */
     protected function disableDynamicFieldsFromDirectiveArgs(): bool
     {
@@ -97,17 +88,6 @@ abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirec
 
     /**
      * Get the cache control for this field, and set it on the Engine
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolver.php
@@ -29,8 +29,6 @@ final class CacheControlDirectiveResolver extends AbstractCacheControlDirectiveR
 
     /**
      * The default max-age is configured through an environment variable
-     *
-     * @return integer|null
      */
     public function getMaxAge(): ?int
     {

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolverInterface.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/CacheControlDirectiveResolverInterface.php
@@ -8,14 +8,10 @@ interface CacheControlDirectiveResolverInterface
 {
     /**
      * Resolves the directive. It differs from `resolveDirective` in that it can be executed without params
-     *
-     * @return void
      */
     public function resolveCacheControlDirective(): void;
     /**
      * Cache control max age for this directive, possibly applied to certain fields
-     *
-     * @return integer|null
      */
     public function getMaxAge(): ?int;
 }

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
@@ -39,11 +39,6 @@ class NestedFieldCacheControlDirectiveResolver extends AbstractCacheControlDirec
 
     /**
      * If any argument is a field, then this directive will involve them to calculate the minimum max-age
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $directiveName
-     * @param array $directiveArgs
-     * @return boolean
      */
     public function resolveCanProcess(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, string $field, array &$variables): bool
     {
@@ -81,7 +76,6 @@ class NestedFieldCacheControlDirectiveResolver extends AbstractCacheControlDirec
     /**
      * Calculate the max-age involving also the composed fields
      *
-     * @param array $idsDataFields
      * @return integer
      */
     public function resolveDirective(

--- a/layers/Engine/packages/cache-control/src/Managers/CacheControlEngine.php
+++ b/layers/Engine/packages/cache-control/src/Managers/CacheControlEngine.php
@@ -10,9 +10,6 @@ class CacheControlEngine implements CacheControlEngineInterface
 
     /**
      * Add a max age from a requested field
-     *
-     * @param integer $maxAge
-     * @return void
      */
     public function addMaxAge(int $maxAge): void
     {

--- a/layers/Engine/packages/cache-control/src/Managers/CacheControlEngineInterface.php
+++ b/layers/Engine/packages/cache-control/src/Managers/CacheControlEngineInterface.php
@@ -8,9 +8,6 @@ interface CacheControlEngineInterface
 {
     /**
      * Add a max age from a requested field
-     *
-     * @param integer $maxAge
-     * @return void
      */
     public function addMaxAge(int $maxAge): void;
     /**

--- a/layers/Engine/packages/cache-control/src/TypeResolverDecorators/ConfigurableCacheControlTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/cache-control/src/TypeResolverDecorators/ConfigurableCacheControlTypeResolverDecoratorTrait.php
@@ -17,7 +17,6 @@ trait ConfigurableCacheControlTypeResolverDecoratorTrait
      * By default, only the admin can see the roles from the users
      *
      * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     protected function getMandatoryDirectives($entryValue = null): array
     {

--- a/layers/Engine/packages/component-model/src/Cache/Cache.php
+++ b/layers/Engine/packages/component-model/src/Cache/Cache.php
@@ -108,7 +108,6 @@ class Cache implements CacheInterface
     /**
      * Save immediately. Can override to save as deferred
      *
-     * @param CacheItemInterface $cacheItem
      * @return void
      */
     protected function saveCache(CacheItemInterface $cacheItem)

--- a/layers/Engine/packages/component-model/src/Cache/Cache.php
+++ b/layers/Engine/packages/component-model/src/Cache/Cache.php
@@ -12,15 +12,10 @@ class Cache implements CacheInterface
 {
     use ReplaceCurrentExecutionDataWithPlaceholdersTrait;
 
-    protected CacheItemPoolInterface $cacheItemPool;
-    protected ModelInstanceInterface $modelInstance;
-
     public function __construct(
-        CacheItemPoolInterface $cacheItemPool,
-        ModelInstanceInterface $modelInstance
+        protected CacheItemPoolInterface $cacheItemPool,
+        protected ModelInstanceInterface $modelInstance
     ) {
-        $this->cacheItemPool = $cacheItemPool;
-        $this->modelInstance = $modelInstance;
     }
 
     protected function getKey($id, $type)

--- a/layers/Engine/packages/component-model/src/Cache/CacheConfigurationManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/Cache/CacheConfigurationManagerInterface.php
@@ -17,8 +17,6 @@ interface CacheConfigurationManagerInterface
      * items will be stored
      *
      * @see https://symfony.com/doc/current/components/cache/adapters/filesystem_adapter.html
-     *
-     * @return string
      */
     public function getNamespace(): string;
 }

--- a/layers/Engine/packages/component-model/src/Cache/CacheInterface.php
+++ b/layers/Engine/packages/component-model/src/Cache/CacheInterface.php
@@ -18,8 +18,6 @@ interface CacheInterface
     public function deleteCache($id, $type): void;
     /**
      * Remove all entries in the cache
-     *
-     * @return void
      */
     public function clear(): void;
     public function getCache($id, $type);

--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -28,8 +28,6 @@ class ComponentConfiguration
 
     /**
      * Initialize component configuration
-     *
-     * @return void
      */
     public static function init(): void
     {
@@ -44,8 +42,6 @@ class ComponentConfiguration
 
     /**
      * Indicate if the configuration is overriden by params
-     *
-     * @return boolean
      */
     public static function doingOverrideConfiguration(): bool
     {
@@ -77,8 +73,6 @@ class ComponentConfiguration
     /**
      * Access layer to the environment variable, enabling to override its value
      * Indicate if the configuration can be set through params
-     *
-     * @return bool
      */
     public static function enableConfigByParams(): bool
     {
@@ -101,8 +95,6 @@ class ComponentConfiguration
     /**
      * Access layer to the environment variable, enabling to override its value
      * Indicate if to use the cache
-     *
-     * @return bool
      */
     public static function useComponentModelCache(): bool
     {
@@ -135,8 +127,6 @@ class ComponentConfiguration
      * This functionality is not used by PoP itself, hence it defaults to `false`
      * It can be used by making a mapping from type name to type resolver class, as to reference a type
      * by a name, if needed (eg: to save in the application's configuration)
-     *
-     * @return bool
      */
     public static function enableSchemaEntityRegistries(): bool
     {

--- a/layers/Engine/packages/component-model/src/ComponentConfiguration/EnvironmentValueHelpers.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration/EnvironmentValueHelpers.php
@@ -14,7 +14,6 @@ class EnvironmentValueHelpers
      * A string is true if its lowercase value is either "true" or "on", or if it's "1"
      *
      * @param string $value environment value
-     * @return boolean
      */
     public static function toBool(string $value): bool
     {
@@ -36,7 +35,6 @@ class EnvironmentValueHelpers
      * Convert the environment value from a comma separated string to array
      *
      * @param string $value environment value
-     * @return array
      */
     public static function commaSeparatedStringToArray(string $value): array
     {

--- a/layers/Engine/packages/component-model/src/Configuration/Request.php
+++ b/layers/Engine/packages/component-model/src/Configuration/Request.php
@@ -17,8 +17,6 @@ class Request
 
     /**
      * Indicates the version constraint for all fields/directives in the query
-     *
-     * @return string|null
      */
     public static function getVersionConstraint(): ?string
     {

--- a/layers/Engine/packages/component-model/src/DataStructure/DataStructureManager.php
+++ b/layers/Engine/packages/component-model/src/DataStructure/DataStructureManager.php
@@ -13,11 +13,9 @@ class DataStructureManager implements DataStructureManagerInterface
      * @var array<string, DataStructureFormatterInterface>
      */
     public array $formatters = [];
-    protected DataStructureFormatterInterface $defaultFormatter;
 
-    function __construct(DataStructureFormatterInterface $defaultFormatter)
+    function __construct(protected DataStructureFormatterInterface $defaultFormatter)
     {
-        $this->defaultFormatter = $defaultFormatter;
     }
 
     public function addDataStructureFormatter(DataStructureFormatterInterface $formatter): void

--- a/layers/Engine/packages/component-model/src/DataStructure/PropertyDataStructureFormatterTrait.php
+++ b/layers/Engine/packages/component-model/src/DataStructure/PropertyDataStructureFormatterTrait.php
@@ -26,7 +26,6 @@ trait PropertyDataStructureFormatterTrait
      * Iterate all the way down the data entries until it's not an array anymore, and then print the entry in a `property=value` format
      *
      * @param [type] $data
-     * @param string $property
      * @return void
      */
     protected function iterativelyPrintDataEntries(&$data, string $property)

--- a/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineDecorator.php
+++ b/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineDecorator.php
@@ -9,11 +9,8 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class DirectivePipelineDecorator
 {
-    private PipelineInterface $pipeline;
-
-    public function __construct(PipelineInterface $pipeline)
+    public function __construct(private PipelineInterface $pipeline)
     {
-        $this->pipeline = $pipeline;
     }
 
     public function resolveDirectivePipeline(

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -72,8 +72,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * Directives can be either of type "Schema" or "Query" and,
      * depending on one case or the other, might be exposed to the user.
      * By default, use the Query type
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -84,8 +82,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * If a directive does not operate over the resultItems, then it must not allow to add fields or dynamic values in the directive arguments
      * Otherwise, it can lead to errors, since the field would never be transformed/casted to the expected type
      * Eg: <cacheControl(maxAge:id())>
-     *
-     * @return bool
      */
     protected function disableDynamicFieldsFromDirectiveArgs(): bool
     {
@@ -245,13 +241,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
     /**
      * By default, validate if there are deprecated fields
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $directiveArgs
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return array
      */
     public function validateDirectiveArgumentsForSchema(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array
     {
@@ -315,8 +304,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     /**
      * Indicate to what fieldNames this directive can be applied.
      * Returning an empty array means all of them
-     *
-     * @return array
      */
     public function getFieldNamesToApplyTo(): array
     {
@@ -326,9 +313,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
     /**
      * Define if to use the version to decide if to process the directive or not
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return boolean
      */
     public function decideCanProcessBasedOnVersionConstraint(TypeResolverInterface $typeResolver): bool
     {
@@ -338,11 +322,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     /**
      * By default, the directiveResolver instance can process the directive
      * This function can be overriden to force certain value on the directive args before it can be executed
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $directiveName
-     * @param array $directiveArgs
-     * @return boolean
      */
     public function resolveCanProcess(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, string $field, array &$variables): bool
     {
@@ -463,8 +442,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * By default, a directive can be executed only one time for "Schema" and "System"
      * type directives (eg: <translate(en,es),translate(es,en)>),
      * and many times for the other types, "Query" and "Scripting"
-     *
-     * @return boolean
      */
     public function isRepeatable(): bool
     {
@@ -484,9 +461,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
     /**
      * Indicate that there is data in variable $idsDataFields
-     *
-     * @param array $idsDataFields
-     * @return boolean
      */
     protected function hasIDsDataFields(array &$idsDataFields): bool
     {
@@ -736,7 +710,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     //     // Check that the directive can be applied to all provided fields
     //     $this->validateAndFilterFieldsForDirective($idsDataFields, $schemaErrors, $schemaWarnings);
     // }
-
     // /**
     //  * Check that the directive can be applied to all provided fields
     //  *
@@ -747,12 +720,10 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     // protected function validateAndFilterFieldsForDirective(array &$idsDataFields, array &$schemaErrors, array &$schemaWarnings)
     // {
     //     $directiveSupportedFieldNames = $this->getFieldNamesToApplyTo();
-
     //     // If this function returns an empty array, then it supports all fields, then do nothing
     //     if (!$directiveSupportedFieldNames) {
     //         return;
     //     }
-
     //     // Check if all fields are supported by this directive
     //     $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
     //     $failedFields = [];
@@ -798,14 +769,10 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     //         $this->processFailure($failureMessage, $failedFields, $idsDataFields, $schemaErrors, $schemaWarnings);
     //     }
     // }
-
-
     /**
      * Depending on environment configuration, either show a warning,
      * or show an error and remove the fields from the directive pipeline for further execution
      *
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
      * @return void
      */
     protected function processFailure(string $failureMessage, array $failedFields, array &$idsDataFields, array &$succeedingPipelineIDsDataFields, array &$schemaErrors, array &$schemaWarnings)
@@ -887,8 +854,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * Directives may not be directly visible in the schema,
      * eg: because their name is duplicated across directives (eg: "cacheControl")
      * or because they are used through code (eg: "validateIsUserLoggedIn")
-     *
-     * @return boolean
      */
     public function skipAddingToSchemaDefinition(): bool
     {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -361,7 +361,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                  */
                 try {
                     return Semver::satisfies($schemaDirectiveVersion, $versionConstraint);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     return false;
                 }
             }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateCheckpointDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateCheckpointDirectiveResolver.php
@@ -13,9 +13,6 @@ abstract class AbstractValidateCheckpointDirectiveResolver extends AbstractValid
 {
     /**
      * Validate checkpoints
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return boolean
      */
     protected function validateCondition(TypeResolverInterface $typeResolver): bool
     {
@@ -27,9 +24,6 @@ abstract class AbstractValidateCheckpointDirectiveResolver extends AbstractValid
 
     /**
      * Provide the checkpoint to validate
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     abstract protected function getValidationCheckpointSet(TypeResolverInterface $typeResolver): array;
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
@@ -37,14 +37,6 @@ abstract class AbstractValidateConditionDirectiveResolver extends AbstractValida
 
     /**
      * Validate a custom condition
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $dataFields
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $variables
-     * @return void
      */
     protected function validateFields(TypeResolverInterface $typeResolver, array $dataFields, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations, array &$variables, array &$failedDataFields): void
     {
@@ -63,17 +55,12 @@ abstract class AbstractValidateConditionDirectiveResolver extends AbstractValida
 
     /**
      * Condition to validate. Return `true` for success, `false` for failure
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return boolean
      */
     abstract protected function validateCondition(TypeResolverInterface $typeResolver): bool;
 
     /**
      * Show a different error message depending on if we are validating the whole field, or a directive
      * By default, validate the whole field
-     *
-     * @return boolean
      */
     protected function isValidatingDirective(): bool
     {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
@@ -14,8 +14,6 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
 
     /**
      * Validations are by default a "Schema" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -24,8 +22,6 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
 
     /**
      * Each validate can execute multiple times (eg: an added @validateIsUserLoggedIn)
-     *
-     * @return boolean
      */
     public function isRepeatable(): bool
     {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -13,26 +13,16 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
     /**
      * Indicate to what fieldNames this directive can be applied.
      * Returning an empty array means all of them
-     *
-     * @return array
      */
     public function getFieldNamesToApplyTo(): array;
     /**
      * Directives can be either of type "Schema" or "Query" and,
      * depending on one case or the other, might be exposed to the user.
      * By default, use the Query type
-     *
-     * @return string
      */
     public function getDirectiveType(): string;
     /**
      * Extract and validate the directive arguments
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return array
      */
     public function dissectAndValidateDirectiveForSchema(
         TypeResolverInterface $typeResolver,
@@ -47,13 +37,6 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
 
     /**
      * Enable the directiveResolver to validate the directive arguments in a custom way
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $directiveArgs
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return array
      */
     public function validateDirectiveArgumentsForSchema(
         TypeResolverInterface $typeResolver,
@@ -71,18 +54,10 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
      * 1. At the beginning, before the Validate pipeline
      * 2. In the middle, between the Validate and Resolve directives
      * 3. At the end, after the ResolveAndMerge directive
-     *
-     * @return string
      */
     public function getPipelinePosition(): string;
     /**
      * Indicate if the directiveResolver can process the directive with the given name and args
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $directiveName
-     * @param array $directiveArgs
-     * @param string $field
-     * @return boolean
      */
     public function resolveCanProcess(
         TypeResolverInterface $typeResolver,
@@ -93,8 +68,6 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
     ): bool;
     /**
      * Indicates if the directive can be added several times to the pipeline, or only once
-     *
-     * @return boolean
      */
     public function isRepeatable(): bool;
     /**
@@ -105,24 +78,6 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
     public function needsIDsDataFieldsToExecute(): bool;
     /**
      * Execute the directive
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $idsDataFields
-     * @param array $succeedingPipelineIDsDataFields
-     * @param array $succeedingPipelineDirectiveResolverInstances
-     * @param array $resultIDItems
-     * @param array $unionDBKeyIDs
-     * @param array $dbItems
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $dbDeprecations
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,
@@ -149,7 +104,6 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
     /**
      * Get an instance of the object defining the schema for this fieldResolver
      *
-     * @param TypeResolverInterface $typeResolver
      * @param string $fieldName
      * @param array<string, mixed> $fieldArgs
      * @return void
@@ -164,16 +118,10 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
     public function getSchemaDefinitionForDirective(TypeResolverInterface $typeResolver): array;
     /**
      * Define if to use the version to decide if to process the directive or not
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return boolean
      */
     public function decideCanProcessBasedOnVersionConstraint(TypeResolverInterface $typeResolver): bool;
     /**
      * The version of the directive, using semantic versioning
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return string|null
      */
     public function getSchemaDirectiveVersion(TypeResolverInterface $typeResolver): ?string;
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -23,8 +23,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
 
     /**
      * This is a system directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
@@ -10,52 +10,34 @@ interface SchemaDirectiveResolverInterface
 {
     /**
      * Description of the directive, to be output as documentation in the schema
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return string|null
      */
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string;
     /**
      * Indicates if the directive argument names can be omitted from the query, deducing them from the order in which they were defined in the schema
      *
-     * @param TypeResolverInterface $typeResolver
      * @param string $directive
-     * @return boolean
      */
     public function enableOrderedSchemaDirectiveArgs(TypeResolverInterface $typeResolver): bool;
     /**
      * Schema Directive Arguments
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array;
     /**
      * Filtered Schema Directive Arguments
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getFilteredSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array;
     /**
      * Expressions set by the directive
      *
-     * @param TypeResolverInterface $typeResolver
      * @return string|null
      */
     public function getSchemaDirectiveExpressions(TypeResolverInterface $typeResolver): array;
     /**
      * Raise warnings concerning the directive
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return string|null
      */
     public function getSchemaDirectiveWarningDescription(TypeResolverInterface $typeResolver): ?string;
     /**
      * Indicate if the directive has been deprecated, why, when, and/or how it must be replaced
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return string|null
      */
     public function getSchemaDirectiveDeprecationDescription(TypeResolverInterface $typeResolver): ?string;
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -20,8 +20,6 @@ final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver 
 
     /**
      * This is a system directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -30,8 +28,6 @@ final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver 
 
     /**
      * Execute only once
-     *
-     * @return boolean
      */
     public function isRepeatable(): bool
     {

--- a/layers/Engine/packages/component-model/src/Enums/AbstractEnum.php
+++ b/layers/Engine/packages/component-model/src/Enums/AbstractEnum.php
@@ -51,8 +51,6 @@ abstract class AbstractEnum implements EnumInterface
 
     /**
      * Enum name
-     *
-     * @return string
      */
     abstract protected function getEnumName(): string;
 
@@ -64,8 +62,6 @@ abstract class AbstractEnum implements EnumInterface
      * values => ["ONE", "TWO"] and coreValues => ["one", "two"]
      *
      * If `null`, `getValues` is used
-     *
-     * @return array|null
      */
     public function getCoreValues(): ?array
     {
@@ -73,9 +69,6 @@ abstract class AbstractEnum implements EnumInterface
     }
     /**
      * Given an enum value, obtain its core value
-     *
-     * @param string $enumValue
-     * @return string|null
      */
     final public function getCoreValue(string $enumValue): ?string
     {

--- a/layers/Engine/packages/component-model/src/Environment.php
+++ b/layers/Engine/packages/component-model/src/Environment.php
@@ -16,8 +16,6 @@ class Environment
 
     /**
      * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
-     *
-     * @return bool
      */
     public static function removeFieldIfDirectiveFailed(): bool
     {
@@ -26,8 +24,6 @@ class Environment
 
     /**
      * Indicate: If a directive fails, then stop execution of the directive pipeline altogether
-     *
-     * @return bool
      */
     public static function stopDirectivePipelineExecutionIfDirectiveFailed(): bool
     {
@@ -39,7 +35,6 @@ class Environment
      * using the same semantic versioning constraint rules used by Composer
      *
      * @see https://getcomposer.org/doc/articles/versions.md Composer's semver constraint rules
-     * @return bool
      */
     public static function enableSemanticVersionConstraints(): bool
     {

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -55,9 +55,6 @@ abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverI
      * This will make fieldArg "versionConstraint" be always added to fields implementing an interface,
      * even if they do not have a version. However, the other way around, to say `false`,
      * would not allow any field implementing an interface to be versioned. So this way is better.
-     *
-     * @param string $fieldName
-     * @return boolean
      */
     protected function hasSchemaFieldVersion(string $fieldName): bool
     {

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/EnumTypeFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/EnumTypeFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -34,10 +34,7 @@ trait EnumTypeFieldInterfaceSchemaDefinitionResolverTrait
     /**
      * Add the enum values in the schema: arrays of enum name, description, deprecated and deprecation description
      *
-     * @param array $schemaDefinition
      * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return void
      */
     protected function addSchemaDefinitionEnumValuesForField(array &$schemaDefinition, string $fieldName): void
     {

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceResolverInterface.php
@@ -10,14 +10,10 @@ interface FieldInterfaceResolverInterface extends FieldInterfaceSchemaDefinition
 {
     /**
      * Get an array with the fieldNames that the fieldResolver must implement
-     *
-     * @return array
      */
     public function getFieldNamesToImplement(): array;
     /**
      * An interface can itself implement other interfaces!
-     *
-     * @return array
      */
     public function getImplementedFieldInterfaceResolverClasses(): array;
     public function getInterfaceName(): string;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -89,9 +89,6 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
 
     /**
      * Define if to use the version to decide if to process the field or not
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return boolean
      */
     public function decideCanProcessBasedOnVersionConstraint(TypeResolverInterface $typeResolver): bool
     {
@@ -102,9 +99,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
      * Indicates if the fieldResolver can process this combination of fieldName and fieldArgs
      * It is required to support a multiverse of fields: different fieldResolvers can resolve the field, based on the required version (passed through $fieldArgs['branch'])
      *
-     * @param string $fieldName
      * @param array<string, mixed> $fieldArgs
-     * @return boolean
      */
     public function resolveCanProcess(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): bool
     {
@@ -233,10 +228,6 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
      * Fields may not be directly visible in the schema,
      * eg: because they are used only by the application, and must not
      * be exposed to the user (eg: "accessControlLists")
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return boolean
      */
     public function skipAddingToSchemaDefinition(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
@@ -245,8 +236,6 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
 
     /**
      * Get the "schema" properties as for the fieldName
-     *
-     * @return array
      */
     public function getSchemaDefinitionForField(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): array
     {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -147,7 +147,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                  */
                 try {
                     return Semver::satisfies($schemaFieldVersion, $versionConstraint);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     return false;
                 }
             }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
@@ -50,9 +50,6 @@ abstract class AbstractReflectionPropertyFieldResolver extends AbstractDBDataFie
     /**
      * Extract the description from the docComment
      * Adapted from https://github.com/nadirlc/comment-manager/blob/master/DescriptionParser.php
-     *
-     * @param string $docComment
-     * @return string
      */
     public function extractDescriptionText(string $docComment): string
     {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -123,7 +123,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
             case 'isType':
                 $typeName = $fieldArgs['type'];
                 // If the provided typeName contains the namespace separator, then compare by qualifiedType
-                if (strpos($typeName, SchemaDefinition::TOKEN_NAMESPACE_SEPARATOR) !== false) {
+                if (str_contains($typeName, SchemaDefinition::TOKEN_NAMESPACE_SEPARATOR)) {
                     /**
                      * @todo Replace the code below with:
                      *
@@ -146,7 +146,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
                 $interface = $fieldArgs['interface'];
                 $implementedInterfaceResolverInstances = $typeResolver->getAllImplementedInterfaceResolverInstances();
                 // If the provided interface contains the namespace separator, then compare by qualifiedInterface
-                $useNamespaced = strpos($interface, SchemaDefinition::TOKEN_NAMESPACE_SEPARATOR) !== false;
+                $useNamespaced = str_contains($interface, SchemaDefinition::TOKEN_NAMESPACE_SEPARATOR);
                 $implementedInterfaceNames = array_map(
                     function ($interfaceResolver) use ($useNamespaced) {
                         if ($useNamespaced) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/EnumTypeFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/EnumTypeFieldSchemaDefinitionResolverTrait.php
@@ -33,11 +33,6 @@ trait EnumTypeFieldSchemaDefinitionResolverTrait
 
     /**
      * Add the enum values in the schema: arrays of enum name, description, deprecated and deprecation description
-     *
-     * @param array $schemaDefinition
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return void
      */
     protected function addSchemaDefinitionEnumValuesForField(array &$schemaDefinition, TypeResolverInterface $typeResolver, string $fieldName): void
     {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -12,26 +12,19 @@ interface FieldResolverInterface extends AttachableExtensionInterface
 {
     /**
      * Get an array with the fieldNames that this fieldResolver resolves
-     *
-     * @return array
      */
     public function getFieldNamesToResolve(): array;
     /**
      * A list of classes of all the (GraphQL-style) interfaces the fieldResolver implements
-     *
-     * @return array
      */
     public function getImplementedFieldInterfaceResolverClasses(): array;
     /**
      * Obtain the fieldNames from all implemented interfaces
-     *
-     * @return array
      */
     public function getFieldNamesFromInterfaces(): array;
     /**
      * Get an instance of the object defining the schema for this fieldResolver
      *
-     * @param TypeResolverInterface $typeResolver
      * @param string $fieldName
      * @param array<string, mixed> $fieldArgs
      * @return void
@@ -41,20 +34,12 @@ interface FieldResolverInterface extends AttachableExtensionInterface
      * Fields may not be directly visible in the schema,
      * eg: because they are used only by the application, and must not
      * be exposed to the user (eg: "accessControlLists")
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return boolean
      */
     public function skipAddingToSchemaDefinition(TypeResolverInterface $typeResolver, string $fieldName): bool;
     public function getSchemaDefinitionForField(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): array;
     public function getSchemaFieldVersion(TypeResolverInterface $typeResolver, string $fieldName): ?string;
     /**
      * Indicate if the fields are global (i.e. they apply to all typeResolvers)
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return boolean
      */
     public function isGlobal(TypeResolverInterface $typeResolver, string $fieldName): bool;
 
@@ -62,9 +47,7 @@ interface FieldResolverInterface extends AttachableExtensionInterface
      * Indicates if the fieldResolver can process this combination of fieldName and fieldArgs
      * It is required to support a multiverse of fields: different fieldResolvers can resolve the field, based on the required version (passed through $fieldArgs['branch'])
      *
-     * @param string $fieldName
      * @param array<string, mixed> $fieldArgs
-     * @return boolean
      */
     public function resolveCanProcess(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): bool;
     public function resolveSchemaValidationErrorDescriptions(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?array;
@@ -117,9 +100,6 @@ interface FieldResolverInterface extends AttachableExtensionInterface
     ): ?array;
     /**
      * Define if to use the version to decide if to process the field or not
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return boolean
      */
     public function decideCanProcessBasedOnVersionConstraint(TypeResolverInterface $typeResolver): bool;
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -16,7 +16,6 @@ trait SelfFieldSchemaDefinitionResolverTrait
     /**
      * The object resolves its own schema definition
      *
-     * @param TypeResolverInterface $typeResolver
      * @param string $fieldName
      * @param array<string, mixed> $fieldArgs
      * @return void

--- a/layers/Engine/packages/component-model/src/Misc/GeneralUtils.php
+++ b/layers/Engine/packages/component-model/src/Misc/GeneralUtils.php
@@ -46,10 +46,6 @@ class GeneralUtils
     /**
      * Add paramters "key" => "value" to the URL
      * Implementation based on that from https://stackoverflow.com/a/5809881
-     *
-     * @param array $keyValues
-     * @param string $url
-     * @return string
      */
     public static function addQueryArgs(array $keyValues, string $url): string
     {
@@ -82,8 +78,6 @@ class GeneralUtils
      * Implementation based on that from https://stackoverflow.com/a/5809881
      *
      * @param array $keyValues
-     * @param string $url
-     * @return string
      */
     public static function removeQueryArgs(array $keys, string $url): string
     {

--- a/layers/Engine/packages/component-model/src/Misc/RequestUtils.php
+++ b/layers/Engine/packages/component-model/src/Misc/RequestUtils.php
@@ -138,7 +138,6 @@ class RequestUtils
      * Return the requested full URL
      *
      * @param boolean $useHostRequestedByClient If true, get the host from user-provided HTTP_HOST, otherwise from the server-defined SERVER_NAME
-     * @return string
      */
     public static function getRequestedFullURL(bool $useHostRequestedByClient = false): string
     {

--- a/layers/Engine/packages/component-model/src/ModelInstance/ModelInstance.php
+++ b/layers/Engine/packages/component-model/src/ModelInstance/ModelInstance.php
@@ -16,18 +16,11 @@ class ModelInstance implements ModelInstanceInterface
     public const HOOK_COMPONENTSFROMVARS_POSTORGETCHANGE = __CLASS__ . ':componentsFromVars:postOrGetChange';
     public const HOOK_COMPONENTSFROMVARS_RESULT = __CLASS__ . ':componentsFromVars:result';
 
-    protected TranslationAPIInterface $translationAPI;
-    protected HooksAPIInterface $hooksAPI;
-    protected ApplicationInfoInterface $applicationInfo;
-
     public function __construct(
-        TranslationAPIInterface $translationAPI,
-        HooksAPIInterface $hooksAPI,
-        ApplicationInfoInterface $applicationInfo
+        protected TranslationAPIInterface $translationAPI,
+        protected HooksAPIInterface $hooksAPI,
+        protected ApplicationInfoInterface $applicationInfo
     ) {
-        $this->translationAPI = $translationAPI;
-        $this->hooksAPI = $hooksAPI;
-        $this->applicationInfo = $applicationInfo;
     }
 
     public function getModelInstanceId(): string

--- a/layers/Engine/packages/component-model/src/ModuleFiltering/ModuleFilterManager.php
+++ b/layers/Engine/packages/component-model/src/ModuleFiltering/ModuleFilterManager.php
@@ -34,16 +34,10 @@ class ModuleFilterManager implements ModuleFilterManagerInterface
     // When targeting modules in pop-engine.php (eg: when doing ->get_dbobjectids()) those modules are already and always included, so no need to check for their ancestors or anything
     protected bool $neverExclude = false;
 
-    // Services
-    protected ModulePathManagerInterface $modulePathManager;
-    protected ModulePathHelpersInterface $modulePathHelpers;
-
     public function __construct(
-        ModulePathManagerInterface $modulePathManager,
-        ModulePathHelpersInterface $modulePathHelpers
+        protected ModulePathManagerInterface $modulePathManager,
+        protected ModulePathHelpersInterface $modulePathHelpers
     ) {
-        $this->modulePathManager = $modulePathManager;
-        $this->modulePathHelpers = $modulePathHelpers;
     }
 
     public function addModuleFilter(ModuleFilterInterface $moduleFilter): void

--- a/layers/Engine/packages/component-model/src/ModuleFilters/ModulePaths.php
+++ b/layers/Engine/packages/component-model/src/ModuleFilters/ModulePaths.php
@@ -23,11 +23,8 @@ class ModulePaths extends AbstractModuleFilter
      * @var array<string, array>
      */
     protected array $backlog_unsettled_paths = [];
-
-    protected ModulePathManagerInterface $modulePathManager;
-    public function __construct(ModulePathManagerInterface $modulePathManager)
+    public function __construct(protected ModulePathManagerInterface $modulePathManager)
     {
-        $this->modulePathManager = $modulePathManager;
     }
 
     protected function init()

--- a/layers/Engine/packages/component-model/src/ModulePath/ModulePathHelpers.php
+++ b/layers/Engine/packages/component-model/src/ModulePath/ModulePathHelpers.php
@@ -9,11 +9,8 @@ use PoP\ComponentModel\Modules\ModuleUtils;
 
 class ModulePathHelpers implements ModulePathHelpersInterface
 {
-    protected ModulePathManagerInterface $modulePathManager;
-
-    public function __construct(ModulePathManagerInterface $modulePathManager)
+    public function __construct(protected ModulePathManagerInterface $modulePathManager)
     {
-        $this->modulePathManager = $modulePathManager;
     }
 
     public function getStringifiedModulePropagationCurrentPath(array $module)

--- a/layers/Engine/packages/component-model/src/ModulePath/ModulePathUtils.php
+++ b/layers/Engine/packages/component-model/src/ModulePath/ModulePathUtils.php
@@ -25,7 +25,7 @@ class ModulePathUtils
                 $paths,
                 function ($item) use ($paths) {
                     foreach ($paths as $path) {
-                        if (strlen($item) > strlen($path) && strpos($item, $path) === 0 && $item[strlen($path)] == ModulePath::MODULE_SEPARATOR) {
+                        if (strlen($item) > strlen($path) && str_starts_with($item, $path) && $item[strlen($path)] == ModulePath::MODULE_SEPARATOR) {
                             return false;
                         }
                     }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
@@ -1281,7 +1281,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         return array();
     }
 
-    final private function getSubmodulesByGroup(array $module, $components = array()): array
+    private function getSubmodulesByGroup(array $module, $components = array()): array
     {
         if (empty($components)) {
             $components = array(

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
@@ -10,9 +10,6 @@ trait FilterInputModuleProcessorTrait
 {
     /**
      * Return an array of elements, instead of a single element, to enable filters with several inputs (such as "date", with inputs "date-from" and "date-to") to document all of them
-     *
-     * @param array $module
-     * @return array
      */
     public function getFilterInputSchemaDefinitionItems(array $module): array
     {
@@ -26,8 +23,6 @@ trait FilterInputModuleProcessorTrait
     /**
      * Function to override
      *
-     * @param array $schemaDefinitionItems
-     * @param array $module
      * @return void
      */
     protected function modifyFilterSchemaDefinitionItems(array &$schemaDefinitionItems, array $module)
@@ -41,9 +36,6 @@ trait FilterInputModuleProcessorTrait
 
     /**
      * Documentation for the module
-     *
-     * @param array $module
-     * @return array
      */
     protected function getFilterInputSchemaDefinition(array $module): array
     {

--- a/layers/Engine/packages/component-model/src/MutationResolverBridges/AbstractComponentMutationResolverBridge.php
+++ b/layers/Engine/packages/component-model/src/MutationResolverBridges/AbstractComponentMutationResolverBridge.php
@@ -45,7 +45,6 @@ abstract class AbstractComponentMutationResolverBridge implements ComponentMutat
     }
 
     /**
-     * @param array $data_properties
      * @return array<string, mixed>|null
      */
     public function execute(array &$data_properties): ?array

--- a/layers/Engine/packages/component-model/src/MutationResolverBridges/ComponentMutationResolverBridgeInterface.php
+++ b/layers/Engine/packages/component-model/src/MutationResolverBridges/ComponentMutationResolverBridgeInterface.php
@@ -7,7 +7,6 @@ namespace PoP\ComponentModel\MutationResolverBridges;
 interface ComponentMutationResolverBridgeInterface
 {
     /**
-     * @param array $data_properties
      * @return array<string, mixed>|null
      */
     public function execute(array &$data_properties): ?array;

--- a/layers/Engine/packages/component-model/src/Resolvers/EnumTypeSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/EnumTypeSchemaDefinitionResolverTrait.php
@@ -12,10 +12,8 @@ trait EnumTypeSchemaDefinitionResolverTrait
     /**
      * Add the enum values in the schema: arrays of enum name, description, deprecated and deprecation description
      *
-     * @param array $schemaDefinition
      * @param TypeResolverInterface $typeResolver
      * @param string $fieldName
-     * @return void
      */
     protected function doAddSchemaDefinitionEnumValuesForField(
         array &$schemaDefinition,

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -62,7 +62,6 @@ trait FieldOrDirectiveResolverTrait
      * In that case, the validation will be done inside ->resolveValue(),
      * and will be treated as a $dbError, not a $schemaError
      *
-     * @param TypeResolverInterface $typeResolver
      * @param string $directiveName
      * @param array $directiveArgs
      * @param array $schemaDirectiveArgs

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -27,8 +27,6 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
     /**
      * This function will never be called for the Adapter,
      * but must be implemented to satisfy the interface
-     *
-     * @return array
      */
     public function getFieldNamesToResolve(): array
     {

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -17,11 +17,8 @@ use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
  */
 class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionResolverInterface
 {
-    private FieldInterfaceResolverInterface $fieldInterfaceResolver;
-
-    public function __construct(FieldInterfaceResolverInterface $fieldInterfaceResolver)
+    public function __construct(private FieldInterfaceResolverInterface $fieldInterfaceResolver)
     {
-        $this->fieldInterfaceResolver = $fieldInterfaceResolver;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Resolvers/WithVersionConstraintFieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/WithVersionConstraintFieldOrDirectiveResolverTrait.php
@@ -25,7 +25,6 @@ trait WithVersionConstraintFieldOrDirectiveResolverTrait
      *
      * @param array $schemaDirectiveArgs
      * @param string|null $version the version of the fieldResolver/directiveResolver
-     * @return void
      */
     protected function maybeAddVersionConstraintSchemaFieldOrDirectiveArg(array &$schemaFieldOrDirectiveArgs, bool $hasVersion): void
     {

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -68,18 +68,13 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
      */
     private array $directiveSchemaDefinitionArgsCache = [];
 
-
-    // Services
-    protected TypeCastingExecuterInterface $typeCastingExecuter;
-
     public function __construct(
         TranslationAPIInterface $translationAPI,
         FeedbackMessageStoreInterface $feedbackMessageStore,
-        TypeCastingExecuterInterface $typeCastingExecuter,
+        protected TypeCastingExecuterInterface $typeCastingExecuter,
         QueryParserInterface $queryParser
     ) {
         parent::__construct($translationAPI, $feedbackMessageStore, $queryParser);
-        $this->typeCastingExecuter = $typeCastingExecuter;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -88,7 +88,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
      *
      * @param TypeResolverInterface $typeResolver
      * @param string $field
-     * @return array
      */
     public function extractStaticDirectiveArguments(string $directive, ?array $variables = null): array
     {
@@ -104,8 +103,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop
      *
      * @param TypeResolverInterface $typeResolver
-     * @param string $field
-     * @return array
      */
     public function extractStaticFieldArguments(string $field, ?array $variables = null): array
     {
@@ -194,15 +191,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
 
     /**
      * Extract the arguments for either the field or directive. If the argument name has not been provided, attempt to deduce it from the schema, or show a warning if not possible
-     *
-     * @param string $fieldOrDirective
-     * @param array $fieldOrDirectiveArgElems
-     * @param boolean $orderedFieldOrDirectiveArgNamesEnabled
-     * @param array $fieldOrDirectiveArgumentNameTypes
-     * @param array $fieldArgumentNameDefaultValues
-     * @param array|null $variables
-     * @param array $schemaWarnings
-     * @return array
      */
     protected function extractAndValidateFielOrDirectiveArguments(
         string $fieldOrDirective,

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -11,10 +11,6 @@ interface FieldQueryInterpreterInterface extends \PoP\FieldQuery\FieldQueryInter
 {
     /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop
-     *
-     * @param string $field
-     * @param array|null $variables
-     * @return array
      */
     public function extractStaticFieldArguments(string $field, ?array $variables = null): array;
     public function extractStaticDirectiveArguments(string $directive, ?array $variables = null): array;

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryUtils.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryUtils.php
@@ -36,10 +36,6 @@ class FieldQueryUtils
 
     /**
      * Indicate if the fieldArgValue is whatever is needed to know, executed against a $callback function
-     *
-     * @param array $fieldArgValues
-     * @param callback $callback
-     * @return boolean
      */
     public static function isAnyFieldArgumentValueASomething(array $fieldArgValues, callable $callback): bool
     {

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -70,7 +70,6 @@ class SchemaHelpers
     /**
      * Remove the deprecated enumValues from the schema definition
      *
-     * @param array $enumValueDefinitions
      * @return void
      */
     public static function removeDeprecatedEnumValuesFromSchemaDefinition(array $enumValueDefinitions): array
@@ -149,11 +148,6 @@ class SchemaHelpers
 
     /**
      * If the internal type is "id", convert it to its type name
-     *
-     * @param string $type
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return string
      */
     public static function convertTypeIDToTypeName(
         string $type,
@@ -187,9 +181,6 @@ class SchemaHelpers
     /**
      * Following PSR-4, namespaces must contain the owner (eg: "PoP") and project name (eg: "ComponentModel")
      * Extract these 2 elements to namespace the types/interfaces
-     *
-     * @param string $namespace
-     * @return string
      */
     protected static function getOwnerAndProjectFromNamespace(string $namespace): string
     {

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -22,7 +22,6 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
     /**
      * Cast the value to the indicated type, or return null or Error (with a message) if it fails
      *
-     * @param string $type
      * @param string $value
      * @return void
      */

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -11,12 +11,8 @@ use DateTime;
 
 class TypeCastingExecuter implements TypeCastingExecuterInterface
 {
-    private TranslationAPIInterface $translationAPI;
-
-    public function __construct(
-        TranslationAPIInterface $translationAPI
-    ) {
-        $this->translationAPI = $translationAPI;
+    public function __construct(private TranslationAPIInterface $translationAPI)
+    {
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuterInterface.php
@@ -9,7 +9,6 @@ interface TypeCastingExecuterInterface
     /**
      * Cast the value to the indicated type, or return null or Error (with a message) if it fails
      *
-     * @param string $type
      * @param string $value
      * @return void
      */

--- a/layers/Engine/packages/component-model/src/TypeDataLoaders/AbstractUnionTypeDataLoader.php
+++ b/layers/Engine/packages/component-model/src/TypeDataLoaders/AbstractUnionTypeDataLoader.php
@@ -12,9 +12,6 @@ abstract class AbstractUnionTypeDataLoader extends AbstractTypeDataLoader
 
     /**
      * Iterate through all unionTypes and delegate to each resolving the IDs each of them can resolve
-     *
-     * @param array $ids
-     * @return array
      */
     public function getObjects(array $ids): array
     {

--- a/layers/Engine/packages/component-model/src/TypeResolverDecorators/AbstractTypeResolverDecorator.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverDecorators/AbstractTypeResolverDecorator.php
@@ -18,7 +18,6 @@ abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInt
     /**
      * Allow to disable the functionality
      *
-     * @param TypeResolverInterface $typeResolver
      * @return array
      */
     public function enabled(TypeResolverInterface $typeResolver): bool
@@ -28,9 +27,6 @@ abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInt
 
     /**
      * Return an array of fieldNames as keys, and, for each fieldName, an array of directives (including directive arguments) to be applied always on the field
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getMandatoryDirectivesForFields(TypeResolverInterface $typeResolver): array
     {
@@ -40,9 +36,6 @@ abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInt
     /**
      * Return an array of directiveName as keys, and, for each directiveName,
      * an array of directives (including directive arguments) to be applied before
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {
@@ -52,9 +45,6 @@ abstract class AbstractTypeResolverDecorator implements TypeResolverDecoratorInt
     /**
      * Return an array of directiveName as keys, and, for each directiveName,
      * an array of directives (including directive arguments) to be applied after
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getSucceedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {

--- a/layers/Engine/packages/component-model/src/TypeResolverDecorators/TypeResolverDecoratorInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolverDecorators/TypeResolverDecoratorInterface.php
@@ -12,31 +12,21 @@ interface TypeResolverDecoratorInterface extends AttachableExtensionInterface
     /**
      * Allow to disable the functionality
      *
-     * @param TypeResolverInterface $typeResolver
      * @return array
      */
     public function enabled(TypeResolverInterface $typeResolver): bool;
     /**
      * Return an array of fieldNames as keys, and, for each fieldName, an array of directives (including directive arguments) to be applied always on the field
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getMandatoryDirectivesForFields(TypeResolverInterface $typeResolver): array;
     /**
      * Return an array of directiveName as keys, and, for each directiveName,
      * an array of directives (including directive arguments) to be applied before
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array;
     /**
      * Return an array of directiveName as keys, and, for each directiveName,
      * an array of directives (including directive arguments) to be applied after
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getSucceedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -196,15 +196,6 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
      * 1. the directiveResolverInstance
      * 2. its fieldDirective
      * 3. the fields it affects
-     *
-     * @param array $fieldDirectives
-     * @param array $fieldDirectiveFields
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $schemaNotices
-     * @param array $schemaTraces
-     * @return array
      */
     public function resolveDirectivesIntoPipelineData(
         array $fieldDirectives,
@@ -693,12 +684,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     /**
      * By default, do nothing
      *
-     * @param string $field
      * @param array<string, mixed> $fieldArgs
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return array
      */
     public function validateFieldArgumentsForSchema(string $field, array $fieldArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array
     {
@@ -819,9 +805,6 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
      * Eg: a directive `@validateDoesUserHaveCapability` must be preceded by a directive `@validateIsUserLoggedIn`
      *
      * The process is recursive: mandatory directives can have their own mandatory directives, and these are added too
-     *
-     * @param array $directives
-     * @return array
      */
     protected function addMandatoryDirectivesForDirectives(array $directives): array
     {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -36,7 +36,6 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
     /**
      * Remove the type from the ID to resolve the objects through `getObjects` (check parent class)
      *
-     * @param array $ids_data_fields
      * @return void
      */
     protected function getIDsToQuery(array $ids_data_fields)
@@ -464,10 +463,6 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
 
     /**
      * Because the UnionTypeResolver doesn't know yet which TypeResolver will be used (that depends on each resultItem), it can't resolve error validation
-     *
-     * @param string $field
-     * @param array $variables
-     * @return array
      */
     public function resolveSchemaValidationErrorDescriptions(string $field, array &$variables = null): array
     {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/FieldHelpers.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/FieldHelpers.php
@@ -9,7 +9,6 @@ class FieldHelpers
     /**
      * Extracts all the deep conditional fields as an array of unique elements
      *
-     * @param array $dataFields
      * @return void
      */
     public static function extractConditionalFields(array $dataFields): array

--- a/layers/Engine/packages/component-model/src/TypeResolvers/TypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/TypeResolverInterface.php
@@ -76,15 +76,6 @@ interface TypeResolverInterface
      * 1. the directiveResolverInstance
      * 2. its fieldDirective
      * 3. the fields it affects
-     *
-     * @param array $fieldDirectives
-     * @param array $fieldDirectiveFields
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $schemaNotices
-     * @param array $schemaTraces
-     * @return array
      */
     public function resolveDirectivesIntoPipelineData(
         array $fieldDirectives,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/UnionTypeHelpers.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/UnionTypeHelpers.php
@@ -15,9 +15,6 @@ class UnionTypeHelpers
 {
     /**
      * If the type data resolver starts with "*" then it's union
-     *
-     * @param string $type
-     * @return boolean
      */
     public static function isUnionType(string $type): bool
     {
@@ -31,9 +28,6 @@ class UnionTypeHelpers
 
     /**
      * Extract the original Union type name (i.e. without "*")
-     *
-     * @param string $unionTypeCollectionName
-     * @return string
      */
     public static function removePrefixFromUnionTypeName(string $unionTypeCollectionName): string
     {
@@ -93,9 +87,6 @@ class UnionTypeHelpers
      *   and not the Union (since it's more efficient)
      * - If there are none types, return `null`. As a consequence,
      *   the ID is returned as a field, not as a connection
-     *
-     * @param string $unionTypeResolverClass
-     * @return string|null
      */
     public static function getUnionOrTargetTypeResolverClass(string $unionTypeResolverClass): ?string
     {

--- a/layers/Engine/packages/component-model/src/Versioning/VersioningHelpers.php
+++ b/layers/Engine/packages/component-model/src/Versioning/VersioningHelpers.php
@@ -21,8 +21,6 @@ class VersioningHelpers
 
     /**
      * Initialize the dictionary with the version constraints for specific fields in the schema
-     *
-     * @return void
      */
     protected static function initializeVersionConstraintsForFields(): void
     {
@@ -61,10 +59,6 @@ class VersioningHelpers
 
     /**
      * Indicates the version constraints for specific fields in the schema
-     *
-     * @param string $maybeNamespacedTypeName
-     * @param string $fieldName
-     * @return string|null
      */
     public static function getVersionConstraintsForField(string $maybeNamespacedTypeName, string $fieldName): ?string
     {
@@ -79,7 +73,6 @@ class VersioningHelpers
      *
      * @param string $maybeNamespacedTypeName
      * @param string $fieldName
-     * @return string|null
      */
     public static function getVersionConstraintsForDirective(string $directiveName): ?string
     {

--- a/layers/Engine/packages/engine-wp/templates/Output.php
+++ b/layers/Engine/packages/engine-wp/templates/Output.php
@@ -1,5 +1,5 @@
 <?php
-use PoP\ComponentModel\Facades\Engine\EngineFacade;
 
+use PoP\ComponentModel\Facades\Engine\EngineFacade;
 $engine = EngineFacade::getInstance();
 $engine->outputResponse();

--- a/layers/Engine/packages/engine/src/Cache/Cache.php
+++ b/layers/Engine/packages/engine/src/Cache/Cache.php
@@ -42,7 +42,6 @@ class Cache extends \PoP\ComponentModel\Cache\Cache
     /**
      * Override to save as deferred, on hook "popcms:shutdown"
      *
-     * @param CacheItemInterface $cacheItem
      * @return void
      */
     protected function saveCache(CacheItemInterface $cacheItem)

--- a/layers/Engine/packages/engine/src/Cache/Cache.php
+++ b/layers/Engine/packages/engine/src/Cache/Cache.php
@@ -11,15 +11,12 @@ use PoP\ComponentModel\ModelInstance\ModelInstanceInterface;
 
 class Cache extends \PoP\ComponentModel\Cache\Cache
 {
-    protected HooksAPIInterface $hooksAPI;
-
     public function __construct(
         CacheItemPoolInterface $cacheItemPool,
-        HooksAPIInterface $hooksAPI,
+        protected HooksAPIInterface $hooksAPI,
         ModelInstanceInterface $modelInstance
     ) {
         parent::__construct($cacheItemPool, $modelInstance);
-        $this->hooksAPI = $hooksAPI;
 
         // When a plugin is activated/deactivated, ANY plugin, delete the corresponding cached files
         // This is particularly important for the MEMORY, since we can't set by constants to not use it

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/CacheDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/CacheDirectiveResolverTrait.php
@@ -17,8 +17,6 @@ trait CacheDirectiveResolverTrait
 {
     /**
      * This is a "Schema" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -28,10 +26,7 @@ trait CacheDirectiveResolverTrait
     /**
      * Create a unique ID under which to store the cache, based on the type, ID and field (without the alias)
      *
-     * @param TypeResolverInterface $typeResolver
      * @param [type] $id
-     * @param string $field
-     * @return string
      */
     protected function getCacheID(TypeResolverInterface $typeResolver, $id, string $field): string
     {

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
@@ -44,8 +44,6 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     /**
      * This directive is added automatically by @cache, it's not added by the user
-     *
-     * @return boolean
      */
     public function skipAddingToSchemaDefinition(): bool
     {
@@ -54,23 +52,6 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     /**
      * Save all the field values into the cache
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $idsDataFields
-     * @param array $succeedingPipelineIDsDataFields
-     * @param array $resultIDItems
-     * @param array $unionDBKeyIDs
-     * @param array $dbItems
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $dbDeprecations
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
@@ -47,23 +47,6 @@ class SaveCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     /**
      * Save all the field values into the cache
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $idsDataFields
-     * @param array $succeedingPipelineIDsDataFields
-     * @param array $resultIDItems
-     * @param array $unionDBKeyIDs
-     * @param array $dbItems
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $dbDeprecations
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/CacheTypeResolverDecorator.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/CacheTypeResolverDecorator.php
@@ -24,9 +24,6 @@ class CacheTypeResolverDecorator extends AbstractTypeResolverDecorator
 
     /**
      * Directives @loadCache and @saveCache (called @cache) always go together
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
@@ -66,20 +66,6 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
      * 1. Unpack the elements of the array into a temporary property for each, in the current object
      * 2. Execute <transformProperty> on each property
      * 3. Pack into the array, once again, and remove all temporary properties
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,
@@ -333,7 +319,6 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
     }
     /**
      * Place the result for the array in the original property
-     * @param int|string $arrayItemKey
      */
     protected function addProcessedItemBackToDBItems(
         TypeResolverInterface $typeResolver,
@@ -345,7 +330,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
         array &$dbTraces,
         $id,
         string $fieldOutputKey,
-        $arrayItemKey,
+        int|string $arrayItemKey,
         $arrayItemValue
     ): void {
         $dbItems[(string)$id][$fieldOutputKey][$arrayItemKey] = $arrayItemValue;
@@ -379,23 +364,10 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
     //     // $pos = QueryUtils::findLastSymbolPosition($arrayItemProperty, self::PROPERTY_SEPARATOR);
     //     return explode(self::PROPERTY_SEPARATOR, $arrayItemProperty);
     // }
-
     /**
      * Add the $key in addition to the $value
      *
-     * @param TypeResolverInterface $typeResolver
      * @param [type] $id
-     * @param string $field
-     * @param array $resultIDItems
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
      * @return void
      */
     protected function addExpressionsForResultItem(TypeResolverInterface $typeResolver, $id, string $field, array &$resultIDItems, array &$dbItems, array &$previousDBItems, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
@@ -24,8 +24,6 @@ class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolv
 
     /**
      * This is a system directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -49,24 +47,6 @@ class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolv
 
     /**
      * Execute the directive
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $idsDataFields
-     * @param array $succeedingPipelineIDsDataFields
-     * @param array $succeedingPipelineDirectiveResolverInstances
-     * @param array $resultIDItems
-     * @param array $unionDBKeyIDs
-     * @param array $dbItems
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $dbDeprecations
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
@@ -21,8 +21,6 @@ class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectiv
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -31,8 +29,6 @@ class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectiv
 
     /**
      * Do not allow dynamic fields
-     *
-     * @return bool
      */
     protected function disableDynamicFieldsFromDirectiveArgs(): bool
     {
@@ -64,7 +60,6 @@ class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectiv
     /**
      * Directly point to the element under the specified path
      *
-     * @param array $array
      * @return void
      */
     protected function getArrayItems(array &$array, $id, string $field, TypeResolverInterface $typeResolver, array &$resultIDItems, array &$dbItems, array &$previousDBItems, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations): ?array
@@ -98,8 +93,6 @@ class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectiv
      *
      * Otherwise it adds the results under a parallel entry, not overriding
      * the original ones.
-     *
-     * @param int|string $arrayItemKey
      */
     protected function addProcessedItemBackToDBItems(
         TypeResolverInterface $typeResolver,
@@ -111,7 +104,7 @@ class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectiv
         array &$dbTraces,
         $id,
         string $fieldOutputKey,
-        $arrayItemKey,
+        int|string $arrayItemKey,
         $arrayItemValue
     ): void {
         if (!is_array($arrayItemValue)) {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -27,8 +27,6 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -97,15 +95,6 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
     /**
      * Execute a function on the affected field
      *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
      * @return void
      */
     protected function regenerateAndExecuteFunction(TypeResolverInterface $typeResolver, array &$resultIDItems, array &$idsDataFields, array &$dbItems, array &$previousDBItems, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)
@@ -268,19 +257,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
     /**
      * Place all the reserved variables into the `$variables` context
      *
-     * @param TypeResolverInterface $typeResolver
      * @param [type] $id
-     * @param string $field
-     * @param array $resultIDItems
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
      * @return void
      */
     protected function addExpressionsForResultItem(TypeResolverInterface $typeResolver, $id, string $field, array &$resultIDItems, array &$dbItems, array &$previousDBItems, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
@@ -24,8 +24,6 @@ class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItems
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
@@ -22,8 +22,6 @@ final class SetSelfAsExpressionDirectiveResolver extends AbstractGlobalDirective
 
     /**
      * This is a "Scripting" type directive
-     *
-     * @return string
      */
     public function getDirectiveType(): string
     {
@@ -32,8 +30,6 @@ final class SetSelfAsExpressionDirectiveResolver extends AbstractGlobalDirective
 
     /**
      * Do not allow dynamic fields
-     *
-     * @return bool
      */
     protected function disableDynamicFieldsFromDirectiveArgs(): bool
     {
@@ -52,8 +48,6 @@ final class SetSelfAsExpressionDirectiveResolver extends AbstractGlobalDirective
 
     /**
      * Setting it more than once makes no sense
-     *
-     * @return boolean
      */
     public function isRepeatable(): bool
     {
@@ -79,17 +73,6 @@ final class SetSelfAsExpressionDirectiveResolver extends AbstractGlobalDirective
 
     /**
      * Copy the data under the relational object into the current object
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $resultIDItems
-     * @param array $idsDataFields
-     * @param array $dbItems
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/engine/src/Hooks/ModuleFilters/HeadModuleHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/ModuleFilters/HeadModuleHookSet.php
@@ -14,18 +14,15 @@ use PoP\Translation\TranslationAPIInterface;
 
 class HeadModuleHookSet extends AbstractHookSet
 {
-    protected HeadModule $headModule;
-
     public function __construct(
         HooksAPIInterface $hooksAPI,
         TranslationAPIInterface $translationAPI,
-        HeadModule $headModule
+        protected HeadModule $headModule
     ) {
         parent::__construct(
             $hooksAPI,
             $translationAPI
         );
-        $this->headModule = $headModule;
     }
 
     protected function init()

--- a/layers/Engine/packages/engine/src/Hooks/ModuleFilters/MainContentModuleHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/ModuleFilters/MainContentModuleHookSet.php
@@ -12,18 +12,15 @@ use PoP\Translation\TranslationAPIInterface;
 
 class MainContentModuleHookSet extends AbstractHookSet
 {
-    protected MainContentModule $mainContentModule;
-
     public function __construct(
         HooksAPIInterface $hooksAPI,
         TranslationAPIInterface $translationAPI,
-        MainContentModule $mainContentModule
+        protected MainContentModule $mainContentModule
     ) {
         parent::__construct(
             $hooksAPI,
             $translationAPI
         );
-        $this->mainContentModule = $mainContentModule;
     }
 
     protected function init()

--- a/layers/Engine/packages/engine/src/Hooks/ModuleFilters/ModulePathsHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/ModuleFilters/ModulePathsHookSet.php
@@ -15,18 +15,15 @@ use PoP\Translation\TranslationAPIInterface;
 
 class ModulePathsHookSet extends AbstractHookSet
 {
-    protected ModulePaths $modulePaths;
-
     public function __construct(
         HooksAPIInterface $hooksAPI,
         TranslationAPIInterface $translationAPI,
-        ModulePaths $modulePaths
+        protected ModulePaths $modulePaths
     ) {
         parent::__construct(
             $hooksAPI,
             $translationAPI
         );
-        $this->modulePaths = $modulePaths;
     }
 
     protected function init()

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -53,22 +53,14 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
      */
     private ?array $variablesFromRequestCache = null;
 
-    // Services
-    protected TranslationAPIInterface $translationAPI;
-    protected FeedbackMessageStoreInterface $feedbackMessageStore;
-    protected QueryParserInterface $queryParser;
-
     public const ALIAS_POSITION_KEY = 'pos';
     public const ALIAS_LENGTH_KEY = 'length';
 
     public function __construct(
-        TranslationAPIInterface $translationAPI,
-        FeedbackMessageStoreInterface $feedbackMessageStore,
-        QueryParserInterface $queryParser
+        protected TranslationAPIInterface $translationAPI,
+        protected FeedbackMessageStoreInterface $feedbackMessageStore,
+        protected QueryParserInterface $queryParser
     ) {
-        $this->translationAPI = $translationAPI;
-        $this->feedbackMessageStore = $feedbackMessageStore;
-        $this->queryParser = $queryParser;
     }
 
     public function getFieldName(string $field): string

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -221,9 +221,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
     /**
      * Replace the fieldArgs in the field
      *
-     * @param string $field
      * @param array<string, mixed> $fieldArgs
-     * @return string
      */
     protected function replaceFieldArgs(string $field, array $fieldArgs = []): string
     {

--- a/layers/Engine/packages/field-query/src/QueryHelpers.php
+++ b/layers/Engine/packages/field-query/src/QueryHelpers.php
@@ -70,10 +70,7 @@ class QueryHelpers
         ];
     }
 
-    /**
-     * @return int|false
-     */
-    public static function findFieldAliasSymbolPosition(string $field)
+    public static function findFieldAliasSymbolPosition(string $field): int|false
     {
         return QueryUtils::findFirstSymbolPosition(
             $field,
@@ -89,10 +86,7 @@ class QueryHelpers
         );
     }
 
-    /**
-     * @return int|false
-     */
-    public static function findSkipOutputIfNullSymbolPosition(string $field)
+    public static function findSkipOutputIfNullSymbolPosition(string $field): int|false
     {
         return QueryUtils::findFirstSymbolPosition(
             $field,

--- a/layers/Engine/packages/field-query/src/QueryUtils.php
+++ b/layers/Engine/packages/field-query/src/QueryUtils.php
@@ -12,14 +12,13 @@ class QueryUtils
     /**
      * @param string[]|string|null $skipFromChars
      * @param string[]|string|null $skipUntilChars
-     * @return int|false
      */
     public static function findFirstSymbolPosition(
         string $haystack,
         string $needle,
         $skipFromChars = '',
         $skipUntilChars = ''
-    ) {
+    ): int|false {
         // Edge case: If the string starts with the symbol, then the array count of splitting the elements will be 1
         if (substr($haystack, 0, strlen($needle)) == $needle) {
             return 0;
@@ -54,14 +53,13 @@ class QueryUtils
     /**
      * @param string[]|string|null $skipFromChars
      * @param string[]|string|null $skipUntilChars
-     * @return int|false
      */
     public static function findLastSymbolPosition(
         string $haystack,
         string $needle,
         $skipFromChars = '',
         $skipUntilChars = ''
-    ) {
+    ): int|false {
         // Edge case: If the string finishes with the symbol, then the array count of splitting the elements will be 1
         if (substr($haystack, -1 * strlen($needle)) == $needle) {
             return strlen($haystack) - strlen($needle);

--- a/layers/Engine/packages/filestore/src/Renderer/FileRenderer.php
+++ b/layers/Engine/packages/filestore/src/Renderer/FileRenderer.php
@@ -10,15 +10,10 @@ use PoP\FileStore\Store\FileStoreInterface;
 
 class FileRenderer implements FileRendererInterface
 {
-    private FileStoreInterface $fileStore;
-    private string $separator;
-
     public function __construct(
-        FileStoreInterface $fileStore,
-        string $separator = PHP_EOL
+        private FileStoreInterface $fileStore,
+        private string $separator = PHP_EOL
     ) {
-        $this->fileStore = $fileStore;
-        $this->separator = $separator;
     }
     public function render(AbstractAccessibleRenderableFile $file): string
     {

--- a/layers/Engine/packages/guzzle-helpers/src/GuzzleHelpers.php
+++ b/layers/Engine/packages/guzzle-helpers/src/GuzzleHelpers.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace PoP\GuzzleHelpers;
 
-use function GuzzleHttp\Promise\unwrap;
-use function GuzzleHttp\Promise\settle;
 use GuzzleHttp\Client;
-use GuzzleHttp\Promise;
 use PoP\ComponentModel\ErrorHandling\Error;
 use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Exception\RequestException;
 use PoP\Translation\Facades\TranslationAPIFacade;
+
+use function GuzzleHttp\Promise\unwrap;
+use function GuzzleHttp\Promise\settle;
 
 class GuzzleHelpers
 {
@@ -21,10 +21,9 @@ class GuzzleHelpers
      *
      * @param string $url The Endpoint URL
      * @param array $bodyJSONQuery The form params
-     * @param string $method
      * @return array|Error The payload if successful as an array, or an Error object containing the error message in case of failure
      */
-    public static function requestJSON(string $url, array $bodyJSONQuery = [], string $method = 'POST')
+    public static function requestJSON(string $url, array $bodyJSONQuery = [], string $method = 'POST'): array|Error
     {
         $client = new Client();
         try {
@@ -93,7 +92,6 @@ class GuzzleHelpers
      *
      * @param string $url The Endpoint URL
      * @param array $bodyJSONQueries The form params
-     * @param string $method
      * @return mixed The payload if successful as an array, or an Error object containing the error message in case of failure
      */
     public static function requestSingleURLMultipleQueriesAsyncJSON(string $url, array $bodyJSONQueries = [], string $method = 'POST')
@@ -110,7 +108,6 @@ class GuzzleHelpers
      *
      * @param array $urls The endpoints to fetch
      * @param array $bodyJSONQueries the bodyJSONQuery to attach to each URL, on the same order provided in param $urls
-     * @param string $method
      * @return void
      */
     public static function requestAsyncJSON(array $urls, array $bodyJSONQueries = [], string $method = 'POST')

--- a/layers/Engine/packages/guzzle-helpers/src/GuzzleHelpers.php
+++ b/layers/Engine/packages/guzzle-helpers/src/GuzzleHelpers.php
@@ -64,7 +64,7 @@ class GuzzleHelpers
             substr($contentType, 0, strlen('application/json')) == 'application/json'
             || (
                 substr($contentType, 0, strlen('application/')) == 'application/'
-                && strpos($contentType, '+json') !== false
+                && str_contains($contentType, '+json')
             );
         if (!$isJSONContentType) {
             // Throw an error

--- a/layers/Engine/packages/hooks/src/AbstractHookSet.php
+++ b/layers/Engine/packages/hooks/src/AbstractHookSet.php
@@ -10,15 +10,10 @@ use PoP\Translation\TranslationAPIInterface;
 
 abstract class AbstractHookSet extends AbstractAutomaticallyInstantiatedService
 {
-    protected HooksAPIInterface $hooksAPI;
-    protected TranslationAPIInterface $translationAPI;
-
     public function __construct(
-        HooksAPIInterface $hooksAPI,
-        TranslationAPIInterface $translationAPI
+        protected HooksAPIInterface $hooksAPI,
+        protected TranslationAPIInterface $translationAPI
     ) {
-        $this->hooksAPI = $hooksAPI;
-        $this->translationAPI = $translationAPI;
     }
 
     final public function initialize(): void

--- a/layers/Engine/packages/loosecontracts/src/AbstractLooseContractResolutionSet.php
+++ b/layers/Engine/packages/loosecontracts/src/AbstractLooseContractResolutionSet.php
@@ -11,18 +11,11 @@ use PoP\Root\Services\AbstractAutomaticallyInstantiatedService;
 
 abstract class AbstractLooseContractResolutionSet extends AbstractAutomaticallyInstantiatedService
 {
-    protected LooseContractManagerInterface $looseContractManager;
-    protected NameResolverInterface $nameResolver;
-    protected HooksAPIInterface $hooksAPI;
-
     public function __construct(
-        LooseContractManagerInterface $looseContractManager,
-        NameResolverInterface $nameResolver,
-        HooksAPIInterface $hooksAPI
+        protected LooseContractManagerInterface $looseContractManager,
+        protected NameResolverInterface $nameResolver,
+        protected HooksAPIInterface $hooksAPI
     ) {
-        $this->looseContractManager = $looseContractManager;
-        $this->nameResolver = $nameResolver;
-        $this->hooksAPI = $hooksAPI;
     }
 
     final public function initialize(): void

--- a/layers/Engine/packages/loosecontracts/src/AbstractLooseContractSet.php
+++ b/layers/Engine/packages/loosecontracts/src/AbstractLooseContractSet.php
@@ -8,12 +8,8 @@ use PoP\Root\Services\AbstractAutomaticallyInstantiatedService;
 
 abstract class AbstractLooseContractSet extends AbstractAutomaticallyInstantiatedService
 {
-    protected LooseContractManagerInterface $looseContractManager;
-
-    public function __construct(
-        LooseContractManagerInterface $looseContractManager
-    ) {
-        $this->looseContractManager = $looseContractManager;
+    public function __construct(protected LooseContractManagerInterface $looseContractManager)
+    {
     }
 
     final public function initialize(): void

--- a/layers/Engine/packages/loosecontracts/src/AbstractNameResolver.php
+++ b/layers/Engine/packages/loosecontracts/src/AbstractNameResolver.php
@@ -6,12 +6,8 @@ namespace PoP\LooseContracts;
 
 abstract class AbstractNameResolver implements NameResolverInterface
 {
-    protected LooseContractManagerInterface $looseContractManager;
-
-    public function __construct(
-        LooseContractManagerInterface $looseContractManager
-    ) {
-        $this->looseContractManager = $looseContractManager;
+    public function __construct(protected LooseContractManagerInterface $looseContractManager)
+    {
     }
 
     public function implementName(string $abstractName, string $implementationName): void

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForDirectivesTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForDirectivesTrait.php
@@ -10,15 +10,11 @@ trait ConfigurableMandatoryDirectivesForDirectivesTrait
 {
     /**
      * Configuration entries
-     *
-     * @return array
      */
     abstract protected function getConfigurationEntries(): array;
 
     /**
      * Configuration entries
-     *
-     * @return array
      */
     final protected function getEntries(): array
     {
@@ -61,10 +57,6 @@ trait ConfigurableMandatoryDirectivesForDirectivesTrait
 
     /**
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
-     *
-     * @param array $entryList
-     * @param string|null $value
-     * @return array
      */
     final protected function getMatchingEntries(array $entryList, ?string $value): array
     {

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
@@ -10,15 +10,11 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
 {
     /**
      * Configuration entries
-     *
-     * @return array
      */
     abstract protected function getConfigurationEntries(): array;
 
     /**
      * Field names to remove
-     *
-     * @return array
      */
     protected function getFieldNames(): array
     {
@@ -36,8 +32,6 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
 
     /**
      * Configuration entries
-     *
-     * @return array
      */
     final protected function getEntries(
         TypeResolverInterface $typeResolver,
@@ -56,9 +50,6 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
      *
      * @param boolean $include
-     * @param array $entryList
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
      * @return boolean
      */
     final protected function getMatchingEntries(

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/AbstractMandatoryDirectivesForDirectivesTypeResolverDecorator.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/TypeResolverDecorators/AbstractMandatoryDirectivesForDirectivesTypeResolverDecorator.php
@@ -14,8 +14,6 @@ abstract class AbstractMandatoryDirectivesForDirectivesTypeResolverDecorator ext
 
     /**
      * By default, it is valid everywhere
-     *
-     * @return array
      */
     public function getClassesToAttachTo(): array
     {

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -61,8 +61,6 @@ class Component extends AbstractComponent
 
     /**
      * Function called by the Bootloader after all components have been loaded
-     *
-     * @return void
      */
     public static function beforeBoot(): void
     {
@@ -76,8 +74,6 @@ class Component extends AbstractComponent
 
     /**
      * Function called by the Bootloader after all components have been loaded
-     *
-     * @return void
      */
     public static function boot(): void
     {
@@ -91,8 +87,6 @@ class Component extends AbstractComponent
 
     /**
      * Function called by the Bootloader after all components have been loaded
-     *
-     * @return void
      */
     public static function afterBoot(): void
     {

--- a/layers/Engine/packages/root/src/Component/AbstractComponent.php
+++ b/layers/Engine/packages/root/src/Component/AbstractComponent.php
@@ -121,8 +121,6 @@ abstract class AbstractComponent implements ComponentInterface
 
     /**
      * Function called by the Bootloader after all components have been loaded
-     *
-     * @return void
      */
     public static function beforeBoot(): void
     {
@@ -130,8 +128,6 @@ abstract class AbstractComponent implements ComponentInterface
 
     /**
      * Function called by the Bootloader when booting the system
-     *
-     * @return void
      */
     public static function boot(): void
     {
@@ -139,8 +135,6 @@ abstract class AbstractComponent implements ComponentInterface
 
     /**
      * Function called by the Bootloader when booting the system
-     *
-     * @return void
      */
     public static function afterBoot(): void
     {

--- a/layers/Engine/packages/root/src/Component/ComponentInterface.php
+++ b/layers/Engine/packages/root/src/Component/ComponentInterface.php
@@ -45,25 +45,18 @@ interface ComponentInterface
     //  * Initialize services
     //  */
     // public static function init(): void;
-
     /**
      * Function called by the Bootloader after all components have been loaded
-     *
-     * @return void
      */
     public static function beforeBoot(): void;
 
     /**
      * Function called by the Bootloader when booting the system
-     *
-     * @return void
      */
     public static function boot(): void;
 
     /**
      * Function called by the Bootloader when booting the system
-     *
-     * @return void
      */
     public static function afterBoot(): void;
 }

--- a/layers/Engine/packages/root/src/Component/InitializeContainerServicesInComponentTrait.php
+++ b/layers/Engine/packages/root/src/Component/InitializeContainerServicesInComponentTrait.php
@@ -50,8 +50,6 @@ trait InitializeContainerServicesInComponentTrait
      * Initialize the services defined in the YAML configuration file.
      * If not provided, use "services.yaml"
      *
-     * @param string $componentDir
-     * @param string $configPath
      * @param string $fileName
      * @return void
      */

--- a/layers/Engine/packages/root/src/Container/ContainerBuilderFactoryTrait.php
+++ b/layers/Engine/packages/root/src/Container/ContainerBuilderFactoryTrait.php
@@ -25,7 +25,6 @@ trait ContainerBuilderFactoryTrait
      * @param bool|null $cacheContainerConfiguration Indicate if to cache the container configuration. If null, the default value is used
      * @param string|null $namespace subdirectory under which to store the cache. If null, it will use a system temp folder
      * @param string|null $directory directory where to store the cache. If null, the default value is used
-     * @return void
      */
     public static function init(
         ?bool $cacheContainerConfiguration = null,

--- a/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
+++ b/layers/Engine/packages/root/src/Container/ContainerBuilderWrapper.php
@@ -9,11 +9,8 @@ use Symfony\Component\DependencyInjection\Definition;
 
 final class ContainerBuilderWrapper implements ContainerBuilderWrapperInterface
 {
-    private ContainerBuilder $containerBuilder;
-
-    final public function __construct(ContainerBuilder $containerBuilder)
+    public final function __construct(private ContainerBuilder $containerBuilder)
     {
-        $this->containerBuilder = $containerBuilder;
     }
 
     final public function getContainerBuilder(): ContainerBuilder

--- a/layers/Engine/packages/root/src/Container/Loader/ForceAutoconfigureYamlFileLoader.php
+++ b/layers/Engine/packages/root/src/Container/Loader/ForceAutoconfigureYamlFileLoader.php
@@ -10,15 +10,12 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class ForceAutoconfigureYamlFileLoader extends YamlFileLoader
 {
-    protected bool $autoconfigure;
-
     public function __construct(
         ContainerBuilder $container,
         FileLocatorInterface $locator,
-        bool $autoconfigure = true
+        protected bool $autoconfigure = true
     ) {
         parent::__construct($container, $locator);
-        $this->autoconfigure = $autoconfigure;
     }
 
     /**

--- a/layers/Engine/packages/root/src/Dotenv/DotenvBuilderFactory.php
+++ b/layers/Engine/packages/root/src/Dotenv/DotenvBuilderFactory.php
@@ -10,8 +10,6 @@ class DotenvBuilderFactory
 {
     /**
      * Initialize the file location to the document root
-     *
-     * @return void
      */
     public static function init(): void
     {

--- a/layers/Engine/packages/root/src/Managers/ComponentManager.php
+++ b/layers/Engine/packages/root/src/Managers/ComponentManager.php
@@ -32,8 +32,6 @@ class ComponentManager
 
     /**
      * Boot all components
-     *
-     * @return void
      */
     public static function beforeBoot(): void
     {
@@ -44,8 +42,6 @@ class ComponentManager
 
     /**
      * Boot all components
-     *
-     * @return void
      */
     public static function boot(): void
     {
@@ -56,8 +52,6 @@ class ComponentManager
 
     /**
      * Boot all components
-     *
-     * @return void
      */
     public static function afterBoot(): void
     {

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
@@ -46,23 +46,6 @@ class EndTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveReso
 
     /**
      * Save all the field values into the cache
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $idsDataFields
-     * @param array $succeedingPipelineIDsDataFields
-     * @param array $resultIDItems
-     * @param array $unionDBKeyIDs
-     * @param array $dbItems
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $dbDeprecations
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
@@ -35,8 +35,6 @@ class StartTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveRe
 
     /**
      * This directive is added automatically by @traceExecutionTime, it's not added by the user
-     *
-     * @return boolean
      */
     public function skipAddingToSchemaDefinition(): bool
     {
@@ -45,23 +43,6 @@ class StartTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveRe
 
     /**
      * Save all the field values into the cache
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $idsDataFields
-     * @param array $succeedingPipelineIDsDataFields
-     * @param array $resultIDItems
-     * @param array $unionDBKeyIDs
-     * @param array $dbItems
-     * @param array $previousDBItems
-     * @param array $variables
-     * @param array $messages
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $dbDeprecations
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/TraceDirectiveResolverTrait.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/TraceDirectiveResolverTrait.php
@@ -11,8 +11,6 @@ trait TraceDirectiveResolverTrait
 {
     /**
      * Operations can be executed only once
-     *
-     * @return boolean
      */
     public function isRepeatable(): bool
     {

--- a/layers/Engine/packages/trace-tools/src/TypeResolverDecorators/TraceTypeResolverDecorator.php
+++ b/layers/Engine/packages/trace-tools/src/TypeResolverDecorators/TraceTypeResolverDecorator.php
@@ -25,9 +25,6 @@ class TraceTypeResolverDecorator extends AbstractTypeResolverDecorator
     /**
      * Directives @startTraceExecutionTime and @endTraceExecutionTime
      * (called @traceExecutionTime) always go together
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
@@ -25,18 +25,11 @@ class SchemaModuleResolver extends AbstractSchemaTypeModuleResolver
      * Function `getDescription` will only be accessed from the Application Container,
      * so the properties will not be null in that situation.
      */
-    protected ?UpperCaseStringDirectiveResolver $upperCaseStringDirectiveResolver;
-    protected ?LowerCaseStringDirectiveResolver $lowerCaseStringDirectiveResolver;
-    protected ?TitleCaseStringDirectiveResolver $titleCaseStringDirectiveResolver;
-
     public function __construct(
-        ?UpperCaseStringDirectiveResolver $upperCaseStringDirectiveResolver,
-        ?LowerCaseStringDirectiveResolver $lowerCaseStringDirectiveResolver,
-        ?TitleCaseStringDirectiveResolver $titleCaseStringDirectiveResolver
+        protected ?UpperCaseStringDirectiveResolver $upperCaseStringDirectiveResolver,
+        protected ?LowerCaseStringDirectiveResolver $lowerCaseStringDirectiveResolver,
+        protected ?TitleCaseStringDirectiveResolver $titleCaseStringDirectiveResolver
     ) {
-        $this->upperCaseStringDirectiveResolver = $upperCaseStringDirectiveResolver;
-        $this->lowerCaseStringDirectiveResolver = $lowerCaseStringDirectiveResolver;
-        $this->titleCaseStringDirectiveResolver = $titleCaseStringDirectiveResolver;
     }
 
     public function getModulesToResolve(): array

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/AbstractItemListTable.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/AbstractItemListTable.php
@@ -34,15 +34,11 @@ abstract class AbstractItemListTable extends WP_List_Table
 
     /**
      * Singular name of the listed records
-     *
-     * @return string
      */
     abstract public function getItemSingularName(): string;
 
     /**
      * Plural name of the listed records
-     *
-     * @return string
      */
     abstract public function getItemPluralName(): string;
 
@@ -75,8 +71,6 @@ abstract class AbstractItemListTable extends WP_List_Table
 
     /**
      * Enqueue the required assets
-     *
-     * @return void
      */
     public function enqueueAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/ModuleListTable.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/ModuleListTable.php
@@ -21,8 +21,6 @@ class ModuleListTable extends AbstractItemListTable
 
     /**
      * Singular name of the listed records
-     *
-     * @return string
      */
     public function getItemSingularName(): string
     {
@@ -31,8 +29,6 @@ class ModuleListTable extends AbstractItemListTable
 
     /**
      * Plural name of the listed records
-     *
-     * @return string
      */
     public function getItemPluralName(): string
     {
@@ -81,8 +77,6 @@ class ModuleListTable extends AbstractItemListTable
 
     /**
      * Gets the current filtering view
-     *
-     * @return string
      */
     protected function getCurrentView(): string
     {
@@ -530,8 +524,6 @@ class ModuleListTable extends AbstractItemListTable
 
     /**
      * Enqueue the required assets
-     *
-     * @return void
      */
     public function enqueueAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ComponentConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ComponentConfiguration.php
@@ -31,7 +31,6 @@ class ComponentConfiguration
     //     $envVariable = Environment::MODULE_URL_BASE;
     //     $selfProperty = &self::$getModuleURLBase;
     //     $defaultValue = 'https://graphql-api.com/modules/';
-
     //     // Initialize property from the environment/hook
     //     self::maybeInitializeConfigurationValue(
     //         $envVariable,
@@ -40,11 +39,8 @@ class ComponentConfiguration
     //     );
     //     return $selfProperty;
     // }
-
     /**
      * Group the fields under the type when printing it for the user
-     *
-     * @return boolean
      */
     public static function groupFieldsUnderTypeForPrint(): bool
     {
@@ -105,8 +101,6 @@ class ComponentConfiguration
 
     /**
      * The slug to use as base when accessing the custom endpoint
-     *
-     * @return string
      */
     public static function getCustomEndpointSlugBase(): string
     {
@@ -126,8 +120,6 @@ class ComponentConfiguration
 
     /**
      * The slug to use as base when accessing the persisted query
-     *
-     * @return string
      */
     public static function getPersistedQuerySlugBase(): string
     {
@@ -149,8 +141,6 @@ class ComponentConfiguration
      * If `"admin"`, only the admin can compose a GraphQL query and endpoint
      * If `"post"`, the workflow from creating posts is employed (i.e. Author role can create
      * but not publish the query, Editor role can publish it, etc)
-     *
-     * @return string
      */
     public static function getEditingAccessScheme(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/ConditionalOnEnvironment/GraphiQLExplorerInAdminClient/Overrides/Services/MenuPages/GraphiQLMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/ConditionalOnEnvironment/GraphiQLExplorerInAdminClient/Overrides/Services/MenuPages/GraphiQLMenuPage.php
@@ -44,8 +44,6 @@ class GraphiQLMenuPage extends UpstreamGraphiQLMenuPage
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueGraphiQLCustomAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/SchemaServices/FieldResolvers/CPTFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/SchemaServices/FieldResolvers/CPTFieldResolver.php
@@ -55,10 +55,6 @@ class CPTFieldResolver extends AbstractQueryableFieldResolver
     /**
      * These fields are used only by the application, so no need to
      * expose them to the user
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return boolean
      */
     public function skipAddingToSchemaDefinition(TypeResolverInterface $typeResolver, string $fieldName): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/Services/Clients/AdminGraphiQLWithExplorerClient.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/Services/Clients/AdminGraphiQLWithExplorerClient.php
@@ -9,11 +9,8 @@ use GraphQLByPoP\GraphQLClientsForWP\ConditionalOnEnvironment\UseGraphiQLExplore
 
 class AdminGraphiQLWithExplorerClient extends GraphiQLWithExplorerClient
 {
-    protected EndpointHelpers $endpointHelpers;
-
-    function __construct(EndpointHelpers $endpointHelpers)
+    function __construct(protected EndpointHelpers $endpointHelpers)
     {
-        $this->endpointHelpers = $endpointHelpers;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/Services/EndpointResolvers/AdminEndpointResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/Services/EndpointResolvers/AdminEndpointResolver.php
@@ -18,14 +18,11 @@ class AdminEndpointResolver extends AbstractEndpointResolver
         EndpointResolverTrait::executeGraphQLQuery as upstreamExecuteGraphQLQuery;
     }
 
-    protected UserAuthorizationInterface $userAuthorization;
-
     function __construct(
         EndpointHelpers $endpointHelpers,
-        UserAuthorizationInterface $userAuthorization
+        protected UserAuthorizationInterface $userAuthorization
     ) {
         parent::__construct($endpointHelpers);
-        $this->userAuthorization = $userAuthorization;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/Services/EndpointResolvers/AdminEndpointResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/Services/EndpointResolvers/AdminEndpointResolver.php
@@ -44,8 +44,6 @@ class AdminEndpointResolver extends AbstractEndpointResolver
     /**
      * Execute the GraphQL query when posting to:
      * /wp-admin/edit.php?page=graphql_api&action=execute_query
-     *
-     * @return boolean
      */
     protected function isGraphQLQueryExecution(): bool
     {
@@ -54,8 +52,6 @@ class AdminEndpointResolver extends AbstractEndpointResolver
 
     /**
      * Initialize the resolver
-     *
-     * @return void
      */
     public function initialize(): void
     {
@@ -79,8 +75,6 @@ class AdminEndpointResolver extends AbstractEndpointResolver
     /**
      * Print JS variables which are used by several blocks,
      * before the blocks are loaded
-     *
-     * @return void
      */
     protected function printGlobalVariables(): void
     {
@@ -100,8 +94,6 @@ class AdminEndpointResolver extends AbstractEndpointResolver
 
     /**
      * Execute the GraphQL query
-     *
-     * @return void
      */
     protected function executeGraphQLQuery(): void
     {
@@ -125,8 +117,6 @@ class AdminEndpointResolver extends AbstractEndpointResolver
      * which are used only in the front-end.
      * When in the admin, we must manually load the template,
      * and then exit
-     *
-     * @return void
      */
     protected function printTemplateInAdminAndExit(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/GraphiQLExplorerInAdminPersistedQueries/Overrides/Services/Blocks/GraphiQLWithExplorerBlockTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/GraphiQLExplorerInAdminPersistedQueries/Overrides/Services/Blocks/GraphiQLWithExplorerBlockTrait.php
@@ -11,8 +11,6 @@ trait GraphiQLWithExplorerBlockTrait
 {
  /**
      * Override the location of the script
-     *
-     * @return string
      */
     protected function getBlockDirURL(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/AbstractContentParser.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/AbstractContentParser.php
@@ -386,10 +386,6 @@ abstract class AbstractContentParser implements ContentParserInterface
 
     /**
      * Convert relative paths to absolute paths for image URLs
-     *
-     * @param string $pathURL
-     * @param string $htmlContent
-     * @return string
      */
     protected function appendPathURLToImages(string $pathURL, string $htmlContent): string
     {
@@ -398,10 +394,6 @@ abstract class AbstractContentParser implements ContentParserInterface
 
     /**
      * Convert relative paths to absolute paths for image URLs
-     *
-     * @param string $pathURL
-     * @param string $htmlContent
-     * @return string
      */
     protected function appendPathURLToAnchors(string $pathURL, string $htmlContent): string
     {
@@ -410,12 +402,6 @@ abstract class AbstractContentParser implements ContentParserInterface
 
     /**
      * Convert relative paths to absolute paths for elements
-     *
-     * @param string $tag
-     * @param string $attr
-     * @param string $pathURL
-     * @param string $htmlContent
-     * @return string
      */
     protected function appendPathURLToElement(string $tag, string $attr, string $pathURL, string $htmlContent): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/MarkdownContentParser.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/MarkdownContentParser.php
@@ -8,11 +8,8 @@ use GraphQLAPI\MarkdownConvertor\MarkdownConvertorInterface;
 
 class MarkdownContentParser extends AbstractContentParser implements MarkdownContentParserInterface
 {
-    protected MarkdownConvertorInterface $markdownConvertorInterface;
-
-    function __construct(MarkdownConvertorInterface $markdownConvertorInterface)
+    function __construct(protected MarkdownConvertorInterface $markdownConvertorInterface)
     {
-        $this->markdownConvertorInterface = $markdownConvertorInterface;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractCacheFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractCacheFunctionalityModuleResolver.php
@@ -26,8 +26,6 @@ abstract class AbstractCacheFunctionalityModuleResolver extends AbstractFunction
 
     /**
      * Allow to change the behavior based on the environment
-     *
-     * @return boolean
      */
     protected function enabledEnvironmentBasedBehavior(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractModuleResolver.php
@@ -104,10 +104,7 @@ abstract class AbstractModuleResolver implements ModuleResolverInterface
     /**
      * Indicate if the given value is valid for that option
      *
-     * @param string $module
-     * @param string $option
      * @param mixed $value
-     * @return bool
      */
     public function isValidValue(string $module, string $option, $value): bool
     {
@@ -117,8 +114,6 @@ abstract class AbstractModuleResolver implements ModuleResolverInterface
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)
@@ -167,12 +162,8 @@ abstract class AbstractModuleResolver implements ModuleResolverInterface
     // {
     //     return ComponentConfiguration::getModuleURLBase();
     // }
-
     /**
      * Does the module have HTML Documentation?
-     *
-     * @param string $module
-     * @return bool
      */
     public function hasDocumentation(string $module): bool
     {
@@ -181,9 +172,6 @@ abstract class AbstractModuleResolver implements ModuleResolverInterface
 
     /**
      * HTML Documentation for the module
-     *
-     * @param string $module
-     * @return string|null
      */
     public function getDocumentation(string $module): ?string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractModuleResolver.php
@@ -11,11 +11,8 @@ use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 
 abstract class AbstractModuleResolver implements ModuleResolverInterface
 {
-    protected ModuleRegistryInterface $moduleRegistry;
-
-    function __construct(ModuleRegistryInterface $moduleRegistry)
+    function __construct(protected ModuleRegistryInterface $moduleRegistry)
     {
-        $this->moduleRegistry = $moduleRegistry;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractSchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractSchemaTypeModuleResolver.php
@@ -10,9 +10,6 @@ abstract class AbstractSchemaTypeModuleResolver extends AbstractModuleResolver
 {
     /**
      * The type of the module
-     *
-     * @param string $module
-     * @return string
      */
     public function getModuleType(string $module): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ClientFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ClientFunctionalityModuleResolver.php
@@ -141,8 +141,6 @@ class ClientFunctionalityModuleResolver extends AbstractFunctionalityModuleResol
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/EndpointFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/EndpointFunctionalityModuleResolver.php
@@ -116,8 +116,6 @@ class EndpointFunctionalityModuleResolver extends AbstractFunctionalityModuleRes
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
@@ -19,7 +19,6 @@ trait HasMarkdownDocumentationModuleResolverTrait
      * The name of the Markdown filename.
      * By default, it's the same as the slug
      *
-     * @param string $module
      * @return string
      */
     public function getMarkdownFilename(string $module): ?string
@@ -29,9 +28,6 @@ trait HasMarkdownDocumentationModuleResolverTrait
 
     /**
      * Does the module have HTML Documentation?
-     *
-     * @param string $module
-     * @return bool
      */
     public function hasDocumentation(string $module): bool
     {
@@ -40,9 +36,6 @@ trait HasMarkdownDocumentationModuleResolverTrait
 
     /**
      * HTML Documentation for the module
-     *
-     * @param string $module
-     * @return string|null
      */
     public function getDocumentation(string $module): ?string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
@@ -52,7 +52,7 @@ trait HasMarkdownDocumentationModuleResolverTrait
                         ContentParserOptions::TAB_CONTENT => true,
                     ]
                 );
-            } catch (InvalidArgumentException $e) {
+            } catch (InvalidArgumentException) {
                 return sprintf(
                     '<p>%s</p>',
                     \__('Oops, the documentation for this module is not available', 'graphql-api')

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverInterface.php
@@ -31,16 +31,10 @@ interface ModuleResolverInterface
     public function getDependedModuleLists(string $module): array;
     /**
      * Indicates if a module has all requirements satisfied (such as version of WordPress) to be enabled
-     *
-     * @param string $module
-     * @return boolean
      */
     public function areRequirementsSatisfied(string $module): bool;
     /**
      * Can the module be disabled by the user?
-     *
-     * @param string $module
-     * @return boolean
      */
     public function canBeDisabled(string $module): bool;
     public function isHidden(string $module): bool;
@@ -50,9 +44,6 @@ interface ModuleResolverInterface
     public function hasSettings(string $module): bool;
     /**
      * The type of the module
-     *
-     * @param string $module
-     * @return string
      */
     public function getModuleType(string $module): string;
     /**
@@ -72,17 +63,12 @@ interface ModuleResolverInterface
     /**
      * Indicate if the given value is valid for that option
      *
-     * @param string $module
-     * @param string $option
      * @param mixed $value
-     * @return bool
      */
     public function isValidValue(string $module, string $option, $value): bool;
     /**
      * Name of the setting item, to store in the DB
      *
-     * @param string $module
-     * @param string $option
      * @return mixed
      */
     public function getSettingsDefaultValue(string $module, string $option);
@@ -91,16 +77,10 @@ interface ModuleResolverInterface
     public function getSlug(string $module): string;
     /**
      * Does the module have HTML Documentation?
-     *
-     * @param string $module
-     * @return bool
      */
     public function hasDocumentation(string $module): bool;
     /**
      * HTML Documentation for the module
-     *
-     * @param string $module
-     * @return string|null
      */
     public function getDocumentation(string $module): ?string;
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/OperationalFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/OperationalFunctionalityModuleResolver.php
@@ -142,8 +142,6 @@ class OperationalFunctionalityModuleResolver extends AbstractFunctionalityModule
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/PerformanceFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/PerformanceFunctionalityModuleResolver.php
@@ -94,8 +94,6 @@ class PerformanceFunctionalityModuleResolver extends AbstractFunctionalityModule
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/PluginManagementFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/PluginManagementFunctionalityModuleResolver.php
@@ -92,8 +92,6 @@ class PluginManagementFunctionalityModuleResolver extends AbstractFunctionalityM
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
@@ -127,8 +127,6 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -341,10 +341,7 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
     /**
      * Indicate if the given value is valid for that option
      *
-     * @param string $module
-     * @param string $option
      * @param mixed $value
-     * @return bool
      */
     public function isValidValue(string $module, string $option, $value): bool
     {
@@ -378,8 +375,6 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
     /**
      * Default value for an option set by the module
      *
-     * @param string $module
-     * @param string $option
      * @return mixed Anything the setting might be: an array|string|bool|int|null
      */
     public function getSettingsDefaultValue(string $module, string $option)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -70,36 +70,17 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
      * Function `getDescription` will only be accessed from the Application Container,
      * so the properties will not be null in that situation.
      */
-    protected ?CommentTypeResolver $commentTypeResolver;
-    protected ?CustomPostUnionTypeResolver $customPostUnionTypeResolver;
-    protected ?GenericCustomPostTypeResolver $genericCustomPostTypeResolver;
-    protected ?MediaTypeResolver $mediaTypeResolver;
-    protected ?PageTypeResolver $pageTypeResolver;
-    protected ?PostTagTypeResolver $postTagTypeResolver;
-    protected ?PostTypeResolver $postTypeResolver;
-    protected ?UserRoleTypeResolver $userRoleTypeResolver;
-    protected ?UserTypeResolver $userTypeResolver;
-
     public function __construct(
-        ?CommentTypeResolver $commentTypeResolver,
-        ?CustomPostUnionTypeResolver $customPostUnionTypeResolver,
-        ?GenericCustomPostTypeResolver $genericCustomPostTypeResolver,
-        ?MediaTypeResolver $mediaTypeResolver,
-        ?PageTypeResolver $pageTypeResolver,
-        ?PostTagTypeResolver $postTagTypeResolver,
-        ?PostTypeResolver $postTypeResolver,
-        ?UserRoleTypeResolver $userRoleTypeResolver,
-        ?UserTypeResolver $userTypeResolver
+        protected ?CommentTypeResolver $commentTypeResolver,
+        protected ?CustomPostUnionTypeResolver $customPostUnionTypeResolver,
+        protected ?GenericCustomPostTypeResolver $genericCustomPostTypeResolver,
+        protected ?MediaTypeResolver $mediaTypeResolver,
+        protected ?PageTypeResolver $pageTypeResolver,
+        protected ?PostTagTypeResolver $postTagTypeResolver,
+        protected ?PostTypeResolver $postTypeResolver,
+        protected ?UserRoleTypeResolver $userRoleTypeResolver,
+        protected ?UserTypeResolver $userTypeResolver
     ) {
-        $this->commentTypeResolver = $commentTypeResolver;
-        $this->customPostUnionTypeResolver = $customPostUnionTypeResolver;
-        $this->genericCustomPostTypeResolver = $genericCustomPostTypeResolver;
-        $this->mediaTypeResolver = $mediaTypeResolver;
-        $this->pageTypeResolver = $pageTypeResolver;
-        $this->postTagTypeResolver = $postTagTypeResolver;
-        $this->postTypeResolver = $postTypeResolver;
-        $this->userRoleTypeResolver = $userRoleTypeResolver;
-        $this->userTypeResolver = $userTypeResolver;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Plugin.php
@@ -171,8 +171,6 @@ class Plugin extends AbstractMainPlugin
     /**
      * Plugin initialization, executed on hook "plugins_loaded"
      * to wait for all extensions to be loaded
-     *
-     * @return void
      */
     public function initialize(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -146,11 +146,6 @@ class PluginConfiguration
 
     /**
      * Process the "URL path" option values
-     *
-     * @param string $value
-     * @param string $module
-     * @param string $option
-     * @return string
      */
     protected static function getURLPathSettingValue(
         string $value,
@@ -167,11 +162,6 @@ class PluginConfiguration
 
     /**
      * Process the "URL base path" option values
-     *
-     * @param string $value
-     * @param string $module
-     * @param string $option
-     * @return string
      */
     protected static function getCPTPermalinkBasePathSettingValue(
         string $value,
@@ -627,9 +617,6 @@ class PluginConfiguration
 
     /**
      * Return the opposite value
-     *
-     * @param boolean $value
-     * @return boolean
      */
     protected static function opposite(bool $value): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -11,14 +11,10 @@ use PoP\Engine\AppLoader;
 
 abstract class AbstractPlugin
 {
-    /**
-     * The main plugin file
-     */
-    protected string $pluginFile;
-
-    final public function __construct(string $pluginFile)
-    {
-        $this->pluginFile = $pluginFile;
+    final public function __construct(
+        /** The main plugin file */
+        protected string $pluginFile
+    ) {
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistry.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistry.php
@@ -121,9 +121,6 @@ class ModuleRegistry implements ModuleRegistryInterface
 
     /**
      * Indicate if a module's depended-upon modules are all enabled
-     *
-     * @param string $module
-     * @return boolean
      */
     protected function areDependedModulesEnabled(string $module): bool
     {
@@ -168,9 +165,6 @@ class ModuleRegistry implements ModuleRegistryInterface
      * If a module was disabled by the user, then the user can enable it.
      * If it is disabled because its requirements are not satisfied,
      * or its dependencies themselves disabled, then it cannot be enabled by the user.
-     *
-     * @param string $module
-     * @return boolean
      */
     public function canModuleBeEnabled(string $module): bool
     {
@@ -188,9 +182,6 @@ class ModuleRegistry implements ModuleRegistryInterface
 
     /**
      * Used to indicate that the dependency on the module is on its being disabled, not enabled
-     *
-     * @param string $dependedModule
-     * @return string
      */
     public function getInverseDependency(string $dependedModule): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistryInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistryInterface.php
@@ -27,16 +27,10 @@ interface ModuleRegistryInterface
      * If a module was disabled by the user, then the user can enable it.
      * If it is disabled because its requirements are not satisfied,
      * or its dependencies themselves disabled, then it cannot be enabled by the user.
-     *
-     * @param string $module
-     * @return boolean
      */
     public function canModuleBeEnabled(string $module): bool;
     /**
      * Used to indicate that the dependency on the module is on its being disabled, not enabled
-     *
-     * @param string $dependedModule
-     * @return string
      */
     public function getInverseDependency(string $dependedModule): string;
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Security/UserAuthorization.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Security/UserAuthorization.php
@@ -28,8 +28,6 @@ class UserAuthorization implements UserAuthorizationInterface
      * The capability needed to access the schema editor (i.e. access clients GraphiQL/Voyager
      * against the admin endpoint /wp-admin/?page=graphql_api, and execute queries against it).
      * If access to admin only, then it is "manage_options". Otherwise, it is "edit_posts"
-     *
-     * @return string
      */
     public function getSchemaEditorAccessCapability(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/AbstractListTableAction.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/AbstractListTableAction.php
@@ -18,7 +18,7 @@ abstract class AbstractListTableAction
      *
      * @return string|false The action name or False if no action was selected
      */
-    public function currentAction()
+    public function currentAction(): string|false
     {
         if (isset($_REQUEST['filter_action']) && ! empty($_REQUEST['filter_action'])) {
             return false;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/ModuleListTableAction.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Admin/TableActions/ModuleListTableAction.php
@@ -24,8 +24,6 @@ class ModuleListTableAction extends AbstractListTableAction
 
     /**
      * Please notice that creatin a new instance carries side effects
-     *
-     * @param boolean $allowSideEffects
      */
     public function __construct(bool $allowSideEffects = true)
     {
@@ -44,8 +42,6 @@ class ModuleListTableAction extends AbstractListTableAction
      * Executing this function from within `setModulesEnabledValue` is too late,
      * since hook "admin_notices" will have been executed by then
      * Then, deduce if there will be an operation, and always say "successful"
-     *
-     * @return void
      */
     public function maybeAddAdminNotice(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/AbstractBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/AbstractBlockCategory.php
@@ -31,15 +31,11 @@ abstract class AbstractBlockCategory extends AbstractAutomaticallyInstantiatedSe
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     abstract protected function getBlockCategorySlug(): string;
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     abstract protected function getBlockCategoryTitle(): string;
 
@@ -47,7 +43,6 @@ abstract class AbstractBlockCategory extends AbstractAutomaticallyInstantiatedSe
      * Register the category when in the corresponding CPT
      *
      * @param array<array> $categories List of categories, each item is an array with props "slug" and "title"
-     * @param WP_Post $post
      * @return array<array> List of categories, each item is an array with props "slug" and "title"
      */
     public function getBlockCategories(array $categories, WP_Post $post): array

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/AccessControlBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/AccessControlBlockCategory.php
@@ -25,8 +25,6 @@ class AccessControlBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -35,8 +33,6 @@ class AccessControlBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/CacheControlBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/CacheControlBlockCategory.php
@@ -24,8 +24,6 @@ class CacheControlBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -34,8 +32,6 @@ class CacheControlBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/EndpointBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/EndpointBlockCategory.php
@@ -24,8 +24,6 @@ class EndpointBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -34,8 +32,6 @@ class EndpointBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/FieldDeprecationBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/FieldDeprecationBlockCategory.php
@@ -24,8 +24,6 @@ class FieldDeprecationBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -34,8 +32,6 @@ class FieldDeprecationBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/PersistedQueryBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/PersistedQueryBlockCategory.php
@@ -24,8 +24,6 @@ class PersistedQueryBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -34,8 +32,6 @@ class PersistedQueryBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/QueryExecutionBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/QueryExecutionBlockCategory.php
@@ -29,8 +29,6 @@ class QueryExecutionBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -39,8 +37,6 @@ class QueryExecutionBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/SchemaConfigurationBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/SchemaConfigurationBlockCategory.php
@@ -24,8 +24,6 @@ class SchemaConfigurationBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -34,8 +32,6 @@ class SchemaConfigurationBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractBlock.php
@@ -27,15 +27,10 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
 {
     use HasDocumentationScriptTrait;
 
-    protected ModuleRegistryInterface $moduleRegistry;
-    protected UserAuthorizationInterface $userAuthorization;
-
     function __construct(
-        ModuleRegistryInterface $moduleRegistry,
-        UserAuthorizationInterface $userAuthorization
+        protected ModuleRegistryInterface $moduleRegistry,
+        protected UserAuthorizationInterface $userAuthorization
     ) {
-        $this->moduleRegistry = $moduleRegistry;
-        $this->userAuthorization = $userAuthorization;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractBlock.php
@@ -40,8 +40,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
 
     /**
      * Execute this function to initialize the block
-     *
-     * @return void
      */
     final public function initialize(): void
     {
@@ -67,26 +65,18 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
 
     /**
      * Plugin dir
-     *
-     * @return string
      */
     abstract protected function getPluginDir(): string;
     /**
      * Plugin URL
-     *
-     * @return string
      */
     abstract protected function getPluginURL(): string;
     /**
      * Block namespace
-     *
-     * @return string
      */
     abstract protected function getBlockNamespace(): string;
     /**
      * Block name
-     *
-     * @return string
      */
     abstract protected function getBlockName(): string;
 
@@ -118,8 +108,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
     }
     /**
      * Register index.css
-     *
-     * @return boolean
      */
     protected function registerEditorCSS(): bool
     {
@@ -127,8 +115,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
     }
     /**
      * Register style-index.css
-     *
-     * @return boolean
      */
     protected function registerCommonStyleCSS(): bool
     {
@@ -136,8 +122,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
     }
     /**
      * The block full name: namespace/blockName
-     *
-     * @return string
      */
     final public function getBlockFullName(): string
     {
@@ -149,8 +133,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
     }
     /**
      * Block registration name: namespace-blockName
-     *
-     * @return string
      */
     final protected function getBlockRegistrationName(): string
     {
@@ -162,8 +144,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
     }
     /**
      * Block registration name: namespace-blockName
-     *
-     * @return string
      */
     final protected function getBlockLocalizationName(): string
     {
@@ -174,8 +154,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
     }
     /**
      * Block class name: wp-block-namespace-blockName
-     *
-     * @return string
      */
     protected function getBlockClassName(): string
     {
@@ -205,8 +183,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
 
     /**
      * Where is the block stored
-     *
-     * @return string
      */
     protected function getBlockDirURL(): string
     {
@@ -215,8 +191,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService
 
     /**
      * Where is the block stored
-     *
-     * @return string
      */
     protected function getBlockDir(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractGraphiQLBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractGraphiQLBlock.php
@@ -23,15 +23,12 @@ abstract class AbstractGraphiQLBlock extends AbstractBlock
     public const ATTRIBUTE_NAME_QUERY = 'query';
     public const ATTRIBUTE_NAME_VARIABLES = 'variables';
 
-    protected EndpointHelpers $endpointHelpers;
-
     function __construct(
         ModuleRegistryInterface $moduleRegistry,
         UserAuthorizationInterface $userAuthorization,
-        EndpointHelpers $endpointHelpers
+        protected EndpointHelpers $endpointHelpers
     ) {
         parent::__construct($moduleRegistry, $userAuthorization);
-        $this->endpointHelpers = $endpointHelpers;
     }
 
     protected function getBlockName(): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractGraphiQLBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractGraphiQLBlock.php
@@ -78,8 +78,6 @@ abstract class AbstractGraphiQLBlock extends AbstractBlock
 
     /**
      * Load index.css from editor.scss
-     *
-     * @return boolean
      */
     protected function registerEditorCSS(): bool
     {
@@ -88,8 +86,6 @@ abstract class AbstractGraphiQLBlock extends AbstractBlock
 
     /**
      * GraphiQL default query
-     *
-     * @return string
      */
     protected function getDefaultQuery(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractSchemaConfigPostListBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractSchemaConfigPostListBlock.php
@@ -124,8 +124,6 @@ EOF;
     }
     /**
      * Register index.css
-     *
-     * @return boolean
      */
     protected function registerEditorCSS(): bool
     {
@@ -135,8 +133,6 @@ EOF;
     /**
      * Register style-index.css
      * It contains the styles for the list of elements
-     *
-     * @return boolean
      */
     protected function registerCommonStyleCSS(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/CacheControlBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/CacheControlBlock.php
@@ -46,8 +46,6 @@ class CacheControlBlock extends AbstractControlBlock
 
     /**
      * Add the locale language to the localized data?
-     *
-     * @return bool
      */
     protected function addLocalLanguage(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryOptionsBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryOptionsBlock.php
@@ -27,8 +27,6 @@ class PersistedQueryOptionsBlock extends AbstractQueryExecutionOptionsBlock
 
     /**
      * Add the locale language to the localized data?
-     *
-     * @return bool
      */
     protected function addLocalLanguage(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/SchemaConfigOptionsBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/SchemaConfigOptionsBlock.php
@@ -140,8 +140,6 @@ EOT;
 
     /**
      * Register index.css
-     *
-     * @return boolean
      */
     protected function registerEditorCSS(): bool
     {
@@ -149,8 +147,6 @@ EOT;
     }
     /**
      * Register style-index.css
-     *
-     * @return boolean
      */
     protected function registerCommonStyleCSS(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Clients/CustomEndpointClientTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Clients/CustomEndpointClientTrait.php
@@ -23,8 +23,6 @@ trait CustomEndpointClientTrait
 
     /**
      * Endpoint URL
-     *
-     * @return string
      */
     protected function getEndpointURL(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractCustomPostType.php
@@ -18,18 +18,11 @@ use WP_Post;
 
 abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedService implements CustomPostTypeInterface
 {
-    protected Menu $menu;
-    protected ModuleRegistryInterface $moduleRegistry;
-    protected UserAuthorizationInterface $userAuthorization;
-
     function __construct(
-        Menu $menu,
-        ModuleRegistryInterface $moduleRegistry,
-        UserAuthorizationInterface $userAuthorization
+        protected Menu $menu,
+        protected ModuleRegistryInterface $moduleRegistry,
+        protected UserAuthorizationInterface $userAuthorization
     ) {
-        $this->menu = $menu;
-        $this->moduleRegistry = $moduleRegistry;
-        $this->userAuthorization = $userAuthorization;
     }
     /**
      * Add the hook to initialize the different post types

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractCustomPostType.php
@@ -33,8 +33,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
     }
     /**
      * Add the hook to initialize the different post types
-     *
-     * @return void
      */
     public function initialize(): void
     {
@@ -146,8 +144,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
     /**
      * Indicate if, whenever this CPT is created/updated,
      * the timestamp must be regenerated
-     *
-     * @return boolean
      */
     protected function regenerateTimestampOnSave(): bool
     {
@@ -232,8 +228,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Indicate if the excerpt must be used as the CPT's description and rendered when rendering the post
-     *
-     * @return boolean
      */
     public function usePostExcerptAsDescription(): bool
     {
@@ -286,8 +280,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Custom Post Type singular name
-     *
-     * @return string
      */
     abstract protected function getPostTypeName(): string;
     /**
@@ -295,8 +287,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
      * From documentation: Max. 20 characters and may only contain lowercase alphanumeric characters,
      * dashes, and underscores.
      * @see https://codex.wordpress.org/Function_Reference/register_post_type#Parameters
-     *
-     * @return string
      */
     protected function getCustomPostType(): string
     {
@@ -306,7 +296,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
      * Custom Post Type plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getPostTypePluralNames(bool $uppercase): string
     {
@@ -322,8 +311,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
      * By default it's false because, for configuration CPTs (Access Control Lists,
      * Cache Control Lists, Schema Configuration, etc), this data is private,
      * must not be exposed.
-     *
-     * @return boolean
      */
     protected function isPublic(): bool
     {
@@ -332,8 +319,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Is the excerpt used as description for the CPT?
-     *
-     * @return bool
      */
     protected function isExcerptAsDescriptionEnabled(): bool
     {
@@ -342,8 +327,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Is the API Hierarchy Module enabled?
-     *
-     * @return bool
      */
     protected function isAPIHierarchyModuleEnabled(): bool
     {
@@ -352,8 +335,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Hierarchical
-     *
-     * @return bool
      */
     protected function isHierarchical(): bool
     {
@@ -362,8 +343,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Show in admin bar
-     *
-     * @return bool
      */
     protected function showInAdminBar(): bool
     {
@@ -381,8 +360,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * If provided, rewrite the slug
-     *
-     * @return string|null
      */
     protected function getSlugBase(): ?string
     {
@@ -476,8 +453,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Initialize the post type
-     *
-     * @return void
      */
     public function initCustomPostType(): void
     {
@@ -486,8 +461,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Register the post type
-     *
-     * @return void
      */
     public function registerCustomPostType(): void
     {
@@ -496,8 +469,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Unregister the post type
-     *
-     * @return void
      */
     public function unregisterCustomPostType(): void
     {
@@ -517,7 +488,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
     /**
      * Lock down the Custom Post Type to use the given Gutenberg templates
      *
-     * @return void
      * @see https://developer.wordpress.org/block-editor/developers/block-api/block-templates/#locking
      */
     public function maybeLockGutenbergTemplate(): void
@@ -536,7 +506,7 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
      * @param string[]|bool $allowedBlocks The list of blocks, or `true` for all of them
      * @return string[]|bool The list of blocks, or `true` for all of them
      */
-    public function allowGutenbergBlocksForCustomPostType($allowedBlocks, WP_Post $post)
+    public function allowGutenbergBlocksForCustomPostType(array|bool $allowedBlocks, WP_Post $post): array|bool
     {
         /**
          * Check it is this CPT
@@ -652,8 +622,6 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
 
     /**
      * Indicates if to lock the Gutenberg templates
-     *
-     * @return boolean
      */
     protected function lockGutenbergTemplate(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLQueryExecutionCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLQueryExecutionCustomPostType.php
@@ -201,10 +201,8 @@ abstract class AbstractGraphQLQueryExecutionCustomPostType extends AbstractCusto
 
     /**
      * Read the options block and check the value of attribute "isEnabled"
-     *
-     * @param WP_Post|int $postOrID
      */
-    protected function isOptionsBlockValueOn($postOrID, string $attribute, bool $default): bool
+    protected function isOptionsBlockValueOn(WP_Post|int $postOrID, string $attribute, bool $default): bool
     {
         $optionsBlockDataItem = $this->getOptionsBlockDataItem($postOrID);
         // If there was no options block, something went wrong in the post content
@@ -218,10 +216,8 @@ abstract class AbstractGraphQLQueryExecutionCustomPostType extends AbstractCusto
 
     /**
      * Read the options block and check the value of attribute "isEnabled"
-     *
-     * @param WP_Post|int $postOrID
      */
-    protected function isEnabled($postOrID): bool
+    protected function isEnabled(WP_Post|int $postOrID): bool
     {
         // `true` is the default option in Gutenberg, so it's not saved to the DB!
         return $this->isOptionsBlockValueOn(
@@ -232,10 +228,9 @@ abstract class AbstractGraphQLQueryExecutionCustomPostType extends AbstractCusto
     }
 
     /**
-     * @param WP_Post|int $postOrID
      * @return array<string, mixed>|null Data inside the block is saved as key (string) => value
      */
-    protected function getOptionsBlockDataItem($postOrID): ?array
+    protected function getOptionsBlockDataItem(WP_Post|int $postOrID): ?array
     {
         $instanceManager = InstanceManagerFacade::getInstance();
         /** @var BlockHelpers */
@@ -248,10 +243,8 @@ abstract class AbstractGraphQLQueryExecutionCustomPostType extends AbstractCusto
 
     /**
      * Indicate if the GraphQL variables must override the URL params
-     *
-     * @param WP_Post|int $postOrID
      */
-    protected function doURLParamsOverrideGraphQLVariables($postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int $postOrID): bool
     {
         return true;
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLAccessControlListCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLAccessControlListCustomPostType.php
@@ -19,8 +19,6 @@ class GraphQLAccessControlListCustomPostType extends AbstractCustomPostType
 
     /**
      * Custom Post Type name
-     *
-     * @return string
      */
     protected function getCustomPostType(): string
     {
@@ -55,7 +53,6 @@ class GraphQLAccessControlListCustomPostType extends AbstractCustomPostType
      * Custom Post Type plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getPostTypePluralNames(bool $uppercase): string
     {
@@ -64,8 +61,6 @@ class GraphQLAccessControlListCustomPostType extends AbstractCustomPostType
 
     /**
      * Indicate if the excerpt must be used as the CPT's description and rendered when rendering the post
-     *
-     * @return boolean
      */
     public function usePostExcerptAsDescription(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLCacheControlListCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLCacheControlListCustomPostType.php
@@ -18,8 +18,6 @@ class GraphQLCacheControlListCustomPostType extends AbstractCustomPostType
 
     /**
      * Custom Post Type name
-     *
-     * @return string
      */
     protected function getCustomPostType(): string
     {
@@ -54,7 +52,6 @@ class GraphQLCacheControlListCustomPostType extends AbstractCustomPostType
      * Custom Post Type plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getPostTypePluralNames(bool $uppercase): string
     {
@@ -63,8 +60,6 @@ class GraphQLCacheControlListCustomPostType extends AbstractCustomPostType
 
     /**
      * Indicate if the excerpt must be used as the CPT's description and rendered when rendering the post
-     *
-     * @return boolean
      */
     public function usePostExcerptAsDescription(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLEndpointCustomPostType.php
@@ -266,10 +266,8 @@ class GraphQLEndpointCustomPostType extends AbstractGraphQLQueryExecutionCustomP
 
     /**
      * Read the options block and check the value of attribute "isGraphiQLEnabled"
-     *
-     * @param WP_Post|int $postOrID
      */
-    protected function isGraphiQLEnabled($postOrID): bool
+    protected function isGraphiQLEnabled(WP_Post|int $postOrID): bool
     {
         // Check if disabled by module
         if (!$this->moduleRegistry->isModuleEnabled(ClientFunctionalityModuleResolver::GRAPHIQL_FOR_CUSTOM_ENDPOINTS)) {
@@ -291,10 +289,8 @@ class GraphQLEndpointCustomPostType extends AbstractGraphQLQueryExecutionCustomP
 
     /**
      * Read the options block and check the value of attribute "isVoyagerEnabled"
-     *
-     * @param WP_Post|int $postOrID
      */
-    protected function isVoyagerEnabled($postOrID): bool
+    protected function isVoyagerEnabled(WP_Post|int $postOrID): bool
     {
         // Check if disabled by module
         if (!$this->moduleRegistry->isModuleEnabled(ClientFunctionalityModuleResolver::INTERACTIVE_SCHEMA_FOR_CUSTOM_ENDPOINTS)) {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLFieldDeprecationListCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLFieldDeprecationListCustomPostType.php
@@ -18,8 +18,6 @@ class GraphQLFieldDeprecationListCustomPostType extends AbstractCustomPostType
 
     /**
      * Custom Post Type name
-     *
-     * @return string
      */
     protected function getCustomPostType(): string
     {
@@ -54,7 +52,6 @@ class GraphQLFieldDeprecationListCustomPostType extends AbstractCustomPostType
      * Custom Post Type plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getPostTypePluralNames(bool $uppercase): string
     {
@@ -64,8 +61,6 @@ class GraphQLFieldDeprecationListCustomPostType extends AbstractCustomPostType
     /**
      * Indicate if, whenever this CPT is saved/updated,
      * the timestamp must be regenerated
-     *
-     * @return boolean
      */
     protected function regenerateTimestampOnSave(): bool
     {
@@ -74,8 +69,6 @@ class GraphQLFieldDeprecationListCustomPostType extends AbstractCustomPostType
 
     /**
      * Indicate if the excerpt must be used as the CPT's description and rendered when rendering the post
-     *
-     * @return boolean
      */
     public function usePostExcerptAsDescription(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
@@ -22,23 +22,18 @@ use WP_Post;
 
 class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionCustomPostType
 {
-    protected BlockContentHelpers $blockContentHelpers;
-    protected GraphQLQueryPostTypeHelpers $graphQLQueryPostTypeHelpers;
-
     function __construct(
         Menu $menu,
         ModuleRegistryInterface $moduleRegistry,
         UserAuthorizationInterface $userAuthorization,
-        BlockContentHelpers $blockContentHelpers,
-        GraphQLQueryPostTypeHelpers $graphQLQueryPostTypeHelpers
+        protected BlockContentHelpers $blockContentHelpers,
+        protected GraphQLQueryPostTypeHelpers $graphQLQueryPostTypeHelpers
     ) {
         parent::__construct(
             $menu,
             $moduleRegistry,
             $userAuthorization
         );
-        $this->blockContentHelpers = $blockContentHelpers;
-        $this->graphQLQueryPostTypeHelpers = $graphQLQueryPostTypeHelpers;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
@@ -48,8 +48,6 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
 
     /**
      * Custom Post Type name
-     *
-     * @return string
      */
     protected function getCustomPostType(): string
     {
@@ -74,8 +72,6 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
 
     /**
      * Access endpoints under /graphql-query, or wherever it is configured to
-     *
-     * @return string|null
      */
     protected function getSlugBase(): ?string
     {
@@ -94,7 +90,6 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
      * Custom Post Type plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getPostTypePluralNames(bool $uppercase): string
     {
@@ -103,8 +98,6 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
 
     /**
      * Label to show on the "execute" action in the CPT table
-     *
-     * @return string
      */
     protected function getExecuteActionLabel(): string
     {
@@ -134,8 +127,6 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
 
     /**
      * The Query is publicly accessible, and the permalink must be configurable
-     *
-     * @return boolean
      */
     protected function isPublic(): bool
     {
@@ -201,8 +192,6 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
 
     /**
      * Indicates if to lock the Gutenberg templates
-     *
-     * @return boolean
      */
     protected function lockGutenbergTemplate(): bool
     {
@@ -211,8 +200,6 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
 
     /**
      * Indicate if the excerpt must be used as the CPT's description and rendered when rendering the post
-     *
-     * @return boolean
      */
     public function usePostExcerptAsDescription(): bool
     {
@@ -309,10 +296,8 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
 
     /**
      * Indicate if the GraphQL variables must override the URL params
-     *
-     * @param WP_Post|int $postOrID
      */
-    protected function doURLParamsOverrideGraphQLVariables($postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int $postOrID): bool
     {
         $default = true;
         $optionsBlockDataItem = $this->getOptionsBlockDataItem($postOrID);

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLSchemaConfigurationCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLSchemaConfigurationCustomPostType.php
@@ -22,8 +22,6 @@ class GraphQLSchemaConfigurationCustomPostType extends AbstractCustomPostType
 
     /**
      * Custom Post Type name
-     *
-     * @return string
      */
     protected function getCustomPostType(): string
     {
@@ -58,7 +56,6 @@ class GraphQLSchemaConfigurationCustomPostType extends AbstractCustomPostType
      * Custom Post Type plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getPostTypePluralNames(bool $uppercase): string
     {
@@ -69,8 +66,6 @@ class GraphQLSchemaConfigurationCustomPostType extends AbstractCustomPostType
      * Whenever this CPT is saved/updated, the timestamp must be regenerated,
      * because it contains Field Deprecation Lists,
      * which can change the schema
-     *
-     * @return boolean
      */
     protected function regenerateTimestampOnSave(): bool
     {
@@ -79,8 +74,6 @@ class GraphQLSchemaConfigurationCustomPostType extends AbstractCustomPostType
 
     /**
      * Indicate if the excerpt must be used as the CPT's description and rendered when rendering the post
-     *
-     * @return boolean
      */
     public function usePostExcerptAsDescription(): bool
     {
@@ -122,8 +115,6 @@ class GraphQLSchemaConfigurationCustomPostType extends AbstractCustomPostType
 
     /**
      * Indicates if to lock the Gutenberg templates
-     *
-     * @return boolean
      */
     protected function lockGutenbergTemplate(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/AbstractEditorScript.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/AbstractEditorScript.php
@@ -34,8 +34,6 @@ abstract class AbstractEditorScript extends AbstractScript
 
     /**
      * URL to the script
-     *
-     * @return string
      */
     protected function getScriptDirURL(): string
     {
@@ -59,8 +57,6 @@ abstract class AbstractEditorScript extends AbstractScript
 
     /**
      * Where is the script stored
-     *
-     * @return string
      */
     protected function getScriptDir(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/EndpointComponentEditorScript.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/EndpointComponentEditorScript.php
@@ -17,8 +17,6 @@ class EndpointComponentEditorScript extends AbstractEditorScript
 
     /**
      * Block name
-     *
-     * @return string
      */
     protected function getScriptName(): string
     {
@@ -32,8 +30,6 @@ class EndpointComponentEditorScript extends AbstractEditorScript
 
     /**
      * Add the locale language to the localized data?
-     *
-     * @return bool
      */
     protected function addLocalLanguage(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/HasDocumentationScriptTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/HasDocumentationScriptTrait.php
@@ -54,8 +54,6 @@ trait HasDocumentationScriptTrait
 
     /**
      * Add the locale language to the localized data?
-     *
-     * @return bool
      */
     protected function addLocalLanguage(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/PersistedQueryComponentEditorScript.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EditorScripts/PersistedQueryComponentEditorScript.php
@@ -17,8 +17,6 @@ class PersistedQueryComponentEditorScript extends AbstractEditorScript
 
     /**
      * Block name
-     *
-     * @return string
      */
     protected function getScriptName(): string
     {
@@ -32,8 +30,6 @@ class PersistedQueryComponentEditorScript extends AbstractEditorScript
 
     /**
      * Add the locale language to the localized data?
-     *
-     * @return bool
      */
     protected function addLocalLanguage(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/AbstractEndpointResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/AbstractEndpointResolver.php
@@ -18,8 +18,6 @@ abstract class AbstractEndpointResolver extends AbstractAutomaticallyInstantiate
 
     /**
      * Initialize the resolver
-     *
-     * @return void
      */
     public function initialize(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/AbstractEndpointResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/AbstractEndpointResolver.php
@@ -9,11 +9,8 @@ use PoP\Root\Services\AbstractAutomaticallyInstantiatedService;
 
 abstract class AbstractEndpointResolver extends AbstractAutomaticallyInstantiatedService
 {
-    protected EndpointHelpers $endpointHelpers;
-
-    function __construct(EndpointHelpers $endpointHelpers)
+    function __construct(protected EndpointHelpers $endpointHelpers)
     {
-        $this->endpointHelpers = $endpointHelpers;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/EndpointResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/EndpointResolverTrait.php
@@ -18,8 +18,6 @@ trait EndpointResolverTrait
 {
     /**
      * Execute the GraphQL query
-     *
-     * @return void
      */
     protected function executeGraphQLQuery(): void
     {
@@ -65,10 +63,8 @@ trait EndpointResolverTrait
 
     /**
      * Indicate if the GraphQL variables must override the URL params
-     *
-     * @param WP_Post|int $postOrID
      */
-    protected function doURLParamsOverrideGraphQLVariables($postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int $postOrID): bool
     {
         return false;
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/BlockHelpers.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/BlockHelpers.php
@@ -19,11 +19,10 @@ class BlockHelpers
     /**
      * Extract the blocks from the post
      *
-     * @param WP_Post|int $configurationPostOrID
      * @return array<string, mixed> The block stores its data as property => value
      */
     public function getBlocksFromCustomPost(
-        $configurationPostOrID
+        \WP_Post|int $configurationPostOrID
     ): array {
         if (\is_object($configurationPostOrID)) {
             $configurationPost = $configurationPostOrID;
@@ -55,11 +54,10 @@ class BlockHelpers
     /**
      * Read the configuration post, and extract the configuration, contained through the specified block
      *
-     * @param WP_Post|int $configurationPostOrID
      * @return array<array> A list of block data, each as an array
      */
     public function getBlocksOfTypeFromCustomPost(
-        $configurationPostOrID,
+        \WP_Post|int $configurationPostOrID,
         AbstractBlock $block
     ): array {
         $blocks = $this->getBlocksFromCustomPost($configurationPostOrID);
@@ -76,11 +74,10 @@ class BlockHelpers
      * Read the single block of a certain type, contained in the post.
      * If there are more than 1, or none, return null
      *
-     * @param WP_Post|int $configurationPostOrID
      * @return array<string, mixed>|null Data inside the block is saved as key (string) => value
      */
     public function getSingleBlockOfTypeFromCustomPost(
-        $configurationPostOrID,
+        \WP_Post|int $configurationPostOrID,
         AbstractBlock $block
     ): ?array {
         $blocks = $this->getBlocksOfTypeFromCustomPost($configurationPostOrID, $block);

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/EndpointHelpers.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/EndpointHelpers.php
@@ -26,8 +26,6 @@ class EndpointHelpers
     /**
      * Indicate if we are requesting
      * /wp-admin/edit.php?page=graphql_api&action=execute_query
-     *
-     * @return boolean
      */
     public function isRequestingAdminGraphQLEndpoint(): bool
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/EndpointHelpers.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/EndpointHelpers.php
@@ -12,15 +12,10 @@ use GraphQLByPoP\GraphQLServer\Configuration\Request as GraphQLServerRequest;
 
 class EndpointHelpers
 {
-    protected Menu $menu;
-    protected ModuleRegistryInterface $moduleRegistry;
-
     function __construct(
-        Menu $menu,
-        ModuleRegistryInterface $moduleRegistry
+        protected Menu $menu,
+        protected ModuleRegistryInterface $moduleRegistry
     ) {
-        $this->menu = $menu;
-        $this->moduleRegistry = $moduleRegistry;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/GraphQLQueryPostTypeHelpers.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/GraphQLQueryPostTypeHelpers.php
@@ -8,11 +8,8 @@ use WP_Post;
 
 class GraphQLQueryPostTypeHelpers
 {
-    protected BlockContentHelpers $blockContentHelpers;
-
-    public function __construct(BlockContentHelpers $blockContentHelpers)
+    public function __construct(protected BlockContentHelpers $blockContentHelpers)
     {
-        $this->blockContentHelpers = $blockContentHelpers;
     }
     /**
      * A GraphQL Query Custom Post Type is hierarchical: each query post can have a parent,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/URLParamHelpers.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/URLParamHelpers.php
@@ -13,9 +13,6 @@ class URLParamHelpers
      * // Add variables parameter always (empty if no variables defined), so that GraphiQL doesn't use a cached one
      * $url .= '&variables=' . ($variables ? URLParamHelpers::encodeURIComponent($variables) : '');
      * Taken from https://stackoverflow.com/a/1734255
-     *
-     * @param string $str
-     * @return string
      */
     public function encodeURIComponent(string $str): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Hooks/VarsHooks.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Hooks/VarsHooks.php
@@ -15,15 +15,12 @@ use PoP\Translation\TranslationAPIInterface;
 
 class VarsHooks extends AbstractHookSet
 {
-    protected ModuleRegistryInterface $moduleRegistry;
-
     public function __construct(
         HooksAPIInterface $hooksAPI,
         TranslationAPIInterface $translationAPI,
-        ModuleRegistryInterface $moduleRegistry
+        protected ModuleRegistryInterface $moduleRegistry
     ) {
         parent::__construct($hooksAPI, $translationAPI);
-        $this->moduleRegistry = $moduleRegistry;
     }
 
     protected function init()

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AboutMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AboutMenuPage.php
@@ -38,7 +38,7 @@ class AboutMenuPage extends AbstractDocsMenuPage
         $markdownContentParser = MarkdownContentParserFacade::getInstance();
         try {
             return $markdownContentParser->getContent('about.md', '', [ContentParserOptions::TAB_CONTENT => true]);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             return sprintf(
                 '<p>%s</p>',
                 \__('Oops, there was a problem loading the page', 'graphql-api')

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocAboutMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocAboutMenuPage.php
@@ -55,7 +55,7 @@ abstract class AbstractDocAboutMenuPage extends AbstractDocsMenuPage
         $markdownContentParser = MarkdownContentParserFacade::getInstance();
         try {
             return $markdownContentParser->getContent($doc, $this->getRelativePathDir());
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             return sprintf(
                 '<p>%s</p>',
                 sprintf(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocsMenuPage.php
@@ -53,8 +53,6 @@ abstract class AbstractDocsMenuPage extends AbstractMenuPage
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractMenuPage.php
@@ -16,18 +16,12 @@ use PoP\Root\Services\AbstractAutomaticallyInstantiatedService;
 abstract class AbstractMenuPage extends AbstractAutomaticallyInstantiatedService implements MenuPageInterface
 {
     protected ?string $hookName = null;
-    protected Menu $menu;
-    protected MenuPageHelper $menuPageHelper;
-    protected EndpointHelpers $endpointHelpers;
 
     function __construct(
-        Menu $menu,
-        MenuPageHelper $menuPageHelper,
-        EndpointHelpers $endpointHelpers
+        protected Menu $menu,
+        protected MenuPageHelper $menuPageHelper,
+        protected EndpointHelpers $endpointHelpers
     ) {
-        $this->menu = $menu;
-        $this->menuPageHelper = $menuPageHelper;
-        $this->endpointHelpers = $endpointHelpers;
     }
 
     public function setHookName(string $hookName): void

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractMenuPage.php
@@ -53,8 +53,6 @@ abstract class AbstractMenuPage extends AbstractAutomaticallyInstantiatedService
 
     /**
      * Maybe enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     public function maybeEnqueueAssets(): void
     {
@@ -96,8 +94,6 @@ abstract class AbstractMenuPage extends AbstractAutomaticallyInstantiatedService
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/EnqueueReactMenuPageTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/EnqueueReactMenuPageTrait.php
@@ -9,8 +9,6 @@ trait EnqueueReactMenuPageTrait
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueReactAssets(bool $addInFooter = true): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/GraphQLVoyagerMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/GraphQLVoyagerMenuPage.php
@@ -29,8 +29,6 @@ class GraphQLVoyagerMenuPage extends AbstractMenuPage
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/GraphiQLMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/GraphiQLMenuPage.php
@@ -29,8 +29,6 @@ class GraphiQLMenuPage extends AbstractMenuPage
      * Override, because this is the default page, so it is invoked
      * with the menu slug wp-admin/admin.php?page=graphql_api,
      * and not the menu page slug wp-admin/admin.php?page=graphql_api_graphiql
-     *
-     * @return string
      */
     public function getScreenID(): string
     {
@@ -44,8 +42,6 @@ class GraphiQLMenuPage extends AbstractMenuPage
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueGraphiQLClientAssets(): void
     {
@@ -59,8 +55,6 @@ class GraphiQLMenuPage extends AbstractMenuPage
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueGraphiQLCustomAssets(): void
     {
@@ -111,8 +105,6 @@ class GraphiQLMenuPage extends AbstractMenuPage
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/MenuPageInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/MenuPageInterface.php
@@ -11,8 +11,6 @@ interface MenuPageInterface
 {
     /**
      * Print the menu page HTML content
-     *
-     * @return void
      */
     public function print(): void;
     public function getScreenID(): string;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ModuleDocumentationMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ModuleDocumentationMenuPage.php
@@ -69,7 +69,7 @@ class ModuleDocumentationMenuPage extends AbstractDocsMenuPage
         $module = urldecode($vars[RequestParams::MODULE]);
         try {
             $moduleResolver = $this->moduleRegistry->getModuleResolver($module);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             return sprintf(
                 '<p>%s</p>',
                 sprintf(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ModuleDocumentationMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ModuleDocumentationMenuPage.php
@@ -19,16 +19,13 @@ use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
  */
 class ModuleDocumentationMenuPage extends AbstractDocsMenuPage
 {
-    protected ModuleRegistryInterface $moduleRegistry;
-
     function __construct(
         Menu $menu,
         MenuPageHelper $menuPageHelper,
         EndpointHelpers $endpointHelpers,
-        ModuleRegistryInterface $moduleRegistry
+        protected ModuleRegistryInterface $moduleRegistry
     ) {
         parent::__construct($menu, $menuPageHelper, $endpointHelpers);
-        $this->moduleRegistry = $moduleRegistry;
     }
 
     public function getMenuPageSlug(): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/OpenInModalTriggerMenuPageTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/OpenInModalTriggerMenuPageTrait.php
@@ -11,8 +11,6 @@ trait OpenInModalTriggerMenuPageTrait
 {
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueModalTriggerAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -43,8 +43,6 @@ class SettingsMenuPage extends AbstractMenuPage
 
     /**
      * Initialize the class instance
-     *
-     * @return void
      */
     public function initialize(): void
     {
@@ -226,8 +224,6 @@ class SettingsMenuPage extends AbstractMenuPage
     /**
      * If `true`, print the sections using tabs
      * If `false`, print the sections one below the other
-     *
-     * @return boolean
      */
     protected function printWithTabs(): bool
     {
@@ -236,8 +232,6 @@ class SettingsMenuPage extends AbstractMenuPage
 
     /**
      * Print the settings form
-     *
-     * @return void
      */
     public function print(): void
     {
@@ -326,8 +320,6 @@ class SettingsMenuPage extends AbstractMenuPage
 
     /**
      * Enqueue the required assets and initialize the localized scripts
-     *
-     * @return void
      */
     protected function enqueueAssets(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -24,16 +24,13 @@ class SettingsMenuPage extends AbstractMenuPage
     public const FORM_ORIGIN = 'form-origin';
     public const SETTINGS_FIELD = 'graphql-api-settings';
 
-    protected ModuleRegistryInterface $moduleRegistry;
-
     function __construct(
         Menu $menu,
         MenuPageHelper $menuPageHelper,
         EndpointHelpers $endpointHelpers,
-        ModuleRegistryInterface $moduleRegistry
+        protected ModuleRegistryInterface $moduleRegistry
     ) {
         parent::__construct($menu, $menuPageHelper, $endpointHelpers);
-        $this->moduleRegistry = $moduleRegistry;
     }
 
     public function getMenuPageSlug(): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SupportMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SupportMenuPage.php
@@ -30,7 +30,7 @@ class SupportMenuPage extends AbstractDocsMenuPage
         $markdownContentParser = MarkdownContentParserFacade::getInstance();
         try {
             return $markdownContentParser->getContent('support.md', '', [ContentParserOptions::TAB_CONTENT => false]);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             return sprintf(
                 '<p>%s</p>',
                 \__('Oops, there was a problem loading the page', 'graphql-api')

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Menus/AbstractMenu.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Menus/AbstractMenu.php
@@ -15,8 +15,6 @@ abstract class AbstractMenu extends AbstractAutomaticallyInstantiatedService
 
     /**
      * Initialize the endpoints
-     *
-     * @return void
      */
     public function initialize(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Menus/Menu.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Menus/Menu.php
@@ -25,18 +25,11 @@ use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
  */
 class Menu extends AbstractMenu
 {
-    protected MenuPageHelper $menuPageHelper;
-    protected ModuleRegistryInterface $moduleRegistry;
-    protected UserAuthorizationInterface $userAuthorization;
-
     function __construct(
-        MenuPageHelper $menuPageHelper,
-        ModuleRegistryInterface $moduleRegistry,
-        UserAuthorizationInterface $userAuthorization
+        protected MenuPageHelper $menuPageHelper,
+        protected ModuleRegistryInterface $moduleRegistry,
+        protected UserAuthorizationInterface $userAuthorization
     ) {
-        $this->menuPageHelper = $menuPageHelper;
-        $this->moduleRegistry = $moduleRegistry;
-        $this->userAuthorization = $userAuthorization;
     }
 
     public function getName(): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfiguratorExecuters/EditingPersistedQuerySchemaConfiguratorExecuter.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfiguratorExecuters/EditingPersistedQuerySchemaConfiguratorExecuter.php
@@ -11,15 +11,10 @@ use GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators\PersistedQuerySchemaConfi
 
 class EditingPersistedQuerySchemaConfiguratorExecuter extends AbstractSchemaConfiguratorExecuter
 {
-    protected EndpointHelpers $endpointHelpers;
-    protected PersistedQuerySchemaConfigurator $persistedQuerySchemaConfigurator;
-
     function __construct(
-        EndpointHelpers $endpointHelpers,
-        PersistedQuerySchemaConfigurator $persistedQuerySchemaConfigurator
+        protected EndpointHelpers $endpointHelpers,
+        protected PersistedQuerySchemaConfigurator $persistedQuerySchemaConfigurator
     ) {
-        $this->endpointHelpers = $endpointHelpers;
-        $this->persistedQuerySchemaConfigurator = $persistedQuerySchemaConfigurator;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfiguratorExecuters/EndpointSchemaConfiguratorExecuter.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfiguratorExecuters/EndpointSchemaConfiguratorExecuter.php
@@ -10,12 +10,8 @@ use GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators\SchemaConfiguratorInterfa
 
 class EndpointSchemaConfiguratorExecuter extends AbstractLoadingCPTSchemaConfiguratorExecuter
 {
-    protected EndpointSchemaConfigurator $endpointSchemaConfigurator;
-
-    function __construct(
-        EndpointSchemaConfigurator $endpointSchemaConfigurator
-    ) {
-        $this->endpointSchemaConfigurator = $endpointSchemaConfigurator;
+    function __construct(protected EndpointSchemaConfigurator $endpointSchemaConfigurator)
+    {
     }
 
     protected function getCustomPostType(): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfiguratorExecuters/PersistedQuerySchemaConfiguratorExecuter.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfiguratorExecuters/PersistedQuerySchemaConfiguratorExecuter.php
@@ -10,12 +10,8 @@ use GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators\PersistedQuerySchemaConfi
 
 class PersistedQuerySchemaConfiguratorExecuter extends AbstractLoadingCPTSchemaConfiguratorExecuter
 {
-    protected PersistedQuerySchemaConfigurator $persistedQuerySchemaConfigurator;
-
-    function __construct(
-        PersistedQuerySchemaConfigurator $persistedQuerySchemaConfigurator
-    ) {
-        $this->persistedQuerySchemaConfigurator = $persistedQuerySchemaConfigurator;
+    function __construct(protected PersistedQuerySchemaConfigurator $persistedQuerySchemaConfigurator)
+    {
     }
 
     protected function getCustomPostType(): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractGraphQLQueryConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractGraphQLQueryConfigurator.php
@@ -15,12 +15,8 @@ use PoP\ComponentModel\Facades\Registries\TypeRegistryFacade;
  */
 abstract class AbstractGraphQLQueryConfigurator implements SchemaConfiguratorInterface
 {
-    protected ModuleRegistryInterface $moduleRegistry;
-
-    function __construct(
-        ModuleRegistryInterface $moduleRegistry
-    ) {
-        $this->moduleRegistry = $moduleRegistry;
+    function __construct(protected ModuleRegistryInterface $moduleRegistry)
+    {
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractQueryExecutionSchemaConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractQueryExecutionSchemaConfigurator.php
@@ -34,18 +34,11 @@ use WP_Post;
 
 abstract class AbstractQueryExecutionSchemaConfigurator implements SchemaConfiguratorInterface
 {
-    protected ModuleRegistryInterface $moduleRegistry;
-    protected AccessControlGraphQLQueryConfigurator $accessControlGraphQLQueryConfigurator;
-    protected FieldDeprecationGraphQLQueryConfigurator $fieldDeprecationGraphQLQueryConfigurator;
-
     function __construct(
-        ModuleRegistryInterface $moduleRegistry,
-        AccessControlGraphQLQueryConfigurator $accessControlGraphQLQueryConfigurator,
-        FieldDeprecationGraphQLQueryConfigurator $fieldDeprecationGraphQLQueryConfigurator
+        protected ModuleRegistryInterface $moduleRegistry,
+        protected AccessControlGraphQLQueryConfigurator $accessControlGraphQLQueryConfigurator,
+        protected FieldDeprecationGraphQLQueryConfigurator $fieldDeprecationGraphQLQueryConfigurator
     ) {
-        $this->moduleRegistry = $moduleRegistry;
-        $this->accessControlGraphQLQueryConfigurator = $accessControlGraphQLQueryConfigurator;
-        $this->fieldDeprecationGraphQLQueryConfigurator = $fieldDeprecationGraphQLQueryConfigurator;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AccessControlGraphQLQueryConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AccessControlGraphQLQueryConfigurator.php
@@ -58,8 +58,6 @@ class AccessControlGraphQLQueryConfigurator extends AbstractIndividualControlGra
     /**
      * Extract the access control items defined in the CPT,
      * and inject them into the service as to take effect in the current GraphQL query
-     *
-     * @return void
      */
     public function executeSchemaConfiguration(int $aclPostID): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/CacheControlGraphQLQueryConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/CacheControlGraphQLQueryConfigurator.php
@@ -18,8 +18,6 @@ class CacheControlGraphQLQueryConfigurator extends AbstractGraphQLQueryConfigura
     /**
      * Extract the configuration items defined in the CPT,
      * and inject them into the service as to take effect in the current GraphQL query
-     *
-     * @return void
      */
     public function executeSchemaConfiguration(int $cclPostID): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/FieldDeprecationGraphQLQueryConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/FieldDeprecationGraphQLQueryConfigurator.php
@@ -19,8 +19,6 @@ class FieldDeprecationGraphQLQueryConfigurator extends AbstractGraphQLQueryConfi
     /**
      * Extract the configuration items defined in the CPT,
      * and inject them into the service as to take effect in the current GraphQL query
-     *
-     * @return void
      */
     public function executeSchemaConfiguration(int $fdlPostID): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/PersistedQuerySchemaConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/PersistedQuerySchemaConfigurator.php
@@ -16,16 +16,13 @@ use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 
 class PersistedQuerySchemaConfigurator extends AbstractQueryExecutionSchemaConfigurator
 {
-    protected CacheControlGraphQLQueryConfigurator $cacheControlGraphQLQueryConfigurator;
-
     function __construct(
         ModuleRegistryInterface $moduleRegistry,
         AccessControlGraphQLQueryConfigurator $accessControlGraphQLQueryConfigurator,
         FieldDeprecationGraphQLQueryConfigurator $fieldDeprecationGraphQLQueryConfigurator,
-        CacheControlGraphQLQueryConfigurator $cacheControlGraphQLQueryConfigurator
+        protected CacheControlGraphQLQueryConfigurator $cacheControlGraphQLQueryConfigurator
     ) {
         parent::__construct($moduleRegistry, $accessControlGraphQLQueryConfigurator, $fieldDeprecationGraphQLQueryConfigurator);
-        $this->cacheControlGraphQLQueryConfigurator = $cacheControlGraphQLQueryConfigurator;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/PersistedQuerySchemaConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/PersistedQuerySchemaConfigurator.php
@@ -33,9 +33,6 @@ class PersistedQuerySchemaConfigurator extends AbstractQueryExecutionSchemaConfi
      * - Access Control Lists
      * - Cache Control Lists
      * - Field Deprecation Lists
-     *
-     * @param integer $schemaConfigurationID
-     * @return void
      */
     protected function executeSchemaConfigurationItems(int $schemaConfigurationID): void
     {
@@ -48,9 +45,6 @@ class PersistedQuerySchemaConfigurator extends AbstractQueryExecutionSchemaConfi
     /**
      * Apply all the settings defined in the Schema Configuration for:
      * - Cache Control Lists
-     *
-     * @param integer $schemaConfigurationID
-     * @return void
      */
     protected function executeSchemaConfigurationCacheControlLists(int $schemaConfigurationID): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/SchemaConfiguratorInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/SchemaConfiguratorInterface.php
@@ -8,9 +8,6 @@ interface SchemaConfiguratorInterface
 {
     /**
      * Execute the schema configuration contained in the custom post with certain ID
-     *
-     * @param integer $customPostID
-     * @return void
      */
     public function executeSchemaConfiguration(int $customPostID): void;
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Scripts/AbstractScript.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Scripts/AbstractScript.php
@@ -19,12 +19,8 @@ use PoP\Root\Services\AbstractAutomaticallyInstantiatedService;
  */
 abstract class AbstractScript extends AbstractAutomaticallyInstantiatedService
 {
-    protected ModuleRegistryInterface $moduleRegistry;
-
-    function __construct(
-        ModuleRegistryInterface $moduleRegistry
-    ) {
-        $this->moduleRegistry = $moduleRegistry;
+    function __construct(protected ModuleRegistryInterface $moduleRegistry)
+    {
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Taxonomies/GraphQLQueryTaxonomy.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Taxonomies/GraphQLQueryTaxonomy.php
@@ -13,8 +13,6 @@ class GraphQLQueryTaxonomy extends AbstractTaxonomy
 
     /**
      * Taxonomy
-     *
-     * @return string
      */
     public function getTaxonomy(): string
     {
@@ -33,7 +31,6 @@ class GraphQLQueryTaxonomy extends AbstractTaxonomy
      * Taxonomy plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getTaxonomyPluralNames(bool $uppercase = true): string
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManagerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManagerInterface.php
@@ -9,8 +9,6 @@ interface UserSettingsManagerInterface
     /**
      * Timestamp of latest executed write to DB, concerning plugin activation,
      * module enabled/disabled, user settings updated
-     *
-     * @return integer
      */
     public function getTimestamp(): int;
     /**
@@ -20,8 +18,6 @@ interface UserSettingsManagerInterface
     public function storeTimestamp(): void;
     /**
      * Remove the timestamp
-     *
-     * @return void
      */
     public function removeTimestamp(): void;
     public function hasSetting(string $item): bool;

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/src/BlockCategories/SchemaFeedbackBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/src/BlockCategories/SchemaFeedbackBlockCategory.php
@@ -25,8 +25,6 @@ class SchemaFeedbackBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's slug
-     *
-     * @return string
      */
     protected function getBlockCategorySlug(): string
     {
@@ -35,8 +33,6 @@ class SchemaFeedbackBlockCategory extends AbstractBlockCategory
 
     /**
      * Block category's title
-     *
-     * @return string
      */
     protected function getBlockCategoryTitle(): string
     {

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/src/SchemaConfigurators/SchemaFeedbackGraphQLQueryConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/src/SchemaConfigurators/SchemaFeedbackGraphQLQueryConfigurator.php
@@ -19,8 +19,6 @@ class SchemaFeedbackGraphQLQueryConfigurator extends AbstractGraphQLQueryConfigu
      * Extract the configuration items defined in the CPT,
      * and inject them into the service as to take effect
      * in the current GraphQL query
-     *
-     * @return void
      */
     public function executeSchemaConfiguration(int $fdlPostID): void
     {

--- a/layers/GraphQLAPIForWP/plugins/schema-feedback/src/Services/CustomPostTypes/GraphQLSchemaFeedbackListCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/schema-feedback/src/Services/CustomPostTypes/GraphQLSchemaFeedbackListCustomPostType.php
@@ -18,8 +18,6 @@ class GraphQLSchemaFeedbackListCustomPostType extends AbstractCustomPostType
 
     /**
      * Custom Post Type name
-     *
-     * @return string
      */
     protected function getCustomPostType(): string
     {
@@ -56,7 +54,6 @@ class GraphQLSchemaFeedbackListCustomPostType extends AbstractCustomPostType
      * Custom Post Type plural name
      *
      * @param bool $uppercase Indicate if the name must be uppercase (for starting a sentence) or, otherwise, lowercase
-     * @return string
      */
     protected function getPostTypePluralNames(bool $uppercase): string
     {
@@ -66,8 +63,6 @@ class GraphQLSchemaFeedbackListCustomPostType extends AbstractCustomPostType
     /**
      * Indicate if, whenever this CPT is saved/updated,
      * the timestamp must be regenerated
-     *
-     * @return boolean
      */
     protected function regenerateTimestampOnSave(): bool
     {
@@ -76,8 +71,6 @@ class GraphQLSchemaFeedbackListCustomPostType extends AbstractCustomPostType
 
     /**
      * Indicate if the excerpt must be used as the CPT's description and rendered when rendering the post
-     *
-     * @return boolean
      */
     public function usePostExcerptAsDescription(): bool
     {
@@ -86,8 +79,6 @@ class GraphQLSchemaFeedbackListCustomPostType extends AbstractCustomPostType
 
     /**
      * Gutenberg templates to lock down the Custom Post Type to
-     *
-     * @return array
      */
     protected function getGutenbergTemplate(): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractClient.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractClient.php
@@ -16,8 +16,6 @@ abstract class AbstractClient extends AbstractEndpointHandler
 
     /**
      * Initialize the client
-     *
-     * @return void
      */
     public function initialize(): void
     {
@@ -31,8 +29,6 @@ abstract class AbstractClient extends AbstractEndpointHandler
 
     /**
      * Indicate if the client is disabled
-     *
-     * @return boolean
      */
     protected function isClientDisabled(): bool
     {

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractGraphiQLClient.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractGraphiQLClient.php
@@ -11,8 +11,6 @@ abstract class AbstractGraphiQLClient extends AbstractClient
 {
     /**
      * Indicate if the client is disabled
-     *
-     * @return boolean
      */
     protected function isClientDisabled(): bool
     {

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/VoyagerClient.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/VoyagerClient.php
@@ -11,8 +11,6 @@ class VoyagerClient extends AbstractClient
 {
     /**
      * Indicate if the client is disabled
-     *
-     * @return boolean
      */
     protected function isClientDisabled(): bool
     {

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/WPClientTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/WPClientTrait.php
@@ -20,8 +20,6 @@ trait WPClientTrait
     }
     /**
      * Base Dir
-     *
-     * @return string
      */
     protected function getComponentBaseDir(): string
     {
@@ -30,8 +28,6 @@ trait WPClientTrait
 
     /**
      * Endpoint URL
-     *
-     * @return string
      */
     protected function getEndpointURL(): string
     {

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/src/EndpointHandlers/GraphQLEndpointHandler.php
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/src/EndpointHandlers/GraphQLEndpointHandler.php
@@ -16,8 +16,6 @@ class GraphQLEndpointHandler extends AbstractEndpointHandler
 {
     /**
      * Initialize the endpoints
-     *
-     * @return void
      */
     public function initialize(): void
     {
@@ -38,8 +36,6 @@ class GraphQLEndpointHandler extends AbstractEndpointHandler
 
     /**
      * Check if GrahQL has been enabled
-     *
-     * @return boolean
      */
     protected function isGraphQLAPIEnabled(): bool
     {
@@ -51,8 +47,6 @@ class GraphQLEndpointHandler extends AbstractEndpointHandler
 
     /**
      * Indicate this is a GraphQL request
-     *
-     * @return void
      */
     protected function executeEndpoint(): void
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Execution/Request.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Execution/Request.php
@@ -216,11 +216,9 @@ class Request
     }
 
     /**
-     * @param array|string $variables
-     *
      * @return $this
      */
-    public function setVariables($variables)
+    public function setVariables(array|string $variables)
     {
         if (!is_array($variables)) {
             $variables = json_decode($variables, true);

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Argument.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Argument.php
@@ -22,8 +22,6 @@ class Argument extends AbstractAst
 
     /**
      * @param string         $name
-     * @param ValueInterface $value
-     * @param Location       $location
      */
     public function __construct($name, ValueInterface $value, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputList.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputList.php
@@ -17,10 +17,6 @@ class InputList extends AbstractAst implements ValueInterface
 
     protected $list = [];
 
-    /**
-     * @param array    $list
-     * @param Location $location
-     */
     public function __construct(array $list, Location $location)
     {
         parent::__construct($location);

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputObject.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputObject.php
@@ -17,10 +17,6 @@ class InputObject extends AbstractAst implements ValueInterface
 
     protected $object = [];
 
-    /**
-     * @param array    $object
-     * @param Location $location
-     */
     public function __construct(array $object, Location $location)
     {
         parent::__construct($location);

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Literal.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Literal.php
@@ -19,7 +19,6 @@ class Literal extends AbstractAst implements ValueInterface
 
     /**
      * @param mixed $value
-     * @param Location $location
      */
     public function __construct($value, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Variable.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Variable.php
@@ -48,7 +48,6 @@ class Variable extends AbstractAst implements ValueInterface
      * @param bool     $nullable
      * @param bool     $isArray
      * @param bool     $arrayElementNullable
-     * @param Location $location
      */
     public function __construct($name, $type, $nullable, $isArray, $arrayElementNullable, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/VariableReference.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/ArgumentValue/VariableReference.php
@@ -27,7 +27,6 @@ class VariableReference extends AbstractAst implements ValueInterface
     /**
      * @param string        $name
      * @param Variable|null $variable
-     * @param Location      $location
      */
     public function __construct($name, Variable $variable = null, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Directive.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Directive.php
@@ -20,8 +20,6 @@ class Directive extends AbstractAst
 
     /**
      * @param string   $name
-     * @param array    $arguments
-     * @param Location $location
      */
     public function __construct($name, array $arguments, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Field.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Field.php
@@ -25,9 +25,6 @@ class Field extends AbstractAst implements FieldInterface
     /**
      * @param string   $name
      * @param string   $alias
-     * @param array    $arguments
-     * @param array    $directives
-     * @param Location $location
      */
     public function __construct($name, $alias, array $arguments, array $directives, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Fragment.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Fragment.php
@@ -27,9 +27,7 @@ class Fragment extends AbstractAst
     /**
      * @param string          $name
      * @param string          $model
-     * @param array           $directives
      * @param Field[]|Query[] $fields
-     * @param Location        $location
      */
     public function __construct($name, $model, array $directives, array $fields, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/FragmentReference.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/FragmentReference.php
@@ -19,7 +19,6 @@ class FragmentReference extends AbstractAst implements FragmentInterface
 
     /**
      * @param string   $name
-     * @param Location $location
      */
     public function __construct($name, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Query.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/Query.php
@@ -31,10 +31,6 @@ class Query extends AbstractAst implements FieldInterface
      *
      * @param string   $name
      * @param string   $alias
-     * @param array    $arguments
-     * @param array    $fields
-     * @param array    $directives
-     * @param Location $location
      */
     public function __construct($name, $alias, array $arguments, array $fields, array $directives, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/TypedFragmentReference.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Ast/TypedFragmentReference.php
@@ -25,7 +25,6 @@ class TypedFragmentReference extends AbstractAst implements FragmentInterface
      * @param string          $typeName
      * @param Field[]|Query[] $fields
      * @param Directive[]     $directives
-     * @param Location        $location
      */
     public function __construct($typeName, array $fields, array $directives, Location $location)
     {

--- a/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Parser.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/src/Parser/Parser.php
@@ -388,11 +388,9 @@ class Parser extends Tokenizer
     }
 
     /**
-     * @return array|InputList|InputObject|Literal|VariableReference
-     *
      * @throws SyntaxErrorException
      */
-    protected function parseValue()
+    protected function parseValue(): array|InputList|InputObject|Literal|VariableReference
     {
         switch ($this->lookAhead->getType()) {
             case Token::TYPE_LSQUARE_BRACE:

--- a/layers/GraphQLByPoP/packages/graphql-parser/tests/Library/Validator/RequestValidatorTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-parser/tests/Library/Validator/RequestValidatorTest.php
@@ -26,7 +26,6 @@ class RequestValidatorTest extends TestCase
 
     /**
      * @dataProvider invalidRequestProvider
-     * @param Request $request
      */
     public function testInvalidRequests(Request $request)
     {

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
@@ -33,15 +33,10 @@ use PoP\Translation\TranslationAPIInterface;
 
 class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
 {
-    protected TranslationAPIInterface $translationAPI;
-    protected FeedbackMessageStoreInterface $feedbackMessageStore;
-
     public function __construct(
-        TranslationAPIInterface $translationAPI,
-        FeedbackMessageStoreInterface $feedbackMessageStore
+        protected TranslationAPIInterface $translationAPI,
+        protected FeedbackMessageStoreInterface $feedbackMessageStore
     ) {
-        $this->translationAPI = $translationAPI;
-        $this->feedbackMessageStore = $feedbackMessageStore;
     }
 
     /**

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
@@ -139,9 +139,6 @@ class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
 
     /**
      * Indicates if the variable must be dealt with as an expression: if its name starts with "_"
-     *
-     * @param string $variableName
-     * @return boolean
      */
     public function treatVariableAsExpression(string $variableName): bool
     {
@@ -309,8 +306,6 @@ class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
 
     /**
      * Restrain fields to the model through directive <include(if:isType($model))>
-     *
-     * @return array
      */
     protected function restrainFieldsByTypeOrInterface(array $fragmentFieldPaths, string $fragmentModel): array
     {
@@ -496,7 +491,6 @@ class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
      * Function copied from youshido/graphql/src/Execution/Processor.php
      *
      * @param [type] $payload
-     * @param array $variables
      * @return void
      */
     protected function parseAndCreateRequest(

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertorInterface.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertorInterface.php
@@ -19,9 +19,6 @@ interface GraphQLQueryConvertorInterface
 
     /**
      * Indicates if the variable must be dealt with as an expression: if its name starts with "_"
-     *
-     * @param string $variableName
-     * @return boolean
      */
     public function treatVariableAsExpression(string $variableName): bool;
 }

--- a/layers/GraphQLByPoP/packages/graphql-request/src/Hooks/VarsHooks.php
+++ b/layers/GraphQLByPoP/packages/graphql-request/src/Hooks/VarsHooks.php
@@ -147,8 +147,6 @@ class VarsHooks extends AbstractHookSet
     /**
      * Function is public so it can be invoked from the WordPress plugin
      *
-     * @param array $vars
-     * @param string $graphQLQuery
      * @return void
      */
     public function addGraphQLQueryToVars(array &$vars, string $graphQLQuery, ?string $operationName = null)

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -39,8 +39,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnEnvironment/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
@@ -121,23 +121,7 @@ class ExportDirectiveResolver extends AbstractGlobalDirectiveResolver
      *
      * ... exports variable $postIDsAndTitles as an array, where each item is a dictionary {"id": post ID, "title": post title}
      *
-     * @param TypeResolverInterface $typeResolver
-     * @param array $idsDataFields
-     * @param array $succeedingPipelineIDsDataFields
-     * @param array $succeedingPipelineDirectiveResolverInstances
-     * @param array $resultIDItems
-     * @param array $unionDBKeyIDs
-     * @param array $dbItems
-     * @param array $previousDBItems
-     * @param array $variables
      * @param array $_messages
-     * @param array $dbErrors
-     * @param array $dbWarnings
-     * @param array $dbDeprecations
-     * @param array $schemaErrors
-     * @param array $schemaWarnings
-     * @param array $schemaDeprecations
-     * @return void
      */
     public function resolveDirective(
         TypeResolverInterface $typeResolver,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -36,10 +36,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
     /**
      * Only use this fieldResolver when parameter `namespaced` is provided. Otherwise, use the default implementation
      *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
      * @param array<string, mixed> $fieldArgs
-     * @return boolean
      */
     public function resolveCanProcess(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): bool
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractDynamicType.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractDynamicType.php
@@ -18,8 +18,6 @@ abstract class AbstractDynamicType extends AbstractType
      * field in the schema or, if not provided, it is dynamically generated.
      * This name is either namespaced or not (depending on configuration),
      * it doesn't support the two different cases
-     *
-     * @return string
      */
     public function getNamespacedName(): string
     {
@@ -31,8 +29,6 @@ abstract class AbstractDynamicType extends AbstractType
      * field in the schema or, if not provided, it is dynamically generated
      * This name is either namespaced or not (depending on configuration),
      * it doesn't support the two different cases
-     *
-     * @return string
      */
     public function getElementName(): string
     {
@@ -71,8 +67,6 @@ abstract class AbstractDynamicType extends AbstractType
     /**
      * Indicate under what property in the schema definition
      * is the Dynamic Type's name provided
-     *
-     * @return string
      */
     abstract protected function getDynamicTypeNamePropertyInSchema(): string;
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractNestableType.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractNestableType.php
@@ -8,11 +8,13 @@ use GraphQLByPoP\GraphQLServer\ObjectModels\AbstractType;
 
 abstract class AbstractNestableType extends AbstractType
 {
-    protected AbstractType $nestedType;
-    public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath, AbstractType $nestedType, array $customDefinition = [])
-    {
+    public function __construct(
+        array &$fullSchemaDefinition,
+        array $schemaDefinitionPath,
+        protected AbstractType $nestedType,
+        array $customDefinition = []
+    ) {
         parent::__construct($fullSchemaDefinition, $schemaDefinitionPath, $customDefinition);
-        $this->nestedType = $nestedType;
     }
     public function getNestedType(): AbstractType
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractSchemaDefinitionReferenceObject.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractSchemaDefinitionReferenceObject.php
@@ -24,8 +24,6 @@ abstract class AbstractSchemaDefinitionReferenceObject
     /**
      * Build a new Schema Definition Reference Object
      *
-     * @param array $fullSchemaDefinition
-     * @param array $schemaDefinitionPath
      * @param array $customDefinition Pass custom values that will override the ones defined in $schemaDefinition
      */
     public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath, array $customDefinition = [])
@@ -51,8 +49,6 @@ abstract class AbstractSchemaDefinitionReferenceObject
 
     /**
      * By default, types are static
-     *
-     * @return boolean
      */
     public function isDynamicType(): bool
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractSchemaDefinitionReferenceObject.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractSchemaDefinitionReferenceObject.php
@@ -26,8 +26,11 @@ abstract class AbstractSchemaDefinitionReferenceObject
      *
      * @param array $customDefinition Pass custom values that will override the ones defined in $schemaDefinition
      */
-    public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath, array $customDefinition = [])
-    {
+    public function __construct(
+        array &$fullSchemaDefinition,
+        array $schemaDefinitionPath,
+        array $customDefinition = []
+    ) {
         // Also save this variable to lazy initi new types in HasTypeSchemaDefinitionReferenceTrait
         $this->fullSchemaDefinition = $fullSchemaDefinition;
         $this->schemaDefinitionPath = $schemaDefinitionPath;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractType.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractType.php
@@ -13,8 +13,6 @@ abstract class AbstractType extends AbstractSchemaDefinitionReferenceObject
 
     /**
      * Once all types are initialized, call this function to further link to other types
-     *
-     * @return void
      */
     public function initializeTypeDependencies(): void
     {
@@ -33,8 +31,6 @@ abstract class AbstractType extends AbstractSchemaDefinitionReferenceObject
     /**
      * Static types: their names are defined under property "name"
      * from the schema definition
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -46,8 +42,6 @@ abstract class AbstractType extends AbstractSchemaDefinitionReferenceObject
     }
     /**
      * There are no extensions currently implemented for the Type
-     *
-     * @return array
      */
     public function getExtensions(): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasInterfacesTypeInterface.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasInterfacesTypeInterface.php
@@ -9,8 +9,6 @@ interface HasInterfacesTypeInterface
     public function getInterfaces(): array;
     /**
      * Return the interfaces through their ID representation: Kind + Name
-     *
-     * @return array
      */
     public function getInterfaceIDs(): array;
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasInterfacesTypeTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasInterfacesTypeTrait.php
@@ -19,8 +19,6 @@ trait HasInterfacesTypeTrait
     protected array $interfaces;
     /**
      * Reference the already-registered interfaces
-     *
-     * @return void
      */
     protected function initInterfaces(array &$fullSchemaDefinition, array $schemaDefinitionPath): void
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasPossibleTypesTypeTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasPossibleTypesTypeTrait.php
@@ -25,8 +25,6 @@ trait HasPossibleTypesTypeTrait
     }
     /**
      * Obtain the reference to the type from the registryMap
-     *
-     * @return void
      */
     protected function initPossibleTypes(): void
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasTypeSchemaDefinitionReferenceTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasTypeSchemaDefinitionReferenceTrait.php
@@ -20,8 +20,6 @@ trait HasTypeSchemaDefinitionReferenceTrait
     }
     /**
      * Obtain the reference to the type from the registryMap
-     *
-     * @return void
      */
     protected function initType(): void
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
@@ -26,8 +26,6 @@ class InputValue extends AbstractSchemaDefinitionReferenceObject
     }
     /**
      * Undocumented function
-     *
-     * @return string|null
      */
     public function getDefaultValue(): ?string
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/ScalarType.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/ScalarType.php
@@ -11,12 +11,13 @@ class ScalarType extends AbstractType
 {
     use NonDocumentableTypeTrait;
 
-    protected string $name;
-
-    public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath, string $name, array $customDefinition = [])
-    {
+    public function __construct(
+        array &$fullSchemaDefinition,
+        array $schemaDefinitionPath,
+        protected string $name,
+        array $customDefinition = []
+    ) {
         parent::__construct($fullSchemaDefinition, $schemaDefinitionPath, $customDefinition);
-        $this->name = $name;
     }
 
     public function getName(): string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
@@ -289,7 +289,7 @@ class Schema
     public function getType(string $typeName): ?AbstractType
     {
         // If the provided typeName contains the namespace separator, then compare by qualifiedType
-        $useQualifiedName = strpos($typeName, SchemaDefinition::TOKEN_NAMESPACE_SEPARATOR) !== false;
+        $useQualifiedName = str_contains($typeName, SchemaDefinition::TOKEN_NAMESPACE_SEPARATOR);
         // From all the types, get the one that has this name
         foreach ($this->types as $type) {
             // The provided `$typeName` can include namespaces or not

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
@@ -21,7 +21,6 @@ use GraphQLByPoP\GraphQLServer\Facades\Registries\SchemaDefinitionReferenceRegis
 
 class Schema
 {
-    protected string $id;
     /**
      * @var ScalarType[]
      */
@@ -34,10 +33,10 @@ class Schema
     protected ?AbstractType $mutationType = null;
     protected ?AbstractType $subscriptionType = null;
 
-    public function __construct(array $fullSchemaDefinition, string $id)
-    {
-        $this->id = $id;
-
+    public function __construct(
+        array $fullSchemaDefinition,
+        protected string $id
+    ) {
         // Initialize the global elements before anything, since they will
         // be references from the ObjectType: Fields/Connections/Directives
         // 1. Initialize all the Scalar types

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/Services/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/Services/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -25,9 +25,6 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
 {
     /**
      * If it is a Union Type, we must remove the "*" from the name
-     *
-     * @param string $dbKey
-     * @return string
      */
     protected function getTypeName(string $dbKey): string
     {
@@ -57,7 +54,6 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
      *
      * @param string $dbKey
      * @param [type] $id
-     * @param array $item
      * @return array
      */
     protected function addFieldOrDirectiveEntryToExtensions(array &$extensions, array $item): void
@@ -89,10 +85,7 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
     /**
      * Change properties for GraphQL
      *
-     * @param string $dbKey
      * @param [type] $id
-     * @param array $item
-     * @return array
      */
     protected function getDBEntryExtensions(string $dbKey, $id, array $item): array
     {
@@ -110,10 +103,6 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
 
     /**
      * Change properties for GraphQL
-     *
-     * @param string $dbKey
-     * @param array $item
-     * @return array
      */
     protected function getSchemaEntryExtensions(string $dbKey, array $item): array
     {
@@ -130,8 +119,6 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
     /**
      * Override the parent function, to place the locations from outside extensions
      *
-     * @param string $message
-     * @param array $extensions
      * @return void
      */
     protected function getQueryEntry(string $message, array $extensions): array
@@ -159,8 +146,6 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
 
     /**
      * Change properties for GraphQL
-     *
-     * @return array
      */
     protected function getQueryEntryExtensions(): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -46,8 +46,6 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
      * It can store the value in the cache.
      * Use cache with care: if the schema is dynamic, it should not be cached.
      * Public schema: can cache, Private schema: cannot cache.
-     *
-     * @return array
      */
     public function &getFullSchemaDefinition(): array
     {
@@ -351,9 +349,6 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     }
     /**
      * Convert the field type from its internal representation (eg: "array:Post") to the GraphQL standard representation (eg: "[Post]")
-     *
-     * @param array $fieldSchemaDefinitionPath
-     * @return void
      */
     protected function introduceSDLNotationToFieldSchemaDefinition(array $fieldSchemaDefinitionPath): void
     {
@@ -391,9 +386,6 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
      * When doing /?edit_schema=true, "Schema" type directives will also be added the FIELD location,
      * so that they show up in GraphiQL and can be added to a persisted query
      * When that happens, append '("Schema" type directive)' to the directive's description
-     *
-     * @param array $directiveSchemaDefinitionPath
-     * @return void
      */
     protected function maybeAddTypeToSchemaDirectiveDescription(array $directiveSchemaDefinitionPath): void
     {
@@ -416,8 +408,6 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
 
     /**
      * Append the field or directive's version to its description
-     *
-     * @param array $fieldOrDirectiveSchemaDefinitionPath
      */
     protected function addVersionToSchemaFieldDescription(array $fieldOrDirectiveSchemaDefinitionPath): void
     {
@@ -436,8 +426,6 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
 
     /**
      * Append param "nestedUnder" to the directive
-     *
-     * @param array $directiveSchemaDefinitionPath
      */
     protected function addNestedDirectiveDataToSchemaDirectiveArgs(array $directiveSchemaDefinitionPath): void
     {
@@ -453,8 +441,6 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
 
     /**
      * Append the "Mutation" label to the field's description
-     *
-     * @param array $fieldSchemaDefinitionPath
      */
     protected function addMutationLabelToSchemaFieldDescription(array $fieldSchemaDefinitionPath): void
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistryInterface.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistryInterface.php
@@ -10,8 +10,6 @@ interface SchemaDefinitionReferenceRegistryInterface
 {
     /**
      * It returns the full schema, expanded with all data required to satisfy GraphQL's introspection fields (starting from "__schema")
-     *
-     * @return array
      */
     public function &getFullSchemaDefinition(): array;
     public function registerSchemaDefinitionReference(

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinitionHelpers.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinitionHelpers.php
@@ -40,10 +40,6 @@ class SchemaDefinitionHelpers
      *
      * @deprecated 0.1.0 The error above must be fixed for the Enum, by unifying its name wherever it is referenced
      * This solution with the interfaces creates other issue: The type cannot customize its field schema definition
-     *
-     * @param array $fullSchemaDefinition
-     * @param array $interfaceNames
-     * @return array
      */
     protected static function getFieldInterfaces(array &$fullSchemaDefinition, array $interfaceNames): array
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
@@ -19,10 +19,6 @@ class SchemaHelpers
      *
      * - field response: isNonNullable
      * - field argument: isMandatory (its provided value can still be null)
-     *
-     * @param string $type
-     * @param boolean|null $isNonNullableOrMandatory
-     * @return string
      */
     public static function getTypeToOutputInSchema(string $type, ?bool $isNonNullableOrMandatory = false): string
     {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Syntax/SyntaxHelpers.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Syntax/SyntaxHelpers.php
@@ -8,9 +8,6 @@ class SyntaxHelpers
 {
     /**
      * Indicate if the type if of type "LIST"
-     *
-     * @param string $type
-     * @return boolean
      */
     public static function isListType(string $type): bool
     {
@@ -19,9 +16,6 @@ class SyntaxHelpers
 
     /**
      * Extract the nested types inside the list
-     *
-     * @param string $type
-     * @return string
      */
     public static function getListTypeNestedTypeName(string $type): string
     {
@@ -30,9 +24,6 @@ class SyntaxHelpers
 
     /**
      * Indicate if the type if of type "NON_NULL"
-     *
-     * @param string $type
-     * @return boolean
      */
     public static function isNonNullType(string $type): bool
     {
@@ -41,9 +32,6 @@ class SyntaxHelpers
 
     /**
      * Extract the nested types which are "non null"
-     *
-     * @param string $type
-     * @return string
      */
     public static function getNonNullTypeNestedTypeName(string $type): string
     {

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/AbstractCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/AbstractCacheTypeResolverDecorator.php
@@ -19,8 +19,6 @@ abstract class AbstractCacheTypeResolverDecorator extends AbstractPublicSchemaTy
     /**
      * Time that the cache is valid
      * By default, it caches for 1 hour
-     *
-     * @return integer|null
      */
     protected function getTime(): ?int
     {
@@ -30,8 +28,6 @@ abstract class AbstractCacheTypeResolverDecorator extends AbstractPublicSchemaTy
 
     /**
      * Get the fields to cache. Function to override
-     *
-     * @return array
      */
     protected function getFieldNamesToCache(): array
     {
@@ -40,8 +36,6 @@ abstract class AbstractCacheTypeResolverDecorator extends AbstractPublicSchemaTy
 
     /**
      * Get the directives to cache. Function to override
-     *
-     * @return array
      */
     protected function getDirectiveNamesToCache(): array
     {
@@ -50,8 +44,6 @@ abstract class AbstractCacheTypeResolverDecorator extends AbstractPublicSchemaTy
 
     /**
      * Get the cache directive
-     *
-     * @return array
      */
     protected function getCacheDirective(): array
     {
@@ -69,9 +61,6 @@ abstract class AbstractCacheTypeResolverDecorator extends AbstractPublicSchemaTy
 
     /**
      * Cache fields
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getMandatoryDirectivesForFields(TypeResolverInterface $typeResolver): array
     {
@@ -89,9 +78,6 @@ abstract class AbstractCacheTypeResolverDecorator extends AbstractPublicSchemaTy
 
     /**
      * Cache directives
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getSucceedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/GlobalCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/GlobalCacheTypeResolverDecorator.php
@@ -20,8 +20,6 @@ class GlobalCacheTypeResolverDecorator extends AbstractCacheTypeResolverDecorato
 
     /**
      * Get the fields to cache
-     *
-     * @return array
      */
     protected function getFieldNamesToCache(): array
     {

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/RootCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/RootCacheTypeResolverDecorator.php
@@ -20,8 +20,6 @@ class RootCacheTypeResolverDecorator extends AbstractCacheTypeResolverDecorator
 
     /**
      * Get the fields to cache
-     *
-     * @return array
      */
     protected function getFieldNamesToCache(): array
     {

--- a/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/TranslateCacheTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/ConditionalOnEnvironment/UseComponentModelCache/SchemaServices/TypeResolverDecorators/TranslateCacheTypeResolverDecorator.php
@@ -24,8 +24,6 @@ class TranslateCacheTypeResolverDecorator extends AbstractCacheTypeResolverDecor
 
     /**
      * Get the directives to cache
-     *
-     * @return array
      */
     protected function getDirectiveNamesToCache(): array
     {

--- a/layers/Misc/packages/examples-for-pop/src/TypeResolverDecorators/CDNTypeResolverDecorator.php
+++ b/layers/Misc/packages/examples-for-pop/src/TypeResolverDecorators/CDNTypeResolverDecorator.php
@@ -25,9 +25,6 @@ class CDNTypeResolverDecorator extends AbstractPublicSchemaTypeResolverDecorator
     /**
      * If the from/to URLs were defined for the CDN, then attach the CDN directive
      * to the corresponding fields
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getMandatoryDirectivesForFields(TypeResolverInterface $typeResolver): array
     {

--- a/layers/Schema/packages/basic-directives/src/DirectiveResolvers/AbstractUseDefaultValueIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/basic-directives/src/DirectiveResolvers/AbstractUseDefaultValueIfConditionDirectiveResolver.php
@@ -80,7 +80,6 @@ abstract class AbstractUseDefaultValueIfConditionDirectiveResolver extends Abstr
      * Indicate if the value matches the condition under which to inject the default value
      *
      * @param mixed $value
-     * @return boolean
      */
     protected function matchesCondition(string $condition, $value): bool
     {

--- a/layers/Schema/packages/categories-wp/src/TypeAPIs/CategoryTypeAPI.php
+++ b/layers/Schema/packages/categories-wp/src/TypeAPIs/CategoryTypeAPI.php
@@ -17,7 +17,6 @@ class CategoryTypeAPI extends TaxonomyTypeAPI implements CategoryTypeAPIInterfac
      * Indicates if the passed object is of type Category
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfCategoryType($object): bool
     {

--- a/layers/Schema/packages/categories/src/Component.php
+++ b/layers/Schema/packages/categories/src/Component.php
@@ -25,8 +25,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/categories/src/TypeAPIs/CategoryTypeAPIInterface.php
+++ b/layers/Schema/packages/categories/src/TypeAPIs/CategoryTypeAPIInterface.php
@@ -15,7 +15,6 @@ interface CategoryTypeAPIInterface extends TaxonomyTypeAPIInterface
      * Indicates if the passed object is of type Category
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfCategoryType($object): bool;
 }

--- a/layers/Schema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
+++ b/layers/Schema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
@@ -16,7 +16,6 @@ class CommentTypeAPI implements CommentTypeAPIInterface
      * Indicates if the passed object is of type Comment
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfCommentType($object): bool
     {

--- a/layers/Schema/packages/comments/src/Component.php
+++ b/layers/Schema/packages/comments/src/Component.php
@@ -25,8 +25,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/comments/src/TypeAPIs/CommentTypeAPIInterface.php
+++ b/layers/Schema/packages/comments/src/TypeAPIs/CommentTypeAPIInterface.php
@@ -13,7 +13,6 @@ interface CommentTypeAPIInterface
      * Indicates if the passed object is of type Comment
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfCommentType($object): bool;
 }

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -17,11 +17,8 @@ use PoPSchema\CustomPostMediaMutations\MutationResolvers\RemoveFeaturedImageOnCu
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    protected MediaTypeResolver $mediaTypeResolver;
-
-    function __construct(MediaTypeResolver $mediaTypeResolver)
+    function __construct(protected MediaTypeResolver $mediaTypeResolver)
     {
-        $this->mediaTypeResolver = $mediaTypeResolver;
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -18,11 +18,8 @@ use PoP\Engine\ComponentConfiguration as EngineComponentConfiguration;
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
-    protected MediaTypeResolver $mediaTypeResolver;
-
-    function __construct(MediaTypeResolver $mediaTypeResolver)
+    function __construct(protected MediaTypeResolver $mediaTypeResolver)
     {
-        $this->mediaTypeResolver = $mediaTypeResolver;
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/Hooks/CustomPostMutationResolverHooks.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/Hooks/CustomPostMutationResolverHooks.php
@@ -17,15 +17,12 @@ use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 
 class CustomPostMutationResolverHooks extends AbstractHookSet
 {
-    protected MediaTypeResolver $mediaTypeResolver;
-
     public function __construct(
         HooksAPIInterface $hooksAPI,
         TranslationAPIInterface $translationAPI,
-        MediaTypeResolver $mediaTypeResolver
+        protected MediaTypeResolver $mediaTypeResolver
     ) {
         parent::__construct($hooksAPI, $translationAPI);
-        $this->mediaTypeResolver = $mediaTypeResolver;
     }
 
     protected function init()

--- a/layers/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php
+++ b/layers/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php
@@ -13,9 +13,6 @@ class CustomPostUnionTypeResolver extends \PoPSchema\CustomPosts\TypeResolvers\C
      * instead of calling ->isIDOfType on each object (as in parent function),
      * in which case we must make a DB call for each result,
      * we obtain all the types from executing a single query against the DB
-     *
-     * @param array $ids
-     * @return array
      */
     public function getResultItemIDTargetTypeResolvers(array $ids): array
     {

--- a/layers/Schema/packages/customposts-wp/src/TypeAPIs/CustomPostTypeAPI.php
+++ b/layers/Schema/packages/customposts-wp/src/TypeAPIs/CustomPostTypeAPI.php
@@ -71,8 +71,6 @@ class CustomPostTypeAPI implements CustomPostTypeAPIInterface
     /**
      * Limit of how many custom posts can be retrieved in the query.
      * Override this value for specific custom post types
-     *
-     * @return integer
      */
     protected function getCustomPostListMaxLimit(): int
     {

--- a/layers/Schema/packages/customposts-wp/src/TypeResolverPickers/CustomPostTypeResolverPickerInterface.php
+++ b/layers/Schema/packages/customposts-wp/src/TypeResolverPickers/CustomPostTypeResolverPickerInterface.php
@@ -10,7 +10,6 @@ interface CustomPostTypeResolverPickerInterface extends \PoPSchema\CustomPosts\T
      * Maybe cast the object of type `WP_Post` returned by function `get_posts`, to a different object type
      *
      * @param array $customPosts An array with "key" the ID, "value" the object
-     * @return array
      */
     public function maybeCastCustomPosts(array $customPosts): array;
 }

--- a/layers/Schema/packages/customposts/src/TypeHelpers/CustomPostUnionTypeHelpers.php
+++ b/layers/Schema/packages/customposts/src/TypeHelpers/CustomPostUnionTypeHelpers.php
@@ -47,9 +47,6 @@ class CustomPostUnionTypeHelpers
      *   and not the Union (since it's more efficient)
      * - If there are none types, return `null`. As a consequence,
      *   the ID is returned as a field, not as a connection
-     *
-     * @param string $unionTypeResolverClass
-     * @return string|null
      */
     public static function getCustomPostUnionOrTargetTypeResolverClass(
         string $unionTypeResolverClass = CustomPostUnionTypeResolver::class

--- a/layers/Schema/packages/customposts/src/TypeResolverPickers/CustomPostTypeResolverPickerInterface.php
+++ b/layers/Schema/packages/customposts/src/TypeResolverPickers/CustomPostTypeResolverPickerInterface.php
@@ -8,8 +8,6 @@ interface CustomPostTypeResolverPickerInterface
 {
     /**
      * Get the post type of the Type (eg: Post is "post", Media is "attachment", etc)
-     *
-     * @return string
      */
     public function getCustomPostType(): string;
 }

--- a/layers/Schema/packages/events-wp-em/src/ConditionalOnEnvironment/AddEventTypeToCustomPostUnionTypes/Overrides/SchemaServices/TypeResolverPickers/EventCustomPostTypeResolverPicker.php
+++ b/layers/Schema/packages/events-wp-em/src/ConditionalOnEnvironment/AddEventTypeToCustomPostUnionTypes/Overrides/SchemaServices/TypeResolverPickers/EventCustomPostTypeResolverPicker.php
@@ -16,7 +16,6 @@ class EventCustomPostTypeResolverPicker extends UpstreamEventCustomPostTypeResol
      * Needed as to be able to access all fields from an event
      *
      * @param array $customPosts An array with "key" the ID, "value" the object
-     * @return array
      */
     public function maybeCastCustomPosts(array $customPosts): array
     {

--- a/layers/Schema/packages/events-wp-em/src/TypeAPIs/EventTypeAPI.php
+++ b/layers/Schema/packages/events-wp-em/src/TypeAPIs/EventTypeAPI.php
@@ -39,7 +39,6 @@ class EventTypeAPI extends CustomPostTypeAPI implements EventTypeAPIInterface
      * Indicates if the passed object is of type Event
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfEventType($object): bool
     {

--- a/layers/Schema/packages/events/src/Component.php
+++ b/layers/Schema/packages/events/src/Component.php
@@ -26,8 +26,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/events/src/TypeAPIs/EventTypeAPIInterface.php
+++ b/layers/Schema/packages/events/src/TypeAPIs/EventTypeAPIInterface.php
@@ -15,7 +15,6 @@ interface EventTypeAPIInterface extends CustomPostTypeAPIInterface
      * Indicates if the passed object is of type Event
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfEventType($object): bool;
     /**
@@ -36,15 +35,12 @@ interface EventTypeAPIInterface extends CustomPostTypeAPIInterface
      * Get the list of events
      *
      * @param array $query
-     * @param array $options
-     * @return array
      */
     public function getEvents($query = array(), array $options = []): array;
     /**
      * Get the number of events
      *
      * @param array $query
-     * @param array $options
      * @return array
      */
     public function getEventCount($query = array(), array $options = []): int;

--- a/layers/Schema/packages/everythingelse-wp/src/Component.php
+++ b/layers/Schema/packages/everythingelse-wp/src/Component.php
@@ -26,8 +26,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/generic-customposts/src/ModuleProcessors/GenericCustomPostFilterInnerModuleProcessor.php
+++ b/layers/Schema/packages/generic-customposts/src/ModuleProcessors/GenericCustomPostFilterInnerModuleProcessor.php
@@ -27,29 +27,25 @@ class GenericCustomPostFilterInnerModuleProcessor extends AbstractModuleProcesso
     {
         $ret = parent::getSubmodules($module);
 
-        switch ($module[1]) {
-            case self::MODULE_FILTERINNER_GENERICCUSTOMPOSTLIST:
-                $inputmodules = [
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH],
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ORDER],
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT],
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_OFFSET],
-                    [CommonFilterMultipleInputModuleProcessor::class, CommonFilterMultipleInputModuleProcessor::MODULE_FILTERINPUT_DATES],
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_IDS],
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],
-                    [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_GENERICPOSTTYPES],
-                ];
-                break;
-            case self::MODULE_FILTERINNER_GENERICCUSTOMPOSTCOUNT:
-                $inputmodules = [
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH],
-                    [CommonFilterMultipleInputModuleProcessor::class, CommonFilterMultipleInputModuleProcessor::MODULE_FILTERINPUT_DATES],
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_IDS],
-                    [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],
-                    [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_GENERICPOSTTYPES],
-                ];
-                break;
-        }
+        $inputmodules = match ($module[1]) {
+            self::MODULE_FILTERINNER_GENERICCUSTOMPOSTLIST => [
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH],
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ORDER],
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT],
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_OFFSET],
+                [CommonFilterMultipleInputModuleProcessor::class, CommonFilterMultipleInputModuleProcessor::MODULE_FILTERINPUT_DATES],
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_IDS],
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],
+                [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_GENERICPOSTTYPES],
+            ],
+            self::MODULE_FILTERINNER_GENERICCUSTOMPOSTCOUNT => [
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH],
+                [CommonFilterMultipleInputModuleProcessor::class, CommonFilterMultipleInputModuleProcessor::MODULE_FILTERINPUT_DATES],
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_IDS],
+                [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],
+                [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_GENERICPOSTTYPES],
+            ],
+        };
         if (
             $modules = HooksAPIFacade::getInstance()->applyFilters(
                 'GenericCustomPosts:FilterInnerModuleProcessor:inputmodules',

--- a/layers/Schema/packages/generic-customposts/src/TypeDataLoaders/GenericCustomPostTypeDataLoader.php
+++ b/layers/Schema/packages/generic-customposts/src/TypeDataLoaders/GenericCustomPostTypeDataLoader.php
@@ -12,9 +12,6 @@ class GenericCustomPostTypeDataLoader extends AbstractCustomPostTypeDataLoader
 {
     /**
      * Override the custompost-types from the parent
-     *
-     * @param array $ids
-     * @return array
      */
     public function getObjectQuery(array $ids): array
     {

--- a/layers/Schema/packages/google-translate-directive/src/DirectiveResolvers/AbstractGoogleTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/google-translate-directive/src/DirectiveResolvers/AbstractGoogleTranslateDirectiveResolver.php
@@ -15,8 +15,6 @@ abstract class AbstractGoogleTranslateDirectiveResolver extends AbstractTranslat
 
     /**
      * The name of the API's provider
-     *
-     * @return array
      */
     public function getProvidersToResolve(): array
     {

--- a/layers/Schema/packages/highlights-wp/src/TypeAPIs/HighlightTypeAPI.php
+++ b/layers/Schema/packages/highlights-wp/src/TypeAPIs/HighlightTypeAPI.php
@@ -29,7 +29,6 @@ class HighlightTypeAPI implements HighlightTypeAPIInterface
      * Indicates if the passed object is of type Highlight
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfHighlightType($object): bool
     {

--- a/layers/Schema/packages/highlights/src/TypeAPIs/HighlightTypeAPIInterface.php
+++ b/layers/Schema/packages/highlights/src/TypeAPIs/HighlightTypeAPIInterface.php
@@ -20,7 +20,6 @@ interface HighlightTypeAPIInterface
      * Indicates if the passed object is of type Highlight
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfHighlightType($object): bool;
     /**

--- a/layers/Schema/packages/locationposts-wp/src/TypeAPIs/LocationPostTypeAPI.php
+++ b/layers/Schema/packages/locationposts-wp/src/TypeAPIs/LocationPostTypeAPI.php
@@ -19,7 +19,6 @@ class LocationPostTypeAPI extends PostTypeAPI implements LocationPostTypeAPIInte
      * Indicates if the passed object is of type LocationPost
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfLocationPostType($object): bool
     {

--- a/layers/Schema/packages/locationposts/src/Component.php
+++ b/layers/Schema/packages/locationposts/src/Component.php
@@ -26,8 +26,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/locationposts/src/TypeAPIs/LocationPostTypeAPIInterface.php
+++ b/layers/Schema/packages/locationposts/src/TypeAPIs/LocationPostTypeAPIInterface.php
@@ -13,7 +13,6 @@ interface LocationPostTypeAPIInterface
      * Indicates if the passed object is of type LocationPost
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfLocationPostType($object): bool;
     /**

--- a/layers/Schema/packages/locations-wp-em/src/TypeAPIs/LocationTypeAPI.php
+++ b/layers/Schema/packages/locations-wp-em/src/TypeAPIs/LocationTypeAPI.php
@@ -26,7 +26,6 @@ class LocationTypeAPI implements LocationTypeAPIInterface
      * Indicates if the passed object is of type Location
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfLocationType($object): bool
     {

--- a/layers/Schema/packages/locations/src/TypeAPIs/LocationTypeAPIInterface.php
+++ b/layers/Schema/packages/locations/src/TypeAPIs/LocationTypeAPIInterface.php
@@ -20,7 +20,6 @@ interface LocationTypeAPIInterface
      * Indicates if the passed object is of type Location
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfLocationType($object): bool;
 }

--- a/layers/Schema/packages/media-wp/src/TypeAPIs/MediaTypeAPI.php
+++ b/layers/Schema/packages/media-wp/src/TypeAPIs/MediaTypeAPI.php
@@ -16,7 +16,6 @@ class MediaTypeAPI implements MediaTypeAPIInterface
      * Indicates if the passed object is of type Media
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfMediaType($object): bool
     {

--- a/layers/Schema/packages/media/src/Component.php
+++ b/layers/Schema/packages/media/src/Component.php
@@ -26,8 +26,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -16,11 +16,8 @@ use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
-    protected CustomPostTypeResolver $customPostTypeResolver;
-
-    function __construct(CustomPostTypeResolver $customPostTypeResolver)
+    function __construct(protected CustomPostTypeResolver $customPostTypeResolver)
     {
-        $this->customPostTypeResolver = $customPostTypeResolver;
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/media/src/TypeAPIs/MediaTypeAPIInterface.php
+++ b/layers/Schema/packages/media/src/TypeAPIs/MediaTypeAPIInterface.php
@@ -13,7 +13,6 @@ interface MediaTypeAPIInterface
      * Indicates if the passed object is of type Media
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfMediaType($object): bool;
 }

--- a/layers/Schema/packages/menus-wp/src/TypeAPIs/MenuTypeAPI.php
+++ b/layers/Schema/packages/menus-wp/src/TypeAPIs/MenuTypeAPI.php
@@ -16,7 +16,6 @@ class MenuTypeAPI implements MenuTypeAPIInterface
      * Indicates if the passed object is of type Menu
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfMenuType($object): bool
     {

--- a/layers/Schema/packages/menus/src/TypeAPIs/MenuTypeAPIInterface.php
+++ b/layers/Schema/packages/menus/src/TypeAPIs/MenuTypeAPIInterface.php
@@ -13,7 +13,6 @@ interface MenuTypeAPIInterface
      * Indicates if the passed object is of type Menu
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfMenuType($object): bool;
 }

--- a/layers/Schema/packages/notifications/src/Component.php
+++ b/layers/Schema/packages/notifications/src/Component.php
@@ -26,8 +26,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/pages-wp/src/TypeAPIs/PageTypeAPI.php
+++ b/layers/Schema/packages/pages-wp/src/TypeAPIs/PageTypeAPI.php
@@ -39,7 +39,6 @@ class PageTypeAPI extends CustomPostTypeAPI implements PageTypeAPIInterface
      * Indicates if the passed object is of type Page
      *
      * @param object $object
-     * @return boolean
      */
     public function isInstanceOfPageType($object): bool
     {
@@ -65,7 +64,6 @@ class PageTypeAPI extends CustomPostTypeAPI implements PageTypeAPIInterface
      * Indicate if an page with provided ID exists
      *
      * @param int $id
-     * @return bool
      */
     public function pageExists($id): bool
     {
@@ -75,8 +73,6 @@ class PageTypeAPI extends CustomPostTypeAPI implements PageTypeAPIInterface
     /**
      * Limit of how many custom posts can be retrieved in the query.
      * Override this value for specific custom post types
-     *
-     * @return integer
      */
     protected function getCustomPostListMaxLimit(): int
     {

--- a/layers/Schema/packages/pages/src/Component.php
+++ b/layers/Schema/packages/pages/src/Component.php
@@ -25,8 +25,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/pages/src/TypeAPIs/PageTypeAPIInterface.php
+++ b/layers/Schema/packages/pages/src/TypeAPIs/PageTypeAPIInterface.php
@@ -15,7 +15,6 @@ interface PageTypeAPIInterface extends CustomPostTypeAPIInterface
      * Indicates if the passed object is of type Page
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfPageType($object): bool;
     /**
@@ -34,24 +33,16 @@ interface PageTypeAPIInterface extends CustomPostTypeAPIInterface
     public function getPage($id);
     /**
      * Get the list of pages
-     *
-     * @param array $query
-     * @param array $options
-     * @return array
      */
     public function getPages(array $query, array $options = []): array;
     /**
      * Get the number of pages
      *
-     * @param array $query
-     * @param array $options
      * @return array
      */
     public function getPageCount(array $query = [], array $options = []): int;
     /**
      * Page custom post type
-     *
-     * @return string
      */
     public function getPageCustomPostType(): string;
     /**

--- a/layers/Schema/packages/post-tags-wp/src/TypeAPIs/PostTagTypeAPI.php
+++ b/layers/Schema/packages/post-tags-wp/src/TypeAPIs/PostTagTypeAPI.php
@@ -16,7 +16,6 @@ class PostTagTypeAPI extends TagTypeAPI implements PostTagTypeAPIInterface
      * Indicates if the passed object is of type Tag
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfPostTagType($object): bool
     {
@@ -25,8 +24,6 @@ class PostTagTypeAPI extends TagTypeAPI implements PostTagTypeAPIInterface
 
     /**
      * The taxonomy name representing a post tag ("post_tag")
-     *
-     * @return string
      */
     public function getPostTagTaxonomyName(): string
     {

--- a/layers/Schema/packages/post-tags/src/Component.php
+++ b/layers/Schema/packages/post-tags/src/Component.php
@@ -28,8 +28,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/post-tags/src/TypeAPIs/PostTagTypeAPIInterface.php
+++ b/layers/Schema/packages/post-tags/src/TypeAPIs/PostTagTypeAPIInterface.php
@@ -15,14 +15,11 @@ interface PostTagTypeAPIInterface extends TagTypeAPIInterface
      * Indicates if the passed object is of type PostTag
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfPostTagType($object): bool;
 
     /**
      * The taxonomy name representing a post tag ("post_tag")
-     *
-     * @return string
      */
     public function getPostTagTaxonomyName(): string;
 }

--- a/layers/Schema/packages/posts-wp/src/TypeAPIs/PostTypeAPI.php
+++ b/layers/Schema/packages/posts-wp/src/TypeAPIs/PostTypeAPI.php
@@ -38,7 +38,6 @@ class PostTypeAPI extends CustomPostTypeAPI implements PostTypeAPIInterface
      * Indicates if the passed object is of type Post
      *
      * @param object $object
-     * @return boolean
      */
     public function isInstanceOfPostType($object): bool
     {
@@ -74,8 +73,6 @@ class PostTypeAPI extends CustomPostTypeAPI implements PostTypeAPIInterface
     /**
      * Limit of how many custom posts can be retrieved in the query.
      * Override this value for specific custom post types
-     *
-     * @return integer
      */
     protected function getCustomPostListMaxLimit(): int
     {

--- a/layers/Schema/packages/posts/src/Component.php
+++ b/layers/Schema/packages/posts/src/Component.php
@@ -27,8 +27,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
@@ -14,8 +14,6 @@ class ExperimentalBranchFieldResolver extends CustomPostFieldResolver
 {
     /**
      * Attach to Posts only
-     *
-     * @return array
      */
     public function getClassesToAttachTo(): array
     {

--- a/layers/Schema/packages/posts/src/TypeAPIs/PostTypeAPIInterface.php
+++ b/layers/Schema/packages/posts/src/TypeAPIs/PostTypeAPIInterface.php
@@ -15,7 +15,6 @@ interface PostTypeAPIInterface extends CustomPostTypeAPIInterface
      * Indicates if the passed object is of type Post
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfPostType($object): bool;
     /**
@@ -34,24 +33,16 @@ interface PostTypeAPIInterface extends CustomPostTypeAPIInterface
     public function getPost($id);
     /**
      * Get the list of posts
-     *
-     * @param array $query
-     * @param array $options
-     * @return array
      */
     public function getPosts(array $query, array $options = []): array;
     /**
      * Get the number of posts
      *
-     * @param array $query
-     * @param array $options
      * @return array
      */
     public function getPostCount(array $query = [], array $options = []): int;
     /**
      * Post custom post type
-     *
-     * @return string
      */
     public function getPostCustomPostType(): string;
 }

--- a/layers/Schema/packages/queriedobject/src/TypeAPIs/TypeAPIUtils.php
+++ b/layers/Schema/packages/queriedobject/src/TypeAPIs/TypeAPIUtils.php
@@ -12,10 +12,6 @@ class TypeAPIUtils
 {
     /**
      * Return the minimum number from between the request limit and the max limit.
-     *
-     * @param integer|null $limit
-     * @param integer|null $maxLimit
-     * @return integer|null
      */
     public static function getLimitOrMaxLimit(
         ?int $limit,

--- a/layers/Schema/packages/schema-commons/src/ModuleProcessors/FormInputs/CommonFilterInputModuleProcessor.php
+++ b/layers/Schema/packages/schema-commons/src/ModuleProcessors/FormInputs/CommonFilterInputModuleProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\SchemaCommons\ModuleProcessors\FormInputs;
 
+use PoP\ComponentModel\Tokens\Param;
 use PoP\ComponentModel\FormInputs\FormMultipleInput;
 use PoP\ComponentModel\ModuleProcessors\AbstractFormInputModuleProcessor;
 use PoP\ComponentModel\ModuleProcessors\DataloadQueryArgsFilterInputModuleProcessorInterface;
@@ -103,11 +104,11 @@ class CommonFilterInputModuleProcessor extends AbstractFormInputModuleProcessor 
             self::MODULE_FILTERINPUT_SEARCH => $translationAPI->__('Search for elements containing the given string', 'pop-engine'),
             self::MODULE_FILTERINPUT_IDS => sprintf(
                 $translationAPI->__('Limit results to elements with the given IDs', 'pop-engine'),
-                \PoP\ComponentModel\Tokens\Param::VALUE_SEPARATOR
+                Param::VALUE_SEPARATOR
             ),
             self::MODULE_FILTERINPUT_ID => sprintf(
                 $translationAPI->__('Limit results to elements with the given ID, or IDs (separated by \'%s\')', 'pop-engine'),
-                \PoP\ComponentModel\Tokens\Param::VALUE_SEPARATOR
+                Param::VALUE_SEPARATOR
             ),
         ];
         return $descriptions[$module[1]] ?? null;

--- a/layers/Schema/packages/stances-wp/src/TypeAPIs/StanceTypeAPI.php
+++ b/layers/Schema/packages/stances-wp/src/TypeAPIs/StanceTypeAPI.php
@@ -29,7 +29,6 @@ class StanceTypeAPI implements StanceTypeAPIInterface
      * Indicates if the passed object is of type Stance
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfStanceType($object): bool
     {

--- a/layers/Schema/packages/stances/src/TypeAPIs/StanceTypeAPIInterface.php
+++ b/layers/Schema/packages/stances/src/TypeAPIs/StanceTypeAPIInterface.php
@@ -20,7 +20,6 @@ interface StanceTypeAPIInterface
      * Indicates if the passed object is of type Stance
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfStanceType($object): bool;
     /**

--- a/layers/Schema/packages/tags-wp/src/TypeAPIs/TagTypeAPI.php
+++ b/layers/Schema/packages/tags-wp/src/TypeAPIs/TagTypeAPI.php
@@ -17,7 +17,6 @@ class TagTypeAPI extends TaxonomyTypeAPI implements TagTypeAPIInterface
      * Indicates if the passed object is of type Tag
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfTagType($object): bool
     {

--- a/layers/Schema/packages/tags/src/TypeAPIs/TagTypeAPIInterface.php
+++ b/layers/Schema/packages/tags/src/TypeAPIs/TagTypeAPIInterface.php
@@ -15,7 +15,6 @@ interface TagTypeAPIInterface extends TaxonomyTypeAPIInterface
      * Indicates if the passed object is of type Tag
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfTagType($object): bool;
 }

--- a/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
+++ b/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
@@ -19,7 +19,6 @@ class TaxonomyTypeAPI implements TaxonomyTypeAPIInterface
      * Retrieves the taxonomy name of the object ("post_tag", "category", etc)
      *
      * @param [type] $object
-     * @return string
      */
     public function getTermTaxonomyName($termObjectOrID): string
     {

--- a/layers/Schema/packages/taxonomies/src/TypeAPIs/TaxonomyTypeAPIInterface.php
+++ b/layers/Schema/packages/taxonomies/src/TypeAPIs/TaxonomyTypeAPIInterface.php
@@ -13,7 +13,6 @@ interface TaxonomyTypeAPIInterface
      * Retrieves the taxonomy name of the object ("post_tag", "category", etc)
      *
      * @param [type] $object
-     * @return string
      */
     public function getTermTaxonomyName($termObjectOrID): string;
 }

--- a/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
@@ -26,8 +26,6 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
 
         /**
      * The name of the API's provider
-     *
-     * @return array
      */
     abstract public function getProvidersToResolve(): array;
 
@@ -37,7 +35,6 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
      * Using this function because `resolveCanProcess` doesn't get the default value,
      * i.e. when arg "provider" is not provided in the query
      *
-     * @param array $directiveArgs
      * @return void
      */
     protected function getProvider(array $directiveArgs): ?string
@@ -51,11 +48,6 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
 
     /**
      * Only process the directive if this directiveResolver can handle the provider
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $directiveName
-     * @param array $directiveArgs
-     * @return boolean
      */
     public function resolveCanProcess(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, string $field, array &$variables): bool
     {
@@ -291,8 +283,6 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
     /**
      * Failure message to show the user, originated from Guzzle client's error
      *
-     * @param Error $error
-     * @param string $provider
      * @return void
      */
     protected function getClientFailureMessage(Error $error, string $provider): string

--- a/layers/Schema/packages/user-roles-access-control/src/Component.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Component.php
@@ -30,8 +30,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/AbstractMaybeDisableDirectivesIfLoggedInUserDoesNotHaveItemPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/AbstractMaybeDisableDirectivesIfLoggedInUserDoesNotHaveItemPrivateSchemaHookSet.php
@@ -23,7 +23,6 @@ abstract class AbstractMaybeDisableDirectivesIfLoggedInUserDoesNotHaveItemPrivat
      * Indicate if the user has the item, to be implemented
      *
      * @param string $item
-     * @return boolean
      */
     abstract protected function doesCurrentUserHaveAnyItem(array $items): bool;
 

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableDirectivesIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableDirectivesIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
@@ -13,8 +13,6 @@ class MaybeDisableDirectivesIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHook
 {
     /**
      * Configuration entries
-     *
-     * @return array
      */
     protected function getConfigurationEntries(): array
     {
@@ -26,7 +24,6 @@ class MaybeDisableDirectivesIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHook
      * Indicate if the user has the item, to be implemented
      *
      * @param string $item
-     * @return boolean
      */
     protected function doesCurrentUserHaveAnyItem(array $capabilities): bool
     {

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableDirectivesIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableDirectivesIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
@@ -13,8 +13,6 @@ class MaybeDisableDirectivesIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet ex
 {
     /**
      * Configuration entries
-     *
-     * @return array
      */
     protected function getConfigurationEntries(): array
     {
@@ -26,7 +24,6 @@ class MaybeDisableDirectivesIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet ex
      * Indicate if the user has the item, to be implemented
      *
      * @param string $item
-     * @return boolean
      */
     protected function doesCurrentUserHaveAnyItem(array $roles): bool
     {

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
@@ -32,8 +32,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet 
 
     /**
      * Configuration entries
-     *
-     * @return array
      */
     protected function getConfigurationEntries(): array
     {
@@ -43,11 +41,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet 
 
     /**
      * Decide if to remove the fieldNames
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param FieldResolverInterface $fieldResolver
-     * @param string $fieldName
-     * @return boolean
      */
     protected function removeFieldName(
         TypeResolverInterface $typeResolver,

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
@@ -32,8 +32,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet extend
 
     /**
      * Configuration entries
-     *
-     * @return array
      */
     protected function getConfigurationEntries(): array
     {
@@ -43,11 +41,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet extend
 
     /**
      * Decide if to remove the fieldNames
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param FieldResolverInterface $fieldResolver
-     * @param string $fieldName
-     * @return boolean
      */
     protected function removeFieldName(
         TypeResolverInterface $typeResolver,

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
@@ -20,8 +20,6 @@ class GlobalValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator
 
     /**
      * Provide the classes for all the directiveResolverClasses that need the "validateIsUserLoggedIn" directive
-     *
-     * @return array
      */
     protected function getDirectiveResolverClasses(): array
     {

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/GlobalValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
@@ -20,8 +20,6 @@ class GlobalValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator ext
 
     /**
      * Provide the classes for all the directiveResolverClasses that need the "validateIsUserLoggedIn" directive
-     *
-     * @return array
      */
     protected function getDirectiveResolverClasses(): array
     {

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveCapabilityPublicSchemaTypeResolverDecoratorTrait.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveCapabilityPublicSchemaTypeResolverDecoratorTrait.php
@@ -15,7 +15,6 @@ trait ValidateDoesLoggedInUserHaveCapabilityPublicSchemaTypeResolverDecoratorTra
      * By default, only the admin can see the roles from the users
      *
      * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     protected function getMandatoryDirectives($entryValue = null): array
     {

--- a/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveRolePublicSchemaTypeResolverDecoratorTrait.php
+++ b/layers/Schema/packages/user-roles-access-control/src/TypeResolverDecorators/ValidateDoesLoggedInUserHaveRolePublicSchemaTypeResolverDecoratorTrait.php
@@ -16,7 +16,6 @@ trait ValidateDoesLoggedInUserHaveRolePublicSchemaTypeResolverDecoratorTrait
      * By default, only the admin can see the roles from the users
      *
      * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     protected function getMandatoryDirectives($entryValue = null): array
     {

--- a/layers/Schema/packages/user-roles-wp/src/Component.php
+++ b/layers/Schema/packages/user-roles-wp/src/Component.php
@@ -26,8 +26,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -27,10 +27,6 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      * Because we can't obtain this data from reflection yet, explicitly define it
      *
      * @see https://github.com/getpop/component-model/issues/1
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return string|null
      */
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
@@ -45,10 +41,6 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      * Because we can't obtain this data from reflection yet, explicitly define it
      *
      * @see https://github.com/getpop/component-model/issues/1
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return boolean
      */
     public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
@@ -66,10 +58,6 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      * Because we can't obtain this data from reflection yet, explicitly define it
      *
      * @see https://github.com/getpop/component-model/issues/1
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param string $fieldName
-     * @return string|null
      */
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {

--- a/layers/Schema/packages/user-roles/src/TypeDataResolvers/UserRoleTypeDataResolverInterface.php
+++ b/layers/Schema/packages/user-roles/src/TypeDataResolvers/UserRoleTypeDataResolverInterface.php
@@ -8,34 +8,26 @@ interface UserRoleTypeDataResolverInterface
 {
     /**
      * Admin role name
-     *
-     * @return string
      */
     public function getAdminRoleName(): string;
     /**
      * Role names
-     *
-     * @return array
      */
     public function getRoleNames(): array;
     /**
      * All available capabilities
-     *
-     * @return array
      */
     public function getCapabilities(): array;
     /**
      * User roles
      *
      * @param [type] $userObjectOrID
-     * @return array
      */
     public function getUserRoles($userObjectOrID): array;
     /**
      * User capabilities
      *
      * @param [type] $userObjectOrID
-     * @return array
      */
     public function getUserCapabilities($userObjectOrID): array;
     public function getTheUserRole($userObjectOrID);

--- a/layers/Schema/packages/user-state-access-control/src/Component.php
+++ b/layers/Schema/packages/user-state-access-control/src/Component.php
@@ -30,8 +30,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/user-state-access-control/src/Conditional/CacheControl/TypeResolverDecorators/NoCacheUserStateTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-state-access-control/src/Conditional/CacheControl/TypeResolverDecorators/NoCacheUserStateTypeResolverDecorator.php
@@ -26,9 +26,6 @@ class NoCacheUserStateTypeResolverDecorator extends AbstractTypeResolverDecorato
 
     /**
      * If validating if the user is logged-in, then we can't cache the response
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {

--- a/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractDisableFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractDisableFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -13,11 +13,6 @@ abstract class AbstractDisableFieldsIfUserIsNotLoggedInAccessControlForFieldsInP
 {
     /**
      * Decide if to remove the fieldNames
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @param FieldResolverInterface $fieldResolver
-     * @param string $fieldName
-     * @return boolean
      */
     protected function removeFieldName(
         TypeResolverInterface $typeResolver,
@@ -33,8 +28,6 @@ abstract class AbstractDisableFieldsIfUserIsNotLoggedInAccessControlForFieldsInP
 
     /**
      * Helper function to get user state from $vars
-     *
-     * @return boolean
      */
     protected function isUserLoggedIn(): bool
     {

--- a/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractUserStateConfigurableAccessControlForDirectivesInPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractUserStateConfigurableAccessControlForDirectivesInPrivateSchemaHookSet.php
@@ -22,8 +22,6 @@ abstract class AbstractUserStateConfigurableAccessControlForDirectivesInPrivateS
 
     /**
      * Configuration entries
-     *
-     * @return array
      */
     protected function getConfigurationEntries(): array
     {

--- a/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractUserStateConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractUserStateConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -13,8 +13,6 @@ abstract class AbstractUserStateConfigurableAccessControlForFieldsInPrivateSchem
 {
     /**
      * Configuration entries
-     *
-     * @return array
      */
     protected function getConfigurationEntries(): array
     {

--- a/layers/Schema/packages/user-state-access-control/src/Hooks/DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-state-access-control/src/Hooks/DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -26,8 +26,6 @@ class DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSc
 
     /**
      * Apply to all fields
-     *
-     * @return array
      */
     protected function getFieldNames(): array
     {
@@ -37,10 +35,6 @@ class DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSc
      * Remove the fieldNames if the fieldResolver is an instance of the "user state" one
      *
      * @param boolean $include
-     * @param TypeResolverInterface $typeResolver
-     * @param FieldResolverInterface $fieldResolver
-     * @param string $fieldName
-     * @return boolean
      */
     protected function removeFieldName(
         TypeResolverInterface $typeResolver,

--- a/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolverDecorator.php
@@ -15,9 +15,6 @@ abstract class AbstractValidateIsUserLoggedInForDirectivesPublicSchemaTypeResolv
 {
     /**
      * Verify that the user is logged in before checking the roles/capabilities
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {

--- a/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
+++ b/layers/Schema/packages/user-state-access-control/src/TypeResolverDecorators/AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDecorator.php
@@ -15,9 +15,6 @@ abstract class AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDe
 {
     /**
      * Verify that the user is logged in before checking the roles/capabilities
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getPrecedingMandatoryDirectivesForDirectives(TypeResolverInterface $typeResolver): array
     {
@@ -44,8 +41,6 @@ abstract class AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDe
     }
     /**
      * Provide the classes for all the directiveResolverClasses that need the "validateIsUserLoggedIn" directive
-     *
-     * @return array
      */
     protected function getDirectiveResolverClasses(): array
     {
@@ -54,9 +49,6 @@ abstract class AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDe
 
     /**
      * Verify that the user is logged in before checking the roles/capabilities
-     *
-     * @param TypeResolverInterface $typeResolver
-     * @return array
      */
     public function getMandatoryDirectivesForFields(TypeResolverInterface $typeResolver): array
     {
@@ -81,8 +73,6 @@ abstract class AbstractValidateIsUserLoggedInForFieldsPublicSchemaTypeResolverDe
     }
     /**
      * Provide the classes for all the directiveResolverClasses that need the "validateIsUserLoggedIn" directive
-     *
-     * @return array
      */
     protected function getFieldNames(): array
     {

--- a/layers/Schema/packages/user-state/src/Hooks/DBEntriesHooks.php
+++ b/layers/Schema/packages/user-state/src/Hooks/DBEntriesHooks.php
@@ -11,18 +11,15 @@ use PoPSchema\UserState\FieldResolvers\GlobalFieldResolver;
 
 class DBEntriesHooks extends AbstractHookSet
 {
-    protected GlobalFieldResolver $globalFieldResolver;
-
     public function __construct(
         HooksAPIInterface $hooksAPI,
         TranslationAPIInterface $translationAPI,
-        GlobalFieldResolver $globalFieldResolver
+        protected GlobalFieldResolver $globalFieldResolver
     ) {
         parent::__construct(
             $hooksAPI,
             $translationAPI
         );
-        $this->globalFieldResolver = $globalFieldResolver;
     }
 
     protected function init()

--- a/layers/Schema/packages/users-wp/src/Component.php
+++ b/layers/Schema/packages/users-wp/src/Component.php
@@ -26,8 +26,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -16,7 +16,6 @@ class UserTypeAPI implements UserTypeAPIInterface
      * Indicates if the passed object is of type User
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfUserType($object): bool
     {

--- a/layers/Schema/packages/users/src/Component.php
+++ b/layers/Schema/packages/users/src/Component.php
@@ -27,8 +27,6 @@ class Component extends AbstractComponent
 
     /**
      * All conditional component classes that this component depends upon, to initialize them
-     *
-     * @return array
      */
     public static function getDependedConditionalComponentClasses(): array
     {

--- a/layers/Schema/packages/users/src/TypeAPIs/UserTypeAPIInterface.php
+++ b/layers/Schema/packages/users/src/TypeAPIs/UserTypeAPIInterface.php
@@ -13,7 +13,6 @@ interface UserTypeAPIInterface
      * Indicates if the passed object is of type User
      *
      * @param [type] $object
-     * @return boolean
      */
     public function isInstanceOfUserType($object): bool;
 }

--- a/layers/SiteBuilder/packages/definitionpersistence/src/FileDefinitionPersistence.php
+++ b/layers/SiteBuilder/packages/definitionpersistence/src/FileDefinitionPersistence.php
@@ -10,15 +10,10 @@ use PoP\Definitions\AbstractDefinitionPersistence;
 
 class FileDefinitionPersistence extends AbstractDefinitionPersistence
 {
-    protected FileStoreInterface $fileStore;
-    protected AbstractFile $file;
-
     public function __construct(
-        FileStoreInterface $fileStore,
-        AbstractFile $file
+        protected FileStoreInterface $fileStore,
+        protected AbstractFile $file
     ) {
-        $this->fileStore = $fileStore;
-        $this->file = $file;
         parent::__construct();
     }
 

--- a/layers/Wassup/packages/event-mutations/src/MutationResolvers/AbstractCreateUpdateEventMutationResolver.php
+++ b/layers/Wassup/packages/event-mutations/src/MutationResolvers/AbstractCreateUpdateEventMutationResolver.php
@@ -60,8 +60,6 @@ abstract class AbstractCreateUpdateEventMutationResolver extends AbstractCreateU
     }
 
     /**
-     * @param \EM_Event $EM_Event
-     * @param array $post_data
      * @return mixed
      */
     protected function save(\EM_Event &$EM_Event, array $post_data)

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolverBridges/FileUploadPictureMutationResolverBridge.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolverBridges/FileUploadPictureMutationResolverBridge.php
@@ -27,7 +27,6 @@ class FileUploadPictureMutationResolverBridge extends AbstractComponentMutationR
         ];
     }
     /**
-     * @param array $data_properties
      * @return array<string, mixed>|null
      */
     public function execute(array &$data_properties): ?array

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolverBridges/SettingsMutationResolverBridge.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolverBridges/SettingsMutationResolverBridge.php
@@ -22,7 +22,6 @@ class SettingsMutationResolverBridge extends AbstractComponentMutationResolverBr
     }
 
     /**
-     * @param array $data_properties
      * @return array<string, mixed>|null
      */
     public function execute(array &$data_properties): ?array

--- a/layers/Wassup/packages/form-mutations/src/MutationResolverBridges/AbstractFormComponentMutationResolverBridge.php
+++ b/layers/Wassup/packages/form-mutations/src/MutationResolverBridges/AbstractFormComponentMutationResolverBridge.php
@@ -13,7 +13,6 @@ use PoP\ComponentModel\ErrorHandling\Error;
 abstract class AbstractFormComponentMutationResolverBridge extends AbstractComponentMutationResolverBridge
 {
     /**
-     * @param array $data_properties
      * @return array<string, mixed>|null
      */
     public function execute(array &$data_properties): ?array

--- a/layers/Wassup/packages/user-state-mutations/src/MutationResolverBridges/LostPasswordMutationResolverBridge.php
+++ b/layers/Wassup/packages/user-state-mutations/src/MutationResolverBridges/LostPasswordMutationResolverBridge.php
@@ -27,7 +27,6 @@ class LostPasswordMutationResolverBridge extends AbstractComponentMutationResolv
     }
 
     /**
-     * @param array $data_properties
      * @return array<string, mixed>|null
      */
     public function execute(array &$data_properties): ?array

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/CustomBumpInterdependencyCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/CustomBumpInterdependencyCommand.php
@@ -21,31 +21,12 @@ final class CustomBumpInterdependencyCommand extends AbstractSymplifyCommand
      */
     private const VERSION_ARGUMENT = 'version';
 
-    /**
-     * @var CustomDependencyUpdater
-     */
-    private $customDependencyUpdater;
-
-    /**
-     * @var ComposerJsonProvider
-     */
-    private $composerJsonProvider;
-
-    /**
-     * @var SourcesPresenceValidator
-     */
-    private $sourcesPresenceValidator;
-
     public function __construct(
-        CustomDependencyUpdater $customDependencyUpdater,
-        ComposerJsonProvider $composerJsonProvider,
-        SourcesPresenceValidator $sourcesPresenceValidator
+        private CustomDependencyUpdater $customDependencyUpdater,
+        private ComposerJsonProvider $composerJsonProvider,
+        private SourcesPresenceValidator $sourcesPresenceValidator
     ) {
         parent::__construct();
-
-        $this->customDependencyUpdater = $customDependencyUpdater;
-        $this->composerJsonProvider = $composerJsonProvider;
-        $this->sourcesPresenceValidator = $sourcesPresenceValidator;
     }
 
     protected function configure(): void

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/MergePhpstanCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/MergePhpstanCommand.php
@@ -15,16 +15,10 @@ use Symplify\PackageBuilder\Console\ShellCode;
 
 final class MergePhpstanCommand extends AbstractSymplifyCommand
 {
-    private PHPStanNeonContentProvider $phpstanNeonContentProvider;
-    private NeonFilePrinter $neonFilePrinter;
-
     public function __construct(
-        PHPStanNeonContentProvider $phpstanNeonContentProvider,
-        NeonFilePrinter $neonFilePrinter
+        private PHPStanNeonContentProvider $phpstanNeonContentProvider,
+        private NeonFilePrinter $neonFilePrinter
     ) {
-        $this->phpstanNeonContentProvider = $phpstanNeonContentProvider;
-        $this->neonFilePrinter = $neonFilePrinter;
-
         parent::__construct();
     }
 

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/PackageEntriesJsonCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/PackageEntriesJsonCommand.php
@@ -15,12 +15,8 @@ use Symplify\PackageBuilder\Console\ShellCode;
 
 final class PackageEntriesJsonCommand extends AbstractSymplifyCommand
 {
-    private PackageEntriesJsonProvider $packageEntriesJsonProvider;
-
-    public function __construct(PackageEntriesJsonProvider $packageEntriesJsonProvider)
+    public function __construct(private PackageEntriesJsonProvider $packageEntriesJsonProvider)
     {
-        $this->packageEntriesJsonProvider = $packageEntriesJsonProvider;
-
         parent::__construct();
     }
 

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
@@ -15,12 +15,8 @@ use Symplify\PackageBuilder\Console\ShellCode;
 
 final class SourcePackagesCommand extends AbstractSymplifyCommand
 {
-    private SourcePackagesProvider $sourcePackagesProvider;
-
-    public function __construct(SourcePackagesProvider $sourcePackagesProvider)
+    public function __construct(private SourcePackagesProvider $sourcePackagesProvider)
     {
-        $this->sourcePackagesProvider = $sourcePackagesProvider;
-
         parent::__construct();
     }
 

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/SymlinkLocalPackageCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/SymlinkLocalPackageCommand.php
@@ -16,16 +16,10 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class SymlinkLocalPackageCommand extends AbstractSymplifyCommand
 {
-    private ComposerJsonProvider $composerJsonProvider;
-    private ComposerJsonRepositoriesUpdater $composerJsonRepositoriesUpdater;
-
     public function __construct(
-        ComposerJsonProvider $composerJsonProvider,
-        ComposerJsonRepositoriesUpdater $composerJsonRepositoriesUpdater
+        private ComposerJsonProvider $composerJsonProvider,
+        private ComposerJsonRepositoriesUpdater $composerJsonRepositoriesUpdater
     ) {
-        $this->composerJsonProvider = $composerJsonProvider;
-        $this->composerJsonRepositoriesUpdater = $composerJsonRepositoriesUpdater;
-
         parent::__construct();
     }
 

--- a/src/Extensions/Symplify/MonorepoBuilder/CustomDependencyUpdater.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/CustomDependencyUpdater.php
@@ -10,14 +10,8 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class CustomDependencyUpdater
 {
-    /**
-     * @var JsonFileManager
-     */
-    private $jsonFileManager;
-
-    public function __construct(JsonFileManager $jsonFileManager)
+    public function __construct(private JsonFileManager $jsonFileManager)
     {
-        $this->jsonFileManager = $jsonFileManager;
     }
 
     /**

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PackageEntriesJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PackageEntriesJsonProvider.php
@@ -12,22 +12,17 @@ use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class PackageEntriesJsonProvider
 {
-    private CustomPackageProvider $customPackageProvider;
-    private PackageUtils $packageUtils;
-
     /**
      * @var array<string, string>
      */
     private array $packageOrganizations = [];
 
     public function __construct(
-        CustomPackageProvider $customPackageProvider,
+        private CustomPackageProvider $customPackageProvider,
         ParameterProvider $parameterProvider,
-        PackageUtils $packageUtils
+        private PackageUtils $packageUtils
     ) {
-        $this->customPackageProvider = $customPackageProvider;
         $this->packageOrganizations = $parameterProvider->provideArrayParameter(Option::PACKAGE_ORGANIZATIONS);
-        $this->packageUtils = $packageUtils;
     }
 
     /**

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
@@ -10,15 +10,10 @@ use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\CustomPackage;
 
 final class SourcePackagesProvider
 {
-    private CustomPackageProvider $customPackageProvider;
-    private PackageUtils $packageUtils;
-
     public function __construct(
-        CustomPackageProvider $customPackageProvider,
-        PackageUtils $packageUtils
+        private CustomPackageProvider $customPackageProvider,
+        private PackageUtils $packageUtils
     ) {
-        $this->customPackageProvider = $customPackageProvider;
-        $this->packageUtils = $packageUtils;
     }
 
     /**

--- a/src/Extensions/Symplify/MonorepoBuilder/Neon/NeonFilePrinter.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Neon/NeonFilePrinter.php
@@ -10,13 +10,10 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class NeonFilePrinter
 {
-    private SmartFileSystem $smartFileSystem;
-    private SymfonyStyle $symfonyStyle;
-
-    public function __construct(SmartFileSystem $smartFileSystem, SymfonyStyle $symfonyStyle)
-    {
-        $this->smartFileSystem = $smartFileSystem;
-        $this->symfonyStyle = $symfonyStyle;
+    public function __construct(
+        private SmartFileSystem $smartFileSystem,
+        private SymfonyStyle $symfonyStyle
+    ) {
     }
 
     public function printContentToOutputFile(string $neonFileContent, string $outputFilePath): void

--- a/src/Extensions/Symplify/MonorepoBuilder/PHPStanNeonContentProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/PHPStanNeonContentProvider.php
@@ -17,15 +17,10 @@ final class PHPStanNeonContentProvider
      */
     private const INCLUDES_KEY = 'includes';
 
-    private SourcePackagesProvider $sourcePackagesProvider;
-    private NeonPrinter $neonPrinter;
-
     public function __construct(
-        SourcePackagesProvider $sourcePackagesProvider,
-        NeonPrinter $neonPrinter
+        private SourcePackagesProvider $sourcePackagesProvider,
+        private NeonPrinter $neonPrinter
     ) {
-        $this->sourcePackagesProvider = $sourcePackagesProvider;
-        $this->neonPrinter = $neonPrinter;
     }
 
     /**

--- a/src/Extensions/Symplify/MonorepoBuilder/Package/CustomPackageProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Package/CustomPackageProvider.php
@@ -12,20 +12,10 @@ use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class CustomPackageProvider
 {
-    /**
-     * @var ComposerJsonProvider
-     */
-    private $composerJsonProvider;
-
-    /**
-     * @var JsonFileManager
-     */
-    private $jsonFileManager;
-
-    public function __construct(ComposerJsonProvider $composerJsonProvider, JsonFileManager $jsonFileManager)
-    {
-        $this->composerJsonProvider = $composerJsonProvider;
-        $this->jsonFileManager = $jsonFileManager;
+    public function __construct(
+        private ComposerJsonProvider $composerJsonProvider,
+        private JsonFileManager $jsonFileManager
+    ) {
     }
 
     /**

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/CustomPackage.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/CustomPackage.php
@@ -10,11 +10,6 @@ use Symplify\SmartFileSystem\SmartFileInfo;
 final class CustomPackage
 {
     /**
-     * @var string
-     */
-    private $name;
-
-    /**
      * @var SmartFileInfo
      */
     private $rootDirectoryFileInfo;
@@ -29,10 +24,10 @@ final class CustomPackage
      */
     private $shortDirectory;
 
-    public function __construct(string $name, SmartFileInfo $composerJsonFileInfo)
-    {
-        $this->name = $name;
-
+    public function __construct(
+        private string $name,
+        SmartFileInfo $composerJsonFileInfo
+    ) {
         $this->shortName = (string) Strings::after($name, '/', -1);
 
         $this->rootDirectoryFileInfo = new SmartFileInfo($composerJsonFileInfo->getPath());


### PR DESCRIPTION
Upgrade to PHP 8.0:

- Constructor property promotion
- `str_contains`, `str_starts_with`, `str_ends_with`
- Remove unused exception vars
- Use union types

Also converted from `switch` to `match` but it doesn't really work (and it's buggy), so it'd rather be used manually.

Used this Rector config file:

```php
<?php

declare(strict_types=1);

use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
use Rector\Php80\Rector\Identical\StrEndsWithRector;
use Rector\Php80\Rector\Identical\StrStartsWithRector;
use Rector\Php80\Rector\NotIdentical\StrContainsRector;
use Rector\Core\Configuration\Option;
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

return static function (ContainerConfigurator $containerConfigurator): void {
    // get parameters
    $parameters = $containerConfigurator->parameters();
    $parameters->set(Option::SETS, []);

    $services = $containerConfigurator->services();

    $services->set(UnionTypesRector::class);
    $services->set(StrContainsRector::class);
    $services->set(StrStartsWithRector::class);
    $services->set(StrEndsWithRector::class);
    $services->set(RemoveUnusedVariableInCatchRector::class);
    $services->set(ClassPropertyAssignToConstructorPromotionRector::class);

    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);

    // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
    $parameters->set(Option::AUTOLOAD_PATHS, [
        // full directory
        __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
        // Avoid error: "Class EM_Event not found"
        __DIR__ . '/stubs/wpackagist-plugin/events-manager/em-stubs.php',
    ]);

    // folders to process
    $parameters->set(Option::PATHS, [
        __DIR__ . '/src/*',
        __DIR__ . '/layers/*',
    ]);

    // folders to skip
    $parameters->set(Option::SKIP, [
        '*/migrate-*',
        '*/vendor/*',
        '*/rector-downgrade-code.php',
        '*/graphql-api-convert-case-directives.php',
        '*/GraphQLAPIExtension.php',
        '*/PluginConfiguration.php',
    ]);
};
```