### PR TITLE
Generate graphql-api.zip plugin during PRs

### DIFF
--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -24,6 +24,7 @@ name: Generate Installable Plugin and Upload as Release Asset
 on:
     release:
         types: [published]
+    pull_request: null
 
 env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
@@ -119,9 +120,11 @@ jobs:
                     path: build/graphql-api.zip
                     retention-days: 1
 
+    # Only execute when doing a release
     upload_and_deploy:
         name: Upload release, and deploy to DIST repo
         needs: build
+        if: github.event_name == 'release'
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -20,7 +20,7 @@
 # - Upload the .zip file as an artifact to the action (this step is possibly optional)
 # - Upload the .zip file as a release, for download
 ####################################################################################
-name: Generate Installable Plugin and Upload as Release Asset
+name: Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Release Asset
 on:
     release:
         types: [published]

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -120,7 +120,7 @@ jobs:
 
     upload_and_deploy:
         name: Upload release, and deploy to DIST repo
-        needs: test
+        needs: build
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -24,6 +24,9 @@ name: Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Rel
 on:
     release:
         types: [published]
+    push:
+        branches:
+            - master
     pull_request: null
 
 env:

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -117,6 +117,7 @@ jobs:
                 with:
                     name: generated-plugin
                     path: build/graphql-api.zip
+                    retention-days: 1
 
     upload_and_deploy:
         name: Upload release, and deploy to DIST repo

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -118,46 +118,6 @@ jobs:
                     name: generated-plugin
                     path: build/graphql-api.zip
 
-    test:
-        name: Test downgraded code
-        needs: build
-        runs-on: ubuntu-latest
-        steps:
-            -   name: Checkout code
-                uses: actions/checkout@v2
-
-            -   name: Create build folder
-                run: mkdir build
-
-            -   name: Download artifact
-                uses: actions/download-artifact@v2
-                with:
-                    name: generated-plugin
-                    path: build
-
-            -   name: Uncompress artifact
-                uses: montudor/action-zip@v0.1.0
-                with:
-                    args: unzip -qq build/graphql-api.zip -d build/downgraded-graphql-api-for-wp
-
-                # pcre.jit=0 => @see https://github.com/composer/composer/issues/9595
-            -   name: Use PHP 7.1
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: 7.1
-                    coverage: none
-                    ini-values: pcre.jit=0
-                env:
-                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            -   name: Avoid Composer v2 platform checks
-                run: composer config platform-check false --no-interaction --ansi
-
-            -   name: Install Composer dependencies
-                uses: "ramsey/composer-install@v1"
-                with:
-                    composer-options: "--ignore-platform-reqs"
-
     upload_and_deploy:
         name: Upload release, and deploy to DIST repo
         needs: test

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/rector-downgrade-code.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/rector-downgrade-code.php
@@ -23,7 +23,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_71);
 
     // Rector relies on autoload setup of your project; Composer autoload is included by default; to add more:
-    $parameters->set(Option::AUTOLOAD_PATHS, [
+    $parameters->set(Option::BOOTSTRAP_FILES, [
         __DIR__ . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
     ]);
 


### PR DESCRIPTION
Upload `graphql-api.zip` always as an artifact when testing PRs, in addition to when tagging a new release.