### PR TITLE
Use Rector in 7.1 for testing

### DIFF
--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -66,7 +66,7 @@ jobs:
                     composer-options: "--no-dev"
 
             # We need the WordPress stubs for testing (they are installed in DEV)
-            -   name: Install WordPress stubs
+            -   name: Install WordPress stubs (for testing)
                 run: composer require php-stubs/wordpress-stubs
 
             # Executing `composer config platform-check false` throws error:

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -61,7 +61,9 @@ jobs:
 
             # Only PROD dependencies must be tested
             -   name: Keep dependencies for PROD only (for testing)
-                run: composer install --no-dev --no-progress --ansi
+                uses: "ramsey/composer-install@v1"
+                with:
+                    composer-options: "--no-dev"
 
             # Executing `composer config platform-check false` throws error:
             # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -90,7 +90,7 @@ jobs:
                 with:
                     name: downgraded-code
                     path: build/downgraded-code.zip
-                    retention-days: 3
+                    retention-days: 1
 
             -   name: Switch to PHP 7.1
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -78,6 +78,20 @@ jobs:
                 # run: composer config platform-check false
                 run: rm vendor/composer/platform_check.php
 
+            # Upload artifact with downgraded code, for debugging
+            -   name: Create build folder
+                run: mkdir build
+            -   name: Install zip
+                uses: montudor/action-zip@v0.1.1
+            -   name: Create zip
+                run: zip -X -r build/downgraded-code.zip layers/ vendor/
+            -   name: Upload artifact
+                uses: actions/upload-artifact@v2
+                with:
+                    name: downgraded-code
+                    path: build/downgraded-code.zip
+                    retention-days: 3
+
             -   name: Switch to PHP 7.1
                 uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -60,8 +60,9 @@ jobs:
                 run: composer global require rector/rector-prefixed
 
             # We need the WordPress stubs for testing (they are installed in DEV)
-            -   name: Install WordPress stubs (for testing)
-                run: composer require php-stubs/wordpress-stubs
+            # Symfony Cache has "psr/simple-cache" for DEV not PROD, making the static analysis fail
+            -   name: Install DEV dependencies needed in PROD (for testing)
+                run: composer require php-stubs/wordpress-stubs psr/simple-cache:^1.0
 
             # Only PROD dependencies must be tested
             -   name: Keep dependencies for PROD only (for testing)

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -65,6 +65,10 @@ jobs:
                 with:
                     composer-options: "--no-dev"
 
+            # We need the WordPress stubs for testing (they are installed in DEV)
+            -   name: Install WordPress stubs
+                run: composer require php-stubs/wordpress-stubs
+
             # Executing `composer config platform-check false` throws error:
             # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR
             # @see https://github.com/leoloso/PoP/pull/304/checks?check_run_id=1668406313#step:4:5

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -85,9 +85,9 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
-            # (which we just applied), then there should be no changes and exit with success
-            # Test everything, including migrate-* packages, and Composer dependencies not requiring downgrade
+            # Test everything, including Composer dependencies which (supposedly)
+            # do not require downgrading
+            # Applying the same Rector downgrade config is good enough (any Rector would do the job)
             -   name: Run Rector on PHP 7.1
-                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process layers/ vendor/ --config=rector-downgrade-code.php --ansi --dry-run
+                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process layers/ vendor/ --config=rector-downgrade-code.php --ansi
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -81,8 +81,7 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
-            # (which we just applied), then there should be no changes and exit with success
+            # Execute some Rector (it doesn't matter which one)
             -   name: Run Rector on PHP 7.1
-                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-downgrade-code.php --ansi --dry-run
+                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-code-quality.php --ansi
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -70,9 +70,11 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            # @todo Fix this code
-            # @see https://github.com/leoloso/PoP/issues/299
+            -   name: Install Rector prefixed
+                run: composer require rector/rector-prefixed
+
+            # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
+            # (which we just applied), then there should be no changes and exit with success
             -   name: Run Rector on PHP 7.1
-                run: echo "Running Rector on PHP 7.1 must be enabled, once available (https://github.com/leoloso/PoP/issues/299)"
-            #   run: vendor/bin/rector-php71 process $LOCAL_PACKAGE_SRCS vendor --ansi --dry-run
+                run: vendor/bin/rector-prefixed process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-downgrade-code.php --ansi --dry-run
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -81,7 +81,8 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            # Execute some Rector (it doesn't matter which one)
+            # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
+            # (which we just applied), then there should be no changes and exit with success
             -   name: Run Rector on PHP 7.1
-                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-code-quality.php --ansi
+                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-downgrade-code.php --ansi --dry-run
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -54,6 +54,10 @@ jobs:
             -   name: Dependencies - Downgrade PHP code via Rector
                 run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
