### PR TITLE
Forbid access to the API by code

### DIFF
--- a/layers/Engine/packages/hooks/tests/HooksAPITest.php
+++ b/layers/Engine/packages/hooks/tests/HooksAPITest.php
@@ -7,7 +7,7 @@ namespace PoP\Hooks;
 use PHPUnit\Framework\TestCase;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\Hooks\Facades\HooksAPIFacade;
-use PoP\Hooks\ContractImplementations\HooksAPI;
+use PoP\Hooks\Services\HooksAPI;
 use PoP\Root\Container\ContainerBuilderFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/layers/Engine/packages/hooks/tests/Services/HooksAPI.php
+++ b/layers/Engine/packages/hooks/tests/Services/HooksAPI.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PoP\Hooks\ContractImplementations;
+namespace PoP\Hooks\Services;
 
 use PoP\Hooks\HooksAPIInterface;
+
 class HooksAPI implements HooksAPIInterface
 {
     public function addFilter(string $tag, callable $function_to_add, int $priority = 10, int $accepted_args = 1): void

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
@@ -11,13 +11,14 @@ use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\PersistedQueryGraphiQLBlock;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\PersistedQueryOptionsBlock;
+use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\AbstractGraphQLQueryExecutionCustomPostType;
 use GraphQLAPI\GraphQLAPI\Services\Helpers\BlockContentHelpers;
 use GraphQLAPI\GraphQLAPI\Services\Helpers\GraphQLQueryPostTypeHelpers;
 use GraphQLAPI\GraphQLAPI\Services\Menus\Menu;
-use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\AbstractGraphQLQueryExecutionCustomPostType;
 use GraphQLAPI\GraphQLAPI\Services\Taxonomies\GraphQLQueryTaxonomy;
 use GraphQLByPoP\GraphQLRequest\Hooks\VarsHooks as GraphQLRequestVarsHooks;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\Hooks\HooksAPIInterface;
 use WP_Post;
 
 class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionCustomPostType
@@ -26,13 +27,15 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
         Menu $menu,
         ModuleRegistryInterface $moduleRegistry,
         UserAuthorizationInterface $userAuthorization,
+        HooksAPIInterface $hooksAPI,
         protected BlockContentHelpers $blockContentHelpers,
         protected GraphQLQueryPostTypeHelpers $graphQLQueryPostTypeHelpers
     ) {
         parent::__construct(
             $menu,
             $moduleRegistry,
-            $userAuthorization
+            $userAuthorization,
+            $hooksAPI
         );
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/Hooks.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/Hooks.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\GraphQLAPI\Services\CustomPostTypes;
+
+class Hooks
+{
+    public const FORBID_ACCESS = __CLASS__ . ':forbid-access';
+}


### PR DESCRIPTION
Added hook to disable access to Custom Endpoints or Persisted Queries via a hook filter, triggered on the `init` hook:

```php
/**
 * Hook to forbid access to the API
 */
protected function isAccessForbidden(): bool
{
    return $this->hooksAPI->applyFilters(
        Hooks::FORBID_ACCESS,
        false
    );
}
```

This way, developers can add code to limit who can access each endpoint.

For instance, to only allow logged-in users to access some custom endpoint (knowing its ID, under `$someCustomEndpointPostID`), we can do:

```php
use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\Hooks;

add_action(
    Hooks::FORBID_ACCESS,
    function(bool $forbidAccess): bool {
        if (is_single($someCustomEndpointPostID)) {
            return is_user_logged_in();
        }
        return $forbidAccess;
    }
);
```