### PR TITLE
Run plugin generation workflow as matrix

### DIFF
--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -189,7 +189,7 @@ jobs:
                 uses: montudor/action-zip@v0.1.1
 
             -   name: Create plugin as zip
-                run: zip -X -r ../scoped-plugin.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json dev-helpers/\* lando/\* docs/images/\* tests/\* **/tests/\*
+                run: zip -X -r ../scoped-plugin.zip . -x *.git* node_modules/\* .* "*/\.*" *.md phpstan.neon rector-downgrade-code.php rector-test-scoping.php scoper.inc.php *.dist composer.* **/package-lock.json tests/\* **/tests/\* ${{ fromJson(needs.matrix.outputs.plugin_config).exclude_files }}
                 working-directory: build/scoped-plugin
 
             -   name: Upload job output zip as artifact

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -71,7 +71,7 @@ jobs:
             plugin_config: ${{ steps.output_data.outputs.plugin_config }}
 
     build_and_downgrade:
-        name: Build plugin and Downgrade its code (${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }})
+        name: Build plugin and Downgrade code (${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }})
         needs: [provide_data, matrix]
         runs-on: ubuntu-latest
         defaults:

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -256,8 +256,8 @@ jobs:
                 with:
                     branch: 'master'
                     package-directory: 'build/dist-plugin'
-                    split-repository-organization: 'GraphQLAPI'
-                    split-repository-name: 'graphql-api-for-wp-dist'
+                    split-repository-organization: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_organization
+                    split-repository-name: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_name
                     tag: ${{ steps.previous_tag.outputs.tag }}
                     user-name: "leoloso"
                     user-email: "leo@getpop.org"

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -52,21 +52,31 @@ jobs:
             -   id: output_data
                 run: |
                     echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json)"
-
         outputs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 
-    build_and_downgrade:
-        name: Build plugin and Downgrade its code
+    matrix:
+        name: Initialize Matrix
         needs: provide_data
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
                 pluginConfig: ${{ fromJson(needs.provide_data.outputs.plugin_config_entries) }}
+        steps:
+            -   id: output_data
+                run: |
+                    echo "::set-output name=plugin_config::${{ toJson(matrix.pluginConfig) }}"
+        outputs:
+            plugin_config: ${{ steps.output_data.outputs.plugin_config }}
+
+    build_and_downgrade:
+        name: Build plugin and Downgrade its code
+        needs: [provide_data, matrix]
+        runs-on: ubuntu-latest
         defaults:
             run:
-                working-directory: ${{ matrix.pluginConfig.path }}
+                working-directory: ${{ needs.matrix.outputs.plugin_config.path }}
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
@@ -89,7 +99,7 @@ jobs:
             -   name: Localize package paths
                 run: |
                     vendor/bin/monorepo-builder custom-bump-interdependency "dev-master"
-                    vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.pluginConfig.path }}/composer.json --ansi
+                    vendor/bin/monorepo-builder localize-composer-paths ${{ needs.matrix.outputs.plugin_config.path }}/composer.json --ansi
                 working-directory: .
 
             -   name: Install plugin dependencies, avoiding v2 platform check
@@ -132,7 +142,7 @@ jobs:
     # Only execute when enabled by configuration
     scope:
         name: Scope plugin
-        needs: build_and_downgrade
+        needs: [build_and_downgrade, matrix]
         runs-on: ubuntu-latest
         steps:
             -   name: Download artifact
@@ -190,9 +200,9 @@ jobs:
                     retention-days: 1
 
     # Only execute when doing a release
-    upload_final_plugin_as_artifact:
+    upload_plugin_as_artifact:
         name: Rename the artifact to the plugin name
-        needs: scope
+        needs: [scope, matrix]
         runs-on: ubuntu-latest
         steps:
             -   name: Download artifact
@@ -202,19 +212,19 @@ jobs:
                     path: build
 
             -   name: Rename artifact to plugin name
-                run: mv build/scoped-plugin.zip build/${{ matrix.pluginConfig.zip_file }}
+                run: mv build/scoped-plugin.zip build/${{ needs.matrix.outputs.plugin_config.zip_file }}
 
             -   name: Upload final plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: generated-plugins
-                    path: build/${{ matrix.pluginConfig.zip_file }}
+                    path: build/${{ needs.matrix.outputs.plugin_config.zip_file }}
                     retention-days: 1
 
     # Only execute when doing a release
     upload_and_deploy:
         name: Upload release, and deploy to DIST repo
