### PR TITLE
Avoid PHP error when object can't be loaded

### DIFF
--- a/layers/API/packages/api-mirrorquery/src/DataStructureFormatters/MirrorQueryDataStructureFormatter.php
+++ b/layers/API/packages/api-mirrorquery/src/DataStructureFormatters/MirrorQueryDataStructureFormatter.php
@@ -137,7 +137,10 @@ class MirrorQueryDataStructureFormatter extends AbstractJSONDataStructureFormatt
                 $dbKey,
                 $dbObjectID
             ) = UnionTypeHelpers::extractDBObjectTypeAndID(
-                $dbObjectID
+                // If the object could not be loaded, $dbObjectID will be all ID, with no $dbKey
+                // Since that could be an int, the strict typing would throw an error,
+                // so make sure to type it as a string
+                (string) $dbObjectID
             );
         } else {
             // Add all properties requested from the object

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -753,10 +753,12 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         $ids = $this->getIDsToQuery($ids_data_fields);
         $typeDataLoaderClass = $this->getTypeDataLoaderClass();
         $typeDataLoader = $instanceManager->getInstance($typeDataLoaderClass);
-        foreach ($typeDataLoader->getObjects($ids) as $resultItem) {
+        // If any ID cannot be resolved, the resultItem will be null
+        $resultItems = array_filter($typeDataLoader->getObjects($ids));
+        foreach ($resultItems as $resultItem) {
             $resultItemID = $this->getID($resultItem);
             // If the UnionTypeResolver doesn't have a TypeResolver to process this element, the ID will be null, and an error will be show below
-            if (is_null($resultItemID)) {
+            if ($resultItemID === null) {
                 continue;
             }
             $resultIDItems[$resultItemID] = $resultItem;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/UnionTypeHelpers.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/UnionTypeHelpers.php
@@ -39,10 +39,15 @@ class UnionTypeHelpers
      */
     public static function extractDBObjectTypeAndID(string $composedDBKeyResultItemID): array
     {
-        return explode(
+        $parts = explode(
             UnionTypeSymbols::DBOBJECT_COMPOSED_TYPE_ID_SEPARATOR,
             $composedDBKeyResultItemID
         );
+        // If the object could not be loaded, $composedDBKeyResultItemID will be all ID, with no $dbKey
+        if (count($parts) === 1) {
+            return ['', $parts[0]];
+        }
+        return $parts;
     }
 
     /**

--- a/layers/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php
+++ b/layers/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php
@@ -19,10 +19,11 @@ class CustomPostUnionTypeResolver extends \PoPSchema\CustomPosts\TypeResolvers\C
         $resultItemIDTargetTypeResolvers = [];
         $instanceManager = InstanceManagerFacade::getInstance();
         $customPostUnionTypeDataLoader = $instanceManager->getInstance($this->getTypeDataLoaderClass());
-        if ($customPosts = $customPostUnionTypeDataLoader->getObjects($ids)) {
+        // If any ID cannot be resolved, the resultItem will be null
+        if ($customPosts = array_filter($customPostUnionTypeDataLoader->getObjects($ids))) {
             foreach ($customPosts as $customPost) {
                 $targetTypeResolver = $this->getTargetTypeResolver($customPost);
-                if (!is_null($targetTypeResolver)) {
+                if ($targetTypeResolver !== null) {
                     $resultItemIDTargetTypeResolvers[$targetTypeResolver->getID($customPost)] = $targetTypeResolver;
                 }
             }


### PR DESCRIPTION
When an object could not be loaded by `getObjects($ids)`, there was a PHP error.

For instance, this query retrieves custom posts, including `Event`s:

```graphql
query {
  unrestrictedCustomPosts(status:[draft,publish,pending],limit:20) {
    id
    title @upperCase
    url
    status
  }
}
```

An `Event` with scope `past` was not retrieved, because `'scope' => 'all'` was missing, throwing this error:

```
2021-04-15T16:19:14.849288139Z [Thu Apr 15 16:19:14.848918 2021] [php:error] [pid 214] [client 172.20.0.2:41396] PHP Fatal error:  Uncaught TypeError: PoP\\ComponentModel\\TypeResolvers\\AbstractUnionTypeResolver::getTargetTypeResolver(): Argument #1 ($resultItem) must be of type object, null given, called in /app/wordpress/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php on line 26 and defined in /app/wordpress/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php:357
Stack trace:
#0 /app/wordpress/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php(26): PoP\\ComponentModel\\TypeResolvers\\AbstractUnionTypeResolver->getTargetTypeResolver(NULL)
#1 /app/wordpress/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php(59): PoPSchema\\CustomPostsWP\\Overrides\\TypeResolvers\\CustomPostUnionTypeResolver->getResultItemIDTargetTypeResolvers(Array)
#2 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(1639): PoP\\ComponentModel\\TypeResolvers\\AbstractUnionTypeResolver->getQualifiedDBObjectIDOrIDs(Array)
#3 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(1524): PoP\\ComponentModel\\Engine\\Engine->processSubcomponentData(Object(PoP\\Engine\\TypeResolvers\\RootTypeResolver), Object(PoP\\Engine\\TypeResolvers\\RootTypeResolver), Array, 'GraphQLByPoP\\\\Gr...', Array, Array, Array, Array, Array)
#4 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(351): PoP\\ComponentModel\\Engine\\Engine->getDatabases()
#5 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(192): PoP\\ComponentModel\\Engine\\Engine->processAndGenerateData()
#6 /app/wordpress/Engine/packages/engine/src/Engine/Engine.php(40): PoP\\ComponentModel\\Engine\\Engine->generateData()
#7 /app/wordpress/Engine/packages/engine/src/Engine/Engine.php(62): PoP\\Engine\\Engine\\Engine->generateData()
#8 /app/wordpress/Engine/packages/engine-wp/templates/Output.php(5): PoP\\Engine\\Engine\\Engine->outputResponse()
#9 /app/wordpress/wp-content/plugins/graphql-api/src/ConditionalOnEnvironment/Admin/Services/EndpointResolvers/AdminEndpointResolver.php(125): include('/app/wordpress/...')
#10 /app/wordpress/wp-includes/class-wp-hook.php(292): GraphQLAPI\\GraphQLAPI\\ConditionalOnEnvironment\\Admin\\Services\\EndpointResolvers\\AdminEndpointResolver->GraphQLAPI\\GraphQLAPI\\ConditionalOnEnvironment\\Admin\\Services\\EndpointResolvers\\{closure}('')
#11 /app/wordpress/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters(NULL, Array)
#12 /app/wordpress/wp-includes/plugin.php(484): WP_Hook->do_action(Array)
#13 /app/wordpress/wp-admin/admin.php(175): do_action('admin_init')
#14 /app/wordpress/wp-admin/edit.php(10): require_once('/app/wordpress/...')
#15 {main}
  thrown in /app/wordpress/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php on line 357, referer: https://graphql-api.lndo.site/wp-admin/admin.php?page=graphql_api&query=query%20%7B%0A%20%20unrestrictedCustomPosts(status%3A%5Bdraft%2Cpublish%2Cpending%5D%2Climit%3A20)%20%7B%0A%20%20%20%20id%0A%20%20%20%20title%20%40upperCase%0A%20%20%20%20url%0A%20%20%20%20status%0A%20%20%7D%0A%7D
```

This PR fixes it, returning the proper error message in the response:

```json
{
  "errors": [
    {
      "message": "Either the DataLoader can't load data, or no TypeResolver resolves, object with ID '247'",
      "extensions": {
        "type": "CustomPostUnion",
        "field": "id', 'title<upperCase>', 'url', 'status"
      }
    }
  ]
}
```