### PR TITLE
Override "cache-dir" via: 1. environment variable, 2. constant in wp-config.php

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
@@ -16,6 +16,7 @@ GitHub Plugin URI: GraphQLAPI/graphql-api-for-wp-dist
 */
 
 use GraphQLAPI\GraphQLAPI\Plugin;
+use GraphQLAPI\GraphQLAPI\PluginEnvironment;
 use GraphQLAPI\GraphQLAPI\PluginInfo;
 
 // Exit if accessed directly
@@ -78,9 +79,12 @@ PluginInfo::init([
     'slug' => 'graphql-api',
     'dir' => dirname(__FILE__),
     'url' => plugin_dir_url(__FILE__),
-    // Use the plugin's "cache/" subfolder to store the config cache,
-    // for both /pop-cache (container) and /symfony-cache (config persistent cache)
-    'cache-dir' => dirname(__FILE__) . \DIRECTORY_SEPARATOR . 'cache',
+    /**
+     * Where to store the config cache,
+     * for both /pop-cache (container) and /symfony-cache
+     * (config persistent cache: component model configuration + schema)
+     */
+    'cache-dir' => PluginEnvironment::getCacheDir(),
 ]);
 
 // Create and set-up the plugin instance

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI;
 
+use GraphQLAPI\GraphQLAPI\Config\PluginConfigurationHelpers;
 use PoP\Root\Environment;
 
 class PluginEnvironment
 {
     public const CACHE_CONTAINERS = 'CACHE_CONTAINERS';
+    public const CACHE_DIR = 'CACHE_DIR';
 
     /**
      * By default, do not cache for DEV, cache otherwise
@@ -18,5 +20,23 @@ class PluginEnvironment
         return getenv(self::CACHE_CONTAINERS) !== false ?
             strtolower(getenv(self::CACHE_CONTAINERS)) == "true"
             : !Environment::isApplicationEnvironmentDev();
+    }
+
+    /**
+     * If the cache dir is provided by either environment variable
+     * or constant in wp-config.php, use it.
+     * Otherwise, set the default to wp-content/plugins/graphql-api/cache
+     */
+    public static function getCacheDir(): string
+    {
+        if (getenv(self::CACHE_DIR) !== false) {
+            return rtrim(getenv(self::CACHE_DIR), '/');
+        }
+
+        if (PluginConfigurationHelpers::isWPConfigConstantDefined(self::CACHE_DIR)) {
+            return rtrim(PluginConfigurationHelpers::getWPConfigConstantValue(self::CACHE_DIR), '/');
+        }
+        
+        return dirname(__FILE__, 2) . \DIRECTORY_SEPARATOR . 'cache';
     }
 }


### PR DESCRIPTION
The folder where cache the container/configuration/schema is by default `wp-content/plugins/graphql-api/cache`.

This PR enables to override this location, via:

1. Environment variable: `CACHE_DIR`
2. Constant defined in `wp-config.php`: `GRAPHQL_API_CACHE_DIR`