-        needs: upload_final_plugin_as_artifact
+        needs: [upload_plugin_as_artifact, matrix]
         if: github.event_name == 'release'
         runs-on: ubuntu-latest
         steps:
@@ -227,14 +237,14 @@ jobs:
             -   name: Upload to release
                 uses: JasonEtco/upload-to-release@master
                 with:
-                    args: build/${{ matrix.pluginConfig.zip_file }} application/zip
+                    args: build/${{ needs.matrix.outputs.plugin_config.zip_file }} application/zip
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/${{ matrix.pluginConfig.zip_file }} -d build/downgraded-graphql-api-for-wp
+                    args: unzip -qq build/${{ needs.matrix.outputs.plugin_config.zip_file }} -d build/downgraded-graphql-api-for-wp
             -
                 id: previous_tag
                 uses: "WyriHaximus/github-action-get-previous-tag@master"

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -71,7 +71,7 @@ jobs:
             plugin_config: ${{ steps.output_data.outputs.plugin_config }}
 
     build_and_downgrade:
-        name: Build plugin and Downgrade its code
+        name: Build plugin and Downgrade its code (${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }})
         needs: [provide_data, matrix]
         runs-on: ubuntu-latest
         defaults:
@@ -141,7 +141,7 @@ jobs:
 
     # Only execute when enabled by configuration
     scope:
-        name: Scope plugin
+        name: Scope plugin (${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }})
         needs: [build_and_downgrade, matrix]
         runs-on: ubuntu-latest
         steps:
@@ -201,7 +201,7 @@ jobs:
 
     # Only execute when doing a release
     upload_plugin_as_artifact:
-        name: Rename the artifact to the plugin name
+        name: Rename the artifact to the plugin name (${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }})
         needs: [scope, matrix]
         runs-on: ubuntu-latest
         steps:
@@ -223,7 +223,7 @@ jobs:
 
     # Only execute when doing a release
     upload_and_deploy:
-        name: Upload release, and deploy to DIST repo
+        name: Upload release, and deploy to DIST repo (${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }})
         needs: [upload_plugin_as_artifact, matrix]
         if: github.event_name == 'release'
         runs-on: ubuntu-latest

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -34,12 +34,40 @@ env:
     COMPOSER_ROOT_VERSION: "dev-master"
 
 jobs:
+    provide_data:
+        name: Provide configuration to generate plugins
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.0
+                    coverage: none
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            -   uses: "ramsey/composer-install@v1"
+
+            -   id: output_data
+                run: |
+                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json)"
+
+        outputs:
+            plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
+
+jobs:
     build:
+        name: Build plugin and Downgrade its code
+        needs: provide_data
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                pluginConfig: ${{ fromJson(needs.provide_data.outputs.plugin_config_entries) }}
         defaults:
             run:
-                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
-        name: Build plugin and Downgrade its code
-        runs-on: ubuntu-latest
+                working-directory: ${{ matrix.pluginConfig.path }}
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
@@ -62,7 +90,7 @@ jobs:
             -   name: Localize package paths
                 run: |
                     vendor/bin/monorepo-builder custom-bump-interdependency "dev-master"
-                    vendor/bin/monorepo-builder localize-composer-paths layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json --ansi
+                    vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.pluginConfig.path }}/composer.json --ansi
                 working-directory: .
 
             -   name: Install plugin dependencies, avoiding v2 platform check

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -244,7 +244,7 @@ jobs:
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }} -d build/downgraded-graphql-api-for-wp
+                    args: unzip -qq build/${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }} -d build/dist-plugin
             -
                 id: previous_tag
                 uses: "WyriHaximus/github-action-get-previous-tag@master"
@@ -255,7 +255,7 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
                     branch: 'master'
-                    package-directory: 'build/downgraded-graphql-api-for-wp'
+                    package-directory: 'build/dist-plugin'
                     split-repository-organization: 'GraphQLAPI'
                     split-repository-name: 'graphql-api-for-wp-dist'
                     tag: ${{ steps.previous_tag.outputs.tag }}

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -98,7 +98,7 @@ jobs:
                     composer install --no-progress --no-interaction --ansi
 
             -   name: Downgrade code for production (to PHP 7.1)
