### PR TITLE
Use PHP linter (instead of Rector) to test that code downgraded to PHP 7.1 works well

### DIFF
--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -78,14 +78,6 @@ jobs:
                     path: build/downgraded-code.zip
                     retention-days: 1
 
-            # Executing `composer config platform-check false` throws error:
-            # Failed to execute regex: PREG_JIT_STACKLIMIT_ERROR
-            # @see https://github.com/leoloso/PoP/pull/304/checks?check_run_id=1668406313#step:4:5
-            # Then, just manually delete the platform_check.php file
-            -   name: Avoid Composer v2 platform checks
-                # run: composer config platform-check false
-                run: rm vendor/composer/platform_check.php
-
             -   name: Switch to PHP 7.1
                 uses: shivammathur/setup-php@v2
                 with:
@@ -96,7 +88,7 @@ jobs:
 
             # Test everything, including Composer dependencies which (supposedly)
             # do not require downgrading
-            # Use a PHP Linter. If PHP is not valid, it will throw an error
+            # Use a PHP linter. If PHP is not valid, it will throw an error
             # Also test all the migrate-* packages, but migrate-everythingelse that
             # should not be part of any project, and DOES contain PHP 8.0 (it's not being downgraded)
             -   name: Run PHP Parallel Lint on PHP 7.1

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -59,10 +59,11 @@ jobs:
                 run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi
 
             # Only PROD dependencies must be tested
+            # --ignore-platform-reqs to avoid Composer checking the PHP 8.0 requirement
             -   name: Keep dependencies for PROD only (for testing)
                 uses: "ramsey/composer-install@v1"
                 with:
-                    composer-options: "--no-dev"
+                    composer-options: "--no-dev --ignore-platform-reqs"
 
             # Upload artifact with downgraded code, for debugging
             -   name: Create build folder
@@ -88,7 +89,7 @@ jobs:
 
             # Test everything, including Composer dependencies which (supposedly)
             # do not require downgrading
-            # Use a PHP linter. If PHP is not valid, it will throw an error
+            # Use a PHP Linter. If PHP is not valid, it will throw an error
             # Also test all the migrate-* packages, but migrate-everythingelse that
             # should not be part of any project, and DOES contain PHP 8.0 (it's not being downgraded)
             -   name: Run PHP Parallel Lint on PHP 7.1

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -55,13 +55,8 @@ jobs:
                 run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
             # Prepare for testing on PHP 7.1
-            # Install Rector prefixed global since it conflicts with local packages
-            -   name: Install Rector prefixed
-                run: composer global require rector/rector-prefixed
-
-            # We need the WordPress stubs for testing (they are installed in DEV)
-            -   name: Install DEV dependencies needed in PROD (for testing)
-                run: composer require php-stubs/wordpress-stubs
+            -   name: Install PHP Parallel Lint
+                run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi
 
             # Only PROD dependencies must be tested
             -   name: Keep dependencies for PROD only (for testing)
@@ -101,7 +96,10 @@ jobs:
 
             # Test everything, including Composer dependencies which (supposedly)
             # do not require downgrading