+            # Prepare for testing on PHP 7.1: Use PROD dependencies only
+            -   name: Keep dependencies for PROD only
+                run: composer install --no-dev --no-progress --ansi
+
             # Executing `composer config platform-check false` throws error:
             # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR
             # @see https://github.com/leoloso/PoP/pull/304/checks?check_run_id=1668406313#step:4:5

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -54,8 +54,13 @@ jobs:
             -   name: Dependencies - Downgrade PHP code via Rector
                 run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
-            # Prepare for testing on PHP 7.1: Use PROD dependencies only
-            -   name: Keep dependencies for PROD only
+            # Prepare for testing on PHP 7.1
+            # Install Rector prefixed global since it conflicts with local packages
+            -   name: Install Rector prefixed
+                run: composer global require rector/rector-prefixed
+
+            # Only PROD dependencies must be tested
+            -   name: Keep dependencies for PROD only (for testing)
                 run: composer install --no-dev --no-progress --ansi
 
             # Executing `composer config platform-check false` throws error:
@@ -73,11 +78,6 @@ jobs:
                     coverage: none
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            # Prepare for testing on PHP 7.1
-            # Install global since otherwise it conflicts with other packages
-            -   name: Install Rector prefixed
-                run: composer global require rector/rector-prefixed
 
             # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
             # (which we just applied), then there should be no changes and exit with success

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -70,14 +70,6 @@ jobs:
                 with:
                     composer-options: "--no-dev"
 
-            # Executing `composer config platform-check false` throws error:
-            # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR
-            # @see https://github.com/leoloso/PoP/pull/304/checks?check_run_id=1668406313#step:4:5
-            # Then, just manually delete the platform_check.php file
-            -   name: Avoid Composer v2 platform checks
-                # run: composer config platform-check false
-                run: rm vendor/composer/platform_check.php
-
             # Upload artifact with downgraded code, for debugging
             -   name: Create build folder
                 run: mkdir build
@@ -91,6 +83,14 @@ jobs:
                     name: downgraded-code
                     path: build/downgraded-code.zip
                     retention-days: 1
+
+            # Executing `composer config platform-check false` throws error:
+            # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR
+            # @see https://github.com/leoloso/PoP/pull/304/checks?check_run_id=1668406313#step:4:5
+            # Then, just manually delete the platform_check.php file
+            -   name: Avoid Composer v2 platform checks
+                # run: composer config platform-check false
+                run: rm vendor/composer/platform_check.php
 
             -   name: Switch to PHP 7.1
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -59,15 +59,15 @@ jobs:
             -   name: Install Rector prefixed
                 run: composer global require rector/rector-prefixed
 
+            # We need the WordPress stubs for testing (they are installed in DEV)
+            -   name: Install WordPress stubs (for testing)
+                run: composer require php-stubs/wordpress-stubs
+
             # Only PROD dependencies must be tested
             -   name: Keep dependencies for PROD only (for testing)
                 uses: "ramsey/composer-install@v1"
                 with:
                     composer-options: "--no-dev"
-
-            # We need the WordPress stubs for testing (they are installed in DEV)
-            -   name: Install WordPress stubs (for testing)
-                run: composer require php-stubs/wordpress-stubs
 
             # Executing `composer config platform-check false` throws error:
             # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -54,6 +54,10 @@ jobs:
             -   name: Dependencies - Downgrade PHP code via Rector
                 run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
+            # Prepare for testing on PHP 7.1 (before switching PHP version)
+            -   name: Install Rector prefixed
+                run: composer require rector/rector-prefixed
+
             # Executing `composer config platform-check false` throws error:
             # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR
             # @see https://github.com/leoloso/PoP/pull/304/checks?check_run_id=1668406313#step:4:5
@@ -69,9 +73,6 @@ jobs:
                     coverage: none
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            -   name: Install Rector prefixed
-                run: composer require rector/rector-prefixed
 
             # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
             # (which we just applied), then there should be no changes and exit with success

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -83,6 +83,7 @@ jobs:
 
             # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
             # (which we just applied), then there should be no changes and exit with success
+            # Test everything, including migrate-* packages, and Composer dependencies not requiring downgrade
             -   name: Run Rector on PHP 7.1
-                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-downgrade-code.php --ansi --dry-run
+                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process layers/ vendor/ --config=rector-downgrade-code.php --ansi --dry-run
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -54,10 +54,6 @@ jobs:
             -   name: Dependencies - Downgrade PHP code via Rector
                 run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
-            # Prepare for testing on PHP 7.1 (before switching PHP version)
-            -   name: Install Rector prefixed
-                run: composer require rector/rector-prefixed
-
             # Executing `composer config platform-check false` throws error:
             # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR
             # @see https://github.com/leoloso/PoP/pull/304/checks?check_run_id=1668406313#step:4:5
