### PR TITLE
downgrade_code.sh must also downgrade the root package

### DIFF
--- a/layers/Engine/packages/root/ci/downgrade_code.sh
+++ b/layers/Engine/packages/root/ci/downgrade_code.sh
@@ -75,7 +75,8 @@ if [ -n "$target_php_version" ]; then
     # Switch to dev again
     composer install --no-progress --ansi
 else
-    PACKAGES=$(composer info --name-only --no-dev)
+    # Also add the root package
+    PACKAGES="$rootPackage $(composer info --name-only --no-dev)"
 fi
 
 # Ignore all the "migrate" packages

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -83,12 +83,7 @@
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
         "analyse": "phpstan analyse",
-        "preview-src-downgrade": "rector process src --config=rector-downgrade-code.php --ansi --dry-run || true",
-        "preview-vendor-downgrade": "../../../../layers/Engine/packages/root/ci/downgrade_code.sh rector-downgrade-code.php --dry-run || true",
-        "preview-code-downgrade": [
-            "@preview-src-downgrade",
-            "@preview-vendor-downgrade"
-        ]
+        "preview-code-downgrade": "../../../../layers/Engine/packages/root/ci/downgrade_code.sh rector-downgrade-code.php --dry-run"
     },
     "extra": {
         "wordpress-install-dir": "vendor/wordpress/wordpress",

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -83,7 +83,7 @@
         "check-style": "phpcs src tests",
         "fix-style": "phpcbf src tests",
         "analyse": "phpstan analyse",
-        "preview-code-downgrade": "../../../../layers/Engine/packages/root/ci/downgrade_code.sh rector-downgrade-code.php --dry-run"
+        "preview-code-downgrade": "../../../../layers/Engine/packages/root/ci/downgrade_code.sh rector-downgrade-code.php --dry-run || true"
     },
     "extra": {
         "wordpress-install-dir": "vendor/wordpress/wordpress",


### PR DESCRIPTION
#551 introduced a bug: Because `$(composer info --name-only --no-dev)` does not include the root package, the root project was not being downgraded.

This PR fixes it