-            # Applying the same Rector downgrade config is good enough (any Rector would do the job)
-            -   name: Run Rector on PHP 7.1
-                run: ~/.composer/vendor/rector/rector-prefixed/bin/rector process layers/ vendor/ --config=rector-downgrade-code.php --ansi
+            # Use a PHP Linter. If PHP is not valid, it will throw an error
+            # Also test all the migrate-* packages, but migrate-everythingelse that
+            # should not be part of any project, and DOES contain PHP 8.0 (it's not being downgraded)
+            -   name: Run PHP Parallel Lint on PHP 7.1
+                run: php-parallel-lint/parallel-lint layers/ vendor/ --exclude layers/Schema/packages/migrate-everythingelse/ --exclude vendor/symfony/polyfill-ctype/bootstrap80.php --exclude vendor/symfony/polyfill-intl-grapheme/bootstrap80.php --exclude vendor/symfony/polyfill-intl-idn/bootstrap80.php --exclude vendor/symfony/polyfill-intl-normalizer/bootstrap80.php --exclude vendor/symfony/polyfill-mbstring/bootstrap80.php
+
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -164,7 +164,12 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         // Add the type before the ID
         $dbObjectIDs = is_array($dbObjectIDOrIDs) ? $dbObjectIDOrIDs : [$dbObjectIDOrIDs];
         $qualifiedDBObjectIDs = array_map(
-            function (int | string $id) {
+            /**
+             * Commented temporarily until Rector can downgrade union types on anonymous functions
+             * @see https://github.com/rectorphp/rector/issues/5989
+             */
+            // function (int | string $id) {
+            function ($id) {
                 return UnionTypeHelpers::getDBObjectComposedTypeAndID(
                     $this,
                     $id
@@ -779,7 +784,12 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             }
             $ids_data_fields = array_filter(
                 $ids_data_fields,
-                function (int | string $id) use ($unresolvedResultItemIDs) {
+                /**
+                 * Commented temporarily until Rector can downgrade union types on anonymous functions
+                 * @see https://github.com/rectorphp/rector/issues/5989
+                 */
+                // function (int | string $id) use ($unresolvedResultItemIDs) {
+                function ($id) use ($unresolvedResultItemIDs) {
                     return !in_array($id, $unresolvedResultItemIDs);
                 },
                 ARRAY_FILTER_USE_KEY

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
@@ -41,7 +41,12 @@ trait FilterIDsSatisfyingConditionDirectiveResolverTrait
         // Calculate the $idsDataFields that must be removed from all the upcoming stages of the pipeline
         $idsDataFieldsToRemove = array_filter(
             $idsDataFields,
-            function (int | string $id) use ($idsToRemove) {
+            /**
+             * Commented temporarily until Rector can downgrade union types on anonymous functions
+             * @see https://github.com/rectorphp/rector/issues/5989
+             */
+            // function (int | string $id) use ($idsToRemove) {
+            function ($id) use ($idsToRemove) {
                 return in_array($id, $idsToRemove);
             },
             ARRAY_FILTER_USE_KEY

--- a/rector-downgrade-code.php
+++ b/rector-downgrade-code.php
@@ -44,33 +44,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/vendor/symfony/cache/DoctrineProvider.php',
         __DIR__ . '/vendor/symfony/cache/Messenger/EarlyExpirationHandler.php',
         __DIR__ . '/vendor/symfony/string/Slugger/AsciiSlugger.php',
-
-        // ------------------------------------
-        // The skips below are for testing the downgrade on PHP 7.1
-        // ------------------------------------
-        // Skip testing the code that is not shipped for the GraphQL API,
-        // since this code is not being downgraded in first place (so no need to test it)
-        __DIR__ . '/layers/Misc/*',
-        __DIR__ . '/layers/SiteBuilder/*',
-        __DIR__ . '/layers/Wassup/*',
-        // All the migrate-* packages must also be tested for PHP 7.1.
-        // But I already know they all pass, and they are not added any new code,
-        // so we can skip them to reduce the testing time
-        '*/migrate-*',
-        // Skip the tests also,
-        '*/tests/*',
-        '*/test/*',
-        '*/Test/*',
-        // Avoid errors from downgrading Composer's generated files
-        // (we already know they run on PHP 7.1)
-        __DIR__ . '/vendor/composer/*',
-        // Same for Composer scripts
-        __DIR__ . '/vendor/lkwdwrd/wp-muplugin-loader/*',
-        // Ignore unused classes that fail because they require DEV dependency
-        __DIR__ . '/vendor/symfony/cache/DataCollector/CacheDataCollector.php',
-        __DIR__ . '/vendor/symfony/yaml/Command/LintCommand.php',
-        // All the bootstrap80.php are loaded for PHP 8.0 only
-        __DIR__ . '/vendor/symfony/polyfill-*/bootstrap80.php',
     ]);
 
     // /**


### PR DESCRIPTION
Using Rector to test the validity of PHP code [doesn't work](https://github.com/rectorphp/rector/issues/5963).

So we replace it with [PHP-Parallel-Lint](https://github.com/php-parallel-lint/PHP-Parallel-Lint), following the [approached used by Rector](https://github.com/rectorphp/rector/blob/2d469d30680c30a577ef7661c02748774ad29c73/.github/workflows/build_scoped_rector.yaml#L49-L55).