@@ -74,8 +70,13 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+            # Prepare for testing on PHP 7.1
+            # Install global since otherwise it conflicts with other packages
+            -   name: Install Rector prefixed
+                run: composer global require rector/rector-prefixed
+
             # --dry-run would fail if there are changes. But since we're applying the same downgrade config,
             # (which we just applied), then there should be no changes and exit with success
             -   name: Run Rector on PHP 7.1
-                run: vendor/bin/rector-prefixed process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-downgrade-code.php --ansi --dry-run
+                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} vendor --config=rector-downgrade-code.php --ansi --dry-run
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -76,7 +76,7 @@ jobs:
             -   name: Install zip
                 uses: montudor/action-zip@v0.1.1
             -   name: Create zip
-                run: zip -X -r build/downgraded-code.zip layers/ vendor/
+                run: zip -X -r build/downgraded-code.zip layers/ vendor/ stubs/
             -   name: Upload artifact
                 uses: actions/upload-artifact@v2
                 with:

--- a/layers/Engine/packages/hooks-wp/src/HooksAPI.php
+++ b/layers/Engine/packages/hooks-wp/src/HooksAPI.php
@@ -16,7 +16,7 @@ class HooksAPI implements HooksAPIInterface
     {
         return \remove_filter($tag, $function_to_remove, $priority);
     }
-    public function applyFilters(string $tag, mixed $value, mixed ...$args): mixed
+    public function applyFilters(string $tag, mixed $value, ...$args): mixed
     {
         return \apply_filters($tag, $value, ...$args);
     }
@@ -28,7 +28,7 @@ class HooksAPI implements HooksAPIInterface
     {
         return \remove_action($tag, $function_to_remove, $priority);
     }
-    public function doAction(string $tag, mixed ...$args): void
+    public function doAction(string $tag, ...$args): void
     {
         \do_action($tag, ...$args);
     }

--- a/layers/Engine/packages/hooks/src/HooksAPIInterface.php
+++ b/layers/Engine/packages/hooks/src/HooksAPIInterface.php
@@ -8,8 +8,8 @@ interface HooksAPIInterface
 {
     public function addFilter(string $tag, callable $function_to_add, int $priority = 10, int $accepted_args = 1): void;
     public function removeFilter(string $tag, callable $function_to_remove, int $priority = 10): bool;
-    public function applyFilters(string $tag, mixed $value, mixed ...$args): mixed;
+    public function applyFilters(string $tag, mixed $value, ...$args): mixed;
     public function addAction(string $tag, callable $function_to_add, int $priority = 10, int $accepted_args = 1): void;
     public function removeAction(string $tag, callable $function_to_remove, int $priority = 10): bool;
-    public function doAction(string $tag, mixed ...$args): void;
+    public function doAction(string $tag, ...$args): void;
 }

--- a/layers/Engine/packages/hooks/tests/ContractImplementations/HooksAPI.php
+++ b/layers/Engine/packages/hooks/tests/ContractImplementations/HooksAPI.php
@@ -14,7 +14,7 @@ class HooksAPI implements HooksAPIInterface
     {
         return true;
     }
-    public function applyFilters(string $tag, mixed $value, mixed ...$args): mixed
+    public function applyFilters(string $tag, mixed $value, ...$args): mixed
     {
         return $value;
     }
@@ -25,7 +25,7 @@ class HooksAPI implements HooksAPIInterface
     {
         return true;
     }
-    public function doAction(string $tag, mixed ...$args): void
+    public function doAction(string $tag, ...$args): void
     {
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/SchemaServices/FieldResolvers/CPTFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnEnvironment/Admin/SchemaServices/FieldResolvers/CPTFieldResolver.php
@@ -63,25 +63,27 @@ class CPTFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        return match($fieldName) {
+        $ret = match($fieldName) {
             'accessControlLists' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             'cacheControlLists' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             'fieldDeprecationLists' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             'schemaConfigurations' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             default => parent::getSchemaFieldType($typeResolver, $fieldName),
         };
+        return $ret;
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
         $translationAPI = TranslationAPIFacade::getInstance();
-        return match($fieldName) {
+        $ret = match($fieldName) {
             'accessControlLists' => $translationAPI->__('Access Control Lists', 'graphql-api'),
             'cacheControlLists' => $translationAPI->__('Cache Control Lists', 'graphql-api'),
             'fieldDeprecationLists' => $translationAPI->__('Field Deprecation Lists', 'graphql-api'),
             'schemaConfigurations' => $translationAPI->__('Schema Configurations', 'graphql-api'),
             default => parent::getSchemaFieldDescription($typeResolver, $fieldName),
         };
+        return $ret;
     }
 
     /**

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -40,6 +40,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/symfony/cache/DoctrineProvider.php',
         __DIR__ . '/vendor/symfony/cache/Messenger/EarlyExpirationHandler.php',
         __DIR__ . '/vendor/symfony/string/Slugger/AsciiSlugger.php',
+        // Temporarily skip testing the code that is not yet shipped for any project,
+        // to make the testing process take less time, and be able to complete
+        __DIR__ . '/layers/Misc/*',
+        __DIR__ . '/layers/SiteBuilder/*',
+        __DIR__ . '/layers/Wassup/*',
+        __DIR__ . '/layers/Schema/packages/migrate-everythingelse/*',
     ]);
 
     // /**

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -66,6 +66,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/composer/*',
         // Same for Composer scripts
         __DIR__ . '/vendor/lkwdwrd/wp-muplugin-loader/*',
+        // Ignore unused classes that fail because they require DEV dependency
+        __DIR__ . '/vendor/symfony/cache/DataCollector/CacheDataCollector.php',
+        __DIR__ . '/vendor/symfony/yaml/Command/LintCommand.php',
+        // All the bootstrap80.php are loaded for PHP 8.0 only
+        __DIR__ . '/vendor/symfony/polyfill-*/bootstrap80.php',
     ]);
 
     // /**

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -22,6 +22,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // is your PHP version different from the one your refactor to? [default: your PHP version]
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_71);
 
