### PR TITLE
Split the GitHub Action plugin generation YAML into multiple jobs

### DIFF
--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -93,13 +93,13 @@ jobs:
                 uses: montudor/action-zip@v0.1.1
 
             -   name: Create plugin as zip
-                run: zip -X -r ../../../../build/downgraded-code.zip .
+                run: zip -X -r ../../../../build/graphql-api.zip .
 
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: job-asset
-                    path: build/downgraded-code.zip
+                    path: build/graphql-api.zip
                     retention-days: 1
 
     # Only execute when enabled by configuration
@@ -117,7 +117,7 @@ jobs:
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/downgraded-code.zip -d build/downgraded-plugin
+                    args: unzip -qq build/graphql-api.zip -d build/downgraded-plugin
 
             -   name: Install PHP-Scoper
                 run: |

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -127,7 +127,7 @@ jobs:
 
             # If the scoped results correspond to vendor/ only, we should do "--output-dir ../prefixed-code/vendor"
             -   name: Scope plugin into separate folder
-                run: php-scoper add-prefix --output-dir ../prefixed-code --ansi --no-interaction
+                run: ~/.composer/vendor/bin/php-scoper add-prefix --output-dir ../prefixed-code --ansi --no-interaction
                 working-directory: build/generated-plugin
 
             -   name: Copy scoped code back into plugin

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -131,8 +131,7 @@ jobs:
                 working-directory: build/generated-plugin
 
             -   name: Copy scoped code back into plugin
-                run: rsync -av . ../generated-plugin/ --quiet
-                working-directory: build/prefixed-code
+                run: rsync -av build/prefixed-code/ build/generated-plugin/ --quiet
 
             -   name: Regenerate autoloader
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -98,7 +98,7 @@ jobs:
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
-                    name: job-asset
+                    name: job-assets
                     path: build/graphql-api.zip
                     retention-days: 1
 
@@ -111,7 +111,7 @@ jobs:
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
-                    name: job-asset
+                    name: job-assets
                     path: build
 
             -   name: Uncompress artifact
@@ -158,7 +158,7 @@ jobs:
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
-                    name: job-asset
+                    name: job-assets
                     path: build/graphql-api.zip
                     retention-days: 1
 
@@ -172,7 +172,7 @@ jobs:
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
-                    name: job-asset
+                    name: job-assets
                     path: build
 
             -   name: Upload to release

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -135,7 +135,7 @@ jobs:
             -   name: Merge scoped + non-scoped plugin code
                 run: |
                     mkdir build/scoped-plugin
-                    rsync -av build/generated-code/ build/scoped-plugin/ --quiet
+                    rsync -av build/generated-plugin/ build/scoped-plugin/ --quiet
                     rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
 
             -   name: Regenerate autoloader

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -102,13 +102,12 @@ jobs:
                     path: build/downgraded-code.zip
                     retention-days: 1
 
-    # Only execute when doing a release
+    # Only execute when enabled by configuration
     scope:
         name: Scope plugin
         needs: build
         runs-on: ubuntu-latest
         steps:
-
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
@@ -118,7 +117,7 @@ jobs:
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/downgraded-code.zip
+                    args: unzip -qq build/downgraded-code.zip -d build/generated-plugin
 
             -   name: Install PHP-Scoper
                 run: |
@@ -126,22 +125,23 @@ jobs:
                     composer global config prefer-stable true
                     composer global require humbug/php-scoper
 
-            # If the scoped results correspond to vendor/ only, we should do "--output-dir ../../../../build-prefixed/vendor"
+            # If the scoped results correspond to vendor/ only, we should do "--output-dir ../prefixed-code/vendor"
             -   name: Scope plugin into separate folder
-                run: php-scoper add-prefix --output-dir ../../../../build-prefixed --ansi --no-interaction
-                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
+                run: php-scoper add-prefix --output-dir ../prefixed-code --ansi --no-interaction
+                working-directory: build/generated-plugin
 
             -   name: Copy scoped code back into plugin
