### PR TITLE
Added hook to exclude fieldNames from adding to the schema

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1754,11 +1754,25 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $fieldResolver->getFieldNamesFromInterfaces()
             );
 
-            // If "Admin" Schema is disabled: Remove fields for the admin only
+            // Enable to exclude fieldNames, so they are not added to the schema.
+            $excludedFieldNames = [];
+            // Whenever:
+            // 1. Exclude the admin fields, if "Admin" Schema is not enabled
             if (!ComponentConfiguration::enableAdminSchema()) {
+                $excludedFieldNames = $fieldResolver->getAdminFieldNames();
+            }
+            // 2. By filter hook
+            $hooksAPI = HooksAPIFacade::getInstance();
+            $excludedFieldNames = $hooksAPI->applyFilters(
+                Hooks::EXCLUDE_FIELDNAMES,
+                $excludedFieldNames,
+                $fieldResolver,
+                $fieldNames
+            );
+            if ($excludedFieldNames !== []) {
                 $fieldNames = array_values(array_diff(
                     $fieldNames,
-                    $fieldResolver->getAdminFieldNames()
+                    $excludedFieldNames
                 ));
             }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/Hooks.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/Hooks.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\TypeResolvers;
+
+class Hooks
+{
+    public const EXCLUDE_FIELDNAMES = __CLASS__ . ':exclude-fieldnames';
+}


### PR DESCRIPTION
Hook `Hooks::EXCLUDE_FIELDNAMES` enables to remove fieldNames from being added to the schema.

By default, it contains the field resolver's admin fields, so these can be overridden.