+    // Do not change the code, other than the required rules
+    $parameters->set(Option::AUTO_IMPORT_NAMES, false);
+    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
     $parameters->set(Option::AUTOLOAD_PATHS, [
         // full directory

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -44,15 +44,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/symfony/cache/DoctrineProvider.php',
         __DIR__ . '/vendor/symfony/cache/Messenger/EarlyExpirationHandler.php',
         __DIR__ . '/vendor/symfony/string/Slugger/AsciiSlugger.php',
+
         // ------------------------------------
         // The skips below are for testing the downgrade on PHP 7.1
         // ------------------------------------
-        // Temporarily skip testing the code that is not yet shipped for any project,
-        // to make the testing process take less time, and be able to complete
-        __DIR__ . '/layers/Misc/*',
-        __DIR__ . '/layers/SiteBuilder/*',
-        __DIR__ . '/layers/Wassup/*',
-        __DIR__ . '/layers/Schema/packages/migrate-everythingelse/*',
         // All the migrate-* packages must also be tested for PHP 7.1.
         // But I already know they all pass, and they are not added any new code,
         // so we can skip them to reduce the testing time

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -48,6 +48,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // ------------------------------------
         // The skips below are for testing the downgrade on PHP 7.1
         // ------------------------------------
+        // Skip testing the code that is not shipped for the GraphQL API,
+        // since this code is not being downgraded in first place (so no need to test it)
+        __DIR__ . '/layers/Misc/*',
+        __DIR__ . '/layers/SiteBuilder/*',
+        __DIR__ . '/layers/Wassup/*',
         // All the migrate-* packages must also be tested for PHP 7.1.
         // But I already know they all pass, and they are not added any new code,
         // so we can skip them to reduce the testing time

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -40,6 +40,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/symfony/cache/DoctrineProvider.php',
         __DIR__ . '/vendor/symfony/cache/Messenger/EarlyExpirationHandler.php',
         __DIR__ . '/vendor/symfony/string/Slugger/AsciiSlugger.php',
+        // ------------------------------------
+        // The skips below are for testing the downgrade on PHP 7.1
+        // ------------------------------------
         // Temporarily skip testing the code that is not yet shipped for any project,
         // to make the testing process take less time, and be able to complete
         __DIR__ . '/layers/Misc/*',
@@ -50,6 +53,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // But I already know they all pass, and they are not added any new code,
         // so we can skip them to reduce the testing time
         '*/migrate-*',
+        // Skip the tests also,
+        '*/tests/*',
     ]);
 
     // /**

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -46,6 +46,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/layers/SiteBuilder/*',
         __DIR__ . '/layers/Wassup/*',
         __DIR__ . '/layers/Schema/packages/migrate-everythingelse/*',
+        // All the migrate-* packages must also be tested for PHP 7.1.
+        // But I already know they all pass, and they are not added any new code,
+        // so we can skip them to reduce the testing time
+        '*/migrate-*',
     ]);
 
     // /**

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -59,6 +59,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         '*/migrate-*',
         // Skip the tests also,
         '*/tests/*',
+        '*/test/*',
+        '*/Test/*',
+        // Avoid errors from downgrading Composer's generated files
+        // (we already know they run on PHP 7.1)
+        __DIR__ . '/vendor/composer/*',
+        // Same for Composer scripts
+        __DIR__ . '/vendor/lkwdwrd/wp-muplugin-loader/*',
     ]);
 
     // /**


### PR DESCRIPTION
Fixes #299.

`rectorphp/rector-prefixed` running on PHP 7.1 is now available: https://packagist.org/packages/rector/rector-prefixed