### PR TITLE
Fix editing persisted query issue

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLQueryExecutionCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLQueryExecutionCustomPostType.php
@@ -287,11 +287,11 @@ abstract class AbstractGraphQLQueryExecutionCustomPostType extends AbstractCusto
     /**
      * Indicate if the GraphQL variables must override the URL params
      */
-    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int|null $postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(?WP_Post $customPost): bool
     {
         // If null, we are in the admin (eg: editing a Persisted Query),
         // and there's no need to override params
-        return $postOrID !== null;
+        return $customPost !== null;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLQueryExecutionCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLQueryExecutionCustomPostType.php
@@ -287,9 +287,11 @@ abstract class AbstractGraphQLQueryExecutionCustomPostType extends AbstractCusto
     /**
      * Indicate if the GraphQL variables must override the URL params
      */
-    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int $postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int|null $postOrID): bool
     {
-        return true;
+        // If null, we are in the admin (eg: editing a Persisted Query),
+        // and there's no need to override params
+        return $postOrID !== null;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
@@ -293,11 +293,14 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
     /**
      * Indicate if the GraphQL variables must override the URL params
      */
-    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int $postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int|null $postOrID): bool
     {
+        if ($postOrID === null) {
+            return parent::doURLParamsOverrideGraphQLVariables($postOrID);
+        }
         $default = true;
         $optionsBlockDataItem = $this->getOptionsBlockDataItem($postOrID);
-        if (is_null($optionsBlockDataItem)) {
+        if ($optionsBlockDataItem === null) {
             return $default;
         }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryCustomPostType.php
@@ -293,13 +293,13 @@ class GraphQLPersistedQueryCustomPostType extends AbstractGraphQLQueryExecutionC
     /**
      * Indicate if the GraphQL variables must override the URL params
      */
-    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int|null $postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(?WP_Post $customPost): bool
     {
-        if ($postOrID === null) {
-            return parent::doURLParamsOverrideGraphQLVariables($postOrID);
+        if ($customPost === null) {
+            return parent::doURLParamsOverrideGraphQLVariables($customPost);
         }
         $default = true;
-        $optionsBlockDataItem = $this->getOptionsBlockDataItem($postOrID);
+        $optionsBlockDataItem = $this->getOptionsBlockDataItem($customPost);
         if ($optionsBlockDataItem === null) {
             return $default;
         }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/EndpointResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/EndpointResolverTrait.php
@@ -64,7 +64,7 @@ trait EndpointResolverTrait
     /**
      * Indicate if the GraphQL variables must override the URL params
      */
-    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int|null $postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(?WP_Post $customPost): bool
     {
         return false;
     }
@@ -113,8 +113,8 @@ trait EndpointResolverTrait
             // Normally, GraphQL variables must not override the variables from the request
             // But this behavior can be overriden for the persisted query,
             // by setting "Accept Variables as URL Params" => false
-            // When editing in the editor, 'queried-object-id' will be false, and that's OK
-            $vars['variables'] = $this->doURLParamsOverrideGraphQLVariables($vars['routing-state']['queried-object-id']) ?
+            // When editing in the editor, 'queried-object' will be null, and that's OK
+            $vars['variables'] = $this->doURLParamsOverrideGraphQLVariables($vars['routing-state']['queried-object']) ?
                 array_merge(
                     $graphQLVariables,
                     $vars['variables'] ?? []

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/EndpointResolverTrait.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/EndpointResolvers/EndpointResolverTrait.php
@@ -64,7 +64,7 @@ trait EndpointResolverTrait
     /**
      * Indicate if the GraphQL variables must override the URL params
      */
-    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int $postOrID): bool
+    protected function doURLParamsOverrideGraphQLVariables(WP_Post|int|null $postOrID): bool
     {
         return false;
     }
@@ -113,6 +113,7 @@ trait EndpointResolverTrait
             // Normally, GraphQL variables must not override the variables from the request
             // But this behavior can be overriden for the persisted query,
             // by setting "Accept Variables as URL Params" => false
+            // When editing in the editor, 'queried-object-id' will be false, and that's OK
             $vars['variables'] = $this->doURLParamsOverrideGraphQLVariables($vars['routing-state']['queried-object-id']) ?
                 array_merge(
                     $graphQLVariables,


### PR DESCRIPTION
Fixed error, happening when running a query in GraphiQL when editing a persisted query:

```
2021-04-21T04:42:07.354188995Z [Wed Apr 21 04:42:07.353755 2021] [php:error] [pid 1061] [client 172.20.0.2:45984] PHP Fatal error:  Uncaught TypeError: GraphQLAPI\\GraphQLAPI\\ConditionalOnEnvironment\\Admin\\Services\\EndpointResolvers\\AdminEndpointResolver::doURLParamsOverrideGraphQLVariables(): Argument #1 ($postOrID) must be of type WP_Post|int, null given, called in /app/wordpress/wp-content/plugins/graphql-api/src/Services/EndpointResolvers/EndpointResolverTrait.php on line 116 and defined in /app/wordpress/wp-content/plugins/graphql-api/src/Services/EndpointResolvers/EndpointResolverTrait.php:67
Stack trace:
#0 /app/wordpress/wp-content/plugins/graphql-api/src/Services/EndpointResolvers/EndpointResolverTrait.php(116): GraphQLAPI\\GraphQLAPI\\ConditionalOnEnvironment\\Admin\\Services\\EndpointResolvers\\AdminEndpointResolver->doURLParamsOverrideGraphQLVariables(NULL)
#1 /app/wordpress/wp-includes/class-wp-hook.php(292): GraphQLAPI\\GraphQLAPI\\ConditionalOnEnvironment\\Admin\\Services\\EndpointResolvers\\AdminEndpointResolver->addGraphQLVars(Array)
#2 /app/wordpress/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters(NULL, Array)
#3 /app/wordpress/wp-includes/plugin.php(484): WP_Hook->do_action(Array)
#4 /app/wordpress/Engine/packages/hooks-wp/src/HooksAPI.php(33): do_action('ApplicationStat...', Array)
#5 /app/wordpress/Engine/packages/component-model/src/State/ApplicationState.php(207): PoP\\HooksWP\\HooksAPI->doAction('ApplicationStat...', Array)
#6 /app/wordpress/Schema/packages/user-state-access-control/src/Hooks/AbstractUserStateConfigurableAccessControlForDirectivesInPrivateSchemaHookSet.php(16): PoP\\ComponentModel\\State\\ApplicationState::getVars()
#7 /app/wordpress/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php(18): PoPSchema\\UserStateAccessControl\\Hooks\\AbstractUserStateConfigurableAccessControlForDirectivesInPrivateSchemaHookSet->enabled()
#8 /app/wordpress/wp-includes/class-wp-hook.php(292): PoP\\AccessControl\\Hooks\\AbstractAccessControlForDirectivesHookSet->cmsBoot('')
#9 /app/wordpress/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters(NULL, Array)
#10 /app/wordpress/wp-includes/plugin.php(484): WP_Hook->do_action(Array)
#11 /app/wordpress/Engine/packages/hooks-wp/src/HooksAPI.php(33): do_action('popcms:boot')
#12 /app/wordpress/Engine/packages/engine-wp/src/LooseContracts/LooseContractResolutionSet.php(24): PoP\\HooksWP\\HooksAPI->doAction('popcms:boot')
#13 /app/wordpress/wp-includes/class-wp-hook.php(292): PoP\\EngineWP\\LooseContracts\\LooseContractResolutionSet->PoP\\EngineWP\\LooseContracts\\{closure}('')
#14 /app/wordpress/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters(NULL, Array)
#15 /app/wordpress/wp-includes/plugin.php(484): WP_Hook->do_action(Array)
#16 /app/wordpress/wp-settings.php(582): do_action('wp_loaded')
#17 /app/wordpress/wp-config.php(78): require_once('/app/wordpress/...')
#18 /app/wordpress/wp-load.php(37): require_once('/app/wordpress/...')
#19 /app/wordpress/wp-admin/admin.php(34): require_once('/app/wordpress/...')
#20 /app/wordpress/wp-admin/edit.php(10): require_once('/app/wordpress/...')
#21 {main}
  thrown in /app/wordpress/wp-content/plugins/graphql-api/src/Services/EndpointResolvers/EndpointResolverTrait.php on line 67, referer: https://graphql-api.lndo.site/wp-admin/post.php?post=65&action=edit
```