-                run: ../../../Engine/packages/root/ci/downgrade_code.sh rector-downgrade-code.php
+                run: $GITHUB_WORKSPACE/layers/Engine/packages/root/ci/downgrade_code.sh rector-downgrade-code.php
 
             # Hack to fix bug: https://github.com/rectorphp/rector/issues/5962
             -   name: (Hack) Dependencies - Downgrade PHP code via Rector - CacheItem

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -56,7 +56,7 @@ jobs:
         outputs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 
-    build:
+    build_and_downgrade:
         name: Build plugin and Downgrade its code
         needs: provide_data
         runs-on: ubuntu-latest
@@ -132,7 +132,7 @@ jobs:
     # Only execute when enabled by configuration
     scope:
         name: Scope plugin
-        needs: build
+        needs: build_and_downgrade
         runs-on: ubuntu-latest
         steps:
             -   name: Download artifact

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -203,13 +203,13 @@ jobs:
                     path: build
 
             -   name: Rename artifact to plugin name
-                run: mv build/scoped-plugin.zip build/graphql-api.zip
+                run: mv build/scoped-plugin.zip build/${{ matrix.pluginConfig.zip_file }}
 
             -   name: Upload final plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: generated-plugins
-                    path: build/graphql-api.zip
+                    path: build/${{ matrix.pluginConfig.zip_file }}
                     retention-days: 1
 
     # Only execute when doing a release
@@ -228,14 +228,14 @@ jobs:
             -   name: Upload to release
                 uses: JasonEtco/upload-to-release@master
                 with:
-                    args: build/graphql-api.zip application/zip
+                    args: build/${{ matrix.pluginConfig.zip_file }} application/zip
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/graphql-api.zip -d build/downgraded-graphql-api-for-wp
+                    args: unzip -qq build/${{ matrix.pluginConfig.zip_file }} -d build/downgraded-graphql-api-for-wp
             -
                 id: previous_tag
                 uses: "WyriHaximus/github-action-get-previous-tag@master"

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -56,7 +56,6 @@ jobs:
         outputs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 
-jobs:
     build:
         name: Build plugin and Downgrade its code
         needs: provide_data

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -254,10 +254,10 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
-                    branch: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_branch
+                    branch: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_branch }}
                     package-directory: 'build/dist-plugin'
-                    split-repository-organization: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_organization
-                    split-repository-name: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_name
+                    split-repository-organization: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_organization }}
+                    split-repository-name: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_name }}
                     tag: ${{ steps.previous_tag.outputs.tag }}
                     user-name: "leoloso"
                     user-email: "leo@getpop.org"

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -116,7 +116,7 @@ jobs:
 
             -   name: Replace PHP version in plugin main file
                 run: |
-                    sed -i 's/Requires PHP: 8.0/Requires PHP: 7.1/' graphql-api.php
+                    sed -i 's/Requires PHP: 8.0/Requires PHP: 7.1/' ${{ fromJson(needs.matrix.outputs.plugin_config).main_file }}
 
             -   name: Build project for production
                 run: composer install --no-dev --optimize-autoloader --no-progress --no-interaction --ansi
@@ -181,7 +181,7 @@ jobs:
 
             -   name: Use Scoper autoload in plugin main file
                 run: |
-                    sed -i 's/autoload.php/scoper-autoload.php/' graphql-api.php
+                    sed -i 's/autoload.php/scoper-autoload.php/' ${{ fromJson(needs.matrix.outputs.plugin_config).main_file }}
                 working-directory: build/scoped-plugin
 
             # Zipping a folder from a different work dir

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -254,7 +254,7 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
-                    branch: 'master'
+                    branch: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_branch
                     package-directory: 'build/dist-plugin'
                     split-repository-organization: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_organization
                     split-repository-name: ${{ fromJson(needs.matrix.outputs.plugin_config).dist_repo_name

--- a/.github/workflows/generate_graphql_api_for_wp_plugin.yml
+++ b/.github/workflows/generate_graphql_api_for_wp_plugin.yml
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         defaults:
             run:
-                working-directory: ${{ needs.matrix.outputs.plugin_config.path }}
+                working-directory: ${{ fromJson(needs.matrix.outputs.plugin_config).path }}
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
@@ -99,7 +99,7 @@ jobs:
             -   name: Localize package paths
                 run: |
                     vendor/bin/monorepo-builder custom-bump-interdependency "dev-master"
-                    vendor/bin/monorepo-builder localize-composer-paths ${{ needs.matrix.outputs.plugin_config.path }}/composer.json --ansi
+                    vendor/bin/monorepo-builder localize-composer-paths ${{ fromJson(needs.matrix.outputs.plugin_config).path }}/composer.json --ansi
                 working-directory: .
 
             -   name: Install plugin dependencies, avoiding v2 platform check
@@ -212,13 +212,13 @@ jobs:
                     path: build
 
             -   name: Rename artifact to plugin name
-                run: mv build/scoped-plugin.zip build/${{ needs.matrix.outputs.plugin_config.zip_file }}
+                run: mv build/scoped-plugin.zip build/${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }}
 
             -   name: Upload final plugin zip as artifact
                 uses: actions/upload-artifact@v2
                 with:
                     name: generated-plugins
-                    path: build/${{ needs.matrix.outputs.plugin_config.zip_file }}
+                    path: build/${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }}
                     retention-days: 1
 
     # Only execute when doing a release
