### PR TITLE
Convert scope tests workflow to use matrix

### DIFF
--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
     provide_data:
-        name: Provide configuration to generate plugins
+        name: Provide configuration of scoped releases
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 
     main:
-        name: Scope the release code via PHP-Scoper, and execute tests
+        name: Scope the release via PHP-Scoper, and execute tests
         needs: provide_data
         runs-on: ubuntu-latest
         strategy:
@@ -66,25 +66,25 @@ jobs:
                     vendor/bin/monorepo-builder custom-bump-interdependency "dev-master"
                     vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.pluginConfig.path }}/composer.json --ansi
 
-            -   name: Install plugin dependencies for PROD
+            -   name: Install release dependencies for PROD
                 run: composer install --no-dev --no-progress --no-interaction --ansi
                 working-directory: ${{ matrix.pluginConfig.path }}
 
-            -   name: Install PHP-Scoper
+            -   name: Install PHP-Scoper (globally)
                 run: |
                     composer global config minimum-stability dev
                     composer global config prefer-stable true
                     composer global require humbug/php-scoper
 
             # If the scoped results correspond to vendor/ only, we should do "--output-dir ../../../../build-prefixed/vendor"
-            -   name: Scope plugin into separate folder
+            -   name: Scope code into separate folder
                 run: php-scoper add-prefix --output-dir ../../../../build-prefixed --ansi
                 working-directory: ${{ matrix.pluginConfig.path }}
 
-            -   name: Copy scoped code back into plugin
+            -   name: Copy scoped code back into original location
                 run: rsync -av build-prefixed/ ${{ matrix.pluginConfig.path }} --quiet
 
-            -   name: Regenerate autoloader
+            -   name: Regenerate autoloader for PROD
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi
                 working-directory: ${{ matrix.pluginConfig.path }}
 

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -31,16 +31,18 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json)"
+                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json --scoped-only)"
         outputs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 
     main:
-        defaults:
-            run:
-                working-directory: layers/GraphQLAPIForWP/plugins/graphql-api-for-wp
-        name: Scope the plugin code via PHP-Scoper, and execute tests
+        name: Scope the release code via PHP-Scoper, and execute tests
+        needs: provide_data
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                pluginConfig: ${{ fromJson(needs.provide_data.outputs.plugin_config_entries) }}
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
@@ -62,11 +64,11 @@ jobs:
             -   name: Localize package paths
                 run: |
                     vendor/bin/monorepo-builder custom-bump-interdependency "dev-master"
-                    vendor/bin/monorepo-builder localize-composer-paths layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json --ansi
-                working-directory: .
+                    vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.pluginConfig.path }}/composer.json --ansi
 
             -   name: Install plugin dependencies for PROD
                 run: composer install --no-dev --no-progress --no-interaction --ansi
+                working-directory: ${{ matrix.pluginConfig.path }}
 
             -   name: Install PHP-Scoper
                 run: |
@@ -77,15 +79,15 @@ jobs:
             # If the scoped results correspond to vendor/ only, we should do "--output-dir ../../../../build-prefixed/vendor"
             -   name: Scope plugin into separate folder
                 run: php-scoper add-prefix --output-dir ../../../../build-prefixed --ansi
+                working-directory: ${{ matrix.pluginConfig.path }}
 
             -   name: Copy scoped code back into plugin
-                run: rsync -av build-prefixed/ layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/ --quiet
-                working-directory: .
+                run: rsync -av build-prefixed/ ${{ matrix.pluginConfig.path }} --quiet
 
             -   name: Regenerate autoloader
                 run: composer dumpautoload --optimize --classmap-authoritative --ansi
+                working-directory: ${{ matrix.pluginConfig.path }}
 
             -   name: Run Rector on the scoped code
-                run: vendor/bin/rector process --config=layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/rector-test-scoping.php --ansi
-                working-directory: .
+                run: vendor/bin/rector process --config=${{ matrix.pluginConfig.path }}/rector-test-scoping.php --ansi
 

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -1,4 +1,8 @@
-name: Scope GraphQL API for WP tests
+####################################################################################
+# GitHub Action:
+# Test that scoping the plugins works well
+####################################################################################
+name: Scoping tests
 on:
     push:
         branches:
@@ -10,6 +14,27 @@ env:
     COMPOSER_ROOT_VERSION: "dev-master"
 
 jobs:
+    provide_data:
+        name: Provide configuration to generate plugins
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.0
+                    coverage: none
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            -   uses: "ramsey/composer-install@v1"
+
+            -   id: output_data
+                run: |
+                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json)"
+        outputs:
+            plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
+
     main:
         defaults:
             run:

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -36,7 +36,7 @@ jobs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 
     main:
-        name: Scope the release via PHP-Scoper, and execute tests
+        name: Scope the code from ${{ matrix.pluginConfig.zip_file }} (via PHP-Scoper), and execute tests
         needs: provide_data
         runs-on: ubuntu-latest
         strategy:

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/PluginConfigEntriesJsonCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/PluginConfigEntriesJsonCommand.php
@@ -6,7 +6,9 @@ namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
 
 use Nette\Utils\Json;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\Json\PluginConfigEntriesJsonProvider;
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\PackageBuilder\Console\ShellCode;
@@ -21,11 +23,18 @@ final class PluginConfigEntriesJsonCommand extends AbstractSymplifyCommand
     protected function configure(): void
     {
         $this->setDescription('Provides plugin configuration entries in json format. Useful for GitHub Actions Workflow');
+        $this->addOption(
+            Option::SCOPED_ONLY,
+            null,
+            InputOption::VALUE_NONE,
+            'Only fetch releases that must be scoped.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $pluginConfigEntries = $this->pluginConfigEntriesJsonProvider->providePluginConfigEntries();
+        $scopedOnly = (bool) $input->getOption(Option::SCOPED_ONLY);
+        $pluginConfigEntries = $this->pluginConfigEntriesJsonProvider->providePluginConfigEntries($scopedOnly);
 
         // must be without spaces, otherwise it breaks GitHub Actions json
         $json = Json::encode($pluginConfigEntries);

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/PluginConfigEntriesJsonProvider.php
@@ -25,7 +25,7 @@ final class PluginConfigEntriesJsonProvider
      * @param string[] $fileListFilter
      * @return array<array<string,string>>
      */
-    public function providePluginConfigEntries(array $fileListFilter = []): array
+    public function providePluginConfigEntries(bool $scopedOnly = false): array
     {
         /**
          * Validate that all required entries have been provided
@@ -38,7 +38,14 @@ final class PluginConfigEntriesJsonProvider
             'dist_repo_name',
         ];
         $pluginConfigEntries = [];
-        foreach ($this->pluginConfigEntries as $entryConfig) {
+        $sourcePluginConfigEntries = $this->pluginConfigEntries;
+        if ($scopedOnly) {
+            $sourcePluginConfigEntries = array_filter(
+                $sourcePluginConfigEntries,
+                fn (array $entry) => $entry['scope'] ?? false
+            );
+        }
+        foreach ($sourcePluginConfigEntries as $entryConfig) {
             $unprovidedEntries = array_diff(
                 $requiredEntries,
                 array_keys((array) $entryConfig)

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
@@ -42,4 +42,8 @@ final class Option
      * @var string
      */
     public const OUTPUT_FILE = 'output-file';
+    /**
+     * @var string
+     */
+    public const SCOPED_ONLY = 'scoped-only';
 }


### PR DESCRIPTION
Test that scoping works for any release (not only `graphql-api.zip`), as configured via `monorepo-builder.php`