### PR TITLE
Mandatory fieldArg, set without value, must also be validated

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -17,7 +17,8 @@ class SchemaHelpers
         return array_values(array_filter(
             $fieldArgProps,
             function ($fieldArgProp) use ($fieldArgs) {
-                return !array_key_exists($fieldArgProp, $fieldArgs);
+                // Do not use `empty` to avoid "0" failing
+                return !array_key_exists($fieldArgProp, $fieldArgs) || $fieldArgs[$fieldArgProp] === null || $fieldArgs[$fieldArgProp] === '' || $fieldArgs[$fieldArgProp] === [];
             }
         ));
     }


### PR DESCRIPTION
Function `getMissingFieldArgs` was only checking that the mandatory field arg is not set in the fieldArgs array. So, this worked:

```graphql
{
  customPost {
    id
  }
}
```

But this failed throwing a validation error:

```graphql
{
  customPost(id: "") {
    id
  }
}
```

It has been fixed, also checking that the value is not null, an empty string, or an empty array