@@ -237,14 +237,14 @@ jobs:
             -   name: Upload to release
                 uses: JasonEtco/upload-to-release@master
                 with:
-                    args: build/${{ needs.matrix.outputs.plugin_config.zip_file }} application/zip
+                    args: build/${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }} application/zip
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             -   name: Uncompress artifact
                 uses: montudor/action-zip@v0.1.0
                 with:
-                    args: unzip -qq build/${{ needs.matrix.outputs.plugin_config.zip_file }} -d build/downgraded-graphql-api-for-wp
+                    args: unzip -qq build/${{ fromJson(needs.matrix.outputs.plugin_config).zip_file }} -d build/downgraded-graphql-api-for-wp
             -
                 id: previous_tag
                 uses: "WyriHaximus/github-action-get-previous-tag@master"

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -50,6 +50,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'zip_file' => 'graphql-api.zip',
             'main_file' => 'graphql-api.php',
             'exclude_files' => 'dev-helpers/\* lando/\* docs/images/\*',
+            'dist_repo_organization' => 'GraphQLAPI',
+            'dist_repo_name' => 'graphql-api-for-wp-dist',
         ],
     ]);
 

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -49,6 +49,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'path' => 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp',
             'zip_file' => 'graphql-api.zip',
             'main_file' => 'graphql-api.php',
+            'exclude_files' => 'dev-helpers/\* lando/\* docs/images/\*',
         ],
     ]);
 

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -41,6 +41,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         'graphql-api-for-wp/wordpress',
     ]);
 
+    /**
+     * Plugins to generate
+     */
+    $parameters->set(CustomOption::PLUGIN_CONFIG_ENTRIES, [
+        [
+            'path' => 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp',
+            'zip_file' => 'graphql-api.zip',
+        ],
+    ]);
+
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::DATA_TO_REMOVE, [
         'require-dev' => [

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -48,6 +48,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         [
             'path' => 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp',
             'zip_file' => 'graphql-api.zip',
+            'main_file' => 'graphql-api.php',
         ],
     ]);
 

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/PluginConfigEntriesJsonCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/PluginConfigEntriesJsonCommand.php
@@ -5,25 +5,17 @@ declare(strict_types=1);
 namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
 
 use Nette\Utils\Json;
