### PR TITLE
Fixed Rector autoload path bug

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5044,16 +5044,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.10.1",
+            "version": "0.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "90ba00cecf430a8d3c15704490455f7d6c5423bc"
+                "reference": "e776d753efb775f769916e66b1848d93143f93ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/90ba00cecf430a8d3c15704490455f7d6c5423bc",
-                "reference": "90ba00cecf430a8d3c15704490455f7d6c5423bc",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e776d753efb775f769916e66b1848d93143f93ae",
+                "reference": "e776d753efb775f769916e66b1848d93143f93ae",
                 "shasum": ""
             },
             "require": {
@@ -5070,14 +5070,14 @@
                 "nette/utils": "^3.2",
                 "nikic/php-parser": "^4.10.4",
                 "php": "^7.3|^8.0",
-                "phpstan/phpdoc-parser": "^0.5.1",
+                "phpstan/phpdoc-parser": "^0.5.2",
                 "phpstan/phpstan": "^0.12.82",
                 "phpstan/phpstan-phpunit": "^0.12.18",
-                "rector/rector-cakephp": "^0.10.0",
+                "rector/rector-cakephp": "^0.10.1",
                 "rector/rector-doctrine": "^0.10.0",
                 "rector/rector-laravel": "^0.10.0",
                 "rector/rector-nette": "^0.10.0",
-                "rector/rector-phpunit": "^0.10.0",
+                "rector/rector-phpunit": "^0.10.2",
                 "rector/rector-symfony": "^0.10.0",
                 "sebastian/diff": "^4.0.4",
                 "symfony/console": "^4.4.8|^5.1",
@@ -5163,7 +5163,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.10.1"
+                "source": "https://github.com/rectorphp/rector/tree/0.10.3"
             },
             "funding": [
                 {
@@ -5171,20 +5171,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-22T22:28:54+00:00"
+            "time": "2021-03-23T23:48:07+00:00"
         },
         {
             "name": "rector/rector-cakephp",
-            "version": "0.10.0",
+            "version": "0.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector-cakephp.git",
-                "reference": "a96728adb127cc98ec044858d736f5b09f3b2ad7"
+                "reference": "d665305a0267078373b52fd4f3262ed9b922211d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector-cakephp/zipball/a96728adb127cc98ec044858d736f5b09f3b2ad7",
-                "reference": "a96728adb127cc98ec044858d736f5b09f3b2ad7",
+                "url": "https://api.github.com/repos/rectorphp/rector-cakephp/zipball/d665305a0267078373b52fd4f3262ed9b922211d",
+                "reference": "d665305a0267078373b52fd4f3262ed9b922211d",
                 "shasum": ""
             },
             "require": {
@@ -5196,9 +5196,15 @@
                 "phpunit/phpunit": "^9.5",
                 "symplify/easy-coding-standard": "^9.2",
                 "symplify/phpstan-extensions": "^9.2",
-                "symplify/phpstan-rules": "^9.2"
+                "symplify/phpstan-rules": "^9.2",
+                "symplify/rule-doc-generator": "^9.2"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Rector\\CakePHP\\": "src"
@@ -5211,9 +5217,9 @@
             "description": "Rector upgrades rules for CakePHP",
             "support": {
                 "issues": "https://github.com/rectorphp/rector-cakephp/issues",
-                "source": "https://github.com/rectorphp/rector-cakephp/tree/0.10.0"
+                "source": "https://github.com/rectorphp/rector-cakephp/tree/0.10.1"
             },
-            "time": "2021-03-21T23:19:28+00:00"
+            "time": "2021-03-23T20:49:22+00:00"
         },
         {
             "name": "rector/rector-doctrine",
@@ -5352,16 +5358,16 @@
         },
         {
             "name": "rector/rector-phpunit",
-            "version": "0.10.0",
+            "version": "0.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector-phpunit.git",
-                "reference": "d00356b7716c63dbca4a21c731efbede95899a8f"
+                "reference": "f836b6aac19bc71637a3d4da81ab51c00181c18f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector-phpunit/zipball/d00356b7716c63dbca4a21c731efbede95899a8f",
-                "reference": "d00356b7716c63dbca4a21c731efbede95899a8f",
+                "url": "https://api.github.com/repos/rectorphp/rector-phpunit/zipball/f836b6aac19bc71637a3d4da81ab51c00181c18f",
+                "reference": "f836b6aac19bc71637a3d4da81ab51c00181c18f",
                 "shasum": ""
             },
             "require": {
@@ -5373,9 +5379,15 @@
                 "symplify/easy-coding-standard": "^9.2",
                 "symplify/phpstan-extensions": "^9.2",
                 "symplify/phpstan-rules": "^9.2",
+                "symplify/rule-doc-generator": "^9.2",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Rector\\PHPUnit\\": "src"
@@ -5388,9 +5400,9 @@
             "description": "Rector upgrades rules for PHPUnit",
             "support": {
                 "issues": "https://github.com/rectorphp/rector-phpunit/issues",
-                "source": "https://github.com/rectorphp/rector-phpunit/tree/0.10.0"
+                "source": "https://github.com/rectorphp/rector-phpunit/tree/0.10.2"
             },
-            "time": "2021-03-20T20:03:34+00:00"
+            "time": "2021-03-23T20:57:25+00:00"
         },
         {
             "name": "rector/rector-symfony",

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/rector-test-scoping.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/rector-test-scoping.php
@@ -23,7 +23,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
-    $parameters->set(Option::AUTOLOAD_PATHS, [
+    $parameters->set(Option::BOOTSTRAP_FILES, [
         __DIR__ . '/vendor/scoper-autoload.php',
         __DIR__ . '/vendor/jrfnl/php-cast-to-type/cast-to-type.php',
         __DIR__ . '/vendor/jrfnl/php-cast-to-type/class.cast-to-type.php',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/dataloads/maps.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/dataloads/maps.php
@@ -38,7 +38,7 @@ class PoP_Module_Processor_LocationsMapDataloads extends PoP_Module_Processor_Da
                 $ret[] = [PoP_Module_Processor_MapResetMarkerScripts::class, PoP_Module_Processor_MapResetMarkerScripts::MODULE_MAP_SCRIPT_RESETMARKERS];
                 break;
         }
-    
+
         return $ret;
     }
 
@@ -66,7 +66,7 @@ class PoP_Module_Processor_LocationsMapDataloads extends PoP_Module_Processor_Da
             case self::MODULE_DATALOAD_LOCATIONSMAP:
                 return LocationTypeResolver::class;
         }
-        
+
         return parent::getTypeResolverClass($module);
     }
 }

--- a/rector-code-quality.php
+++ b/rector-code-quality.php
@@ -26,7 +26,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
-    $parameters->set(Option::AUTOLOAD_PATHS, [
+    $parameters->set(Option::BOOTSTRAP_FILES, [
         // full directory
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
         // Avoid error: "Class EM_Event not found"

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -27,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
-    $parameters->set(Option::AUTOLOAD_PATHS, [
+    $parameters->set(Option::BOOTSTRAP_FILES, [
         // full directory
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
         // Avoid error: "Class EM_Event not found"

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -7,15 +7,6 @@ use Rector\Core\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\DowngradeSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-/**
- * Temporary bug fix:
- * `Option::AUTOLOAD_PATHS` not working, so load the files outside the config
- *
- * @see https://github.com/rectorphp/rector/issues/5951#issuecomment-804790816
- */
-require_once __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php';
-require_once __DIR__ . '/stubs/wpackagist-plugin/events-manager/em-stubs.php';
-
 return static function (ContainerConfigurator $containerConfigurator): void {
     // get parameters
     $parameters = $containerConfigurator->parameters();


### PR DESCRIPTION
Rector 0.10.3 [fixed `Options::AUTOLOAD_PATH` not working](https://github.com/rectorphp/rector/issues/5951).

So upgraded to this version, and removed the temporary patch.