### PR TITLE
[Revert #567] Mandatory fields: Only validate if key is missing

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -12,13 +12,18 @@ use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 
 class SchemaHelpers
 {
+    /**
+     * Only validate that if the key is missing, and not if the value is empty,
+     * because empty values could be allowed.
+     *
+     * Eg: `setTagsOnPost(tagIDs:[])` where `tagIDs` is mandatory
+     */
     public static function getMissingFieldArgs(array $fieldArgProps, array $fieldArgs): array
     {
         return array_values(array_filter(
             $fieldArgProps,
             function ($fieldArgProp) use ($fieldArgs) {
-                // Do not use `empty` to avoid "0" failing
-                return !array_key_exists($fieldArgProp, $fieldArgs) || $fieldArgs[$fieldArgProp] === null || $fieldArgs[$fieldArgProp] === '' || $fieldArgs[$fieldArgProp] === [];
+                return !array_key_exists($fieldArgProp, $fieldArgs);
             }
         ));
     }


### PR DESCRIPTION
This PR reverts #567.

A mandatory field could have an empty value, for instance for input `tagIDs` on this mutation:

```graphql
mutation MyMutation {
  setTagsOnPost(
    postID:1,
    append:false,
    tagIDs:[]
  ) {
    id
  }
}
```

Then, do not validate if the value for mandatory fields is empty, only if the key has been set or not.