### PR TITLE
Fix default schema configuration settings

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -101,6 +101,7 @@ class SettingsMenuPage extends AbstractMenuPage
                                 $possibleValues = $itemSetting[Properties::POSSIBLE_VALUES] ?? [];
                                 if (
                                     in_array($type, [
+                                        Properties::TYPE_INT,
                                         Properties::TYPE_STRING,
                                         Properties::TYPE_ARRAY,
                                     ]) && !empty($possibleValues)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -99,13 +99,7 @@ class SettingsMenuPage extends AbstractMenuPage
                             function () use ($module, $itemSetting) {
                                 $type = $itemSetting[Properties::TYPE] ?? null;
                                 $possibleValues = $itemSetting[Properties::POSSIBLE_VALUES] ?? [];
-                                if (
-                                    in_array($type, [
-                                        Properties::TYPE_INT,
-                                        Properties::TYPE_STRING,
-                                        Properties::TYPE_ARRAY,
-                                    ]) && !empty($possibleValues)
-                                ) {
+                                if (!empty($possibleValues)) {
                                     $this->printSelectField($module, $itemSetting);
                                 } elseif ($type == Properties::TYPE_ARRAY && empty($possibleValues)) {
                                     $this->printTextareaField($module, $itemSetting);

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -101,7 +101,7 @@ class SettingsMenuPage extends AbstractMenuPage
                                 $possibleValues = $itemSetting[Properties::POSSIBLE_VALUES] ?? [];
                                 if (!empty($possibleValues)) {
                                     $this->printSelectField($module, $itemSetting);
-                                } elseif ($type == Properties::TYPE_ARRAY && empty($possibleValues)) {
+                                } elseif ($type == Properties::TYPE_ARRAY) {
                                     $this->printTextareaField($module, $itemSetting);
                                 } elseif ($type == Properties::TYPE_BOOL) {
                                     $this->printCheckboxField($module, $itemSetting);


### PR DESCRIPTION
The input for "Default Schema Configuration" in the settings went from a select to a normal input. Fixed it back.