-use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PluginConfigEntriesJsonProvider;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\PackageBuilder\Console\ShellCode;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 final class PluginConfigEntriesJsonCommand extends AbstractSymplifyCommand
 {
-    /**
-     * @var array<string, string>
-     */
-    private array $pluginConfigEntries = [];
-
-    public function __construct(
-        ParameterProvider $parameterProvider
-    ) {
+    public function __construct(private PluginConfigEntriesJsonProvider $pluginConfigEntriesJsonProvider)
+    {
         parent::__construct();
-        $this->pluginConfigEntries = $parameterProvider->provideArrayParameter(Option::PLUGIN_CONFIG_ENTRIES);
     }
 
     protected function configure(): void
@@ -33,8 +25,10 @@ final class PluginConfigEntriesJsonCommand extends AbstractSymplifyCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $pluginConfigEntries = $this->pluginConfigEntriesJsonProvider->providePluginConfigEntries();
+
         // must be without spaces, otherwise it breaks GitHub Actions json
-        $json = Json::encode($this->pluginConfigEntries);
+        $json = Json::encode($pluginConfigEntries);
         $this->symfonyStyle->writeln($json);
 
         return ShellCode::SUCCESS;

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/PluginConfigEntriesJsonCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/PluginConfigEntriesJsonCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
+
+use Nette\Utils\Json;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
+use Symplify\PackageBuilder\Console\ShellCode;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+
+final class PluginConfigEntriesJsonCommand extends AbstractSymplifyCommand
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $pluginConfigEntries = [];
+
+    public function __construct(
+        ParameterProvider $parameterProvider
+    ) {
+        parent::__construct();
+        $this->pluginConfigEntries = $parameterProvider->provideArrayParameter(Option::PLUGIN_CONFIG_ENTRIES);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Provides plugin configuration entries in json format. Useful for GitHub Actions Workflow');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // must be without spaces, otherwise it breaks GitHub Actions json
+        $json = Json::encode($this->pluginConfigEntries);
+        $this->symfonyStyle->writeln($json);
+
+        return ShellCode::SUCCESS;
+    }
+}

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
@@ -32,7 +32,11 @@ final class PluginConfigEntriesJsonProvider
         /**
          * Validate that all required entries have been provided
          */
-        $requiredEntries = ['path', 'zip_file'];
+        $requiredEntries = [
+            'path',
+            'zip_file',
+            'main_file',
+        ];
         foreach ($this->pluginConfigEntries as $entryConfig) {
             $unprovidedEntries = array_diff(
                 $requiredEntries,

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json;
+
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Utils\PackageUtils;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Package\CustomPackageProvider;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
+
+final class PluginConfigEntriesJsonProvider
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $pluginConfigEntries = [];
+
+    public function __construct(
+        ParameterProvider $parameterProvider
+    ) {
+        $this->pluginConfigEntries = $parameterProvider->provideArrayParameter(Option::PLUGIN_CONFIG_ENTRIES);
+    }
+
+    /**
+     * @param string[] $fileListFilter
+     * @return array<array<string,string>>
+     */
+    public function providePluginConfigEntries(array $fileListFilter = []): array
+    {
+        /**
+         * Validate that all required entries have been provided
+         */
+        $requiredEntries = ['path', 'zip_file'];
+        foreach ($this->pluginConfigEntries as $entryConfig) {
+            $unprovidedEntries = array_diff(
+                $requiredEntries,
+                array_keys((array) $entryConfig)
+            );
+            if ($unprovidedEntries !== []) {
+                throw new ShouldNotHappenException(sprintf(
+                    "The following entries must be provided for generating the plugin: '%s'",
+                    implode("', '", $unprovidedEntries)
+                ));
+            }
+        }
+
+        return $this->pluginConfigEntries;
+    }
+}

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
@@ -36,6 +36,8 @@ final class PluginConfigEntriesJsonProvider
             'path',
             'zip_file',
             'main_file',
+            'dist_repo_organization',
+            'dist_repo_name',
         ];
         foreach ($this->pluginConfigEntries as $entryConfig) {
             $unprovidedEntries = array_diff(

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
@@ -39,6 +39,7 @@ final class PluginConfigEntriesJsonProvider
             'dist_repo_organization',
             'dist_repo_name',
         ];
+        $pluginConfigEntries = [];
         foreach ($this->pluginConfigEntries as $entryConfig) {
             $unprovidedEntries = array_diff(
                 $requiredEntries,
@@ -50,8 +51,13 @@ final class PluginConfigEntriesJsonProvider
                     implode("', '", $unprovidedEntries)
                 ));
             }
+
+            // If it doens't specify a branch, use "master" by default
+            $entryConfig['dist_repo_branch'] ??= 'master';
+
+            $pluginConfigEntries[] = $entryConfig;
         }
 
-        return $this->pluginConfigEntries;
+        return $pluginConfigEntries;
     }
 }

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
@@ -13,6 +13,10 @@ final class Option
     /**
      * @var string
      */
+    public const PLUGIN_CONFIG_ENTRIES = 'plugin_config_entries';
+    /**
+     * @var string
+     */
     public const JSON = 'json';
     /**
      * @var string


### PR DESCRIPTION
This PR is the second step (following #553) of multiple steps to accomplish the following goal:

Transform [`generate_graphql_api_for_wp_plugin.yml`](https://github.com/leoloso/PoP/blob/bb767c90d60ae5b8b62e8ae680feaaeaab350b84/.github/workflows/generate_graphql_api_for_wp_plugin.yml) into a workflow that can generate all the plugins:

- Embed a matrix, to launch 1 instance per plugin to generate
- Pass configuration via `monorepo-builder.php`

This will enable to generate plugin `graphql-api-convert-case-directives.zip`.