### PR TITLE
Schema modules can still work in the GraphQL client in the admin, so don't disable them

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/SchemaModuleResolver.php
@@ -48,21 +48,6 @@ class SchemaModuleResolver extends AbstractSchemaTypeModuleResolver
         return 90;
     }
 
-    public function getDependedModuleLists(string $module): array
-    {
-        switch ($module) {
-            case self::CONVERT_CASE_DIRECTIVES:
-                return [
-                    [
-                        EndpointFunctionalityModuleResolver::SINGLE_ENDPOINT,
-                        EndpointFunctionalityModuleResolver::PERSISTED_QUERIES,
-                        EndpointFunctionalityModuleResolver::CUSTOM_ENDPOINTS,
-                    ],
-                ];
-        }
-        return parent::getDependedModuleLists($module);
-    }
-
     public function getName(string $module): string
     {
         $names = [

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/OperationalFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/OperationalFunctionalityModuleResolver.php
@@ -66,14 +66,6 @@ class OperationalFunctionalityModuleResolver extends AbstractFunctionalityModule
     public function getDependedModuleLists(string $module): array
     {
         switch ($module) {
-            case self::MULTIPLE_QUERY_EXECUTION:
-                return [
-                    [
-                        EndpointFunctionalityModuleResolver::PERSISTED_QUERIES,
-                        EndpointFunctionalityModuleResolver::SINGLE_ENDPOINT,
-                        EndpointFunctionalityModuleResolver::CUSTOM_ENDPOINTS,
-                    ],
-                ];
             case self::REMOVE_IF_NULL_DIRECTIVE:
             case self::PROACTIVE_FEEDBACK:
             case self::EMBEDDABLE_FIELDS:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -152,18 +152,6 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
     public function getDependedModuleLists(string $module): array
     {
         switch ($module) {
-            case self::SCHEMA_USERS:
-            case self::SCHEMA_MEDIA:
-            case self::SCHEMA_CUSTOMPOSTS:
-            case self::SCHEMA_MENUS:
-            case self::SCHEMA_SETTINGS:
-                return [
-                    [
-                        EndpointFunctionalityModuleResolver::SINGLE_ENDPOINT,
-                        EndpointFunctionalityModuleResolver::PERSISTED_QUERIES,
-                        EndpointFunctionalityModuleResolver::CUSTOM_ENDPOINTS,
-                    ],
-                ];
             case self::SCHEMA_USER_ROLES:
                 return [
                     [


### PR DESCRIPTION
Removed the dependency below for schema modules, since the GraphQL client in the admin will always be enabled, so that schema modules can still be accessed.

```php
[
    EndpointFunctionalityModuleResolver::SINGLE_ENDPOINT,
    EndpointFunctionalityModuleResolver::PERSISTED_QUERIES,
    EndpointFunctionalityModuleResolver::CUSTOM_ENDPOINTS,
],
```