### PR TITLE
Added "psr/simple-cache" to PROD

### DIFF
--- a/layers/Engine/packages/component-model/composer.json
+++ b/layers/Engine/packages/component-model/composer.json
@@ -22,6 +22,7 @@
         "getpop/migrate-component-model": "^0.8",
         "jrfnl/php-cast-to-type": "^2.0",
         "league/pipeline": "^1.0",
+        "psr/simple-cache": "^1.0",
         "symfony/cache": "^5.1",
         "symfony/expression-language": "^5.1"
     },


### PR DESCRIPTION
`symfony/cache` references package `psr/simple-cache` but has added it under `require-dev`, not `require`. This creates trouble when running Rector, since it can't find those classes.

Then add it to PROD for ComponentModel, which is the one loading package `symfony/cache`