### PR TITLE
`execute`: Indicate Error can be returned with mixed

### DIFF
--- a/layers/Engine/packages/component-model/src/MutationResolvers/MutationResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/MutationResolverInterface.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\MutationResolvers;
 
-use PoP\ComponentModel\ErrorHandling\Error;
-
 interface MutationResolverInterface
 {
+    /**
+     * Please notice: the return type `mixed` includes `Error`
+     */
     public function execute(array $form_data): mixed;
     public function validateErrors(array $form_data): ?array;
     public function validateWarnings(array $form_data): ?array;

--- a/layers/Schema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoPSchema\CommentMutations\MutationResolvers;
 
 use PoP\ComponentModel\ErrorHandling\Error;
+use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\MutationResolvers\AbstractMutationResolver;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\Hooks\Facades\HooksAPIFacade;
@@ -86,6 +87,9 @@ class AddCommentToCustomPostMutationResolver extends AbstractMutationResolver
     {
         $comment_data = $this->getCommentData($form_data);
         $comment_id = $this->insertComment($comment_data);
+        if (GeneralUtils::isError($comment_id)) {
+            return $comment_id;
+        }
 
         // Allow for additional operations (eg: set Action categories)
         $this->additionals($comment_id, $form_data);

--- a/layers/Schema/packages/custompost-mutations/src/MutationResolvers/UpdateCustomPostMutationResolverTrait.php
+++ b/layers/Schema/packages/custompost-mutations/src/MutationResolvers/UpdateCustomPostMutationResolverTrait.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMutations\MutationResolvers;
 
-use PoP\ComponentModel\ErrorHandling\Error;
-
 trait UpdateCustomPostMutationResolverTrait
 {
     public function execute(array $form_data): mixed


### PR DESCRIPTION
Related to #523: since the return type for a `MutationResolver`'s [function `execute`](https://github.com/leoloso/PoP/blob/238a67fe6bb8b95c04166ffc51bbffcc50d5152f/layers/Engine/packages/component-model/src/MutationResolvers/MutationResolverInterface.php#L12) is `mixed`, added a comment stating that it can include an `Error`