### PR TITLE
Fixed setting dir and URL for markdown content

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/docs/en/modules/convert-case-directives.md
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/docs/en/modules/convert-case-directives.md
@@ -6,7 +6,7 @@ Set of directives to manipulate strings:
 - `@lowerCase`: converts the text to lowercase => `"hello friends"`
 - `@titleCase`: converts the text to title case => `"Hello Friends"`
 
-## Usage
+## How to use it
 
 For instance, if these query produces the results below:
 

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ContentProcessors/PluginMarkdownContentRetrieverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ContentProcessors/PluginMarkdownContentRetrieverTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\ConvertCaseDirectives\ContentProcessors;
+
+use GraphQLAPI\ConvertCaseDirectives\PluginInfo;
+
+trait PluginMarkdownContentRetrieverTrait
+{
+    /**
+     * Get the dir where to look for the documentation.
+     */
+    protected function getBaseDir(): string
+    {
+        return PluginInfo::get('dir');
+    }
+
+    /**
+     * Get the URL where to look for the documentation.
+     */
+    protected function getBaseURL(): string
+    {
+        return PluginInfo::get('url');
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/ModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/src/ModuleResolvers/ModuleResolverTrait.php
@@ -4,26 +4,11 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\ConvertCaseDirectives\ModuleResolvers;
 
-use GraphQLAPI\ConvertCaseDirectives\PluginInfo;
+use GraphQLAPI\ConvertCaseDirectives\ContentProcessors\PluginMarkdownContentRetrieverTrait;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\HasMarkdownDocumentationModuleResolverTrait;
 
 trait ModuleResolverTrait
 {
     use HasMarkdownDocumentationModuleResolverTrait;
-
-    /**
-     * Get the dir where to look for the documentation.
-     */
-    protected function getBaseDir(): string
-    {
-        return PluginInfo::get('dir');
-    }
-
-    /**
-     * Get the URL where to look for the documentation.
-     */
-    protected function getBaseURL(): string
-    {
-        return PluginInfo::get('url');
-    }
+    use PluginMarkdownContentRetrieverTrait;
 }

--- a/layers/GraphQLAPIForWP/plugins/events-manager/src/ContentProcessors/PluginMarkdownContentRetrieverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/events-manager/src/ContentProcessors/PluginMarkdownContentRetrieverTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\EventsManager\ContentProcessors;
+
+use GraphQLAPI\EventsManager\PluginInfo;
+
+trait PluginMarkdownContentRetrieverTrait
+{
+    /**
+     * Get the dir where to look for the documentation.
+     */
+    protected function getBaseDir(): string
+    {
+        return PluginInfo::get('dir');
+    }
+
+    /**
+     * Get the URL where to look for the documentation.
+     */
+    protected function getBaseURL(): string
+    {
+        return PluginInfo::get('url');
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/events-manager/src/ModuleResolvers/ModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/events-manager/src/ModuleResolvers/ModuleResolverTrait.php
@@ -4,26 +4,11 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\EventsManager\ModuleResolvers;
 
-use GraphQLAPI\EventsManager\PluginInfo;
+use GraphQLAPI\EventsManager\ContentProcessors\PluginMarkdownContentRetrieverTrait;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\HasMarkdownDocumentationModuleResolverTrait;
 
 trait ModuleResolverTrait
 {
     use HasMarkdownDocumentationModuleResolverTrait;
-
-    /**
-     * Get the dir where to look for the documentation.
-     */
-    protected function getBaseDir(): string
-    {
-        return PluginInfo::get('dir');
-    }
-
-    /**
-     * Get the URL where to look for the documentation.
-     */
-    protected function getBaseURL(): string
-    {
-        return PluginInfo::get('url');
-    }
+    use PluginMarkdownContentRetrieverTrait;
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/support.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/support.md
@@ -6,13 +6,13 @@ We provide support to use and extend the GraphQL API.
 
 ## Build a GraphQL integration
 
-We build custom extensions to integrate the GraphQL API with any WordPress website, theme or plugin.
+We build custom extensions to integrate the GraphQL API with WordPress sites, themes and plugins.
 
 Contact us at [graphql-api.com/contact](https://graphql-api.com/contact), or send an email to [contact@graphql-api.com](mailto:contact@graphql-api.com).
 
 ---
 
-## Personal support (for sponsors)
+## Personal support (paid plan)
 
 Support concerning the plugin and GraphQL is available for all [sponsors](https://github.com/sponsors/leoloso/).
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/AbstractContentParser.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/AbstractContentParser.php
@@ -17,8 +17,8 @@ abstract class AbstractContentParser implements ContentParserInterface
 {
     public const PATH_URL_TO_DOCS = 'pathURLToDocs';
 
-    protected string $baseDir;
-    protected string $baseURL;
+    protected string $baseDir = '';
+    protected string $baseURL = '';
 
     /**
      * @param string|null $baseDir Where to look for the documentation

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/MarkdownContentRetrieverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/MarkdownContentRetrieverTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\GraphQLAPI\ContentProcessors;
+
+use InvalidArgumentException;
+use GraphQLAPI\GraphQLAPI\Facades\ContentProcessors\MarkdownContentParserFacade;
+
+trait MarkdownContentRetrieverTrait
+{
+    public function getMarkdownContent(
+        string $markdownFilename,
+        string $relativePathDir = '',
+        array $options = [],
+        ?string $errorMessage = null
+    ): ?string {
+        $markdownContentParser = MarkdownContentParserFacade::getInstance();
+        // Inject the place to look for the documentation
+        $markdownContentParser->setBaseDir($this->getBaseDir());
+        $markdownContentParser->setBaseURL($this->getBaseURL());
+        try {
+            return $markdownContentParser->getContent(
+                $markdownFilename,
+                $relativePathDir,
+                $options
+            );
+        } catch (InvalidArgumentException) {
+            $errorMessage ??= sprintf(
+                \__('Oops, there was a problem retrieving content from file \'%s\'', 'graphql-api'),
+                $markdownFilename
+            );
+            return sprintf(
+                '<p>%s</p>',
+                $errorMessage
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Get the dir where to look for the documentation.
+     */
+    abstract protected function getBaseDir(): string;
+
+    /**
+     * Get the URL where to look for the documentation.
+     */
+    abstract protected function getBaseURL(): string;
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/PluginMarkdownContentRetrieverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ContentProcessors/PluginMarkdownContentRetrieverTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\GraphQLAPI\ContentProcessors;
+
+use GraphQLAPI\GraphQLAPI\PluginInfo;
+
+trait PluginMarkdownContentRetrieverTrait
+{
+    /**
+     * Get the dir where to look for the documentation.
+     */
+    protected function getBaseDir(): string
+    {
+        return PluginInfo::get('dir');
+    }
+
+    /**
+     * Get the URL where to look for the documentation.
+     */
+    protected function getBaseURL(): string
+    {
+        return PluginInfo::get('url');
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/HasMarkdownDocumentationModuleResolverTrait.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\ModuleResolvers;
 
 use GraphQLAPI\GraphQLAPI\ContentProcessors\ContentParserOptions;
-use InvalidArgumentException;
-use GraphQLAPI\GraphQLAPI\Facades\ContentProcessors\MarkdownContentParserFacade;
+use GraphQLAPI\GraphQLAPI\ContentProcessors\MarkdownContentRetrieverTrait;
 
 trait HasMarkdownDocumentationModuleResolverTrait
 {
+    use MarkdownContentRetrieverTrait;
+
     /**
      * The module slug
      */
@@ -38,35 +39,18 @@ trait HasMarkdownDocumentationModuleResolverTrait
     public function getDocumentation(string $module): ?string
     {
         if ($markdownFilename = $this->getMarkdownFilename($module)) {
-            $markdownContentParser = MarkdownContentParserFacade::getInstance();
-            // Inject the place to look for the documentation
-            $markdownContentParser->setBaseDir($this->getBaseDir());
-            $markdownContentParser->setBaseURL($this->getBaseURL());
-            try {
-                return $markdownContentParser->getContent(
-                    'modules/' . $markdownFilename,
-                    'modules',
-                    [
-                        ContentParserOptions::TAB_CONTENT => true,
-                    ]
-                );
-            } catch (InvalidArgumentException) {
-                return sprintf(
+            return $this->getMarkdownContent(
+                'modules/' . $markdownFilename,
+                'modules',
+                [
+                    ContentParserOptions::TAB_CONTENT => true,
+                ],
+                sprintf(
                     '<p>%s</p>',
                     \__('Oops, the documentation for this module is not available', 'graphql-api')
-                );
-            }
+                )
+            );
         }
         return null;
     }
-
-    /**
-     * Get the dir where to look for the documentation.
-     */
-    abstract protected function getBaseDir(): string;
-
-    /**
-     * Get the URL where to look for the documentation.
-     */
-    abstract protected function getBaseURL(): string;
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverTrait.php
@@ -4,26 +4,11 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\ModuleResolvers;
 
+use GraphQLAPI\GraphQLAPI\ContentProcessors\PluginMarkdownContentRetrieverTrait;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\HasMarkdownDocumentationModuleResolverTrait;
-use GraphQLAPI\GraphQLAPI\PluginInfo;
 
 trait ModuleResolverTrait
 {
     use HasMarkdownDocumentationModuleResolverTrait;
-
-    /**
-     * Get the dir where to look for the documentation.
-     */
-    protected function getBaseDir(): string
-    {
-        return PluginInfo::get('dir');
-    }
-
-    /**
-     * Get the URL where to look for the documentation.
-     */
-    protected function getBaseURL(): string
-    {
-        return PluginInfo::get('url');
-    }
+    use PluginMarkdownContentRetrieverTrait;
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AboutMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AboutMenuPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Services\MenuPages;
 
 use GraphQLAPI\GraphQLAPI\ContentProcessors\ContentParserOptions;
+use GraphQLAPI\GraphQLAPI\ContentProcessors\PluginMarkdownContentRetrieverTrait;
 use GraphQLAPI\GraphQLAPI\Facades\ContentProcessors\MarkdownContentParserFacade;
 use InvalidArgumentException;
 
@@ -14,6 +15,7 @@ use InvalidArgumentException;
 class AboutMenuPage extends AbstractDocsMenuPage
 {
     use OpenInModalTriggerMenuPageTrait;
+    use PluginMarkdownContentRetrieverTrait;
 
     public function getMenuPageSlug(): string
     {
@@ -35,15 +37,17 @@ class AboutMenuPage extends AbstractDocsMenuPage
 
     protected function getContentToPrint(): string
     {
-        $markdownContentParser = MarkdownContentParserFacade::getInstance();
-        try {
-            return $markdownContentParser->getContent('about.md', '', [ContentParserOptions::TAB_CONTENT => true]);
-        } catch (InvalidArgumentException) {
-            return sprintf(
+        return $this->getMarkdownContent(
+            'about.md',
+            '',
+            [
+                ContentParserOptions::TAB_CONTENT => true,
+            ],
+            sprintf(
                 '<p>%s</p>',
                 \__('Oops, there was a problem loading the page', 'graphql-api')
-            );
-        }
+            )
+        );
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocAboutMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocAboutMenuPage.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Services\MenuPages;
 
-use InvalidArgumentException;
 use GraphQLAPI\GraphQLAPI\Constants\RequestParams;
-use GraphQLAPI\GraphQLAPI\Facades\ContentProcessors\MarkdownContentParserFacade;
+use GraphQLAPI\GraphQLAPI\ContentProcessors\MarkdownContentRetrieverTrait;
 
 /**
  * Open documentation within the About page
  */
 abstract class AbstractDocAboutMenuPage extends AbstractDocsMenuPage
 {
+    use MarkdownContentRetrieverTrait;
+
     protected function openInModalWindow(): bool
     {
         return true;
@@ -52,17 +53,14 @@ abstract class AbstractDocAboutMenuPage extends AbstractDocsMenuPage
             'sanitize_file_name_chars',
             [$this, 'enableSpecialCharsForSanitization']
         );
-        $markdownContentParser = MarkdownContentParserFacade::getInstance();
-        try {
-            return $markdownContentParser->getContent($doc, $this->getRelativePathDir());
-        } catch (InvalidArgumentException) {
-            return sprintf(
-                '<p>%s</p>',
-                sprintf(
-                    \__('Page \'%s\' does not exist', 'graphql-api'),
-                    $doc
-                )
-            );
-        }
+        return $this->getMarkdownContent(
+            $doc,
+            $this->getRelativePathDir(),
+            [],
+            sprintf(
+                \__('Page \'%s\' does not exist', 'graphql-api'),
+                $doc
+            )
+        );
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/AbstractDocsMenuPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Services\MenuPages;
 
+use GraphQLAPI\GraphQLAPI\ContentProcessors\MarkdownContentRetrieverTrait;
 use GraphQLAPI\GraphQLAPI\Services\MenuPages\AbstractMenuPage;
 
 /**
@@ -13,6 +14,7 @@ abstract class AbstractDocsMenuPage extends AbstractMenuPage
 {
     use OpenInModalMenuPageTrait;
     use UseTabpanelMenuPageTrait;
+    use MarkdownContentRetrieverTrait;
 
     public function print(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ModuleDocumentationMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ModuleDocumentationMenuPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Services\MenuPages;
 
 use GraphQLAPI\GraphQLAPI\Constants\RequestParams;
+use GraphQLAPI\GraphQLAPI\ContentProcessors\PluginMarkdownContentRetrieverTrait;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Services\Helpers\EndpointHelpers;
 use GraphQLAPI\GraphQLAPI\Services\Helpers\MenuPageHelper;
@@ -19,6 +20,8 @@ use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
  */
 class ModuleDocumentationMenuPage extends AbstractDocsMenuPage
 {
+    use PluginMarkdownContentRetrieverTrait;
+
     function __construct(
         Menu $menu,
         MenuPageHelper $menuPageHelper,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ReleaseNotesAboutMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/ReleaseNotesAboutMenuPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Services\MenuPages;
 
+use GraphQLAPI\GraphQLAPI\ContentProcessors\PluginMarkdownContentRetrieverTrait;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 
 /**
@@ -11,6 +12,8 @@ use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
  */
 class ReleaseNotesAboutMenuPage extends AbstractDocAboutMenuPage
 {
+    use PluginMarkdownContentRetrieverTrait;
+
     public function getMenuPageSlug(): string
     {
         $instanceManager = InstanceManagerFacade::getInstance();

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SupportMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SupportMenuPage.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\Services\MenuPages;
 
-use InvalidArgumentException;
 use GraphQLAPI\GraphQLAPI\ContentProcessors\ContentParserOptions;
-use GraphQLAPI\GraphQLAPI\Facades\ContentProcessors\MarkdownContentParserFacade;
+use GraphQLAPI\GraphQLAPI\ContentProcessors\PluginMarkdownContentRetrieverTrait;
 
 /**
  * Support menu page
@@ -14,6 +13,7 @@ use GraphQLAPI\GraphQLAPI\Facades\ContentProcessors\MarkdownContentParserFacade;
 class SupportMenuPage extends AbstractDocsMenuPage
 {
     use OpenInModalTriggerMenuPageTrait;
+    use PluginMarkdownContentRetrieverTrait;
 
     public function getMenuPageSlug(): string
     {
@@ -27,14 +27,16 @@ class SupportMenuPage extends AbstractDocsMenuPage
 
     protected function getContentToPrint(): string
     {
-        $markdownContentParser = MarkdownContentParserFacade::getInstance();
-        try {
-            return $markdownContentParser->getContent('support.md', '', [ContentParserOptions::TAB_CONTENT => false]);
-        } catch (InvalidArgumentException) {
-            return sprintf(
+        return $this->getMarkdownContent(
+            'support.md',
+            '',
+            [
+                ContentParserOptions::TAB_CONTENT => false,
+            ],
+            sprintf(
                 '<p>%s</p>',
                 \__('Oops, there was a problem loading the page', 'graphql-api')
-            );
-        }
+            )
+        );
     }
 }


### PR DESCRIPTION
This PR fixes rendering `support.md`, since `setBaseDir` and `setBaseURL` for the `MarkdownContentParser` service were not being called.