-                run: rsync -av build-prefixed/ layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/ --quiet
+                run: rsync -av . ../generated-plugin/ --quiet
+                working-directory: build/prefixed-code
 
             -   name: Regenerate autoloader
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi
-                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
+                working-directory: build/generated-plugin
 
             -   name: Use Scoper autoload in plugin main file
                 run: |
                     sed -i 's/autoload.php/scoper-autoload.php/' graphql-api.php
-                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
+                working-directory: build/generated-plugin
 
             # -   name: Create build folder
             #     run: mkdir build
@@ -152,8 +152,8 @@ jobs:
                 uses: montudor/action-zip@v0.1.1
 
             -   name: Create plugin as zip
-                run: zip -X -r ../../../../build/graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
-                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
+                run: zip -X -r ../graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
+                working-directory: build/generated-plugin
 
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -93,13 +93,13 @@ jobs:
                 uses: montudor/action-zip@v0.1.1
 
             -   name: Create plugin as zip
-                run: zip -X -r ../../../../build/graphql-api.zip .
+                run: zip -X -r ../../../../build/downgraded-plugin.zip .
 
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: job-assets
-                    path: build/graphql-api.zip
+                    path: build/downgraded-plugin.zip
                     retention-days: 1
 
     # Only execute when enabled by configuration
@@ -117,7 +117,7 @@ jobs:
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/graphql-api.zip -d build/downgraded-plugin
+                    args: unzip -qq build/downgraded-plugin.zip -d build/downgraded-plugin
 
             -   name: Install PHP-Scoper
                 run: |
@@ -152,14 +152,14 @@ jobs:
                 uses: montudor/action-zip@v0.1.1
 
             -   name: Create plugin as zip
-                run: zip -X -r ../graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
+                run: zip -X -r ../scoped-plugin.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
                 working-directory: build/scoped-plugin
 
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: job-assets
-                    path: build/graphql-api.zip
+                    path: build/scoped-plugin.zip
                     retention-days: 1
 
     # Only execute when doing a release
@@ -174,6 +174,9 @@ jobs:
                 with:
                     name: job-assets
                     path: build
+
+            -   name: Rename artifact to plugin name
+                run: mv build/scoped-plugin.zip build/graphql-api.zip
 
             -   name: Upload to release
                 uses: JasonEtco/upload-to-release@master

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -98,7 +98,7 @@ jobs:
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
-                    name: downgraded-plugin
+                    name: job-asset
                     path: build/downgraded-code.zip
                     retention-days: 1
 
@@ -111,7 +111,7 @@ jobs:
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
-                    name: downgraded-plugin
+                    name: job-asset
                     path: build
 
             -   name: Uncompress artifact
@@ -158,7 +158,7 @@ jobs:
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
-                    name: scoped-plugin
+                    name: job-asset
                     path: build/graphql-api.zip
                     retention-days: 1
 
@@ -178,7 +178,7 @@ jobs:
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
-                    name: generated-plugin
+                    name: job-asset
                     path: build
 
             -   name: Upload to release

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -180,7 +180,7 @@ jobs:
             -   name: Upload final plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
-                    name: job-assets
+                    name: plugins
                     path: build/graphql-api.zip
                     retention-days: 1
 
@@ -194,7 +194,7 @@ jobs:
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
-                    name: job-assets
+                    name: plugins
                     path: build
 
             -   name: Upload to release

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -108,6 +108,9 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -95,7 +95,7 @@ jobs:
             -   name: Create plugin as zip
                 run: zip -X -r ../../../../build/downgraded-plugin.zip .
 
-            -   name: Upload plugin zip as artifact
+            -   name: Upload job output zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: job-assets
@@ -155,7 +155,7 @@ jobs:
                 run: zip -X -r ../scoped-plugin.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
                 working-directory: build/scoped-plugin
 
