### PR TITLE
Temporarily remove `mixed` type from anonymous functions

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -840,7 +840,10 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     {
         // If any casting can't be done, show an error
         if (
-            $failedCastingFieldArgs = array_filter($castedFieldArgs, function (mixed $fieldArgValue) {
+            // Temporarily commented out until Rector can downgrade `mixed` in anonymous functions
+            // @see https://github.com/leoloso/PoP/issues/626
+            // $failedCastingFieldArgs = array_filter($castedFieldArgs, function (mixed $fieldArgValue) {
+            $failedCastingFieldArgs = array_filter($castedFieldArgs, function ($fieldArgValue) {
                 return is_null($fieldArgValue);
             })
         ) {


### PR DESCRIPTION
Because Rector is currently not downgrading it. See #626 