### PR TITLE
Only autoconfigurable services are inititalized by the compiler pass

### DIFF
--- a/layers/API/packages/api-endpoints-for-wp/config/services.yaml
+++ b/layers/API/packages/api-endpoints-for-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\APIEndpointsForWP\EndpointHandlers\:
         resource: '../src/EndpointHandlers/*'

--- a/layers/API/packages/api-graphql/config/services.yaml
+++ b/layers/API/packages/api-graphql/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\GraphQLAPI\DataStructureFormatters\:
         resource: '../src/DataStructureFormatters/*'

--- a/layers/API/packages/api-mirrorquery/config/services.yaml
+++ b/layers/API/packages/api-mirrorquery/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\APIMirrorQuery\DataStructureFormatters\:
         resource: '../src/DataStructureFormatters/*'

--- a/layers/API/packages/api-rest/config/services.yaml
+++ b/layers/API/packages/api-rest/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\RESTAPI\RouteModuleProcessors\:
         resource: '../src/RouteModuleProcessors/*'

--- a/layers/API/packages/api/config/Conditional/AccessControl/services.yaml
+++ b/layers/API/packages/api/config/Conditional/AccessControl/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\API\Conditional\AccessControl\Hooks\:
         resource: '../../../src/Conditional/AccessControl/Hooks/*'

--- a/layers/API/packages/api/config/services.yaml
+++ b/layers/API/packages/api/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\API\Schema\FieldQueryConvertorInterface:
         class: \PoP\API\Schema\FieldQueryConvertor

--- a/layers/Engine/packages/access-control/config/services.yaml
+++ b/layers/Engine/packages/access-control/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\AccessControl\Services\AccessControlManagerInterface:
         class: \PoP\AccessControl\Services\AccessControlManager

--- a/layers/Engine/packages/cache-control/config/services.yaml
+++ b/layers/Engine/packages/cache-control/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\CacheControl\Managers\CacheControlEngineInterface:
         class: \PoP\CacheControl\Managers\CacheControlEngine

--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     memory_cache_item_pool:
         class: \Symfony\Component\Cache\Adapter\ArrayAdapter

--- a/layers/Engine/packages/component-model/config/system-services.yaml
+++ b/layers/Engine/packages/component-model/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ComponentModel\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/Engine/packages/configurable-schema-feedback/config/services.yaml
+++ b/layers/Engine/packages/configurable-schema-feedback/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ConfigurableSchemaFeedback\Managers\SchemaFeedbackManagerInterface:
         class: \PoP\ConfigurableSchemaFeedback\Managers\SchemaFeedbackManager

--- a/layers/Engine/packages/definitions/config/services.yaml
+++ b/layers/Engine/packages/definitions/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Definitions\DefinitionManagerInterface:
         class: \PoP\Definitions\DefinitionManager

--- a/layers/Engine/packages/engine-wp/config/services.yaml
+++ b/layers/Engine/packages/engine-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Engine\ErrorHandling\ErrorManagerInterface:
         class: \PoP\EngineWP\ErrorHandling\ErrorManager

--- a/layers/Engine/packages/engine/config/Overrides/services.yaml
+++ b/layers/Engine/packages/engine/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ComponentModel\Engine\EngineInterface:
         class: \PoP\Engine\Engine\Engine

--- a/layers/Engine/packages/engine/config/services.yaml
+++ b/layers/Engine/packages/engine/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     persistent_cache:
         class: \PoP\Engine\Cache\Cache

--- a/layers/Engine/packages/field-query/config/services.yaml
+++ b/layers/Engine/packages/field-query/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ComponentModel\Schema\FeedbackMessageStoreInterface:
         class: \PoP\FieldQuery\FeedbackMessageStore

--- a/layers/Engine/packages/filestore/config/services.yaml
+++ b/layers/Engine/packages/filestore/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     file_store:
         class: \PoP\FileStore\Store\FileStore

--- a/layers/Engine/packages/hooks-wp/config/services.yaml
+++ b/layers/Engine/packages/hooks-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Hooks\HooksAPIInterface:
         class: \PoP\HooksWP\HooksAPI

--- a/layers/Engine/packages/loosecontracts/config/services.yaml
+++ b/layers/Engine/packages/loosecontracts/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\LooseContracts\LooseContractManagerInterface:
         class: \PoP\LooseContracts\LooseContractManager

--- a/layers/Engine/packages/modulerouting/config/system-services.yaml
+++ b/layers/Engine/packages/modulerouting/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ModuleRouting\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/Engine/packages/query-parsing/config/services.yaml
+++ b/layers/Engine/packages/query-parsing/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\QueryParsing\QueryParserInterface:
         class: \PoP\QueryParsing\QueryParser

--- a/layers/Engine/packages/root/config/hybrid-services.yaml
+++ b/layers/Engine/packages/root/config/hybrid-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Root\Container\ServiceInstantiatorInterface:
         class: \PoP\Root\Container\ServiceInstantiator

--- a/layers/Engine/packages/root/config/system-services.yaml
+++ b/layers/Engine/packages/root/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Root\Registries\CompilerPassRegistryInterface:
         class: \PoP\Root\Registries\CompilerPassRegistry

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -8,6 +8,8 @@ use PoP\Root\Container\ContainerBuilderWrapperInterface;
 
 abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCompilerPass
 {
+    use AutoconfigurableServicesCompilerPassTrait;
+    
     protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         $registryDefinition = $containerBuilderWrapper->getDefinition($this->getRegistryServiceDefinition());
@@ -26,14 +28,19 @@ abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCom
                 continue;
             }
 