-            -   name: Upload plugin zip as artifact
+            -   name: Upload job output zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: job-assets
@@ -163,10 +163,9 @@ jobs:
                     retention-days: 1
 
     # Only execute when doing a release
-    upload_and_deploy:
-        name: Upload release, and deploy to DIST repo
+    upload_final_plugin_as_artifact:
+        name: Rename the artifact to the plugin name
         needs: scope
-        if: github.event_name == 'release'
         runs-on: ubuntu-latest
         steps:
             -   name: Download artifact
@@ -177,6 +176,26 @@ jobs:
 
             -   name: Rename artifact to plugin name
                 run: mv build/scoped-plugin.zip build/graphql-api.zip
+
+            -   name: Upload final plugin zip as artifact
+                uses: actions/upload-artifact@v2
+                with:
+                    name: job-assets
+                    path: build/graphql-api.zip
+                    retention-days: 1
+
+    # Only execute when doing a release
+    upload_and_deploy:
+        name: Upload release, and deploy to DIST repo
+        needs: upload_final_plugin_as_artifact
+        if: github.event_name == 'release'
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Download artifact
+                uses: actions/download-artifact@v2
+                with:
+                    name: job-assets
+                    path: build
 
             -   name: Upload to release
                 uses: JasonEtco/upload-to-release@master

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -172,9 +172,6 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
 
-            -   name: Create build folder
-                run: mkdir build
-
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -169,9 +169,6 @@ jobs:
         if: github.event_name == 'release'
         runs-on: ubuntu-latest
         steps:
-            -   name: Checkout code
-                uses: actions/checkout@v2
-
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -180,7 +180,7 @@ jobs:
             -   name: Upload final plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
-                    name: plugins
+                    name: generated-plugins
                     path: build/graphql-api.zip
                     retention-days: 1
 
@@ -194,7 +194,7 @@ jobs:
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
-                    name: plugins
+                    name: generated-plugins
                     path: build
 
             -   name: Upload to release

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -132,12 +132,11 @@ jobs:
 
             # Can't override original files, so also copy them to new folder
             # @see https://github.community/t/how-to-run-actions-checkout-v1-with-sudo-privileges/17436/11
-            -   name: Create folder
-                run: mkdir build/generated-code
-            -   name: Copy plugin code to new folder
-                run: rsync -av build/generated-code/ build/scoped-plugin/ --quiet
             -   name: Merge scoped + non-scoped plugin code
-                run: rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
+                run: |
+                    mkdir build/scoped-plugin
+                    rsync -av build/generated-code/ build/scoped-plugin/ --quiet
+                    rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
 
             -   name: Regenerate autoloader
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -142,10 +142,6 @@ jobs:
                     sed -i 's/autoload.php/scoper-autoload.php/' graphql-api.php
                 working-directory: build/generated-plugin
 
-            # -   name: Create build folder
-            #     run: mkdir build
-            #     working-directory: .
-
             # Zipping a folder from a different work dir
             -   name: Install zip
                 uses: montudor/action-zip@v0.1.1

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -117,7 +117,7 @@ jobs:
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/downgraded-code.zip -d build/generated-plugin
+                    args: unzip -qq build/downgraded-code.zip -d build/downgraded-plugin
 
             -   name: Install PHP-Scoper
                 run: |
@@ -125,18 +125,18 @@ jobs:
                     composer global config prefer-stable true
                     composer global require humbug/php-scoper
 
-            # If the scoped results correspond to vendor/ only, we should do "--output-dir ../prefixed-code/vendor"
+            # If the scoped results correspond to vendor/ only, we should do "--output-dir ../prefixed-plugin/vendor"
             -   name: Scope plugin into separate folder
