### PR TITLE
Include everything in downgrade tests artifact

### DIFF
--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -54,6 +54,12 @@ jobs:
             -   name: Dependencies - Downgrade PHP code via Rector
                 run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
+            # Run again with --dry-run, check no further downgrades are executed!
+            -   name: (Again) Local packages - Downgrade PHP code via Rector
+                run: vendor/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} --config=rector-downgrade-code.php --ansi --dry-run
+            -   name: (Again) Dependencies - Downgrade PHP code via Rector
+                run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php "--dry-run"
+
             # Prepare for testing on PHP 7.1
             -   name: Install PHP Parallel Lint
                 run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -71,7 +71,7 @@ jobs:
             -   name: Install zip
                 uses: montudor/action-zip@v0.1.1
             -   name: Create zip
-                run: zip -X -r build/downgraded-code.zip layers/ vendor/ stubs/
+                run: zip -X -r build/downgraded-code.zip . -x *.git* build/\* php-parallel-lint/\*
             -   name: Upload artifact
                 uses: actions/upload-artifact@v2
                 with:

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -54,12 +54,6 @@ jobs:
             -   name: Dependencies - Downgrade PHP code via Rector
                 run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php
 
-            # Run again with --dry-run, check no further downgrades are executed!
-            -   name: (Again) Local packages - Downgrade PHP code via Rector
-                run: vendor/bin/rector process ${{ needs.provide_data.outputs.package_srcs }} --config=rector-downgrade-code.php --ansi --dry-run
-            -   name: (Again) Dependencies - Downgrade PHP code via Rector
-                run: layers/Engine/packages/root/ci/downgrade_code.sh 7.1 rector-downgrade-code.php "--dry-run"
-
             # Prepare for testing on PHP 7.1
             -   name: Install PHP Parallel Lint
                 run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi


### PR DESCRIPTION
Currently, only `layers/`, `vendor/` and `stubs/` is included. Include everything else, so we can reproduce the same environment to run Rector locally.