-            // Register the service in the corresponding registry
-            $registryDefinition->addMethodCall(
-                $this->getRegistryMethodCallName(),
-                [
-                    $this->createReference($definitionID),
-                    $definitionID
-                ]
-            );
+            $onlyAddAutoconfigurableServices = $this->onlyAddAutoconfigurableServices();
+            if (!$onlyAddAutoconfigurableServices
+                || ($onlyAddAutoconfigurableServices && $definition->isAutoconfigured())
+            ) {
+                // Register the service in the corresponding registry
+                $registryDefinition->addMethodCall(
+                    $this->getRegistryMethodCallName(),
+                    [
+                        $this->createReference($definitionID),
+                        $definitionID
+                    ]
+                );
+            }
         }
     }
 

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInjectServiceIntoRegistryCompilerPass.php
@@ -9,7 +9,7 @@ use PoP\Root\Container\ContainerBuilderWrapperInterface;
 abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCompilerPass
 {
     use AutoconfigurableServicesCompilerPassTrait;
-    
+
     protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         $registryDefinition = $containerBuilderWrapper->getDefinition($this->getRegistryServiceDefinition());
@@ -28,9 +28,9 @@ abstract class AbstractInjectServiceIntoRegistryCompilerPass extends AbstractCom
                 continue;
             }
 