-                run: ~/.composer/vendor/bin/php-scoper add-prefix --output-dir ../prefixed-code --ansi --no-interaction
-                working-directory: build/generated-plugin
+                run: ~/.composer/vendor/bin/php-scoper add-prefix --output-dir ../prefixed-plugin --ansi --no-interaction
+                working-directory: build/downgraded-plugin
 
             # Can't override original files, so also copy them to new folder
             # @see https://github.community/t/how-to-run-actions-checkout-v1-with-sudo-privileges/17436/11
             -   name: Merge scoped + non-scoped plugin code
                 run: |
                     mkdir build/scoped-plugin
-                    rsync -av build/generated-plugin/ build/scoped-plugin/ --quiet
-                    rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
+                    rsync -av build/downgraded-plugin/ build/scoped-plugin/ --quiet
+                    rsync -av build/prefixed-plugin/ build/scoped-plugin/ --quiet
 
             -   name: Regenerate autoloader
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -134,6 +134,7 @@ jobs:
             # @see https://github.community/t/how-to-run-actions-checkout-v1-with-sudo-privileges/17436/11
             -   name: Merge scoped + non-scoped plugin code
                 run: |
+                    mkdir build/generated-code
                     rsync -av build/generated-code/ build/scoped-plugin/ --quiet
                     rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
 

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -132,11 +132,12 @@ jobs:
 
             # Can't override original files, so also copy them to new folder
             # @see https://github.community/t/how-to-run-actions-checkout-v1-with-sudo-privileges/17436/11
+            -   name: Create folder
+                run: mkdir build/generated-code
+            -   name: Copy plugin code to new folder
+                run: rsync -av build/generated-code/ build/scoped-plugin/ --quiet
             -   name: Merge scoped + non-scoped plugin code
-                run: |
-                    mkdir build/generated-code
-                    rsync -av build/generated-code/ build/scoped-plugin/ --quiet
-                    rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
+                run: rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
 
             -   name: Regenerate autoloader
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -38,7 +38,7 @@ jobs:
         defaults:
             run:
                 working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
-        name: Downgrade code, Build plugin, and Upload as artifact
+        name: Build plugin and Downgrade its code
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
@@ -84,27 +84,6 @@ jobs:
             -   name: Build project for production
                 run: composer install --no-dev --optimize-autoloader --no-progress --no-interaction --ansi
 
-            -   name: Install PHP-Scoper
-                run: |
-                    composer global config minimum-stability dev
-                    composer global config prefer-stable true
-                    composer global require humbug/php-scoper
-
-            # If the scoped results correspond to vendor/ only, we should do "--output-dir ../../../../build-prefixed/vendor"
-            -   name: Scope plugin into separate folder
-                run: php-scoper add-prefix --output-dir ../../../../build-prefixed --ansi --no-interaction
-
-            -   name: Copy scoped code back into plugin
-                run: rsync -av build-prefixed/ layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/ --quiet
-                working-directory: .
-
-            -   name: Regenerate autoloader
-                run: composer dumpautoload --optimize --classmap-authoritative --ansi
-
-            -   name: Use Scoper autoload in plugin main file
-                run: |
-                    sed -i 's/autoload.php/scoper-autoload.php/' graphql-api.php
-
             -   name: Create build folder
                 run: mkdir build
                 working-directory: .
@@ -114,7 +93,67 @@ jobs:
                 uses: montudor/action-zip@v0.1.1
 
             -   name: Create plugin as zip