-            $onlyAddAutoconfigurableServices = $this->onlyAddAutoconfigurableServices();
-            if (!$onlyAddAutoconfigurableServices
-                || ($onlyAddAutoconfigurableServices && $definition->isAutoconfigured())
+            $onlyProcessAutoconfiguredServices = $this->onlyProcessAutoconfiguredServices();
+            if (!$onlyProcessAutoconfiguredServices
+                || ($onlyProcessAutoconfiguredServices && $definition->isAutoconfigured())
             ) {
                 // Register the service in the corresponding registry
                 $registryDefinition->addMethodCall(

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
@@ -9,6 +9,8 @@ use PoP\Root\Container\ServiceInstantiatorInterface;
 
 abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPass
 {
+    use AutoconfigurableServicesCompilerPassTrait;
+
     protected function doProcess(ContainerBuilderWrapperInterface $containerBuilderWrapper): void
     {
         $serviceInstantiatorDefinition = $containerBuilderWrapper->getDefinition(ServiceInstantiatorInterface::class);
@@ -20,10 +22,15 @@ abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPa
                 continue;
             }
 
-            $serviceInstantiatorDefinition->addMethodCall(
-                'addService',
-                [$this->createReference($definitionID)]
-            );
+            $onlyAddAutoconfigurableServices = $this->onlyAddAutoconfigurableServices();
+            if (!$onlyAddAutoconfigurableServices
+                || ($onlyAddAutoconfigurableServices && $definition->isAutoconfigured())
+            ) {
+                $serviceInstantiatorDefinition->addMethodCall(
+                    'addService',
+                    [$this->createReference($definitionID)]
+                );
+            }
         }
     }
 

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AbstractInstantiateServiceCompilerPass.php
@@ -22,9 +22,9 @@ abstract class AbstractInstantiateServiceCompilerPass extends AbstractCompilerPa
                 continue;
             }
 
-            $onlyAddAutoconfigurableServices = $this->onlyAddAutoconfigurableServices();
-            if (!$onlyAddAutoconfigurableServices
-                || ($onlyAddAutoconfigurableServices && $definition->isAutoconfigured())
+            $onlyProcessAutoconfiguredServices = $this->onlyProcessAutoconfiguredServices();
+            if (!$onlyProcessAutoconfiguredServices
+                || ($onlyProcessAutoconfiguredServices && $definition->isAutoconfigured())
             ) {
                 $serviceInstantiatorDefinition->addMethodCall(
                     'addService',

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AutoconfigurableServicesCompilerPassTrait.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AutoconfigurableServicesCompilerPassTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Container\CompilerPasses;
+
+trait AutoconfigurableServicesCompilerPassTrait
+{
+    protected function onlyAddAutoconfigurableServices(): bool
+    {
+        return true;
+    }
+}

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AutoconfigurableServicesCompilerPassTrait.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AutoconfigurableServicesCompilerPassTrait.php
@@ -8,6 +8,6 @@ trait AutoconfigurableServicesCompilerPassTrait
 {
     protected function onlyAddAutoconfigurableServices(): bool
     {
-        return true;
+        return false;
     }
 }

--- a/layers/Engine/packages/root/src/Container/CompilerPasses/AutoconfigurableServicesCompilerPassTrait.php
+++ b/layers/Engine/packages/root/src/Container/CompilerPasses/AutoconfigurableServicesCompilerPassTrait.php
@@ -6,7 +6,7 @@ namespace PoP\Root\Container\CompilerPasses;
 
 trait AutoconfigurableServicesCompilerPassTrait
 {
-    protected function onlyAddAutoconfigurableServices(): bool
+    protected function onlyProcessAutoconfiguredServices(): bool
     {
         return false;
     }

--- a/layers/Engine/packages/root/src/Container/HybridCompilerPasses/AutomaticallyInstantiatedServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/HybridCompilerPasses/AutomaticallyInstantiatedServiceCompilerPass.php
@@ -9,6 +9,11 @@ use PoP\Root\Services\AutomaticallyInstantiatedServiceInterface;
 
 class AutomaticallyInstantiatedServiceCompilerPass extends AbstractInstantiateServiceCompilerPass
 {
+    protected function onlyAddAutoconfigurableServices(): bool
+    {
+        return true;
+    }
+    
     protected function getServiceClass(): string
     {
         return AutomaticallyInstantiatedServiceInterface::class;

--- a/layers/Engine/packages/root/src/Container/HybridCompilerPasses/AutomaticallyInstantiatedServiceCompilerPass.php
+++ b/layers/Engine/packages/root/src/Container/HybridCompilerPasses/AutomaticallyInstantiatedServiceCompilerPass.php
@@ -9,11 +9,11 @@ use PoP\Root\Services\AutomaticallyInstantiatedServiceInterface;
 
 class AutomaticallyInstantiatedServiceCompilerPass extends AbstractInstantiateServiceCompilerPass
 {
-    protected function onlyAddAutoconfigurableServices(): bool
+    protected function onlyProcessAutoconfiguredServices(): bool
     {
         return true;
     }
-    
+
     protected function getServiceClass(): string
     {
         return AutomaticallyInstantiatedServiceInterface::class;

--- a/layers/Engine/packages/routing-wp/config/services.yaml
+++ b/layers/Engine/packages/routing-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Routing\RoutingManagerInterface:
         class: \PoP\RoutingWP\RoutingManager

--- a/layers/Engine/packages/translation-wp/config/services.yaml
+++ b/layers/Engine/packages/translation-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Translation\TranslationAPIInterface:
         class: \PoP\TranslationWP\TranslationAPI

--- a/layers/GraphQLAPIForWP/packages/markdown-convertor/config/services.yaml
+++ b/layers/GraphQLAPIForWP/packages/markdown-convertor/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\MarkdownConvertor\MarkdownConvertorInterface:
         class: \GraphQLAPI\MarkdownConvertor\MarkdownConvertor

--- a/layers/GraphQLAPIForWP/plugins/convert-case-directives/config/module-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/convert-case-directives/config/module-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\ConvertCaseDirectives\ModuleResolvers\:
         resource: '../src/ModuleResolvers/*'

--- a/layers/GraphQLAPIForWP/plugins/events-manager/config/module-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/events-manager/config/module-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\EventsManager\ModuleResolvers\:
         resource: '../src/ModuleResolvers/*'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/Admin/ConditionalOnEnvironment/GraphiQLExplorerInAdminClient/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/Admin/ConditionalOnEnvironment/GraphiQLExplorerInAdminClient/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\GraphQLAPI\Services\MenuPages\GraphiQLMenuPage:
         class: '\GraphQLAPI\GraphQLAPI\ConditionalOnEnvironment\Admin\ConditionalOnEnvironment\GraphiQLExplorerInAdminClient\Overrides\Services\MenuPages\GraphiQLMenuPage'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/Admin/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/Admin/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\GraphQLAPI\ConditionalOnEnvironment\Admin\Services\:
         resource: '../../../src/ConditionalOnEnvironment/Admin/Services/*'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/Admin/system-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/Admin/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     # These classes are invoked after `bootSystem` and before `bootApplication`
     GraphQLAPI\GraphQLAPI\ConditionalOnEnvironment\Admin\SystemServices\:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/CacheControl/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/CacheControl/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     # Override service, to disable caching when doing a preview
     PoP\CacheControl\Managers\CacheControlEngineInterface:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/GraphiQLExplorerInAdminPersistedQueries/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/GraphiQLExplorerInAdminPersistedQueries/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\GraphQLAPI\Services\Blocks\PersistedQueryGraphiQLBlock:
         class: '\GraphQLAPI\GraphQLAPI\ConditionalOnEnvironment\GraphiQLExplorerInAdminPersistedQueries\Overrides\Services\Blocks\PersistedQueryGraphiQLWithExplorerBlock'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/GraphiQLExplorerInCustomEndpointPublicClient/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/GraphiQLExplorerInCustomEndpointPublicClient/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     # Override the GraphiQL clients
     GraphQLAPI\GraphQLAPI\Services\Clients\CustomEndpointGraphiQLClient:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/GraphiQLExplorerInSingleEndpointPublicClient/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/ConditionalOnEnvironment/GraphiQLExplorerInSingleEndpointPublicClient/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     # Override the GraphiQL clients
     GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLClient:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/Overrides/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     # Make sure the GraphiQL client is used, without the Explorer
     # Because if isGraphiQLExplorerEnabled might be true, the explorer is enabled

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/hybrid-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/hybrid-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface:
         class: \GraphQLAPI\GraphQLAPI\Registries\ModuleRegistry

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/module-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/module-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\GraphQLAPI\ModuleResolvers\:
         resource: '../src/ModuleResolvers/*'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\GraphQLAPI\ContentProcessors\MarkdownContentParserInterface:
         class: '\GraphQLAPI\GraphQLAPI\ContentProcessors\MarkdownContentParser'

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
@@ -12,12 +12,19 @@ services:
 
     # All these services are required to maybe execute ModuleListTableAction in Plugin.php
     # Hence, they are defined both in the Application and System containers
+    # Please notice: they must NOT be autoconfigured!
+    # Otherwise, they will also be inititalized twice.
+    # @see https://github.com/leoloso/PoP/issues/636
     GraphQLAPI\GraphQLAPI\Services\Helpers\MenuPageHelper:
         class: ~
+        autoconfigure: false
     GraphQLAPI\GraphQLAPI\Services\Menus\Menu:
         class: ~
+        autoconfigure: false
     GraphQLAPI\GraphQLAPI\Services\Helpers\EndpointHelpers:
         class: ~
+        autoconfigure: false
     GraphQLAPI\GraphQLAPI\Services\MenuPages\ModulesMenuPage:
         class: ~
+        autoconfigure: false
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLAPI\GraphQLAPI\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/config/ConditionalOnEnvironment/UseGraphiQLExplorer/Overrides/services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/config/ConditionalOnEnvironment/UseGraphiQLExplorer/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLByPoP\GraphQLClientsForWP\Clients\GraphiQLClient:
         class: '\GraphQLByPoP\GraphQLClientsForWP\ConditionalOnEnvironment\UseGraphiQLExplorer\Overrides\Services\Clients\GraphiQLWithExplorerClient'

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/config/services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLByPoP\GraphQLClientsForWP\Clients\:
         resource: '../src/Clients/*'

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/config/services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLByPoP\GraphQLEndpointForWP\EndpointHandlers\:
         resource: '../src/EndpointHandlers/*'

--- a/layers/GraphQLByPoP/packages/graphql-query/config/services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-query/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLByPoP\GraphQLQuery\Schema\GraphQLQueryConvertorInterface:
         class: \GraphQLByPoP\GraphQLQuery\Schema\GraphQLQueryConvertor

--- a/layers/GraphQLByPoP/packages/graphql-request/config/services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-request/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLByPoP\GraphQLRequest\PersistedQueries\GraphQLPersistedQueryManagerInterface:
         class: \GraphQLByPoP\GraphQLRequest\PersistedQueries\GraphQLPersistedQueryManager

--- a/layers/GraphQLByPoP/packages/graphql-server/config/Overrides/services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-server/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     # Change the properties printed for the standard GraphQL response:
     PoP\GraphQLAPI\DataStructureFormatters\GraphQLDataStructureFormatter:

--- a/layers/GraphQLByPoP/packages/graphql-server/config/services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-server/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLByPoP\GraphQLServer\Registries\SchemaDefinitionReferenceRegistryInterface:
         class: \GraphQLByPoP\GraphQLServer\Registries\SchemaDefinitionReferenceRegistry

--- a/layers/GraphQLByPoP/packages/graphql-server/config/system-services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-server/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     GraphQLByPoP\GraphQLServer\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/Misc/packages/examples-for-pop/config/system-services.yaml
+++ b/layers/Misc/packages/examples-for-pop/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     Leoloso\ExamplesForPoP\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/Schema/packages/basic-directives/config/services.yaml
+++ b/layers/Schema/packages/basic-directives/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\BasicDirectives\Enums\:
         resource: '../src/Enums/*'

--- a/layers/Schema/packages/categories-wp/config/services.yaml
+++ b/layers/Schema/packages/categories-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CategoriesWP\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/Schema/packages/categories/config/services.yaml
+++ b/layers/Schema/packages/categories/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Categories\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/Schema/packages/comment-mutations-wp/config/services.yaml
+++ b/layers/Schema/packages/comment-mutations-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CommentMutations\TypeAPIs\CommentTypeMutationAPIInterface:
         class: \PoPSchema\CommentMutationsWP\TypeAPIs\CommentTypeMutationAPI

--- a/layers/Schema/packages/commentmeta-wp/config/services.yaml
+++ b/layers/Schema/packages/commentmeta-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CommentMeta\TypeAPIs\CommentMetaTypeAPIInterface:
         class: \PoPSchema\CommentMetaWP\TypeAPIs\CommentMetaTypeAPI

--- a/layers/Schema/packages/comments-wp/config/services.yaml
+++ b/layers/Schema/packages/comments-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Comments\TypeAPIs\CommentTypeAPIInterface:
         class: \PoPSchema\CommentsWP\TypeAPIs\CommentTypeAPI

--- a/layers/Schema/packages/comments/config/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/comments/config/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Comments\Conditional\RESTAPI\Hooks\:
         resource: '../../../src/Conditional/RESTAPI/Hooks/*'

--- a/layers/Schema/packages/comments/config/services.yaml
+++ b/layers/Schema/packages/comments/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Comments\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/custompost-mutations-wp/config/services.yaml
+++ b/layers/Schema/packages/custompost-mutations-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPostMutations\TypeAPIs\CustomPostTypeMutationAPIInterface:
         class: \PoPSchema\CustomPostMutationsWP\TypeAPIs\CustomPostTypeMutationAPI

--- a/layers/Schema/packages/custompost-mutations/config/services.yaml
+++ b/layers/Schema/packages/custompost-mutations/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPostMutations\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/Schema/packages/custompostmedia-mutations-wp/config/services.yaml
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPostMediaMutations\TypeAPIs\CustomPostMediaTypeMutationAPIInterface:
         class: \PoPSchema\CustomPostMediaMutationsWP\TypeAPIs\CustomPostMediaTypeMutationAPI

--- a/layers/Schema/packages/custompostmedia-mutations/config/services.yaml
+++ b/layers/Schema/packages/custompostmedia-mutations/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPostMediaMutations\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/custompostmeta-wp/config/services.yaml
+++ b/layers/Schema/packages/custompostmeta-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPostMeta\TypeAPIs\CustomPostMetaTypeAPIInterface:
         class: \PoPSchema\CustomPostMetaWP\TypeAPIs\CustomPostMetaTypeAPI

--- a/layers/Schema/packages/customposts-wp/config/Overrides/services.yaml
+++ b/layers/Schema/packages/customposts-wp/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPosts\TypeDataLoaders\CustomPostUnionTypeDataLoader:
         class: \PoPSchema\CustomPostsWP\Overrides\TypeDataLoaders\CustomPostUnionTypeDataLoader

--- a/layers/Schema/packages/customposts-wp/config/services.yaml
+++ b/layers/Schema/packages/customposts-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPosts\TypeAPIs\CustomPostTypeAPIInterface:
         class: \PoPSchema\CustomPostsWP\TypeAPIs\CustomPostTypeAPI

--- a/layers/Schema/packages/customposts/config/services.yaml
+++ b/layers/Schema/packages/customposts/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPosts\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/event-mutations-wp-em/config/services.yaml
+++ b/layers/Schema/packages/event-mutations-wp-em/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\EventMutations\TypeAPIs\EventTypeMutationAPIInterface:
         class: \PoPSchema\EventMutationsWPEM\TypeAPIs\EventTypeMutationAPI

--- a/layers/Schema/packages/events-wp-em/config/services.yaml
+++ b/layers/Schema/packages/events-wp-em/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Events\TypeAPIs\EventTypeAPIInterface:
         class: \PoPSchema\EventsWPEM\TypeAPIs\EventTypeAPI

--- a/layers/Schema/packages/events/config/services.yaml
+++ b/layers/Schema/packages/events/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Events\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/Schema/packages/everythingelse-wp/config/Conditional/CustomPosts/services.yaml
+++ b/layers/Schema/packages/everythingelse-wp/config/Conditional/CustomPosts/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\CustomPosts\TypeAPIs\CustomPostTypeAPIInterface:
         class: \PoPSchema\EverythingElseWP\Conditional\CustomPosts\TypeAPIs\CustomPostTypeAPI

--- a/layers/Schema/packages/everythingelse/config/services.yaml
+++ b/layers/Schema/packages/everythingelse/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\EverythingElse\Enums\:
         resource: '../src/Enums/*'

--- a/layers/Schema/packages/generic-customposts/config/services.yaml
+++ b/layers/Schema/packages/generic-customposts/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\GenericCustomPosts\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'

--- a/layers/Schema/packages/highlights-wp/config/services.yaml
+++ b/layers/Schema/packages/highlights-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Highlights\TypeAPIs\HighlightTypeAPIInterface:
         class: \PoPSchema\HighlightsWP\TypeAPIs\HighlightTypeAPI

--- a/layers/Schema/packages/locationposts-wp/config/services.yaml
+++ b/layers/Schema/packages/locationposts-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\LocationPosts\TypeAPIs\LocationPostTypeAPIInterface:
         class: \PoPSchema\LocationPostsWP\TypeAPIs\LocationPostTypeAPI

--- a/layers/Schema/packages/locations-wp-em/config/services.yaml
+++ b/layers/Schema/packages/locations-wp-em/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Locations\TypeAPIs\LocationTypeAPIInterface:
         class: \PoPSchema\LocationsWPEM\TypeAPIs\LocationTypeAPI

--- a/layers/Schema/packages/locations/config/services.yaml
+++ b/layers/Schema/packages/locations/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Locations\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/Schema/packages/media-wp/config/services.yaml
+++ b/layers/Schema/packages/media-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Media\TypeAPIs\MediaTypeAPIInterface:
         class: \PoPSchema\MediaWP\TypeAPIs\MediaTypeAPI

--- a/layers/Schema/packages/media/config/services.yaml
+++ b/layers/Schema/packages/media/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Media\Enums\:
         resource: '../src/Enums/*'

--- a/layers/Schema/packages/menus-wp/config/services.yaml
+++ b/layers/Schema/packages/menus-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Menus\TypeAPIs\MenuTypeAPIInterface:
         class: \PoPSchema\MenusWP\TypeAPIs\MenuTypeAPI

--- a/layers/Schema/packages/pages-wp/config/services.yaml
+++ b/layers/Schema/packages/pages-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Pages\TypeAPIs\PageTypeAPIInterface:
         class: \PoPSchema\PagesWP\TypeAPIs\PageTypeAPI

--- a/layers/Schema/packages/pages/config/Conditional/API/services.yaml
+++ b/layers/Schema/packages/pages/config/Conditional/API/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Pages\Conditional\API\RouteModuleProcessors\:
         resource: '../../../src/Conditional/API/RouteModuleProcessors/*'

--- a/layers/Schema/packages/pages/config/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/pages/config/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Pages\Conditional\RESTAPI\RouteModuleProcessors\:
         resource: '../../../src/Conditional/RESTAPI/RouteModuleProcessors/*'

--- a/layers/Schema/packages/pages/config/services.yaml
+++ b/layers/Schema/packages/pages/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Pages\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/post-categories-wp/config/services.yaml
+++ b/layers/Schema/packages/post-categories-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostCategories\TypeAPIs\PostCategoryTypeAPIInterface:
         class: \PoPSchema\PostCategoriesWP\TypeAPIs\PostCategoryTypeAPI

--- a/layers/Schema/packages/post-categories/config/Conditional/API/services.yaml
+++ b/layers/Schema/packages/post-categories/config/Conditional/API/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostCategories\Conditional\API\RouteModuleProcessors\:
         resource: '../../../src/Conditional/API/RouteModuleProcessors/*'

--- a/layers/Schema/packages/post-categories/config/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/post-categories/config/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostCategories\Conditional\RESTAPI\Hooks\:
         resource: '../../../src/Conditional/RESTAPI/Hooks/*'

--- a/layers/Schema/packages/post-categories/config/services.yaml
+++ b/layers/Schema/packages/post-categories/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostCategories\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'

--- a/layers/Schema/packages/post-category-mutations-wp/config/services.yaml
+++ b/layers/Schema/packages/post-category-mutations-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostCategoryMutations\TypeAPIs\PostCategoryTypeMutationAPIInterface:
         class: \PoPSchema\PostCategoryMutationsWP\TypeAPIs\PostCategoryTypeMutationAPI

--- a/layers/Schema/packages/post-category-mutations/config/services.yaml
+++ b/layers/Schema/packages/post-category-mutations/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostCategoryMutations\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/post-mutations/config/services.yaml
+++ b/layers/Schema/packages/post-mutations/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostMutations\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'

--- a/layers/Schema/packages/post-tag-mutations-wp/config/services.yaml
+++ b/layers/Schema/packages/post-tag-mutations-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostTagMutations\TypeAPIs\PostTagTypeMutationAPIInterface:
         class: \PoPSchema\PostTagMutationsWP\TypeAPIs\PostTagTypeMutationAPI

--- a/layers/Schema/packages/post-tag-mutations/config/services.yaml
+++ b/layers/Schema/packages/post-tag-mutations/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostTagMutations\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/post-tags-wp/config/services.yaml
+++ b/layers/Schema/packages/post-tags-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostTags\TypeAPIs\PostTagTypeAPIInterface:
         class: \PoPSchema\PostTagsWP\TypeAPIs\PostTagTypeAPI

--- a/layers/Schema/packages/post-tags/config/Conditional/API/services.yaml
+++ b/layers/Schema/packages/post-tags/config/Conditional/API/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostTags\Conditional\API\RouteModuleProcessors\:
         resource: '../../../src/Conditional/API/RouteModuleProcessors/*'

--- a/layers/Schema/packages/post-tags/config/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/post-tags/config/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostTags\Conditional\RESTAPI\Hooks\:
         resource: '../../../src/Conditional/RESTAPI/Hooks/*'

--- a/layers/Schema/packages/post-tags/config/services.yaml
+++ b/layers/Schema/packages/post-tags/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\PostTags\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'

--- a/layers/Schema/packages/posts-wp/config/services.yaml
+++ b/layers/Schema/packages/posts-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Posts\TypeAPIs\PostTypeAPIInterface:
         class: \PoPSchema\PostsWP\TypeAPIs\PostTypeAPI

--- a/layers/Schema/packages/posts/config/Conditional/API/services.yaml
+++ b/layers/Schema/packages/posts/config/Conditional/API/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Posts\Conditional\API\RouteModuleProcessors\:
         resource: '../../../src/Conditional/API/RouteModuleProcessors/*'

--- a/layers/Schema/packages/posts/config/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/posts/config/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Posts\Conditional\RESTAPI\RouteModuleProcessors\:
         resource: '../../../src/Conditional/RESTAPI/RouteModuleProcessors/*'

--- a/layers/Schema/packages/posts/config/Conditional/Users/Conditional/API/services.yaml
+++ b/layers/Schema/packages/posts/config/Conditional/Users/Conditional/API/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Posts\Conditional\Users\Conditional\API\RouteModuleProcessors\:
         resource: '../../../../../src/Conditional/Users/Conditional/API/RouteModuleProcessors/*'

--- a/layers/Schema/packages/posts/config/Conditional/Users/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/posts/config/Conditional/Users/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Posts\Conditional\Users\Conditional\RESTAPI\RouteModuleProcessors\:
         resource: '../../../../../src/Conditional/Users/Conditional/RESTAPI/RouteModuleProcessors/*'

--- a/layers/Schema/packages/posts/config/Conditional/Users/services.yaml
+++ b/layers/Schema/packages/posts/config/Conditional/Users/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Posts\Conditional\Users\ModuleProcessors\:
         resource: '../../../src/Conditional/Users/ModuleProcessors/*'

--- a/layers/Schema/packages/posts/config/services.yaml
+++ b/layers/Schema/packages/posts/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Posts\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'

--- a/layers/Schema/packages/schema-commons/config/services.yaml
+++ b/layers/Schema/packages/schema-commons/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface:
         class: \PoPSchema\SchemaCommons\Services\AllowOrDenySettingsService

--- a/layers/Schema/packages/settings-wp/config/services.yaml
+++ b/layers/Schema/packages/settings-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Settings\TypeAPIs\SettingsTypeAPIInterface:
         class: \PoPSchema\SettingsWP\TypeAPIs\SettingsTypeAPI

--- a/layers/Schema/packages/stances-wp/config/services.yaml
+++ b/layers/Schema/packages/stances-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Stances\TypeAPIs\StanceTypeAPIInterface:
         class: \PoPSchema\StancesWP\TypeAPIs\StanceTypeAPI

--- a/layers/Schema/packages/tags-wp/config/services.yaml
+++ b/layers/Schema/packages/tags-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\TagsWP\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/Schema/packages/tags/config/services.yaml
+++ b/layers/Schema/packages/tags/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Tags\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/Schema/packages/taxonomies-wp/config/services.yaml
+++ b/layers/Schema/packages/taxonomies-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Taxonomies\TypeAPIs\TaxonomyTypeAPIInterface:
         class: \PoPSchema\TaxonomiesWP\TypeAPIs\TaxonomyTypeAPI

--- a/layers/Schema/packages/taxonomymeta-wp/config/services.yaml
+++ b/layers/Schema/packages/taxonomymeta-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\TaxonomyMeta\TypeAPIs\TaxonomyMetaTypeAPIInterface:
         class: \PoPSchema\TaxonomyMetaWP\TypeAPIs\TaxonomyMetaTypeAPI

--- a/layers/Schema/packages/translate-directive-acl/config/system-services.yaml
+++ b/layers/Schema/packages/translate-directive-acl/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\TranslateDirectiveACL\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/Schema/packages/translate-directive/config/services.yaml
+++ b/layers/Schema/packages/translate-directive/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\TranslateDirective\Translation\TranslationServiceInterface:
         class: \PoPSchema\TranslateDirective\Translation\TranslationService

--- a/layers/Schema/packages/translate-directive/config/system-services.yaml
+++ b/layers/Schema/packages/translate-directive/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\TranslateDirective\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/Schema/packages/user-roles-access-control/config/services.yaml
+++ b/layers/Schema/packages/user-roles-access-control/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserRolesAccessControl\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/user-roles-acl/config/system-services.yaml
+++ b/layers/Schema/packages/user-roles-acl/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserRolesACL\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/Schema/packages/user-roles-wp/config/services.yaml
+++ b/layers/Schema/packages/user-roles-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserRoles\TypeDataResolvers\UserRoleTypeDataResolverInterface:
         class: \PoPSchema\UserRolesWP\TypeDataResolvers\UserRoleTypeDataResolver

--- a/layers/Schema/packages/user-roles/config/services.yaml
+++ b/layers/Schema/packages/user-roles/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserRoles\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/user-state-access-control/config/services.yaml
+++ b/layers/Schema/packages/user-state-access-control/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserStateAccessControl\TypeResolverDecorators\:
         resource: '../src/TypeResolverDecorators/*'

--- a/layers/Schema/packages/user-state-mutations-wp/config/services.yaml
+++ b/layers/Schema/packages/user-state-mutations-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserStateMutations\TypeAPIs\UserStateTypeMutationAPIInterface:
         class: \PoPSchema\UserStateMutationsWP\TypeAPIs\UserStateTypeMutationAPI

--- a/layers/Schema/packages/user-state-wp/config/services.yaml
+++ b/layers/Schema/packages/user-state-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserState\TypeDataResolvers\UserStateTypeDataResolverInterface:
         class: \PoPSchema\UserStateWP\TypeDataResolvers\UserStateTypeDataResolver

--- a/layers/Schema/packages/user-state/config/services.yaml
+++ b/layers/Schema/packages/user-state/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserState\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/Schema/packages/usermeta-wp/config/services.yaml
+++ b/layers/Schema/packages/usermeta-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\UserMeta\TypeAPIs\UserMetaTypeAPIInterface:
         class: \PoPSchema\UserMetaWP\TypeAPIs\UserMetaTypeAPI

--- a/layers/Schema/packages/users-wp/config/Conditional/CustomPosts/services.yaml
+++ b/layers/Schema/packages/users-wp/config/Conditional/CustomPosts/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Users\Conditional\CustomPosts\TypeAPIs\CustomPostUserTypeAPIInterface:
         class: \PoPSchema\UsersWP\Conditional\CustomPosts\TypeAPIs\CustomPostUserTypeAPI

--- a/layers/Schema/packages/users-wp/config/services.yaml
+++ b/layers/Schema/packages/users-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Users\TypeAPIs\UserTypeAPIInterface:
         class: \PoPSchema\UsersWP\TypeAPIs\UserTypeAPI

--- a/layers/Schema/packages/users/config/Conditional/API/services.yaml
+++ b/layers/Schema/packages/users/config/Conditional/API/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Users\Conditional\API\RouteModuleProcessors\:
         resource: '../../../src/Conditional/API/RouteModuleProcessors/*'

--- a/layers/Schema/packages/users/config/Conditional/CustomPosts/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/users/config/Conditional/CustomPosts/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Users\Conditional\CustomPosts\Conditional\RESTAPI\Hooks\:
         resource: '../../../../../src/Conditional/CustomPosts/Conditional/RESTAPI/Hooks/*'

--- a/layers/Schema/packages/users/config/Conditional/CustomPosts/services.yaml
+++ b/layers/Schema/packages/users/config/Conditional/CustomPosts/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Users\Conditional\CustomPosts\LooseContracts\:
         resource: '../../../src/Conditional/CustomPosts/LooseContracts/*'

--- a/layers/Schema/packages/users/config/Conditional/RESTAPI/services.yaml
+++ b/layers/Schema/packages/users/config/Conditional/RESTAPI/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Users\Conditional\RESTAPI\RouteModuleProcessors\:
         resource: '../../../src/Conditional/RESTAPI/RouteModuleProcessors/*'

--- a/layers/Schema/packages/users/config/services.yaml
+++ b/layers/Schema/packages/users/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSchema\Users\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/SiteBuilder/packages/application-wp/config/services.yaml
+++ b/layers/SiteBuilder/packages/application-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ApplicationWP\LooseContracts\:
         resource: '../src/LooseContracts/*'

--- a/layers/SiteBuilder/packages/application/config/Overrides/services.yaml
+++ b/layers/SiteBuilder/packages/application/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ComponentModel\Engine\EngineInterface:
         class: \PoP\Application\Engine\Engine

--- a/layers/SiteBuilder/packages/application/config/services.yaml
+++ b/layers/SiteBuilder/packages/application/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Application\ModuleFilters\:
         resource: '../src/ModuleFilters/*'

--- a/layers/SiteBuilder/packages/application/config/system-services.yaml
+++ b/layers/SiteBuilder/packages/application/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Application\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/SiteBuilder/packages/component-model-configuration/config/Overrides/services.yaml
+++ b/layers/SiteBuilder/packages/component-model-configuration/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ComponentModel\Engine\EngineInterface:
         class: \PoP\ConfigurationComponentModel\Engine\Engine

--- a/layers/SiteBuilder/packages/component-model-configuration/config/services.yaml
+++ b/layers/SiteBuilder/packages/component-model-configuration/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ConfigurationComponentModel\RouteModuleProcessors\:
         resource: '../src/RouteModuleProcessors/*'

--- a/layers/SiteBuilder/packages/definitionpersistence/config/services.yaml
+++ b/layers/SiteBuilder/packages/definitionpersistence/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     definition_persistence_file:
         class: \PoP\DefinitionPersistence\DefinitionPersistenceFile

--- a/layers/SiteBuilder/packages/definitionpersistence/config/system-services.yaml
+++ b/layers/SiteBuilder/packages/definitionpersistence/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\DefinitionPersistence\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/SiteBuilder/packages/definitions-base36/config/services.yaml
+++ b/layers/SiteBuilder/packages/definitions-base36/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     base36_definition_resolver:
         class: \PoP\Base36Definitions\DefinitionResolver

--- a/layers/SiteBuilder/packages/definitions-emoji/config/services.yaml
+++ b/layers/SiteBuilder/packages/definitions-emoji/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     emoji_definition_resolver:
         class: \PoP\EmojiDefinitions\DefinitionResolver

--- a/layers/SiteBuilder/packages/multisite/config/services.yaml
+++ b/layers/SiteBuilder/packages/multisite/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     site_object:
         class: \PoP\Multisite\ObjectModels\Site

--- a/layers/SiteBuilder/packages/site-wp/config/services.yaml
+++ b/layers/SiteBuilder/packages/site-wp/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\SiteWP\Hooks\:
         resource: '../src/Hooks/*'

--- a/layers/SiteBuilder/packages/site/config/Overrides/services.yaml
+++ b/layers/SiteBuilder/packages/site/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\ComponentModel\Engine\EngineInterface:
         class: \PoP\Site\Engine\Engine

--- a/layers/SiteBuilder/packages/site/config/system-services.yaml
+++ b/layers/SiteBuilder/packages/site/config/system-services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\Site\Container\CompilerPasses\:
         resource: '../src/Container/CompilerPasses/*'

--- a/layers/SiteBuilder/packages/spa/config/services.yaml
+++ b/layers/SiteBuilder/packages/spa/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoP\SPA\ModuleFilters\:
         resource: '../src/ModuleFilters/*'

--- a/layers/Wassup/packages/wassup/config/Overrides/services.yaml
+++ b/layers/Wassup/packages/wassup/config/Overrides/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSitesWassup\ContactUsMutations\MutationResolverBridges\ContactUsMutationResolverBridge:
         class: \PoPSitesWassup\GravityFormsMutations\MutationResolverBridges\GravityFormsAddEntryToFormMutationResolverBridge

--- a/layers/Wassup/packages/wassup/config/services.yaml
+++ b/layers/Wassup/packages/wassup/config/services.yaml
@@ -2,6 +2,7 @@ services:
     _defaults:
         public: true
         autowire: true
+        autoconfigure: true
 
     PoPSitesWassup\Wassup\Hooks\:
         resource: '../src/Hooks/*'


### PR DESCRIPTION
Services may need to be registered in both the System and Application service containers. In that case, these may be initialized twice, producing a bug. See #636.

As solution, enable to initialize services only when they have `autoconfigure: true` in their definition, and enable it for `AutomaticallyInstantiatedServiceCompilerPass`.

Fixes #636.