+                run: zip -X -r ../../../../build/downgraded-code.zip .
+
+            -   name: Upload plugin zip as artifact
+                uses: actions/upload-artifact@v2
+                with:
+                    name: downgraded-plugin
+                    path: build/downgraded-code.zip
+                    retention-days: 1
+
+    # Only execute when doing a release
+    scope:
+        name: Scope plugin
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+
+            -   name: Download artifact
+                uses: actions/download-artifact@v2
+                with:
+                    name: downgraded-plugin
+                    path: build
+
+            -   name: Uncompress artifact
+                uses: montudor/action-zip@v0.1.0
+                with:
+                    args: unzip -qq build/downgraded-code.zip
+
+            -   name: Install PHP-Scoper
+                run: |
+                    composer global config minimum-stability dev
+                    composer global config prefer-stable true
+                    composer global require humbug/php-scoper
+
+            # If the scoped results correspond to vendor/ only, we should do "--output-dir ../../../../build-prefixed/vendor"
+            -   name: Scope plugin into separate folder
+                run: php-scoper add-prefix --output-dir ../../../../build-prefixed --ansi --no-interaction
+                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
+
+            -   name: Copy scoped code back into plugin
+                run: rsync -av build-prefixed/ layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/ --quiet
+
+            -   name: Regenerate autoloader
+                run: composer dumpautoload --optimize --classmap-authoritative --ansi
+                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
+
+            -   name: Use Scoper autoload in plugin main file
+                run: |
+                    sed -i 's/autoload.php/scoper-autoload.php/' graphql-api.php
+                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
+
+            # -   name: Create build folder
+            #     run: mkdir build
+            #     working-directory: .
+
+            # Zipping a folder from a different work dir
+            -   name: Install zip
+                uses: montudor/action-zip@v0.1.1
+
+            -   name: Create plugin as zip
                 run: zip -X -r ../../../../build/graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
+                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
 
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
@@ -126,7 +165,7 @@ jobs:
     # Only execute when doing a release
     upload_and_deploy:
         name: Upload release, and deploy to DIST repo
-        needs: build
+        needs: scope
         if: github.event_name == 'release'
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -108,9 +108,6 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            -   name: Checkout code
-                uses: actions/checkout@v2
-
             -   name: Download artifact
                 uses: actions/download-artifact@v2
                 with:
@@ -133,17 +130,21 @@ jobs:
                 run: ~/.composer/vendor/bin/php-scoper add-prefix --output-dir ../prefixed-code --ansi --no-interaction
                 working-directory: build/generated-plugin
 
-            -   name: Copy scoped code back into plugin
-                run: rsync -av build/prefixed-code/ build/generated-plugin/ --quiet
+            # Can't override original files, so also copy them to new folder
+            # @see https://github.community/t/how-to-run-actions-checkout-v1-with-sudo-privileges/17436/11
+            -   name: Merge scoped + non-scoped plugin code
+                run: |
+                    rsync -av build/generated-code/ build/scoped-plugin/ --quiet
+                    rsync -av build/prefixed-code/ build/scoped-plugin/ --quiet
 
             -   name: Regenerate autoloader
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi
-                working-directory: build/generated-plugin
+                working-directory: build/scoped-plugin
 
             -   name: Use Scoper autoload in plugin main file
                 run: |
                     sed -i 's/autoload.php/scoper-autoload.php/' graphql-api.php
-                working-directory: build/generated-plugin
+                working-directory: build/scoped-plugin
 
             # Zipping a folder from a different work dir
             -   name: Install zip
@@ -151,12 +152,12 @@ jobs:
 
             -   name: Create plugin as zip
                 run: zip -X -r ../graphql-api.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
-                working-directory: build/generated-plugin
+                working-directory: build/scoped-plugin
 
             -   name: Upload plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
-                    name: generated-plugin
+                    name: scoped-plugin
                     path: build/graphql-api.zip
                     retention-days: 1
 


### PR DESCRIPTION
Transform [`generate_graphql_api_for_wp_plugin.yml`](https://github.com/leoloso/PoP/blob/bb767c90d60ae5b8b62e8ae680feaaeaab350b84/.github/workflows/generate_graphql_api_for_wp_plugin.yml) into a workflow that can generate all the plugins:

- Embed a matrix, to launch 1 instance per plugin to generate
- Pass configuration via `monorepo-builder.php`

This will enable to generate plugin `graphql-api-convert-case-directives.zip`.

This PR is the first step of multiple steps to accomplish this goal.