### PR TITLE
Added $translationAPI and $hooksAPI properties into resolvers

### DIFF
--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -40,29 +40,27 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Copy the data from a relational object (which is one level below) to the current object', 'component-model');
+        return $this->translationAPI->__('Copy the data from a relational object (which is one level below) to the current object', 'component-model');
     }
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'copyFromFields',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The fields in the relational object from which to copy the data', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The fields in the relational object from which to copy the data', 'component-model'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'copyToFields',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The fields in the current object to which copy the data. Default value: Same fields provided through \'copyFromFields\' argument', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The fields in the current object to which copy the data. Default value: Same fields provided through \'copyFromFields\' argument', 'component-model'),
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'keepRelationalIDs',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Indicate if the properties are placed under the relational ID as keys (`true`) or as a one-dimensional array (`false`)', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Indicate if the properties are placed under the relational ID as keys (`true`) or as a one-dimensional array (`false`)', 'component-model'),
                 SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
             ],
         ];
@@ -74,7 +72,6 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
     public function validateDirectiveArgumentsForSchema(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array
     {
         $directiveArgs = parent::validateDirectiveArgumentsForSchema($typeResolver, $directiveName, $directiveArgs, $schemaErrors, $schemaWarnings, $schemaDeprecations);
-        $translationAPI = TranslationAPIFacade::getInstance();
 
         if (isset($directiveArgs['copyToFields'])) {
             $copyToFields = $directiveArgs['copyToFields'];
@@ -87,16 +84,16 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                 $schemaWarnings[] = [
                     Tokens::PATH => [$this->directive],
                     Tokens::MESSAGE => sprintf(
-                        $translationAPI->__('Argument \'copyToFields\' has more elements than argument \'copyFromFields\', so the following fields have been ignored: \'%s\'', 'component-model'),
-                        implode($translationAPI->__('\', \''), array_slice($copyToFields, $copyFromFieldsCount))
+                        $this->translationAPI->__('Argument \'copyToFields\' has more elements than argument \'copyFromFields\', so the following fields have been ignored: \'%s\'', 'component-model'),
+                        implode($this->translationAPI->__('\', \''), array_slice($copyToFields, $copyFromFieldsCount))
                     ),
                 ];
             } elseif ($copyToFieldsCount < $copyFromFieldsCount) {
                 $schemaWarnings[] = [
                     Tokens::PATH => [$this->directive],
                     Tokens::MESSAGE => sprintf(
-                        $translationAPI->__('Argument \'copyFromFields\' has more elements than argument \'copyToFields\', so the following fields will be copied to the destination object under their same field name: \'%s\'', 'component-model'),
-                        implode($translationAPI->__('\', \''), array_slice($copyFromFields, $copyToFieldsCount))
+                        $this->translationAPI->__('Argument \'copyFromFields\' has more elements than argument \'copyToFields\', so the following fields will be copied to the destination object under their same field name: \'%s\'', 'component-model'),
+                        implode($this->translationAPI->__('\', \''), array_slice($copyFromFields, $copyToFieldsCount))
                     ),
                 ];
             }
@@ -130,7 +127,6 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
         array &$schemaNotices,
         array &$schemaTraces
     ): void {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
 
@@ -157,7 +153,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                             $dbErrors[(string)$id][] = [
                                 Tokens::PATH => [$this->directive],
                                 Tokens::MESSAGE => sprintf(
-                                    $translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
+                                    $this->translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
                                     $relationalField,
                                     $relationalFieldOutputKey,
                                     $id
@@ -167,7 +163,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                             $dbErrors[(string)$id][] = [
                                 Tokens::PATH => [$this->directive],
                                 Tokens::MESSAGE => sprintf(
-                                    $translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
+                                    $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
                                     $relationalField,
                                     $id
                                 ),
@@ -182,7 +178,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                         $dbWarnings[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('The existing value for field \'%s\' from object with ID \'%s\' has been overriden: \'%s\'', 'component-model'),
+                                $this->translationAPI->__('The existing value for field \'%s\' from object with ID \'%s\' has been overriden: \'%s\'', 'component-model'),
                                 $copyToField,
                                 $id,
                                 $isTargetValueInDBItems ?
@@ -221,7 +217,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                             $dbErrors[(string)$id][] = [
                                 Tokens::PATH => [$this->directive],
                                 Tokens::MESSAGE => sprintf(
-                                    $translationAPI->__('Field \'%s\' hadn\'t been set for object of entity \'%s\' and ID \'%s\', so no data can be copied', 'component-model'),
+                                    $this->translationAPI->__('Field \'%s\' hadn\'t been set for object of entity \'%s\' and ID \'%s\', so no data can be copied', 'component-model'),
                                     $copyFromField,
                                     $relationalDBKey,
                                     $relationalID

--- a/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
@@ -37,18 +37,16 @@ class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Duplicate a property in the current object', 'component-model');
+        return $this->translationAPI->__('Duplicate a property in the current object', 'component-model');
     }
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'to',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The new property name', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The new property name', 'component-model'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
         ];
@@ -79,7 +77,6 @@ class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
         array &$schemaNotices,
         array &$schemaTraces
     ): void {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
         $copyTo = $this->directiveArgsForSchema['to'];
         foreach ($idsDataFields as $id => $dataFields) {
@@ -89,7 +86,7 @@ class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
                     $dbWarnings[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('Property \'%s\' doesn\'t exist in object with ID \'%s\', so it can\'t be copied to \'%s\''),
+                            $this->translationAPI->__('Property \'%s\' doesn\'t exist in object with ID \'%s\', so it can\'t be copied to \'%s\''),
                             $fieldOutputKey,
                             $id,
                             $copyTo

--- a/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
@@ -26,8 +26,7 @@ class RenamePropertyDirectiveResolver extends DuplicatePropertyDirectiveResolver
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Rename a property in the current object', 'component-model');
+        return $this->translationAPI->__('Rename a property in the current object', 'component-model');
     }
 
     /**

--- a/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/SetPropertiesAsExpressionsDirectiveResolver.php
@@ -37,30 +37,27 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Extract a property from the current object, and set it as a expression, so it can be accessed by fieldResolvers', 'component-model');
+        return $this->translationAPI->__('Extract a property from the current object, and set it as a expression, so it can be accessed by fieldResolvers', 'component-model');
     }
 
     public function getSchemaDirectiveDeprecationDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Use directive `getSelfProp` together with field `extract` instead', 'component-model');
+        return $this->translationAPI->__('Use directive `getSelfProp` together with field `extract` instead', 'component-model');
     }
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'properties',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The property in the current object from which to copy the data into the expressions', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The property in the current object from which to copy the data into the expressions', 'component-model'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'expressions',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Name of the expressions. Default value: Same name as the properties', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Name of the expressions. Default value: Same name as the properties', 'component-model'),
             ],
         ];
     }
@@ -71,7 +68,6 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
     public function validateDirectiveArgumentsForSchema(TypeResolverInterface $typeResolver, string $directiveName, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array
     {
         $directiveArgs = parent::validateDirectiveArgumentsForSchema($typeResolver, $directiveName, $directiveArgs, $schemaErrors, $schemaWarnings, $schemaDeprecations);
-        $translationAPI = TranslationAPIFacade::getInstance();
 
         if (isset($directiveArgs['expressions'])) {
             $expressionsName = $directiveArgs['expressions'];
@@ -84,16 +80,16 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
                 $schemaWarnings[] = [
                     Tokens::PATH => [$this->directive],
                     Tokens::MESSAGE => sprintf(
-                        $translationAPI->__('Argument \'expressions\' has more elements than argument \'properties\', so the following expressions have been ignored: \'%s\'', 'component-model'),
-                        implode($translationAPI->__('\', \''), array_slice($expressionsName, $propertiesCount))
+                        $this->translationAPI->__('Argument \'expressions\' has more elements than argument \'properties\', so the following expressions have been ignored: \'%s\'', 'component-model'),
+                        implode($this->translationAPI->__('\', \''), array_slice($expressionsName, $propertiesCount))
                     ),
                 ];
             } elseif ($expressionsNameCount < $propertiesCount) {
                 $schemaWarnings[] = [
                     Tokens::PATH => [$this->directive],
                     Tokens::MESSAGE => sprintf(
-                        $translationAPI->__('Argument \'properties\' has more elements than argument \'expressions\', so the following properties will be assigned to the destination object under their same name: \'%s\'', 'component-model'),
-                        implode($translationAPI->__('\', \''), array_slice($properties, $expressionsNameCount))
+                        $this->translationAPI->__('Argument \'properties\' has more elements than argument \'expressions\', so the following properties will be assigned to the destination object under their same name: \'%s\'', 'component-model'),
+                        implode($this->translationAPI->__('\', \''), array_slice($properties, $expressionsNameCount))
                     ),
                 ];
             }
@@ -127,7 +123,6 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
         array &$schemaNotices,
         array &$schemaTraces
     ): void {
-        $translationAPI = TranslationAPIFacade::getInstance();
         // Send a message to the resolveAndMerge directive, indicating which properties to retrieve
         $properties = $this->directiveArgsForSchema['properties'];
         $expressionNames = $this->directiveArgsForSchema['expressions'] ?? $properties;
@@ -141,7 +136,7 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
                     $dbErrors[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('Property \'%s\' hadn\'t been set for object with ID \'%s\', so no expression has been defined', 'component-model'),
+                            $this->translationAPI->__('Property \'%s\' hadn\'t been set for object with ID \'%s\', so no expression has been defined', 'component-model'),
                             $property,
                             $id
                         ),
@@ -155,7 +150,7 @@ class SetPropertiesAsExpressionsDirectiveResolver extends AbstractGlobalDirectiv
                     $dbWarnings[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('The existing value for expression \'%s\' for object with ID \'%s\' has been overriden: \'%s\'', 'component-model'),
+                            $this->translationAPI->__('The existing value for expression \'%s\' for object with ID \'%s\' has been overriden: \'%s\'', 'component-model'),
                             $expressionName,
                             $id
                         ),

--- a/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
@@ -38,14 +38,13 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
     public function getSchemaDirectiveDeprecationDescription(TypeResolverInterface $typeResolver): ?string
     {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         /** @var DirectiveResolverInterface */
         $forEachDirectiveResolver = $instanceManager->getInstance(ForEachDirectiveResolver::class);
         /** @var DirectiveResolverInterface */
         $applyFunctionDirectiveResolver = $instanceManager->getInstance(ApplyFunctionDirectiveResolver::class);
         return sprintf(
-            $translationAPI->__('Use %s instead', 'component-model'),
+            $this->translationAPI->__('Use %s instead', 'component-model'),
             $fieldQueryInterpreter->getFieldDirectivesAsString([
                 [
                     $forEachDirectiveResolver->getDirectiveName(),
@@ -89,7 +88,6 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
         array &$schemaNotices,
         array &$schemaTraces
     ): void {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
         $dbKey = $typeResolver->getTypeOutputName();
 
@@ -111,7 +109,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -121,7 +119,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             ),
@@ -145,7 +143,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('The value for field \'%s\' (under property \'%s\') is not an array, so execution of this directive can\'t continue', 'component-model'),
+                                $this->translationAPI->__('The value for field \'%s\' (under property \'%s\') is not an array, so execution of this directive can\'t continue', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -155,7 +153,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('The value for field \'%s\' is not an array, so execution of this directive can\'t continue', 'component-model'),
+                                $this->translationAPI->__('The value for field \'%s\' is not an array, so execution of this directive can\'t continue', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             ),
@@ -244,7 +242,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Transformation of element with key \'%s\' on array from property \'%s\' on object with ID \'%s\' failed due to error: %s', 'component-model'),
+                                $this->translationAPI->__('Transformation of element with key \'%s\' on array from property \'%s\' on object with ID \'%s\' failed due to error: %s', 'component-model'),
                                 $key,
                                 $fieldOutputKey,
                                 $id,

--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -53,9 +53,8 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'fullSchema' => $translationAPI->__('The whole API schema, exposing what fields can be queried', ''),
+            'fullSchema' => $this->translationAPI->__('The whole API schema, exposing what fields can be queried', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -63,7 +62,6 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         switch ($fieldName) {
             case 'fullSchema':
@@ -77,14 +75,14 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'deep',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Make a deep introspection of the fields, for all nested objects', ''),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Make a deep introspection of the fields, for all nested objects', ''),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'shape',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                                $translationAPI->__('How to shape the schema output: \'%s\', in which case all types are listed together, or \'%s\', in which the types are listed following where they appear in the graph', ''),
+                                $this->translationAPI->__('How to shape the schema output: \'%s\', in which case all types are listed together, or \'%s\', in which the types are listed following where they appear in the graph', ''),
                                 SchemaDefinition::ARGVALUE_SCHEMA_SHAPE_FLAT,
                                 SchemaDefinition::ARGVALUE_SCHEMA_SHAPE_NESTED
                             ),
@@ -97,14 +95,14 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'compressed',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Output each resolver\'s schema data only once to compress the output. Valid only when field \'deep\' is `true`', ''),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Output each resolver\'s schema data only once to compress the output. Valid only when field \'deep\' is `true`', ''),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'useTypeName',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                                $translationAPI->__('Replace type \'%s\' with the actual type name (such as \'Post\')', ''),
+                                $this->translationAPI->__('Replace type \'%s\' with the actual type name (such as \'Post\')', ''),
                                 SchemaDefinition::TYPE_ID
                             ),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => true,

--- a/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessDirectiveResolver.php
+++ b/layers/Engine/packages/access-control/src/DirectiveResolvers/DisableAccessDirectiveResolver.php
@@ -22,14 +22,13 @@ class DisableAccessDirectiveResolver extends AbstractValidateConditionDirectiveR
 
     protected function getValidationFailedMessage(TypeResolverInterface $typeResolver, array $failedDataFields): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $errorMessage = $this->isValidatingDirective() ?
-            $translationAPI->__('Access to directives in field(s) \'%s\' has been disabled', 'access-control') :
-            $translationAPI->__('Access to field(s) \'%s\' has been disabled', 'access-control');
+            $this->translationAPI->__('Access to directives in field(s) \'%s\' has been disabled', 'access-control') :
+            $this->translationAPI->__('Access to field(s) \'%s\' has been disabled', 'access-control');
         return sprintf(
             $errorMessage,
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $failedDataFields
             )
         );
@@ -37,7 +36,6 @@ class DisableAccessDirectiveResolver extends AbstractValidateConditionDirectiveR
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('It disables access to the field', 'access-control');
+        return $this->translationAPI->__('It disables access to the field', 'access-control');
     }
 }

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
@@ -52,17 +52,15 @@ abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirec
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('HTTP caching (https://tools.ietf.org/html/rfc7234): Cache the response by setting a Cache-Control header with a max-age value; this value is calculated as the minimum max-age value among all requested fields. If any field has max-age: 0, a corresponding \'no-store\' value is sent, indicating to not cache the response', 'component-model');
+        return $this->translationAPI->__('HTTP caching (https://tools.ietf.org/html/rfc7234): Cache the response by setting a Cache-Control header with a max-age value; this value is calculated as the minimum max-age value among all requested fields. If any field has max-age: 0, a corresponding \'no-store\' value is sent, indicating to not cache the response', 'component-model');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'maxAge',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_INT,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Use a specific max-age value for the field, instead of the one configured in the directive', 'translate-directive'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Use a specific max-age value for the field, instead of the one configured in the directive', 'translate-directive'),
             ],
         ];
     }

--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/NestedFieldCacheControlDirectiveResolver.php
@@ -15,18 +15,16 @@ class NestedFieldCacheControlDirectiveResolver extends AbstractCacheControlDirec
 {
     // public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     // {
-    //     $translationAPI = TranslationAPIFacade::getInstance();
     //     return sprintf(
-    //         $translationAPI->__('%1$s %2$s'),
-    //         $translationAPI->__('Helper directive to calculate the Cache Control header when the field composes other fields.', 'cache-control'),
+    //         $this->translationAPI->__('%1$s %2$s'),
+    //         $this->translationAPI->__('Helper directive to calculate the Cache Control header when the field composes other fields.', 'cache-control'),
     //         parent::getSchemaDirectiveDescription($typeResolver)
     //     );
     // }
 
     // protected function addSchemaDefinitionForDirective(array &$schemaDefinition)
     // {
-    //     $translationAPI = TranslationAPIFacade::getInstance();
-    //     $schemaDefinition[SchemaDefinition::ARGNAME_MAX_AGE] = $translationAPI->__('The minimum max-age calculated among the affected fields and all their composed fields.', 'cache-control');
+    //     $schemaDefinition[SchemaDefinition::ARGNAME_MAX_AGE] = $this->translationAPI->__('The minimum max-age calculated among the affected fields and all their composed fields.', 'cache-control');
     // }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -102,7 +102,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         array &$schemaNotices,
         array &$schemaTraces
     ): array {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
 
         // If it has nestedDirectives, extract them and validate them
@@ -176,7 +175,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                 }
                 $schemaErrors[] = [
                     Tokens::PATH => [$this->directive],
-                    Tokens::MESSAGE => $translationAPI->__('This directive can\'t be executed due to errors from its composed directives', 'component-model'),
+                    Tokens::MESSAGE => $this->translationAPI->__('This directive can\'t be executed due to errors from its composed directives', 'component-model'),
                 ];
                 return [
                     null, // $validDirective
@@ -557,9 +556,8 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                  * If this fieldResolver doesn't have versioning, then it accepts everything
                  */
                 if (!$this->decideCanProcessBasedOnVersionConstraint($typeResolver)) {
-                    $translationAPI = TranslationAPIFacade::getInstance();
                     return sprintf(
-                        $translationAPI->__('The DirectiveResolver used to process directive \'%s\' (which has version \'%s\') does not pay attention to the version constraint; hence, argument \'versionConstraint\', with value \'%s\', was ignored', 'component-model'),
+                        $this->translationAPI->__('The DirectiveResolver used to process directive \'%s\' (which has version \'%s\') does not pay attention to the version constraint; hence, argument \'versionConstraint\', with value \'%s\', was ignored', 'component-model'),
                         $this->getDirectiveName(),
                         $this->getSchemaDirectiveVersion($typeResolver) ?? '',
                         $versionConstraint
@@ -748,22 +746,21 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     //     }
     //     // Give an error message for all failed fields
     //     if ($failedFields) {
-    //         $translationAPI = TranslationAPIFacade::getInstance();
     //         $directiveName = $this->getDirectiveName();
     //         $failedFieldNames = array_map(
     //             [$fieldQueryInterpreter, 'getFieldName'],
     //             $failedFields
     //         );
     //         if (count($failedFields) == 1) {
-    //             $message = $translationAPI->__('Directive \'%s\' doesn\'t support field \'%s\' (the only supported field names are: \'%s\')', 'component-model');
+    //             $message = $this->translationAPI->__('Directive \'%s\' doesn\'t support field \'%s\' (the only supported field names are: \'%s\')', 'component-model');
     //         } else {
-    //             $message = $translationAPI->__('Directive \'%s\' doesn\'t support fields \'%s\' (the only supported field names are: \'%s\')', 'component-model');
+    //             $message = $this->translationAPI->__('Directive \'%s\' doesn\'t support fields \'%s\' (the only supported field names are: \'%s\')', 'component-model');
     //         }
     //         $failureMessage = sprintf(
     //             $message,
     //             $directiveName,
-    //             implode($translationAPI->__('\', \''), $failedFieldNames),
-    //             implode($translationAPI->__('\', \''), $directiveSupportedFieldNames)
+    //             implode($this->translationAPI->__('\', \''), $failedFieldNames),
+    //             implode($this->translationAPI->__('\', \''), $directiveSupportedFieldNames)
     //         );
     //         $this->processFailure($failureMessage, $failedFields, $idsDataFields, $schemaErrors, $schemaWarnings);
     //     }
@@ -804,7 +801,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
         // Show the failureMessage either as error or as warning
         // $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $translationAPI = TranslationAPIFacade::getInstance();
         $directiveName = $this->getDirectiveName();
         // $failedFieldNames = array_map(
         //     [$fieldQueryInterpreter, 'getFieldName'],
@@ -812,31 +808,31 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         // );
         if ($removeFieldIfDirectiveFailed) {
             if (count($failedFields) == 1) {
-                $message = $translationAPI->__('%s. Field \'%s\' has been removed from the directive pipeline', 'component-model');
+                $message = $this->translationAPI->__('%s. Field \'%s\' has been removed from the directive pipeline', 'component-model');
             } else {
-                $message = $translationAPI->__('%s. Fields \'%s\' have been removed from the directive pipeline', 'component-model');
+                $message = $this->translationAPI->__('%s. Fields \'%s\' have been removed from the directive pipeline', 'component-model');
             }
             $schemaErrors[] = [
-                Tokens::PATH => [implode($translationAPI->__('\', \''), $failedFields), $this->directive],
+                Tokens::PATH => [implode($this->translationAPI->__('\', \''), $failedFields), $this->directive],
                 Tokens::MESSAGE => sprintf(
                     $message,
                     $failureMessage,
-                    implode($translationAPI->__('\', \''), $failedFields)
+                    implode($this->translationAPI->__('\', \''), $failedFields)
                 ),
             ];
         } else {
             if (count($failedFields) == 1) {
-                $message = $translationAPI->__('%s. Execution of directive \'%s\' has been ignored on field \'%s\'', 'component-model');
+                $message = $this->translationAPI->__('%s. Execution of directive \'%s\' has been ignored on field \'%s\'', 'component-model');
             } else {
-                $message = $translationAPI->__('%s. Execution of directive \'%s\' has been ignored on fields \'%s\'', 'component-model');
+                $message = $this->translationAPI->__('%s. Execution of directive \'%s\' has been ignored on fields \'%s\'', 'component-model');
             }
             $schemaWarnings[] = [
-                Tokens::PATH => [implode($translationAPI->__('\', \''), $failedFields), $this->directive],
+                Tokens::PATH => [implode($this->translationAPI->__('\', \''), $failedFields), $this->directive],
                 Tokens::MESSAGE => sprintf(
                     $message,
                     $failureMessage,
                     $directiveName,
-                    implode($translationAPI->__('\', \''), $failedFields)
+                    implode($this->translationAPI->__('\', \''), $failedFields)
                 ),
             ];
         }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -4,25 +4,26 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\DirectiveResolvers;
 
-use Composer\Semver\Semver;
 use Exception;
+use Composer\Semver\Semver;
+use PoP\FieldQuery\QueryHelpers;
 use League\Pipeline\StageInterface;
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
-use PoP\ComponentModel\DirectivePipeline\DirectivePipelineUtils;
-use PoP\ComponentModel\Directives\DirectiveTypes;
 use PoP\ComponentModel\Environment;
-use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\ComponentModel\Feedback\Tokens;
-use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
+use PoP\Translation\TranslationAPIInterface;
+use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\Resolvers\ResolverTypes;
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\Directives\DirectiveTypes;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\FieldSymbols;
+use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\ComponentModel\TypeResolvers\PipelinePositions;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Versioning\VersioningHelpers;
-use PoP\FieldQuery\QueryHelpers;
-use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\DirectivePipeline\DirectivePipelineUtils;
+use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 
 abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, SchemaDirectiveResolverInterface, StageInterface
 {
@@ -33,6 +34,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     const MESSAGE_EXPRESSIONS = 'expressions';
 
     protected string $directive;
+    protected TranslationAPIInterface $translationAPI;
     /**
      * @var array<string, array>
      */
@@ -45,7 +47,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * @var array[]
      */
     protected array $nestedDirectivePipelineData = [];
-
+    
     /**
      * The directiveResolvers are NOT instantiated through the service container!
      * Instead, the directive will be instantiated in AbstractTypeResolver:
@@ -66,6 +68,8 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         // If the directive is not provided, then it directly the directive name
         // This allows to instantiate the directive through the DependencyInjection component
         $this->directive = $directive ?? $this->getDirectiveName();
+        // Obtain these services directly from the container, instead of using autowiring
+        $this->translationAPI = TranslationAPIFacade::getInstance();
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -7,8 +7,10 @@ namespace PoP\ComponentModel\DirectiveResolvers;
 use Exception;
 use Composer\Semver\Semver;
 use PoP\FieldQuery\QueryHelpers;
+use PoP\Hooks\HooksAPIInterface;
 use League\Pipeline\StageInterface;
 use PoP\ComponentModel\Environment;
+use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\Translation\TranslationAPIInterface;
 use PoP\ComponentModel\State\ApplicationState;
@@ -35,6 +37,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
     protected string $directive;
     protected TranslationAPIInterface $translationAPI;
+    protected HooksAPIInterface $hooksAPI;
     /**
      * @var array<string, array>
      */
@@ -70,6 +73,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         $this->directive = $directive ?? $this->getDirectiveName();
         // Obtain these services directly from the container, instead of using autowiring
         $this->translationAPI = TranslationAPIFacade::getInstance();
+        $this->hooksAPI = HooksAPIFacade::getInstance();
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
@@ -65,14 +65,13 @@ abstract class AbstractValidateConditionDirectiveResolver extends AbstractValida
 
     protected function getValidationFailedMessage(TypeResolverInterface $typeResolver, array $failedDataFields): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $errorMessage = $this->isValidatingDirective() ?
-            $translationAPI->__('Validation failed for directives in fields \'%s\'', 'component-model') :
-            $translationAPI->__('Validation failed for fields \'%s\'', 'component-model');
+            $this->translationAPI->__('Validation failed for directives in fields \'%s\'', 'component-model') :
+            $this->translationAPI->__('Validation failed for fields \'%s\'', 'component-model');
         return sprintf(
             $errorMessage,
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $failedDataFields
             )
         );

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -67,7 +67,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
 
     protected function resolveValueForResultItems(TypeResolverInterface $typeResolver, array &$resultIDItems, array &$idsDataFields, array &$dbItems, array &$previousDBItems, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations)
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
         $enqueueFillingResultItemsFromIDs = [];
         foreach (array_keys($idsDataFields) as $id) {
@@ -79,7 +78,7 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
                 $dbErrors[(string)$id][] = [
                     Tokens::PATH => ['id'],
                     Tokens::MESSAGE => sprintf(
-                        $translationAPI->__('Corrupted data: Object with ID \'%s\' doesn\'t exist', 'component-model'),
+                        $this->translationAPI->__('Corrupted data: Object with ID \'%s\' doesn\'t exist', 'component-model'),
                         $id
                     ),
                 ];
@@ -211,7 +210,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Resolve the value of the field and merge it into results. This directive is already included by the engine, since its execution is mandatory', 'component-model');
+        return $this->translationAPI->__('Resolve the value of the field and merge it into results. This directive is already included by the engine, since its execution is mandatory', 'component-model');
     }
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -80,7 +80,6 @@ final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver 
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('It validates the field, filtering out those field arguments that raised a warning, or directly invalidating the field if any field argument raised an error. For instance, if a mandatory field argument is not provided, then it is an error and the field is invalidated and removed from the output; if a field argument can\'t be casted to its intended type, then it is a warning, the affected field argument is removed and the field is executed without it. This directive is already included by the engine, since its execution is mandatory', 'component-model');
+        return $this->translationAPI->__('It validates the field, filtering out those field arguments that raised a warning, or directly invalidating the field if any field argument raised an error. For instance, if a mandatory field argument is not provided, then it is an error and the field is invalidated and removed from the output; if a field argument can\'t be casted to its intended type, then it is a warning, the affected field argument is removed and the field is executed without it. This directive is already included by the engine, since its execution is mandatory', 'component-model');
     }
 }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
+use PoP\Hooks\HooksAPIInterface;
 use PoP\ComponentModel\Schema\SchemaHelpers;
 use PoP\Translation\TranslationAPIInterface;
 use PoP\ComponentModel\State\ApplicationState;
@@ -14,7 +15,8 @@ abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverI
     use FieldInterfaceSchemaDefinitionResolverTrait;
 
     function __construct(
-        protected TranslationAPIInterface $translationAPI
+        protected TranslationAPIInterface $translationAPI,
+        protected HooksAPIInterface $hooksAPI
     ) {
     }
 

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -5,12 +5,18 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
 use PoP\ComponentModel\Schema\SchemaHelpers;
+use PoP\Translation\TranslationAPIInterface;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceSchemaDefinitionResolverTrait;
 
 abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverInterface
 {
     use FieldInterfaceSchemaDefinitionResolverTrait;
+
+    function __construct(
+        protected TranslationAPIInterface $translationAPI
+    ) {
+    }
 
     public function getFieldNamesToResolve(): array
     {

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -17,8 +17,7 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
 
     public function getSchemaInterfaceDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('The fundamental fields that must be implemented by all objects', 'component-model');
+        return $this->translationAPI->__('The fundamental fields that must be implemented by all objects', 'component-model');
     }
 
     public function getFieldNamesToImplement(): array
@@ -47,9 +46,8 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
 
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'id' => $translationAPI->__('The object\'s unique identifier for its type', 'component-model'),
+            'id' => $this->translationAPI->__('The object\'s unique identifier for its type', 'component-model'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -8,7 +8,6 @@ use Exception;
 use Composer\Semver\Semver;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\ComponentModel\Environment;
-use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\HookHelpers;
 use PoP\ComponentModel\ErrorHandling\Error;
@@ -325,12 +324,11 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
 
             // Hook to override the values, eg: by the Field Deprecation List
             // 1. Applied on the type
-            $hooksAPI = HooksAPIFacade::getInstance();
             $hookName = HookHelpers::getSchemaDefinitionForFieldHookName(
                 get_class($typeResolver),
                 $fieldName
             );
-            $schemaDefinition = $hooksAPI->applyFilters(
+            $schemaDefinition = $this->hooksAPI->applyFilters(
                 $hookName,
                 $schemaDefinition,
                 $typeResolver,
@@ -344,7 +342,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                         get_class($fieldInterfaceResolver),
                         $fieldName
                     );
-                    $schemaDefinition = $hooksAPI->applyFilters(
+                    $schemaDefinition = $this->hooksAPI->applyFilters(
                         $hookName,
                         $schemaDefinition,
                         $typeResolver,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -27,6 +27,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\Translation\TranslationAPIInterface;
 
 abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSchemaDefinitionResolverInterface
 {
@@ -41,6 +42,11 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
      * @var array<string, array>
      */
     protected array $schemaDefinitionForFieldCache = [];
+
+    function __construct(
+        protected TranslationAPIInterface $translationAPI
+    ) {
+    }
 
     public function getImplementedFieldInterfaceResolverClasses(): array
     {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -4,29 +4,30 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
-use Composer\Semver\Semver;
 use Exception;
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
-use PoP\ComponentModel\CheckpointSets\CheckpointSets;
+use Composer\Semver\Semver;
+use PoP\Hooks\HooksAPIInterface;
 use PoP\ComponentModel\Environment;
-use PoP\ComponentModel\ErrorHandling\Error;
-use PoP\ComponentModel\Facades\Engine\EngineFacade;
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
-use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
-use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
-use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverTrait;
-use PoP\ComponentModel\Misc\GeneralUtils;
-use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
-use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
-use PoP\ComponentModel\Resolvers\InterfaceSchemaDefinitionResolverAdapter;
-use PoP\ComponentModel\Resolvers\ResolverTypes;
-use PoP\ComponentModel\Schema\HookHelpers;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\HookHelpers;
+use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\Translation\TranslationAPIInterface;
+use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\Resolvers\ResolverTypes;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Facades\Engine\EngineFacade;
+use PoP\ComponentModel\Versioning\VersioningHelpers;
+use PoP\ComponentModel\CheckpointSets\CheckpointSets;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
+use PoP\ComponentModel\Resolvers\FieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
+use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Resolvers\InterfaceSchemaDefinitionResolverAdapter;
+use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
+use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
 
 abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSchemaDefinitionResolverInterface
 {
@@ -43,7 +44,8 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
     protected array $schemaDefinitionForFieldCache = [];
 
     function __construct(
-        protected TranslationAPIInterface $translationAPI
+        protected TranslationAPIInterface $translationAPI,
+        protected HooksAPIInterface $hooksAPI
     ) {
     }
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -375,7 +375,6 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
     public function resolveSchemaValidationWarningDescriptions(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?array
     {
         $warnings = [];
-        $translationAPI = TranslationAPIFacade::getInstance();
         if (Environment::enableSemanticVersionConstraints()) {
             /**
              * If restricting the version, and this fieldResolver doesn't have any version, then show a warning
@@ -386,7 +385,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                  */
                 if (!$this->decideCanProcessBasedOnVersionConstraint($typeResolver)) {
                     $warnings[] = sprintf(
-                        $translationAPI->__('The FieldResolver used to process field with name \'%s\' (which has version \'%s\') does not pay attention to the version constraint; hence, argument \'versionConstraint\', with value \'%s\', was ignored', 'component-model'),
+                        $this->translationAPI->__('The FieldResolver used to process field with name \'%s\' (which has version \'%s\') does not pay attention to the version constraint; hence, argument \'versionConstraint\', with value \'%s\', was ignored', 'component-model'),
                         $fieldName,
                         $this->getSchemaFieldVersion($typeResolver, $fieldName) ?? '',
                         $versionConstraint
@@ -467,11 +466,10 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
             $validation = $engine->validateCheckpoints($checkpoints);
             if (GeneralUtils::isError($validation)) {
                 $error = $validation;
-                $translationAPI = TranslationAPIFacade::getInstance();
                 $errorMessage = $error->getErrorMessage();
                 if (!$errorMessage) {
                     $errorMessage = sprintf(
-                        $translationAPI->__('Validation with code \'%s\' failed', 'component-model'),
+                        $this->translationAPI->__('Validation with code \'%s\' failed', 'component-model'),
                         $error->getErrorCode()
                     );
                 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -26,7 +26,6 @@ use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Hooks\Facades\HooksAPIFacade;
-use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\Translation\TranslationAPIInterface;
 
 abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSchemaDefinitionResolverInterface

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
@@ -72,8 +72,7 @@ abstract class AbstractReflectionPropertyFieldResolver extends AbstractDBDataFie
             // The line is added to the description
             $docCommentDescLines[] = $docCommentLines[$count];
         }
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return implode($translationAPI->__('. '), $docCommentDescLines);
+        return implode($this->translationAPI->__('. '), $docCommentDescLines);
     }
 
     public function getTypePropertyDocComments(): array

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -49,13 +49,12 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'typeName' => $translationAPI->__('The object\'s type', 'pop-component-model'),
-            'namespace' => $translationAPI->__('The object\'s namespace', 'pop-component-model'),
-            'qualifiedTypeName' => $translationAPI->__('The object\'s namespace + type', 'pop-component-model'),
-            'isType' => $translationAPI->__('Indicate if the object is of a given type', 'pop-component-model'),
-            'implements' => $translationAPI->__('Indicate if the object implements a given interface', 'pop-component-model'),
+            'typeName' => $this->translationAPI->__('The object\'s type', 'pop-component-model'),
+            'namespace' => $this->translationAPI->__('The object\'s namespace', 'pop-component-model'),
+            'qualifiedTypeName' => $this->translationAPI->__('The object\'s namespace + type', 'pop-component-model'),
+            'isType' => $this->translationAPI->__('Indicate if the object is of a given type', 'pop-component-model'),
+            'implements' => $this->translationAPI->__('Indicate if the object implements a given interface', 'pop-component-model'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -63,7 +62,6 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'isType':
                 return array_merge(
@@ -72,7 +70,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'type',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The type name to compare against', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The type name to compare against', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -85,7 +83,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'interface',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The interface name to compare against', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The interface name to compare against', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -56,10 +56,9 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'id' => $translationAPI->__('The object ID', 'pop-component-model'),
-            'self' => $translationAPI->__('The same object', 'pop-component-model'),
+            'id' => $this->translationAPI->__('The object ID', 'pop-component-model'),
+            'self' => $this->translationAPI->__('The same object', 'pop-component-model'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Engine/packages/component-model/src/MutationResolvers/AbstractMutationResolver.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/AbstractMutationResolver.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\MutationResolvers;
 
+use PoP\Translation\TranslationAPIInterface;
+
 abstract class AbstractMutationResolver implements MutationResolverInterface
 {
+    function __construct(
+        protected TranslationAPIInterface $translationAPI
+    ) {
+    }
+
     public function validateErrors(array $form_data): ?array
     {
         return null;

--- a/layers/Engine/packages/component-model/src/MutationResolvers/AbstractMutationResolver.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/AbstractMutationResolver.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\MutationResolvers;
 
+use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
 
 abstract class AbstractMutationResolver implements MutationResolverInterface
 {
     function __construct(
-        protected TranslationAPIInterface $translationAPI
+        protected TranslationAPIInterface $translationAPI,
+        protected HooksAPIInterface $hooksAPI
     ) {
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -18,7 +18,6 @@ use PoP\ComponentModel\ComponentConfiguration;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\FieldHelpers;
 use PoP\ComponentModel\TypeResolvers\UnionTypeHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -225,7 +225,6 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         array &$schemaNotices,
         array &$schemaTraces
     ): array {
-        $translationAPI = TranslationAPIFacade::getInstance();
         /**
         * All directives are placed somewhere in the pipeline. There are 5 positions:
         * 1. At the beginning
@@ -261,7 +260,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             foreach ($directiveSchemaErrors as $directiveSchemaError) {
                 $directive = $directiveSchemaError[Tokens::PATH][0];
                 if ($directiveFields = $fieldDirectiveFields[$directive] ?? null) {
-                    $fields = implode($translationAPI->__(', '), $directiveFields);
+                    $fields = implode($this->translationAPI->__(', '), $directiveFields);
                     $schemaErrors[] = [
                         Tokens::PATH => array_merge([$fields], $directiveSchemaError[Tokens::PATH]),
                         Tokens::MESSAGE => $directiveSchemaError[Tokens::MESSAGE],
@@ -273,7 +272,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             foreach ($directiveSchemaWarnings as $directiveSchemaWarning) {
                 $directive = $directiveSchemaWarning[Tokens::PATH][0];
                 if ($directiveFields = $fieldDirectiveFields[$directive] ?? null) {
-                    $fields = implode($translationAPI->__(', '), $directiveFields);
+                    $fields = implode($this->translationAPI->__(', '), $directiveFields);
                     $schemaWarnings[] = [
                         Tokens::PATH => array_merge([$fields], $directiveSchemaWarning[Tokens::PATH]),
                         Tokens::MESSAGE => $directiveSchemaWarning[Tokens::MESSAGE],
@@ -285,7 +284,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             foreach ($directiveSchemaDeprecations as $directiveSchemaDeprecation) {
                 $directive = $directiveSchemaDeprecation[Tokens::PATH][0];
                 if ($directiveFields = $fieldDirectiveFields[$directive] ?? null) {
-                    $fields = implode($translationAPI->__(', '), $directiveFields);
+                    $fields = implode($this->translationAPI->__(', '), $directiveFields);
                     $schemaDeprecations[] = [
                         Tokens::PATH => array_merge([$fields], $directiveSchemaDeprecation[Tokens::PATH]),
                         Tokens::MESSAGE => $directiveSchemaDeprecation[Tokens::MESSAGE],
@@ -297,7 +296,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             foreach ($directiveSchemaNotices as $directiveSchemaNotice) {
                 $directive = $directiveSchemaNotice[Tokens::PATH][0];
                 if ($directiveFields = $fieldDirectiveFields[$directive] ?? null) {
-                    $fields = implode($translationAPI->__(', '), $directiveFields);
+                    $fields = implode($this->translationAPI->__(', '), $directiveFields);
                     $schemaNotices[] = [
                         Tokens::PATH => array_merge([$fields], $directiveSchemaNotice[Tokens::PATH]),
                         Tokens::MESSAGE => $directiveSchemaNotice[Tokens::MESSAGE],
@@ -309,7 +308,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             foreach ($directiveSchemaTraces as $directiveSchemaTrace) {
                 $directive = $directiveSchemaTrace[Tokens::PATH][0];
                 if ($directiveFields = $fieldDirectiveFields[$directive] ?? null) {
-                    $fields = implode($translationAPI->__(', '), $directiveFields);
+                    $fields = implode($this->translationAPI->__(', '), $directiveFields);
                     $schemaTraces[] = [
                         Tokens::PATH => array_merge([$fields], $directiveSchemaTrace[Tokens::PATH]),
                         Tokens::MESSAGE => $directiveSchemaTrace[Tokens::MESSAGE],
@@ -386,13 +385,12 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         array &$schemaNotices,
         array &$schemaTraces
     ): array {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
 
         // Check if, once a directive fails, the continuing directives must execute or not
         $stopDirectivePipelineExecutionIfDirectiveFailed = Environment::stopDirectivePipelineExecutionIfDirectiveFailed();
         if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
-            $stopDirectivePipelineExecutionPlaceholder = $translationAPI->__('Because directive \'%s\' failed, the succeeding directives in the pipeline have not been executed', 'pop-component-model');
+            $stopDirectivePipelineExecutionPlaceholder = $this->translationAPI->__('Because directive \'%s\' failed, the succeeding directives in the pipeline have not been executed', 'pop-component-model');
         }
 
         $instances = [];
@@ -431,7 +429,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $schemaErrors[] = [
                     Tokens::PATH => [$fieldDirective],
                     Tokens::MESSAGE => sprintf(
-                        $translationAPI->__('No DirectiveResolver resolves directive with name \'%s\'', 'pop-component-model'),
+                        $this->translationAPI->__('No DirectiveResolver resolves directive with name \'%s\'', 'pop-component-model'),
                         $directiveName
                     ),
                 ];
@@ -453,11 +451,11 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $schemaErrors[] = [
                     Tokens::PATH => [$fieldDirective],
                     Tokens::MESSAGE => sprintf(
-                        $translationAPI->__('No DirectiveResolver processes directive with name \'%s\' and arguments \'%s\' in field(s) \'%s\'', 'pop-component-model'),
+                        $this->translationAPI->__('No DirectiveResolver processes directive with name \'%s\' and arguments \'%s\' in field(s) \'%s\'', 'pop-component-model'),
                         $directiveName,
                         json_encode($directiveArgs),
                         implode(
-                            $translationAPI->__('\', \'', 'pop-component-model'),
+                            $this->translationAPI->__('\', \'', 'pop-component-model'),
                             $fieldDirectiveFields[$fieldDirective]
                         )
                     ),
@@ -481,7 +479,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                     $schemaErrors[] = [
                         Tokens::PATH => [$fieldDirective],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('No DirectiveResolver processes directive with name \'%s\' and arguments \'%s\' in field \'%s\'', 'pop-component-model'),
+                            $this->translationAPI->__('No DirectiveResolver processes directive with name \'%s\' and arguments \'%s\' in field \'%s\'', 'pop-component-model'),
                             $directiveName,
                             json_encode($directiveArgs),
                             $field
@@ -628,7 +626,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                     $schemaErrors[] = [
                         Tokens::PATH => [$fieldDirective],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('Directive \'%s\' can be executed only once for field(s) \'%s\'', 'component-model'),
+                            $this->translationAPI->__('Directive \'%s\' can be executed only once for field(s) \'%s\'', 'component-model'),
                             $fieldDirective,
                             implode('\', \'', $alreadyProcessingFields)
                         ),
@@ -718,11 +716,10 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
 
     protected function getUnresolvedResultItemIDError(string | int $resultItemID)
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return new Error(
             'unresolved-resultitem-id',
             sprintf(
-                $translationAPI->__('The DataLoader can\'t load data for object of type \'%s\' with ID \'%s\'', 'pop-component-model'),
+                $this->translationAPI->__('The DataLoader can\'t load data for object of type \'%s\' with ID \'%s\'', 'pop-component-model'),
                 $this->getTypeOutputName(),
                 $resultItemID
             )
@@ -748,7 +745,6 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         array &$schemaTraces
     ): array {
         $instanceManager = InstanceManagerFacade::getInstance();
-        $translationAPI = TranslationAPIFacade::getInstance();
 
         // Obtain the data for the required object IDs
         $resultIDItems = [];
@@ -774,7 +770,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             $failedFields = $ids_data_fields[$unresolvedResultItemID]['direct'] ?? [];
             // Add in $schemaErrors instead of $dbErrors because in the latter one it will attempt to fetch the ID from the object, which it can't do
             $schemaErrors[] = [
-                Tokens::PATH => [implode($translationAPI->__('\', \''), $failedFields)],
+                Tokens::PATH => [implode($this->translationAPI->__('\', \''), $failedFields)],
                 Tokens::MESSAGE => $error->getErrorMessage(),
             ];
 
@@ -1180,14 +1176,13 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         }
 
         // If we reach here, no fieldResolver processes this field, which is an error
-        $translationAPI = TranslationAPIFacade::getInstance();
         /**
          * If the error happened from requesting a version that doesn't exist, show an appropriate error message
          */
         if (Environment::enableSemanticVersionConstraints()) {
             if ($versionConstraint = $fieldArgs[SchemaDefinition::ARGNAME_VERSION_CONSTRAINT] ?? null) {
                 $errorMessage = sprintf(
-                    $translationAPI->__(
+                    $this->translationAPI->__(
                         'No FieldResolver resolves field \'%s\' and version constraint \'%s\' for type \'%s\'',
                         'pop-component-model'
                     ),
@@ -1199,7 +1194,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         }
         if (!isset($errorMessage)) {
             $errorMessage = sprintf(
-                $translationAPI->__(
+                $this->translationAPI->__(
                     'No FieldResolver resolves field \'%s\' for type \'%s\'',
                     'pop-component-model'
                 ),

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -9,7 +9,6 @@ use PoP\FieldQuery\QuerySyntax;
 use PoP\FieldQuery\QueryHelpers;
 use PoP\ComponentModel\Environment;
 use League\Pipeline\PipelineBuilder;
-use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\ComponentModel\Schema\SchemaHelpers;
@@ -876,15 +875,14 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     protected function filterDirectiveNameResolvers(array $directiveNameResolvers): array
     {
         // Execute a hook, allowing to filter them out (eg: removing fieldNames from a private schema)
-        $hooksAPI = HooksAPIFacade::getInstance();
         return array_filter(
             $directiveNameResolvers,
-            function ($directiveName) use ($hooksAPI, $directiveNameResolvers) {
+            function ($directiveName) use ($directiveNameResolvers) {
                 $directiveResolvers = $directiveNameResolvers[$directiveName];
                 foreach ($directiveResolvers as $directiveResolver) {
                     // Execute 2 filters: a generic one, and a specific one
                     if (
-                        $hooksAPI->applyFilters(
+                        $this->hooksAPI->applyFilters(
                             HookHelpers::getHookNameToFilterDirective(),
                             true,
                             $this,
@@ -892,7 +890,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                             $directiveName
                         )
                     ) {
-                        return $hooksAPI->applyFilters(
+                        return $this->hooksAPI->applyFilters(
                             HookHelpers::getHookNameToFilterDirective($directiveName),
                             true,
                             $this,
@@ -1712,9 +1710,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             }
         ));
         // Execute 2 filters: a generic one, and a specific one
-        $hooksAPI = HooksAPIFacade::getInstance();
         if (
-            $hooksAPI->applyFilters(
+            $this->hooksAPI->applyFilters(
                 HookHelpers::getHookNameToFilterField(),
                 true,
                 $this,
@@ -1723,7 +1720,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $fieldName
             )
         ) {
-            return $hooksAPI->applyFilters(
+            return $this->hooksAPI->applyFilters(
                 HookHelpers::getHookNameToFilterField($fieldName),
                 true,
                 $this,
@@ -1758,8 +1755,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $excludedFieldNames = $fieldResolver->getAdminFieldNames();
             }
             // 2. By filter hook
-            $hooksAPI = HooksAPIFacade::getInstance();
-            $excludedFieldNames = $hooksAPI->applyFilters(
+            $excludedFieldNames = $this->hooksAPI->applyFilters(
                 Hooks::EXCLUDE_FIELDNAMES,
                 $excludedFieldNames,
                 $fieldResolver,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -4,36 +4,37 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers;
 
-use League\Pipeline\PipelineBuilder;
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
-use PoP\ComponentModel\ComponentConfiguration;
-use PoP\ComponentModel\DirectivePipeline\DirectivePipelineDecorator;
-use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\FieldQuery\QueryUtils;
+use PoP\FieldQuery\QuerySyntax;
+use PoP\FieldQuery\QueryHelpers;
 use PoP\ComponentModel\Environment;
+use League\Pipeline\PipelineBuilder;
+use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\ErrorHandling\Error;
+use PoP\ComponentModel\Schema\SchemaHelpers;
+use PoP\Translation\TranslationAPIInterface;
+use PoP\ComponentModel\ComponentConfiguration;
+use PoP\ComponentModel\Schema\FieldQueryUtils;
+use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\ComponentModel\TypeResolvers\FieldHelpers;
+use PoP\ComponentModel\TypeResolvers\UnionTypeHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\ErrorHandling\ErrorProviderInterface;
-use PoP\ComponentModel\Facades\AttachableExtensions\AttachableExtensionManagerFacade;
+use PoP\ComponentModel\FieldResolvers\FieldResolverInterface;
 use PoP\ComponentModel\Facades\Engine\DataloadingEngineFacade;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FeedbackMessageStoreFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
+use PoP\ComponentModel\DirectivePipeline\DirectivePipelineDecorator;
 use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
-use PoP\ComponentModel\Feedback\Tokens;
-use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
-use PoP\ComponentModel\FieldResolvers\FieldResolverInterface;
-use PoP\ComponentModel\Schema\FieldQueryUtils;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\SchemaHelpers;
-use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
 use PoP\ComponentModel\TypeResolverDecorators\TypeResolverDecoratorInterface;
-use PoP\ComponentModel\TypeResolvers\FieldHelpers;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\TypeResolvers\UnionTypeHelpers;
-use PoP\FieldQuery\QueryHelpers;
-use PoP\FieldQuery\QuerySyntax;
-use PoP\FieldQuery\QueryUtils;
-use PoP\Hooks\Facades\HooksAPIFacade;
-use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
+use PoP\ComponentModel\Facades\AttachableExtensions\AttachableExtensionManagerFacade;
 
 abstract class AbstractTypeResolver implements TypeResolverInterface
 {
@@ -104,6 +105,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     private array $fieldNamesResolvedByFieldResolver = [];
 
     public function __construct(
+        protected TranslationAPIInterface $translationAPI,
         protected ErrorProviderInterface $errorProvider
     ) {
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -7,6 +7,7 @@ namespace PoP\ComponentModel\TypeResolvers;
 use PoP\FieldQuery\QueryUtils;
 use PoP\FieldQuery\QuerySyntax;
 use PoP\FieldQuery\QueryHelpers;
+use PoP\Hooks\HooksAPIInterface;
 use PoP\ComponentModel\Environment;
 use League\Pipeline\PipelineBuilder;
 use PoP\ComponentModel\Feedback\Tokens;
@@ -104,6 +105,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
 
     public function __construct(
         protected TranslationAPIInterface $translationAPI,
+        protected HooksAPIInterface $hooksAPI,
         protected ErrorProviderInterface $errorProvider
     ) {
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -283,25 +283,24 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
                 }
             );
             if ($notImplementingInterfaceTypeResolverClasses) {
-                $translationAPI = TranslationAPIFacade::getInstance();
                 $typeInterfaceResolver = $instanceManager->getInstance($typeInterfaceClass);
                 throw new Exception(
                     sprintf(
-                        $translationAPI->__('UnionTypeResolver \'%s\' (\'%s\') must return results implementing interface \'%s\' (\'%s\'), however its following member TypeResolvers do not: \'%s\'', 'component-model'),
+                        $this->translationAPI->__('UnionTypeResolver \'%s\' (\'%s\') must return results implementing interface \'%s\' (\'%s\'), however its following member TypeResolvers do not: \'%s\'', 'component-model'),
                         $this->getMaybeNamespacedTypeName(),
                         get_called_class(),
                         $typeInterfaceResolver->getMaybeNamespacedInterfaceName(),
                         $typeInterfaceClass,
                         implode(
-                            $translationAPI->__('\', \''),
+                            $this->translationAPI->__('\', \''),
                             array_map(
-                                function ($typeResolverClass) use ($instanceManager, $translationAPI) {
+                                function ($typeResolverClass) use ($instanceManager) {
                                     /**
                                      * @var TypeResolverInterface
                                      */
                                     $typeResolver = $instanceManager->getInstance($typeResolverClass);
                                     return sprintf(
-                                        $translationAPI->__('%s (%s)'),
+                                        $this->translationAPI->__('%s (%s)'),
                                         $typeResolver->getMaybeNamespacedTypeName(),
                                         $typeResolverClass
                                     );
@@ -370,11 +369,10 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
 
     protected function getUnresolvedResultItemIDError(string | int $resultItemID)
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return new Error(
             'unresolved-resultitem-id',
             sprintf(
-                $translationAPI->__('Either the DataLoader can\'t load data, or no TypeResolver resolves, object with ID \'%s\'', 'pop-component-model'),
+                $this->translationAPI->__('Either the DataLoader can\'t load data, or no TypeResolver resolves, object with ID \'%s\'', 'pop-component-model'),
                 (string) $resultItemID
             )
         );
@@ -382,11 +380,10 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
 
     protected function getUnresolvedResultItemError(object $resultItem): Error
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return new Error(
             'unresolved-resultitem',
             sprintf(
-                $translationAPI->__('No TypeResolver resolves object \'%s\'', 'pop-component-model'),
+                $this->translationAPI->__('No TypeResolver resolves object \'%s\'', 'pop-component-model'),
                 json_encode($resultItem)
             )
         );

--- a/layers/Engine/packages/engine/src/ConditionalOnContext/Guzzle/SchemaServices/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnContext/Guzzle/SchemaServices/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -32,10 +32,9 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'getJSON' => $translationAPI->__('Retrieve data from URL and decode it as a JSON object', 'pop-component-model'),
-            'getAsyncJSON' => $translationAPI->__('Retrieve data from multiple URL asynchronously, and decode each of them as a JSON object', 'pop-component-model'),
+            'getJSON' => $this->translationAPI->__('Retrieve data from URL and decode it as a JSON object', 'pop-component-model'),
+            'getAsyncJSON' => $this->translationAPI->__('Retrieve data from multiple URL asynchronously, and decode each of them as a JSON object', 'pop-component-model'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -43,7 +42,6 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'getJSON':
                 return array_merge(
@@ -52,7 +50,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'url',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_URL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The URL to request', 'pop-component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The URL to request', 'pop-component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -64,7 +62,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'urls',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_URL),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The URLs to request, with format `key:value`, where the value is the URL, and the key, if provided, is the name where to store the JSON data in the result (if not provided, it is accessed under the corresponding numeric index)', 'pop-component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The URLs to request, with format `key:value`, where the value is the URL, and the key, if provided, is the name where to store the JSON data in the result (if not provided, it is accessed under the corresponding numeric index)', 'pop-component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
@@ -123,21 +123,20 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
 
             // Log the cached items
             $feedbackMessageStore = FeedbackMessageStoreFacade::getInstance();
-            $translationAPI = TranslationAPIFacade::getInstance();
             $logCachedIDFields = [];
             foreach ($idsDataFieldsToRemove as $id => $dataFieldsToRemove) {
                 $logCachedIDFields[] = sprintf(
-                    $translationAPI->__('ID: %s, Field(s): \'%s\'', 'engine'),
+                    $this->translationAPI->__('ID: %s, Field(s): \'%s\'', 'engine'),
                     $id,
                     implode('\', \'', $dataFieldsToRemove['direct'])
                 );
             }
             $feedbackMessageStore->addLogEntry(
                 sprintf(
-                    $translationAPI->__('The following fields of type \'%s\' were resolved from the cache - %s', 'engine'),
+                    $this->translationAPI->__('The following fields of type \'%s\' were resolved from the cache - %s', 'engine'),
                     $typeResolver->getTypeName(),
                     implode(
-                        $translationAPI->__('; ', 'engine'),
+                        $this->translationAPI->__('; ', 'engine'),
                         $logCachedIDFields
                     )
                 )
@@ -146,7 +145,6 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Load the cached value for a field', 'engine');
+        return $this->translationAPI->__('Load the cached value for a field', 'engine');
     }
 }

--- a/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
@@ -72,7 +72,6 @@ class SaveCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
     ): void {
         $persistentCache = PersistentCacheFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $translationAPI = TranslationAPIFacade::getInstance();
         $cacheType = CacheTypes::CACHE_DIRECTIVE;
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
@@ -82,7 +81,7 @@ class SaveCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
                     $dbWarnings[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('Property \'%s\' doesn\'t exist in object with ID \'%s\', so it can\'t be cached'),
+                            $this->translationAPI->__('Property \'%s\' doesn\'t exist in object with ID \'%s\', so it can\'t be cached'),
                             $fieldOutputKey,
                             $id
                         ),
@@ -100,17 +99,15 @@ class SaveCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Cache the field value, and retrive from the cache if available', 'engine');
+        return $this->translationAPI->__('Cache the field value, and retrive from the cache if available', 'engine');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'time',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_INT,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Amount of time, in seconds, that the cache is valid. If not defining this value, the cache has no expiry date', 'engine'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Amount of time, in seconds, that the cache is valid. If not defining this value, the cache has no expiry date', 'engine'),
             ],
         ];
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
@@ -27,13 +27,12 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'addExpressions',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                    $translationAPI->__('Expressions to inject to the composed directive. The value of the affected field can be provided under special expression `%s`', 'component-model'),
+                    $this->translationAPI->__('Expressions to inject to the composed directive. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)
                 ),
             ],
@@ -41,7 +40,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                 SchemaDefinition::ARGNAME_NAME => 'appendExpressions',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                    $translationAPI->__('Append a value to an expression which must be an array, to inject to the composed directive. If the array has not been set, it is initialized as an empty array. The value of the affected field can be provided under special expression `%s`', 'component-model'),
+                    $this->translationAPI->__('Append a value to an expression which must be an array, to inject to the composed directive. If the array has not been set, it is initialized as an empty array. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)
                 ),
             ],
@@ -50,10 +49,9 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
 
     public function getSchemaDirectiveExpressions(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             Expressions::NAME_VALUE => sprintf(
-                $translationAPI->__('Value of the array element from the current iteration, available for params \'%s\' and \'%s\'', 'component-model'),
+                $this->translationAPI->__('Value of the array element from the current iteration, available for params \'%s\' and \'%s\'', 'component-model'),
                 'addExpressions',
                 'appendExpressions'
             ),
@@ -89,13 +87,12 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
         array &$schemaNotices,
         array &$schemaTraces
     ): void {
-        $translationAPI = TranslationAPIFacade::getInstance();
 
         // If there are no composed directives to execute, then nothing to do
         if (!$this->nestedDirectivePipelineData) {
             $schemaWarnings[] = [
                 Tokens::PATH => [$this->directive],
-                Tokens::MESSAGE => $translationAPI->__('No composed directives were provided, so nothing to do for this directive', 'component-model'),
+                Tokens::MESSAGE => $this->translationAPI->__('No composed directives were provided, so nothing to do for this directive', 'component-model'),
             ];
             return;
         }
@@ -124,7 +121,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -134,7 +131,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             ),
@@ -158,7 +155,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('The value for field \'%s\' (under property \'%s\') is not an array, so execution of this directive can\'t continue', 'component-model'),
+                                $this->translationAPI->__('The value for field \'%s\' (under property \'%s\') is not an array, so execution of this directive can\'t continue', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -168,7 +165,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('The value for field \'%s\' is not an array, so execution of this directive can\'t continue', 'component-model'),
+                                $this->translationAPI->__('The value for field \'%s\' is not an array, so execution of this directive can\'t continue', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             ),
@@ -301,7 +298,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                             $dbErrors[(string)$id][] = [
                                 Tokens::PATH => [$this->directive],
                                 Tokens::MESSAGE => sprintf(
-                                    $translationAPI->__('Transformation of element with key \'%s\' on array from property \'%s\' on object with ID \'%s\' failed due to error: %s', 'component-model'),
+                                    $this->translationAPI->__('Transformation of element with key \'%s\' on array from property \'%s\' on object with ID \'%s\' failed due to error: %s', 'component-model'),
                                     $key,
                                     $fieldOutputKey,
                                     $id,
@@ -373,7 +370,6 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
         array &$schemaWarnings,
         array &$schemaDeprecations
     ): void {
-        $translationAPI = TranslationAPIFacade::getInstance();
         // Enable the query to provide variables to pass down
         $addExpressions = $this->directiveArgsForSchema['addExpressions'] ?? [];
         $appendExpressions = $this->directiveArgsForSchema['appendExpressions'] ?? [];
@@ -410,7 +406,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Executing field \'%s\' on object with ID \'%s\' produced error: %s. Setting expression \'%s\' was ignored', 'pop-component-model'),
+                                $this->translationAPI->__('Executing field \'%s\' on object with ID \'%s\' produced error: %s. Setting expression \'%s\' was ignored', 'pop-component-model'),
                                 $value,
                                 $id,
                                 $error->getErrorMessage(),
@@ -442,7 +438,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Executing field \'%s\' on object with ID \'%s\' produced error: %s. Setting expression \'%s\' was ignored', 'pop-component-model'),
+                                $this->translationAPI->__('Executing field \'%s\' on object with ID \'%s\' produced error: %s. Setting expression \'%s\' was ignored', 'pop-component-model'),
                                 $value,
                                 $id,
                                 $error->getErrorMessage(),

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AddFeedbackForFieldDirectiveResolver.php
@@ -71,7 +71,6 @@ class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolv
         $type = $this->directiveArgsForSchema['type'];
         $target = $this->directiveArgsForSchema['target'];
         if ($target == FieldFeedbackTargetEnum::DB) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             foreach (array_keys($idsDataFields) as $id) {
                 // Use either the default value passed under param "value" or, if this is NULL, use a predefined value
                 $expressions = $this->getExpressionsForResultItem($id, $variables, $messages);
@@ -92,7 +91,7 @@ class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolv
                 if (is_null($message)) {
                     $dbErrors[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
-                        Tokens::MESSAGE => $translationAPI->__(
+                        Tokens::MESSAGE => $this->translationAPI->__(
                             'The message could not be composed. Check previous errors',
                             'engine'
                         ),
@@ -131,13 +130,11 @@ class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolv
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Whenever a field is queried, add a feedback message to the response, of either type "warning", "deprecation" or "log"', 'engine');
+        return $this->translationAPI->__('Whenever a field is queried, add a feedback message to the response, of either type "warning", "deprecation" or "log"', 'engine');
     }
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         /**
          * @var FieldFeedbackTypeEnum
@@ -151,13 +148,13 @@ class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolv
             [
                 SchemaDefinition::ARGNAME_NAME => 'message',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The feedback message', 'engine'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The feedback message', 'engine'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'type',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The type of feedback', 'engine'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The type of feedback', 'engine'),
                 SchemaDefinition::ARGNAME_ENUM_NAME => $fieldFeedbackTypeEnum->getName(),
                 SchemaDefinition::ARGNAME_ENUM_VALUES => SchemaHelpers::convertToSchemaFieldArgEnumValueDefinitions(
                     $fieldFeedbackTypeEnum->getValues()
@@ -167,7 +164,7 @@ class AddFeedbackForFieldDirectiveResolver extends AbstractGlobalDirectiveResolv
             [
                 SchemaDefinition::ARGNAME_NAME => 'target',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The target for the feedback', 'engine'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The target for the feedback', 'engine'),
                 SchemaDefinition::ARGNAME_ENUM_NAME => $fieldFeedbackTargetEnum->getName(),
                 SchemaDefinition::ARGNAME_ENUM_VALUES => SchemaHelpers::convertToSchemaFieldArgEnumValueDefinitions(
                     $fieldFeedbackTargetEnum->getValues()

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
@@ -37,19 +37,17 @@ class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectiv
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Apply all composed directives on the element found under the \'path\' parameter in the affected array object', 'component-model');
+        return $this->translationAPI->__('Apply all composed directives on the element found under the \'path\' parameter in the affected array object', 'component-model');
     }
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return array_merge(
             [
                 [
                     SchemaDefinition::ARGNAME_NAME => 'path',
                     SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                    SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Path to the element in the array', 'component-model'),
+                    SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Path to the element in the array', 'component-model'),
                     SchemaDefinition::ARGNAME_MANDATORY => true,
                 ],
             ],

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -35,35 +35,33 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'function',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Function to execute on the affected fields', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Function to execute on the affected fields', 'component-model'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'addArguments',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                    $translationAPI->__('Arguments to inject to the function. The value of the affected field can be provided under special expression `%s`', 'component-model'),
+                    $this->translationAPI->__('Arguments to inject to the function. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)
                 ),
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'target',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Property from the current object where to store the results of the function. If the result must not be stored, pass an empty value. Default value: Same property as the affected field', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Property from the current object where to store the results of the function. If the result must not be stored, pass an empty value. Default value: Same property as the affected field', 'component-model'),
             ],
         ];
     }
 
     public function getSchemaDirectiveExpressions(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
-            Expressions::NAME_VALUE => $translationAPI->__('Element being transformed', 'component-model'),
+            Expressions::NAME_VALUE => $this->translationAPI->__('Element being transformed', 'component-model'),
         ];
     }
 
@@ -101,7 +99,6 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
         $addArguments = $this->directiveArgsForSchema['addArguments'] ?? [];
         $target = $this->directiveArgsForSchema['target'] ?? null;
 
-        $translationAPI = TranslationAPIFacade::getInstance();
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
 
         // Maybe re-generate the function: Inject the provided `$addArguments` to the fieldArgs already declared in the query
@@ -127,7 +124,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -137,7 +134,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             ),
@@ -165,7 +162,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbWarnings[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Warning validating function \'%s\' on object with ID \'%s\' and field under property \'%s\': %s)', 'component-model'),
+                                $this->translationAPI->__('Warning validating function \'%s\' on object with ID \'%s\' and field under property \'%s\': %s)', 'component-model'),
                                 $function,
                                 $id,
                                 $fieldOutputKey,
@@ -179,7 +176,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Error validating function \'%s\' on object with ID \'%s\' and field under property \'%s\': %s)', 'component-model'),
+                                $this->translationAPI->__('Error validating function \'%s\' on object with ID \'%s\' and field under property \'%s\': %s)', 'component-model'),
                                 $function,
                                 $id,
                                 $fieldOutputKey,
@@ -191,7 +188,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Applying function on field \'%s\' (under property \'%s\') on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
+                                $this->translationAPI->__('Applying function on field \'%s\' (under property \'%s\') on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -201,7 +198,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Applying function on field \'%s\' on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
+                                $this->translationAPI->__('Applying function on field \'%s\' on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             ),
@@ -231,7 +228,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                     $dbErrors[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('Applying function on \'%s\' on object with ID \'%s\' failed due to error: %s', 'component-model'),
+                            $this->translationAPI->__('Applying function on \'%s\' on object with ID \'%s\' failed due to error: %s', 'component-model'),
                             $fieldOutputKey,
                             $id,
                             $error->getErrorMessage()

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
@@ -32,20 +32,18 @@ class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItems
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Iterate all affected array items and execute the composed directives on them', 'component-model');
+        return $this->translationAPI->__('Iterate all affected array items and execute the composed directives on them', 'component-model');
     }
 
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return array_merge(
             parent::getSchemaDirectiveArgs($typeResolver),
             [
                 [
                     SchemaDefinition::ARGNAME_NAME => 'if',
                     SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                    SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('If provided, iterate only those items that satisfy this condition `%s`', 'component-model'),
+                    SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('If provided, iterate only those items that satisfy this condition `%s`', 'component-model'),
                 ],
             ]
         );
@@ -53,10 +51,9 @@ class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItems
 
     public function getSchemaDirectiveExpressions(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
-            Expressions::NAME_KEY => $translationAPI->__('Key of the array element from the current iteration', 'component-model'),
-            Expressions::NAME_VALUE => $translationAPI->__('Value of the array element from the current iteration', 'component-model'),
+            Expressions::NAME_KEY => $this->translationAPI->__('Key of the array element from the current iteration', 'component-model'),
+            Expressions::NAME_VALUE => $this->translationAPI->__('Value of the array element from the current iteration', 'component-model'),
         ];
     }
 
@@ -66,7 +63,6 @@ class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItems
     protected function getArrayItems(array &$array, int | string $id, string $field, TypeResolverInterface $typeResolver, array &$resultIDItems, array &$dbItems, array &$previousDBItems, array &$variables, array &$messages, array &$dbErrors, array &$dbWarnings, array &$dbDeprecations): ?array
     {
         if ($if = $this->directiveArgsForSchema['if'] ?? null) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             // If it is a field, execute the function against all the values in the array
             // Those that satisfy the condition stay, the others are filtered out
             // We must add each item in the array as expression `%value%`, over which the if function can be evaluated
@@ -95,7 +91,7 @@ class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItems
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Executing field \'%s\' on object with ID \'%s\' produced error: %s. Setting expression \'%s\' was ignored', 'pop-component-model'),
+                                $this->translationAPI->__('Executing field \'%s\' on object with ID \'%s\' produced error: %s. Setting expression \'%s\' was ignored', 'pop-component-model'),
                                 $value,
                                 $id,
                                 $error->getErrorMessage(),

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
@@ -56,17 +56,15 @@ class IncludeDirectiveResolver extends AbstractGlobalDirectiveResolver
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Include the field value in the output only if the argument \'if\' evals to `true`', 'api');
+        return $this->translationAPI->__('Include the field value in the output only if the argument \'if\' evals to `true`', 'api');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'if',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Argument that must evaluate to `true` to include the field value in the output', 'api'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Argument that must evaluate to `true` to include the field value in the output', 'api'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
         ];

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SetSelfAsExpressionDirectiveResolver.php
@@ -54,18 +54,16 @@ final class SetSelfAsExpressionDirectiveResolver extends AbstractGlobalDirective
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return sprintf(
-            $translationAPI->__('Place the current object\'s data under expression `%s`, making it accessible to fields and directives through helper function `getPropertyFromSelf`', 'component-model'),
+            $this->translationAPI->__('Place the current object\'s data under expression `%s`, making it accessible to fields and directives through helper function `getPropertyFromSelf`', 'component-model'),
             QueryHelpers::getExpressionQuery(Expressions::NAME_SELF)
         );
     }
 
     public function getSchemaDirectiveExpressions(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
-            Expressions::NAME_SELF => $translationAPI->__('Object containing all properties for the current object, fetched either in the current or a previous iteration. These properties can be accessed through helper function `getSelfProp`', 'component-model'),
+            Expressions::NAME_SELF => $this->translationAPI->__('Object containing all properties for the current object, fetched either in the current or a previous iteration. These properties can be accessed through helper function `getSelfProp`', 'component-model'),
         ];
     }
 

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
@@ -55,17 +55,15 @@ class SkipDirectiveResolver extends AbstractGlobalDirectiveResolver
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Include the field value in the output only if the argument \'if\' evals to `false`', 'engine');
+        return $this->translationAPI->__('Include the field value in the output only if the argument \'if\' evals to `false`', 'engine');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'if',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Argument that must evaluate to `false` to include the field value in the output', 'engine'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Argument that must evaluate to `false` to include the field value in the output', 'engine'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
         ];

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -39,10 +39,9 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
             'getSelfProp' => sprintf(
-                $translationAPI->__('Get a property from the current object, as stored under expression `%s`', 'pop-component-model'),
+                $this->translationAPI->__('Get a property from the current object, as stored under expression `%s`', 'pop-component-model'),
                 QueryHelpers::getExpressionQuery(Expressions::NAME_SELF)
             ),
         ];
@@ -52,7 +51,6 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'getSelfProp':
                 return array_merge(
@@ -61,13 +59,13 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'self',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_OBJECT,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The `$self` object containing all data for the current object', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The `$self` object containing all data for the current object', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'property',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The property to access from the current object', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The property to access from the current object', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -301,7 +301,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
     {
         if (is_null($this->safeVars)) {
             $this->safeVars = ApplicationState::getVars();
-            HooksAPIFacade::getInstance()->doAction(
+            $this->hooksAPI->doAction(
                 self::HOOK_SAFEVARS,
                 array(&$this->safeVars)
             );

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -80,21 +80,20 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'if' => $translationAPI->__('If a boolean property is true, execute a field, else, execute another field', 'component-model'),
-            'not' => $translationAPI->__('Return the opposite value of a boolean property', 'component-model'),
-            'and' => $translationAPI->__('Return an `AND` operation among several boolean properties', 'component-model'),
-            'or' => $translationAPI->__('Return an `OR` operation among several boolean properties', 'component-model'),
-            'equals' => $translationAPI->__('Indicate if the result from a field equals a certain value', 'component-model'),
-            'empty' => $translationAPI->__('Indicate if a value is empty', 'component-model'),
-            'isNull' => $translationAPI->__('Indicate if a value is null', 'component-model'),
-            'var' => $translationAPI->__('Retrieve the value of a certain property from the `$vars` context object', 'component-model'),
-            'context' => $translationAPI->__('Retrieve the `$vars` context object', 'component-model'),
-            'extract' => $translationAPI->__('Given an object, it retrieves the data under a certain path', 'pop-component-model'),
-            'time' => $translationAPI->__('Return the time now (https://php.net/manual/en/function.time.php)', 'component-model'),
-            'echo' => $translationAPI->__('Repeat back the input, whatever it is', 'function-fields'),
-            'sprintf' => $translationAPI->__('Replace placeholders inside a string with provided values', 'function-fields'),
+            'if' => $this->translationAPI->__('If a boolean property is true, execute a field, else, execute another field', 'component-model'),
+            'not' => $this->translationAPI->__('Return the opposite value of a boolean property', 'component-model'),
+            'and' => $this->translationAPI->__('Return an `AND` operation among several boolean properties', 'component-model'),
+            'or' => $this->translationAPI->__('Return an `OR` operation among several boolean properties', 'component-model'),
+            'equals' => $this->translationAPI->__('Indicate if the result from a field equals a certain value', 'component-model'),
+            'empty' => $this->translationAPI->__('Indicate if a value is empty', 'component-model'),
+            'isNull' => $this->translationAPI->__('Indicate if a value is null', 'component-model'),
+            'var' => $this->translationAPI->__('Retrieve the value of a certain property from the `$vars` context object', 'component-model'),
+            'context' => $this->translationAPI->__('Retrieve the `$vars` context object', 'component-model'),
+            'extract' => $this->translationAPI->__('Given an object, it retrieves the data under a certain path', 'pop-component-model'),
+            'time' => $this->translationAPI->__('Return the time now (https://php.net/manual/en/function.time.php)', 'component-model'),
+            'echo' => $this->translationAPI->__('Repeat back the input, whatever it is', 'function-fields'),
+            'sprintf' => $this->translationAPI->__('Replace placeholders inside a string with provided values', 'function-fields'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -102,7 +101,6 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'if':
                 return array_merge(
@@ -111,19 +109,19 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'condition',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The condition to check if its value is `true` or `false`', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The condition to check if its value is `true` or `false`', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'then',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The value to return if the condition evals to `true`', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The value to return if the condition evals to `true`', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'else',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The value to return if the condition evals to `false`', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The value to return if the condition evals to `false`', 'component-model'),
                         ],
                     ]
                 );
@@ -135,7 +133,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The value from which to return its opposite value', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The value from which to return its opposite value', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -150,7 +148,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                             SchemaDefinition::ARGNAME_NAME => 'values',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_BOOL),
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                                $translationAPI->__('The array of values on which to execute the `%s` operation', 'component-model'),
+                                $this->translationAPI->__('The array of values on which to execute the `%s` operation', 'component-model'),
                                 strtoupper($fieldName)
                             ),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
@@ -165,13 +163,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value1',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The first value to compare', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The first value to compare', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value2',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The second value to compare', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The second value to compare', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -184,7 +182,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The value to check if it is empty', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The value to check if it is empty', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -197,7 +195,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The value to check if it is null', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The value to check if it is null', 'component-model'),
                         ],
                     ]
                 );
@@ -209,7 +207,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'name',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The name of the variable to retrieve from the `$vars` context object', 'component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The name of the variable to retrieve from the `$vars` context object', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -222,13 +220,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'object',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_OBJECT,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The object to retrieve the data from', 'pop-component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The object to retrieve the data from', 'pop-component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'path',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The path to retrieve data from the object. Paths are separated with \'.\' for each sublevel', 'pop-component-model'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The path to retrieve data from the object. Paths are separated with \'.\' for each sublevel', 'pop-component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -241,7 +239,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The input to be echoed back', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The input to be echoed back', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -254,13 +252,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'string',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The string containing the placeholders', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The string containing the placeholders', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'values',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The values to replace the placeholders with inside the string', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The values to replace the placeholders with inside the string', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -281,14 +279,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         // For instance, this doesn't work: /?query=arrayItem(posts(),3)
         // In that case, the validation will be done inside ->resolveValue(), and will be treated as a $dbError, not a $schemaError
         if (!FieldQueryUtils::isAnyFieldArgumentValueAField($fieldArgs)) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             switch ($fieldName) {
                 case 'var':
                     $safeVars = $this->getSafeVars();
                     if (!isset($safeVars[$fieldArgs['name']])) {
                         return [
                             sprintf(
-                                $translationAPI->__('Var \'%s\' does not exist in `$vars`', 'component-model'),
+                                $this->translationAPI->__('Var \'%s\' does not exist in `$vars`', 'component-model'),
                                 $fieldArgs['name']
                             )
                         ];

--- a/layers/Engine/packages/engine/src/TypeResolvers/RootTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/RootTypeResolver.php
@@ -22,8 +22,7 @@ class RootTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Root type, starting from which the query is executed', 'api');
+        return $this->translationAPI->__('Root type, starting from which the query is executed', 'api');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -84,23 +84,22 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'concat' => $translationAPI->__('Concatenate two or more strings', 'function-fields'),
-            'divide' => $translationAPI->__('Divide a number by another number', 'function-fields'),
-            'arrayRandom' => $translationAPI->__('Randomly select one element from the provided ones', 'function-fields'),
-            'arrayJoin' => $translationAPI->__('Join all the strings in an array, using a provided separator', 'function-fields'),
-            'arrayItem' => $translationAPI->__('Access the element on the given position in the array', 'function-fields'),
-            'arraySearch' => $translationAPI->__('Search in what position is an element placed in the array. If found, it returns its position (integer), otherwise it returns `false` (boolean)', 'function-fields'),
-            'arrayFill' => $translationAPI->__('Fill a target array with elements from a source array, where a certain property is the same', 'function-fields'),
-            'arrayValues' => $translationAPI->__('Return the values from a two-dimensional array', 'function-fields'),
-            'arrayUnique' => $translationAPI->__('Filters out all duplicated elements in the array', 'function-fields'),
-            'arrayDiff' => $translationAPI->__('Return an array containing all the elements from the first array which are not present on any of the other arrays', 'function-fields'),
-            'arrayAddItem' => $translationAPI->__('Adds an element to the array', 'function-fields'),
-            'arrayAsQueryStr' => $translationAPI->__('Represent an array as a string', 'function-fields'),
-            'upperCase' => $translationAPI->__('Transform a string to upper case', 'function-fields'),
-            'lowerCase' => $translationAPI->__('Transform a string to lower case', 'function-fields'),
-            'titleCase' => $translationAPI->__('Transform a string to title case', 'function-fields'),
+            'concat' => $this->translationAPI->__('Concatenate two or more strings', 'function-fields'),
+            'divide' => $this->translationAPI->__('Divide a number by another number', 'function-fields'),
+            'arrayRandom' => $this->translationAPI->__('Randomly select one element from the provided ones', 'function-fields'),
+            'arrayJoin' => $this->translationAPI->__('Join all the strings in an array, using a provided separator', 'function-fields'),
+            'arrayItem' => $this->translationAPI->__('Access the element on the given position in the array', 'function-fields'),
+            'arraySearch' => $this->translationAPI->__('Search in what position is an element placed in the array. If found, it returns its position (integer), otherwise it returns `false` (boolean)', 'function-fields'),
+            'arrayFill' => $this->translationAPI->__('Fill a target array with elements from a source array, where a certain property is the same', 'function-fields'),
+            'arrayValues' => $this->translationAPI->__('Return the values from a two-dimensional array', 'function-fields'),
+            'arrayUnique' => $this->translationAPI->__('Filters out all duplicated elements in the array', 'function-fields'),
+            'arrayDiff' => $this->translationAPI->__('Return an array containing all the elements from the first array which are not present on any of the other arrays', 'function-fields'),
+            'arrayAddItem' => $this->translationAPI->__('Adds an element to the array', 'function-fields'),
+            'arrayAsQueryStr' => $this->translationAPI->__('Represent an array as a string', 'function-fields'),
+            'upperCase' => $this->translationAPI->__('Transform a string to upper case', 'function-fields'),
+            'lowerCase' => $this->translationAPI->__('Transform a string to lower case', 'function-fields'),
+            'titleCase' => $this->translationAPI->__('Transform a string to title case', 'function-fields'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -108,7 +107,6 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'concat':
                 return array_merge(
@@ -117,7 +115,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'values',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Strings to concatenate', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Strings to concatenate', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -130,13 +128,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'number',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_FLOAT,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Number to divide', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Number to divide', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'by',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_FLOAT,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The division operandum', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The division operandum', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -149,7 +147,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Array of elements from which to randomly select one', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Array of elements from which to randomly select one', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ]
                     ]
@@ -162,13 +160,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Array of strings to be joined all together', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Array of strings to be joined all together', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'separator',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Separator with which to join all strings in the array', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Separator with which to join all strings in the array', 'function-fields'),
                         ],
                     ]
                 );
@@ -180,13 +178,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Array containing the element to retrieve', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Array containing the element to retrieve', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'position',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Position where the element is placed in the array, starting from 0', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Position where the element is placed in the array, starting from 0', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -199,13 +197,13 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Array containing the element to search', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Array containing the element to search', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'element',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Element to search in the array and retrieve its position', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Element to search in the array and retrieve its position', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -218,25 +216,25 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'target',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Array to be added elements coming from the source array', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Array to be added elements coming from the source array', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'source',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Array whose elements will be added to the target array', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Array whose elements will be added to the target array', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'index',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Property whose value must be the same on both arrays', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Property whose value must be the same on both arrays', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'properties',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Properties to copy from the source to the target array. If empty, all properties in the source array will be copied', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Properties to copy from the source to the target array. If empty, all properties in the source array will be copied', 'function-fields'),
                         ],
                     ]
                 );
@@ -248,7 +246,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The array from which to retrieve the values', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The array from which to retrieve the values', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -261,7 +259,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The array to operate on', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The array to operate on', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -274,7 +272,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'arrays',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The array containing all the arrays. It must have at least 2 elements', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The array containing all the arrays. It must have at least 2 elements', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -287,19 +285,19 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The array to add an item on', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The array to add an item on', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The value to add to the array', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The value to add to the array', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'key',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Key (string or integer) under which to add the value to the array. If not provided, the value is added without key', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Key (string or integer) under which to add the value to the array. If not provided, the value is added without key', 'function-fields'),
                         ],
                     ]
                 );
@@ -311,7 +309,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The array to represented as a string', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The array to represented as a string', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -325,7 +323,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'text',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The string to be transformed', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The string to be transformed', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -346,13 +344,12 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         // For instance, this doesn't work: /?query=arrayItem(posts(),3)
         // In that case, the validation will be done inside ->resolveValue(), and will be treated as a $dbError, not a $schemaError
         if (!FieldQueryUtils::isAnyFieldArgumentValueAField($fieldArgs)) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             switch ($fieldName) {
                 case 'arrayItem':
                     if (count($fieldArgs['array']) < $fieldArgs['position']) {
                         return [
                             sprintf(
-                                $translationAPI->__('The array contains no element at position \'%s\'', 'function-fields'),
+                                $this->translationAPI->__('The array contains no element at position \'%s\'', 'function-fields'),
                                 $fieldArgs['position']
                             ),
                         ];
@@ -362,7 +359,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                     if (count($fieldArgs['arrays']) < 2) {
                         return [
                             sprintf(
-                                $translationAPI->__('The array must contain at least 2 elements: \'%s\'', 'function-fields'),
+                                $this->translationAPI->__('The array must contain at least 2 elements: \'%s\'', 'function-fields'),
                                 json_encode($fieldArgs['arrays'])
                             ),
                         ];
@@ -371,7 +368,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                 case 'divide':
                     if ($fieldArgs['by'] === (float)0) {
                         return [
-                            $translationAPI->__('Cannot divide by 0', 'function-fields'),
+                            $this->translationAPI->__('Cannot divide by 0', 'function-fields'),
                         ];
                     }
                     // Check that all items are arrays
@@ -381,7 +378,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                     // }, true);
                     // if (!$allArrays) {
                     //     return sprintf(
-                    //         $translationAPI->__('The array must contain only arrays as elements: \'%s\'', 'function-fields'),
+                    //         $this->translationAPI->__('The array must contain only arrays as elements: \'%s\'', 'function-fields'),
                     //         json_encode($fieldArgs['arrays'])
                     //     );
                     // }

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/EndTraceExecutionTimeDirectiveResolver.php
@@ -67,14 +67,13 @@ class EndTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveReso
         array &$schemaNotices,
         array &$schemaTraces
     ): void {
-        $translationAPI = TranslationAPIFacade::getInstance();
         // Get the time set by @startTraceExecutionTime
         $startTime = $messages[EndTraceExecutionTimeDirectiveResolver::MESSAGE_EXECUTION_TIME];
         if (is_null($startTime)) {
             $schemaWarnings[] = [
                 Tokens::PATH => [$this->directive],
                 Tokens::MESSAGE => sprintf(
-                    $translationAPI->__('Something went wrong when executing directive \'%s\'', 'trace-tools'),
+                    $this->translationAPI->__('Something went wrong when executing directive \'%s\'', 'trace-tools'),
                     $this->getDirectiveName()
                 ),
             ];
@@ -105,23 +104,22 @@ class EndTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveReso
             $traceIDFields = [];
             foreach ($idsDataFields as $id => $dataFields) {
                 $traceIDFields[] = sprintf(
-                    $translationAPI->__('%s/%s', 'engine'),
+                    $this->translationAPI->__('%s/%s', 'engine'),
                     $id,
-                    implode($translationAPI->__('|'), $dataFields['direct'])
+                    implode($this->translationAPI->__('|'), $dataFields['direct'])
                 );
             }
             $traceMessage = sprintf(
-                $translationAPI->__('Execution time: %s milliseconds [type: \'%s\'; affected IDs/field(s): %s]', 'trace-tools'),
+                $this->translationAPI->__('Execution time: %s milliseconds [type: \'%s\'; affected IDs/field(s): %s]', 'trace-tools'),
                 $executionTime / 1_000_000, // Convert from nanoseconds to milliseconds
                 $typeResolver->getTypeName(),
-                implode($translationAPI->__(', '), $traceIDFields)
+                implode($this->translationAPI->__(', '), $traceIDFields)
             );
             $feedbackMessageStore->addLogEntry($traceMessage);
         }
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Trace the execution time of the resolution of the fields, and log the result', 'trace-tools');
+        return $this->translationAPI->__('Trace the execution time of the resolution of the fields, and log the result', 'trace-tools');
     }
 }

--- a/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
+++ b/layers/Engine/packages/trace-tools/src/DirectiveResolvers/StartTraceExecutionTimeDirectiveResolver.php
@@ -69,7 +69,6 @@ class StartTraceExecutionTimeDirectiveResolver extends AbstractGlobalDirectiveRe
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Start measuring the time for the execution of the field(s)', 'trace-tools');
+        return $this->translationAPI->__('Start measuring the time for the execution of the field(s)', 'trace-tools');
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/CPTFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/CPTFieldResolver.php
@@ -66,12 +66,11 @@ class CPTFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $ret = match($fieldName) {
-            'accessControlLists' => $translationAPI->__('Access Control Lists', 'graphql-api'),
-            'cacheControlLists' => $translationAPI->__('Cache Control Lists', 'graphql-api'),
-            'fieldDeprecationLists' => $translationAPI->__('Field Deprecation Lists', 'graphql-api'),
-            'schemaConfigurations' => $translationAPI->__('Schema Configurations', 'graphql-api'),
+            'accessControlLists' => $this->translationAPI->__('Access Control Lists', 'graphql-api'),
+            'cacheControlLists' => $this->translationAPI->__('Cache Control Lists', 'graphql-api'),
+            'fieldDeprecationLists' => $this->translationAPI->__('Field Deprecation Lists', 'graphql-api'),
+            'schemaConfigurations' => $this->translationAPI->__('Schema Configurations', 'graphql-api'),
             default => parent::getSchemaFieldDescription($typeResolver, $fieldName),
         };
         return $ret;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
@@ -62,7 +62,6 @@ class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'echoStr':
                 return array_merge(
@@ -71,7 +70,7 @@ class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The input string to be echoed back', 'graphql-api'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The input string to be echoed back', 'graphql-api'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -86,9 +85,8 @@ class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
      */
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'echoStr' => $translationAPI->__('Repeat back the input string', 'graphql-api'),
+            'echoStr' => $this->translationAPI->__('Repeat back the input string', 'graphql-api'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/MultipleQueryExecution/SchemaServices/DirectiveResolvers/ExportDirectiveResolver.php
@@ -258,14 +258,13 @@ class ExportDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     protected function setVariable(array &$variables, $value, array &$schemaWarnings): void
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $variableName = $this->directiveArgsForSchema['as'];
         // If the variable already exists, then throw a warning and do nothing
         if (isset($variables[$variableName])) {
             $schemaWarnings[] = [
                 Tokens::PATH => [$this->directive],
                 Tokens::MESSAGE => sprintf(
-                    $translationAPI->__('Cannot export variable with name \'%s\' because this variable has already been set', 'component-model'),
+                    $this->translationAPI->__('Cannot export variable with name \'%s\' because this variable has already been set', 'component-model'),
                     $variableName
                 ),
             ];
@@ -276,18 +275,16 @@ class ExportDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Exports a field value as a variable', 'graphql-server');
+        return $this->translationAPI->__('Exports a field value as a variable', 'graphql-server');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'as',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                    $translationAPI->__('Name of the variable. It must start with \'%s\', or the directive will not work', 'graphql-server'),
+                    $this->translationAPI->__('Name of the variable. It must start with \'%s\', or the directive will not work', 'graphql-server'),
                     QuerySymbols::VARIABLE_AS_EXPRESSION_NAME_PREFIX
                 ),
                 SchemaDefinition::ARGNAME_MANDATORY => true,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
@@ -234,7 +234,6 @@ class RemoveIfNullDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Remove the field from the response if it is `null`', 'engine');
+        return $this->translationAPI->__('Remove the field from the response if it is `null`', 'engine');
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -54,21 +54,20 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         /** @var DirectiveResolverInterface */
         $exportDirectiveResolver = $instanceManager->getInstance(ExportDirectiveResolver::class);
         $exportDirectiveName = $exportDirectiveResolver->getDirectiveName();
         $descriptions = [
             'exportedVariables' => sprintf(
-                $translationAPI->__('Returns a dictionary with the values for all variables exported through the `%s` directive', 'graphql-server'),
+                $this->translationAPI->__('Returns a dictionary with the values for all variables exported through the `%s` directive', 'graphql-server'),
                 $exportDirectiveName
             ),
             // 'exportedVariable' => sprintf(
-            //     $translationAPI->__('Returns the value for a variable exported through the `%s` directive', 'graphql-server'),
+            //     $this->translationAPI->__('Returns the value for a variable exported through the `%s` directive', 'graphql-server'),
             //     $exportDirectiveName
             // ),
-            'echoVar' => $translationAPI->__('Returns the variable value', 'graphql-server'),
+            'echoVar' => $this->translationAPI->__('Returns the variable value', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -76,7 +75,6 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             // case 'exportedVariable':
             //     return array_merge(
@@ -86,7 +84,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
             //                 SchemaDefinition::ARGNAME_NAME => 'name',
             //                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
             //                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-            //                     $translationAPI->__('Exported variable name. It must start with \'%s\'', 'graphql-server'),
+            //                     $this->translationAPI->__('Exported variable name. It must start with \'%s\'', 'graphql-server'),
             //                     QuerySymbols::VARIABLE_AS_EXPRESSION_NAME_PREFIX
             //                 ),
             //                 SchemaDefinition::ARGNAME_MANDATORY => true,
@@ -100,7 +98,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
                         [
                             SchemaDefinition::ARGNAME_NAME => 'variable',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The variable to echo back, of any type', 'graphql-server'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The variable to echo back, of any type', 'graphql-server'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -91,13 +91,12 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'name' => $translationAPI->__('Directive\'s name', 'graphql-server'),
-            'description' => $translationAPI->__('Directive\'s description', 'graphql-server'),
-            'args' => $translationAPI->__('Directive\'s arguments', 'graphql-server'),
-            'locations' => $translationAPI->__('The locations where the directive may be placed', 'graphql-server'),
-            'isRepeatable' => $translationAPI->__('Can the directive be executed more than once in the same field?', 'graphql-server'),
+            'name' => $this->translationAPI->__('Directive\'s name', 'graphql-server'),
+            'description' => $this->translationAPI->__('Directive\'s description', 'graphql-server'),
+            'args' => $this->translationAPI->__('Directive\'s arguments', 'graphql-server'),
+            'locations' => $this->translationAPI->__('The locations where the directive may be placed', 'graphql-server'),
+            'isRepeatable' => $this->translationAPI->__('Can the directive be executed more than once in the same field?', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -52,12 +52,11 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'name' => $translationAPI->__('Enum value\'s name as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACvBBCyBH6rd)', 'graphql-server'),
-            'description' => $translationAPI->__('Enum value\'s description as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACyBIC1BHnjL)', 'graphql-server'),
-            'isDeprecated' => $translationAPI->__('Is the enum value deprecated?', 'graphql-server'),
-            'deprecationReason' => $translationAPI->__('Why was the enum value deprecated?', 'graphql-server'),
+            'name' => $this->translationAPI->__('Enum value\'s name as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACvBBCyBH6rd)', 'graphql-server'),
+            'description' => $this->translationAPI->__('Enum value\'s description as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACyBIC1BHnjL)', 'graphql-server'),
+            'isDeprecated' => $this->translationAPI->__('Is the enum value deprecated?', 'graphql-server'),
+            'deprecationReason' => $this->translationAPI->__('Why was the enum value deprecated?', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -48,9 +48,8 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
 
     // public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     // {
-    //     $translationAPI = TranslationAPIFacade::getInstance();
     //     $descriptions = [
-    //         'directives' => $translationAPI->__('All directives registered in the data graph, allowing to remove the system directives', 'graphql-api'),
+    //         'directives' => $this->translationAPI->__('All directives registered in the data graph, allowing to remove the system directives', 'graphql-api'),
     //     ];
     //     return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     // }
@@ -58,7 +57,6 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         switch ($fieldName) {
             case 'directives':
@@ -72,7 +70,7 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'ofTypes',
                             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ENUM),
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Include only directives of provided types', 'graphql-api'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Include only directives of provided types', 'graphql-api'),
                             // SchemaDefinition::ARGNAME_MANDATORY => true,
                             // SchemaDefinition::ARGNAME_DEFAULT_VALUE => [
                             //     DirectiveTypes::QUERY,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -64,9 +64,8 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'name' => $translationAPI->__('Type\'s name as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACvBBCyBH6rd), indicating if the type must be namespaced or not', 'graphql-server'),
+            'name' => $this->translationAPI->__('Type\'s name as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACvBBCyBH6rd), indicating if the type must be namespaced or not', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -74,7 +73,6 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'name':
                 return array_merge(
@@ -83,7 +81,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'namespaced',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Namespace type name?', 'graphql-server'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Namespace type name?', 'graphql-server'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -63,15 +63,14 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'name' => $translationAPI->__('Field\'s name', 'graphql-server'),
-            'description' => $translationAPI->__('Field\'s description', 'graphql-server'),
-            'args' => $translationAPI->__('Field arguments', 'graphql-server'),
-            'type' => $translationAPI->__('Type to which the field belongs', 'graphql-server'),
-            'isDeprecated' => $translationAPI->__('Is the field deprecated?', 'graphql-server'),
-            'deprecationReason' => $translationAPI->__('Why was the field deprecated?', 'graphql-server'),
-            'extensions' => $translationAPI->__('Custom metadata added to the field (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
+            'name' => $this->translationAPI->__('Field\'s name', 'graphql-server'),
+            'description' => $this->translationAPI->__('Field\'s description', 'graphql-server'),
+            'args' => $this->translationAPI->__('Field arguments', 'graphql-server'),
+            'type' => $this->translationAPI->__('Type to which the field belongs', 'graphql-server'),
+            'isDeprecated' => $this->translationAPI->__('Is the field deprecated?', 'graphql-server'),
+            'deprecationReason' => $this->translationAPI->__('Why was the field deprecated?', 'graphql-server'),
+            'extensions' => $this->translationAPI->__('Custom metadata added to the field (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
 use PoP\API\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -39,9 +39,8 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            '__typename' => $translationAPI->__('The object\'s type', 'graphql-server'),
+            '__typename' => $this->translationAPI->__('The object\'s type', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -53,12 +53,11 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'name' => $translationAPI->__('Input value\'s name as defined by the GraphQL spec', 'graphql-server'),
-            'description' => $translationAPI->__('Input value\'s description', 'graphql-server'),
-            'type' => $translationAPI->__('Type of the input value', 'graphql-server'),
-            'defaultValue' => $translationAPI->__('Default value of the input value', 'graphql-server'),
+            'name' => $this->translationAPI->__('Input value\'s name as defined by the GraphQL spec', 'graphql-server'),
+            'description' => $this->translationAPI->__('Input value\'s description', 'graphql-server'),
+            'type' => $this->translationAPI->__('Type of the input value', 'graphql-server'),
+            'defaultValue' => $this->translationAPI->__('Default value of the input value', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
@@ -48,10 +48,9 @@ class RegisterQueryAndMutationRootsRootFieldResolver extends AbstractDBDataField
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'queryRoot' => $translationAPI->__('Get the Query Root type', 'graphql-server'),
-            'mutationRoot' => $translationAPI->__('Get the Mutation Root type', 'graphql-server'),
+            'queryRoot' => $this->translationAPI->__('Get the Query Root type', 'graphql-server'),
+            'mutationRoot' => $this->translationAPI->__('Get the Mutation Root type', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -61,10 +61,9 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            '__schema' => $translationAPI->__('The GraphQL schema, exposing what fields can be queried', 'graphql-server'),
-            '__type' => $translationAPI->__('Obtain a specific type from the schema', 'graphql-server'),
+            '__schema' => $this->translationAPI->__('The GraphQL schema, exposing what fields can be queried', 'graphql-server'),
+            '__type' => $this->translationAPI->__('Obtain a specific type from the schema', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -72,7 +71,6 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case '__type':
                 return array_merge(
@@ -81,7 +79,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'name',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The name of the type', 'graphql-server'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The name of the type', 'graphql-server'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -60,14 +60,13 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'queryType' => $translationAPI->__('The type, accessible from the root, that resolves queries', 'graphql-server'),
-            'mutationType' => $translationAPI->__('The type, accessible from the root, that resolves mutations', 'graphql-server'),
-            'subscriptionType' => $translationAPI->__('The type, accessible from the root, that resolves subscriptions', 'graphql-server'),
-            'types' => $translationAPI->__('All types registered in the data graph', 'graphql-server'),
-            'directives' => $translationAPI->__('All directives registered in the data graph', 'graphql-server'),
-            'type' => $translationAPI->__('Obtain a specific type from the schema', 'graphql-server'),
+            'queryType' => $this->translationAPI->__('The type, accessible from the root, that resolves queries', 'graphql-server'),
+            'mutationType' => $this->translationAPI->__('The type, accessible from the root, that resolves mutations', 'graphql-server'),
+            'subscriptionType' => $this->translationAPI->__('The type, accessible from the root, that resolves subscriptions', 'graphql-server'),
+            'types' => $this->translationAPI->__('All types registered in the data graph', 'graphql-server'),
+            'directives' => $this->translationAPI->__('All directives registered in the data graph', 'graphql-server'),
+            'type' => $this->translationAPI->__('Obtain a specific type from the schema', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -75,7 +74,6 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'type':
                 return array_merge(
@@ -84,7 +82,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'name',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The name of the type', 'graphql-server'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The name of the type', 'graphql-server'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -106,18 +106,17 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'kind' => $translationAPI->__('Type\'s kind as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACqBBCvBAtrC)', 'graphql-server'),
-            'name' => $translationAPI->__('Type\'s name as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACvBBCyBH6rd)', 'graphql-server'),
-            'description' => $translationAPI->__('Type\'s description as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACyBIC1BHnjL)', 'graphql-server'),
-            'fields' => $translationAPI->__('Type\'s fields (available for Object and Interface types only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLAC3BBCnCA8pY)', 'graphql-server'),
-            'interfaces' => $translationAPI->__('Type\'s interfaces (available for Object type only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACpCBCxCA7tB)', 'graphql-server'),
-            'possibleTypes' => $translationAPI->__('Type\'s possible types (available for Interface and Union types only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACzCBC7CA0vN)', 'graphql-server'),
-            'enumValues' => $translationAPI->__('Type\'s enum values (available for Enum type only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLAC9CDD_CAA2lB)', 'graphql-server'),
-            'inputFields' => $translationAPI->__('Type\'s input Fields (available for InputObject type only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-HAJbLAuDABCBIu9N)', 'graphql-server'),
-            'ofType' => $translationAPI->__('The type of the nested type (available for NonNull and List types only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-HAJbLA4DABCBIu9N)', 'graphql-server'),
-            'extensions' => $translationAPI->__('Custom metadata added to the field (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
+            'kind' => $this->translationAPI->__('Type\'s kind as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACqBBCvBAtrC)', 'graphql-server'),
+            'name' => $this->translationAPI->__('Type\'s name as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACvBBCyBH6rd)', 'graphql-server'),
+            'description' => $this->translationAPI->__('Type\'s description as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACyBIC1BHnjL)', 'graphql-server'),
+            'fields' => $this->translationAPI->__('Type\'s fields (available for Object and Interface types only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLAC3BBCnCA8pY)', 'graphql-server'),
+            'interfaces' => $this->translationAPI->__('Type\'s interfaces (available for Object type only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACpCBCxCA7tB)', 'graphql-server'),
+            'possibleTypes' => $this->translationAPI->__('Type\'s possible types (available for Interface and Union types only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACzCBC7CA0vN)', 'graphql-server'),
+            'enumValues' => $this->translationAPI->__('Type\'s enum values (available for Enum type only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLAC9CDD_CAA2lB)', 'graphql-server'),
+            'inputFields' => $this->translationAPI->__('Type\'s input Fields (available for InputObject type only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-HAJbLAuDABCBIu9N)', 'graphql-server'),
+            'ofType' => $this->translationAPI->__('The type of the nested type (available for NonNull and List types only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-HAJbLA4DABCBIu9N)', 'graphql-server'),
+            'extensions' => $this->translationAPI->__('Custom metadata added to the field (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -125,7 +124,6 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'fields':
             case 'enumValues':
@@ -135,7 +133,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'includeDeprecated',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Include deprecated fields?', 'graphql-server'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Include deprecated fields?', 'graphql-server'),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                         ],
                     ]

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/DirectiveTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/DirectiveTypeResolver.php
@@ -17,8 +17,7 @@ class DirectiveTypeResolver extends AbstractIntrospectionTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('A GraphQL directive in the data graph', 'graphql-server');
+        return $this->translationAPI->__('A GraphQL directive in the data graph', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/EnumValueTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/EnumValueTypeResolver.php
@@ -17,8 +17,7 @@ class EnumValueTypeResolver extends AbstractIntrospectionTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of an Enum value in GraphQL', 'graphql-server');
+        return $this->translationAPI->__('Representation of an Enum value in GraphQL', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/FieldTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/FieldTypeResolver.php
@@ -17,8 +17,7 @@ class FieldTypeResolver extends AbstractIntrospectionTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a GraphQL type\'s field', 'graphql-server');
+        return $this->translationAPI->__('Representation of a GraphQL type\'s field', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/InputValueTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/InputValueTypeResolver.php
@@ -17,8 +17,7 @@ class InputValueTypeResolver extends AbstractIntrospectionTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of an input object in GraphQL', 'graphql-server');
+        return $this->translationAPI->__('Representation of an input object in GraphQL', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/MutationRootTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/MutationRootTypeResolver.php
@@ -21,8 +21,7 @@ class MutationRootTypeResolver extends AbstractUseRootAsSourceForSchemaTypeResol
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Mutation type, starting from which mutations are executed', 'graphql-server');
+        return $this->translationAPI->__('Mutation type, starting from which mutations are executed', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/QueryRootTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/QueryRootTypeResolver.php
@@ -21,8 +21,7 @@ class QueryRootTypeResolver extends AbstractUseRootAsSourceForSchemaTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Query type, starting from which the query is executed', 'graphql-server');
+        return $this->translationAPI->__('Query type, starting from which the query is executed', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/SchemaTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/SchemaTypeResolver.php
@@ -17,8 +17,7 @@ class SchemaTypeResolver extends AbstractIntrospectionTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Schema type, to implement the introspection fields', 'graphql-server');
+        return $this->translationAPI->__('Schema type, to implement the introspection fields', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/TypeTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/TypeTypeResolver.php
@@ -17,8 +17,7 @@ class TypeTypeResolver extends AbstractIntrospectionTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of each GraphQL type in the graph', 'graphql-server');
+        return $this->translationAPI->__('Representation of each GraphQL type in the graph', 'graphql-server');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleDirectiveResolver.php
@@ -26,9 +26,8 @@ class MakeTitleDirectiveResolver extends MakeTitleVersion010DirectiveResolver
         if (Environment::enableSemanticVersionConstraints()) {
             // If the query doesn't specify what version of the directive to use, add a deprecation message
             if (!$this->directiveArgsForSchema[SchemaDefinition::ARGNAME_VERSION_CONSTRAINT] ?? null) {
-                $translationAPI = TranslationAPIFacade::getInstance();
                 return sprintf(
-                    $translationAPI->__('Directive \'%1$s\' has a new version: \'%2$s\'. This version will become the default one on January 1st. We advise you to use this new version already and test that it works fine; if you find any problem, please report the issue in %3$s. To do the switch, please add the \'versionConstraint\' directive argument to your query, using Composer\'s semver constraint rules (%4$s): @%1$s(versionConstraint:"%5$s"). If you are unable to switch to the new version, please make sure to explicitly point to the current version \'%6$s\' before January 1st: @%1$s(versionConstraint:"%6$s"). In case of doubt, please contact us at name@company.com.', 'examples-for-pop'),
+                    $this->translationAPI->__('Directive \'%1$s\' has a new version: \'%2$s\'. This version will become the default one on January 1st. We advise you to use this new version already and test that it works fine; if you find any problem, please report the issue in %3$s. To do the switch, please add the \'versionConstraint\' directive argument to your query, using Composer\'s semver constraint rules (%4$s): @%1$s(versionConstraint:"%5$s"). If you are unable to switch to the new version, please make sure to explicitly point to the current version \'%6$s\' before January 1st: @%1$s(versionConstraint:"%6$s"). In case of doubt, please contact us at name@company.com.', 'examples-for-pop'),
                     $this->getDirectiveName(),
                     '0.2.0',
                     'https://github.com/mycompany/myproject/issues',

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/MakeTitleVersion010DirectiveResolver.php
@@ -64,7 +64,6 @@ class MakeTitleVersion010DirectiveResolver extends AbstractGlobalDirectiveResolv
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Convert a string to Title Case', 'examples-for-pop');
+        return $this->translationAPI->__('Convert a string to Title Case', 'examples-for-pop');
     }
 }

--- a/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/SendByEmailDirectiveResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/DirectiveResolvers/SendByEmailDirectiveResolver.php
@@ -19,23 +19,22 @@ class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
 
     // public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     // {
-    //     $translationAPI = TranslationAPIFacade::getInstance();
     //     return [
     //         [
     //             SchemaDefinition::ARGNAME_NAME => 'to',
     //             SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_EMAIL),
-    //             SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Emails to send the email to', 'component-model'),
+    //             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Emails to send the email to', 'component-model'),
     //             SchemaDefinition::ARGNAME_MANDATORY => true,
     //         ],
     //         [
     //             SchemaDefinition::ARGNAME_NAME => 'subject',
     //             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-    //             SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Email subject', 'component-model'),,
+    //             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Email subject', 'component-model'),,
     //         ],
     //         [
     //             SchemaDefinition::ARGNAME_NAME => 'content',
     //             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-    //             SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Email content', 'component-model'),
+    //             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Email content', 'component-model'),
     //         ],
     //     ];
     // }
@@ -63,7 +62,6 @@ class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
         array &$schemaTraces
     ): void {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $translationAPI = TranslationAPIFacade::getInstance();
         $dbKey = $typeResolver->getTypeOutputName();
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
@@ -75,7 +73,7 @@ class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -85,7 +83,7 @@ class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
+                                $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so it can\'t be transformed', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             )
@@ -104,7 +102,7 @@ class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('The value for field \'%s\' (under property \'%s\') is not an array, so execution of this directive can\'t continue', 'component-model'),
+                                $this->translationAPI->__('The value for field \'%s\' (under property \'%s\') is not an array, so execution of this directive can\'t continue', 'component-model'),
                                 $field,
                                 $fieldOutputKey,
                                 $id
@@ -114,7 +112,7 @@ class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $translationAPI->__('The value for field \'%s\' is not an array, so execution of this directive can\'t continue', 'component-model'),
+                                $this->translationAPI->__('The value for field \'%s\' is not an array, so execution of this directive can\'t continue', 'component-model'),
                                 $fieldOutputKey,
                                 $id
                             )
@@ -129,7 +127,7 @@ class SendByEmailDirectiveResolver extends AbstractGlobalDirectiveResolver
                     $dbErrors[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('The \'to\' item in the array in field \'%s\' (under property \'%s\') is empty, so the emails can\'t be sent', 'component-model'),
+                            $this->translationAPI->__('The \'to\' item in the array in field \'%s\' (under property \'%s\') is empty, so the emails can\'t be sent', 'component-model'),
                             $field,
                             $fieldOutputKey,
                             $id

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/Legacy/Version_0_1_0/RootFieldResolver.php
@@ -56,7 +56,6 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'userServiceURLs':
             case 'userServiceData':
@@ -66,7 +65,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'githubRepo',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('GitHub repository for which to fetch data, in format \'account/repo\' (eg: \'leoloso/PoP\')', 'examples-for-pop'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('GitHub repository for which to fetch data, in format \'account/repo\' (eg: \'leoloso/PoP\')', 'examples-for-pop'),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => 'leoloso/PoP',
                         ],
                     ]
@@ -78,10 +77,9 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'userServiceURLs' => $translationAPI->__('Services used in the application: GitHub data for a specific repository', 'examples-for-pop'),
-            'userServiceData' => $translationAPI->__('Retrieve data from the services', 'examples-for-pop'),
+            'userServiceURLs' => $this->translationAPI->__('Services used in the application: GitHub data for a specific repository', 'examples-for-pop'),
+            'userServiceData' => $this->translationAPI->__('Retrieve data from the services', 'examples-for-pop'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/MeshRootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/MeshRootFieldResolver.php
@@ -43,7 +43,6 @@ class MeshRootFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'meshServices':
             case 'meshServiceData':
@@ -54,19 +53,19 @@ class MeshRootFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'githubRepo',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('GitHub repository for which to fetch data, in format \'account/repo\' (eg: \'leoloso/PoP\')', 'examples-for-pop'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('GitHub repository for which to fetch data, in format \'account/repo\' (eg: \'leoloso/PoP\')', 'examples-for-pop'),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => 'leoloso/PoP',
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'weatherZone',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Zone from which to retrieve weather data, as listed in https://api.weather.gov/zones/forecast', 'examples-for-pop'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Zone from which to retrieve weather data, as listed in https://api.weather.gov/zones/forecast', 'examples-for-pop'),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => 'MOZ028',
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'photoPage',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_INT,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Page from which to fetch photo data. Default value: A random number between 1 and 20', 'examples-for-pop'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Page from which to fetch photo data. Default value: A random number between 1 and 20', 'examples-for-pop'),
                         ],
                     ]
                 );
@@ -77,11 +76,10 @@ class MeshRootFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'meshServices' => $translationAPI->__('Services required to create a \'content mesh\' for the application: GitHub data for a specific repository, weather data from the National Weather Service for a specific zone, and random photo data from Unsplash', 'examples-for-pop'),
-            'meshServiceData' => $translationAPI->__('Retrieve data from the mesh services', 'examples-for-pop'),
-            'contentMesh' => $translationAPI->__('Retrieve data from the mesh services and create a \'content mesh\'', 'examples-for-pop'),
+            'meshServices' => $this->translationAPI->__('Services required to create a \'content mesh\' for the application: GitHub data for a specific repository, weather data from the National Weather Service for a specific zone, and random photo data from Unsplash', 'examples-for-pop'),
+            'meshServiceData' => $this->translationAPI->__('Retrieve data from the mesh services', 'examples-for-pop'),
+            'contentMesh' => $this->translationAPI->__('Retrieve data from the mesh services and create a \'content mesh\'', 'examples-for-pop'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Misc/packages/examples-for-pop/src/FieldResolvers/RootFieldResolver.php
@@ -27,10 +27,9 @@ class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Ve
         if (Environment::enableSemanticVersionConstraints()) {
             // If the query doesn't specify what version of the field to use, add a deprecation message
             if (!isset($fieldArgs[SchemaDefinition::ARGNAME_VERSION_CONSTRAINT]) || !$fieldArgs[SchemaDefinition::ARGNAME_VERSION_CONSTRAINT]) {
-                $translationAPI = TranslationAPIFacade::getInstance();
                 $descriptions = [
                     'userServiceURLs' => sprintf(
-                        $translationAPI->__('Field \'%1$s\' has a new version: \'%2$s\'. This version will become the default one on January 1st. We advise you to use this new version already and test that it works fine; if you find any problem, please report the issue in %3$s. To do the switch, please add the \'versionConstraint\' field argument to your query, using Composer\'s semver constraint rules (%4$s): %1$s(versionConstraint:"%5$s"). If you are unable to switch to the new version, please make sure to explicitly point to the current version \'%6$s\' before January 1st: %1$s(versionConstraint:"%6$s"). In case of doubt, please contact us at name@company.com.', 'examples-for-pop'),
+                        $this->translationAPI->__('Field \'%1$s\' has a new version: \'%2$s\'. This version will become the default one on January 1st. We advise you to use this new version already and test that it works fine; if you find any problem, please report the issue in %3$s. To do the switch, please add the \'versionConstraint\' field argument to your query, using Composer\'s semver constraint rules (%4$s): %1$s(versionConstraint:"%5$s"). If you are unable to switch to the new version, please make sure to explicitly point to the current version \'%6$s\' before January 1st: %1$s(versionConstraint:"%6$s"). In case of doubt, please contact us at name@company.com.', 'examples-for-pop'),
                         $fieldName,
                         '0.2.0',
                         'https://github.com/mycompany/myproject/issues',
@@ -39,12 +38,12 @@ class RootFieldResolver extends \Leoloso\ExamplesForPoP\FieldResolvers\Legacy\Ve
                         '0.1.0'
                     ),
                     'userServiceData' => sprintf(
-                        $translationAPI->__('Field \'%1$s\' has more than 1 version. Please add the \'versionConstraint\' field argument to your query to indicate which version to use (using Composer\'s semver constraint rules: %2$s). To use the latest version, use: %1$s(versionConstraint:"%3$s"). Available versions: \'%4$s\'.', 'examples-for-pop'),
+                        $this->translationAPI->__('Field \'%1$s\' has more than 1 version. Please add the \'versionConstraint\' field argument to your query to indicate which version to use (using Composer\'s semver constraint rules: %2$s). To use the latest version, use: %1$s(versionConstraint:"%3$s"). Available versions: \'%4$s\'.', 'examples-for-pop'),
                         $fieldName,
                         'https://getcomposer.org/doc/articles/versions.md',
                         '^0.2',
                         implode(
-                            $translationAPI->__('\', \'', 'examples-for-pop'),
+                            $this->translationAPI->__('\', \'', 'examples-for-pop'),
                             ['0.2.0', '0.1.0']
                         )
                     ),

--- a/layers/Schema/packages/basic-directives/src/DirectiveResolvers/AbstractTransformFieldStringValueDirectiveResolver.php
+++ b/layers/Schema/packages/basic-directives/src/DirectiveResolvers/AbstractTransformFieldStringValueDirectiveResolver.php
@@ -15,11 +15,10 @@ abstract class AbstractTransformFieldStringValueDirectiveResolver extends Abstra
     protected function validateTypeIsString($value, $id, string $field, string $fieldOutputKey, array &$dbErrors, array &$dbWarnings)
     {
         if (!is_string($value)) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             $dbWarnings[(string)$id][] = [
                 Tokens::PATH => [$this->directive],
                 Tokens::MESSAGE => sprintf(
-                    $translationAPI->__('Directive \'%s\' from field \'%s\' cannot be applied on object with ID \'%s\' because it is not a string', 'practical-directives'),
+                    $this->translationAPI->__('Directive \'%s\' from field \'%s\' cannot be applied on object with ID \'%s\' because it is not a string', 'practical-directives'),
                     $this->getDirectiveName(),
                     $fieldOutputKey,
                     $id

--- a/layers/Schema/packages/basic-directives/src/DirectiveResolvers/AbstractUseDefaultValueIfConditionDirectiveResolver.php
+++ b/layers/Schema/packages/basic-directives/src/DirectiveResolvers/AbstractUseDefaultValueIfConditionDirectiveResolver.php
@@ -91,16 +91,14 @@ abstract class AbstractUseDefaultValueIfConditionDirectiveResolver extends Abstr
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $defaultValue = $this->getDefaultValue();
         if (is_null($defaultValue)) {
-            return $translationAPI->__('If the value of the field is `NULL` (or empty), replace it with the value provided under argument \'value\'', 'basic-directives');
+            return $this->translationAPI->__('If the value of the field is `NULL` (or empty), replace it with the value provided under argument \'value\'', 'basic-directives');
         }
-        return $translationAPI->__('If the value of the field is `NULL` (or empty), replace it with either the value provided under argument \'value\', or with a default value configured in the directive resolver', 'basic-directives');
+        return $this->translationAPI->__('If the value of the field is `NULL` (or empty), replace it with either the value provided under argument \'value\', or with a default value configured in the directive resolver', 'basic-directives');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         /**
          * @var DefaultConditionEnum
@@ -109,7 +107,7 @@ abstract class AbstractUseDefaultValueIfConditionDirectiveResolver extends Abstr
         $schemaDirectiveArg = [
             SchemaDefinition::ARGNAME_NAME => 'value',
             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('If the value of the field is `NULL`, replace it with the value from this argument', 'basic-directives'),
+            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('If the value of the field is `NULL`, replace it with the value from this argument', 'basic-directives'),
         ];
         $defaultValue = $this->getDefaultValue();
         if (is_null($defaultValue)) {
@@ -122,7 +120,7 @@ abstract class AbstractUseDefaultValueIfConditionDirectiveResolver extends Abstr
             [
                 SchemaDefinition::ARGNAME_NAME => 'condition',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Condition under which using the default value kicks in', 'basic-directives'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Condition under which using the default value kicks in', 'basic-directives'),
                 SchemaDefinition::ARGNAME_ENUM_NAME => $defaultConditionEnum->getName(),
                 SchemaDefinition::ARGNAME_ENUM_VALUES => SchemaHelpers::convertToSchemaFieldArgEnumValueDefinitions(
                     $defaultConditionEnum->getValues()

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -48,9 +48,8 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'blockMetadata' => $translationAPI->__('Metadata for all blocks contained in the post, split on a block by block basis', 'pop-block-metadata'),
+            'blockMetadata' => $this->translationAPI->__('Metadata for all blocks contained in the post, split on a block by block basis', 'pop-block-metadata'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -58,7 +57,6 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'blockMetadata':
                 return array_merge(
@@ -67,22 +65,22 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'blockName',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Fetch only the block with this name in the post, filtering out all other blocks', 'block-metadata'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Fetch only the block with this name in the post, filtering out all other blocks', 'block-metadata'),
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'filterBy',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_INPUT_OBJECT,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Filter the block results based on different properties', 'block-metadata'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Filter the block results based on different properties', 'block-metadata'),
                             SchemaDefinition::ARGNAME_ARGS => [
                                 [
                                     SchemaDefinition::ARGNAME_NAME => 'blockNameStartsWith',
                                     SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                                    SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Include only blocks with the given name', 'block-metadata'),
+                                    SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Include only blocks with the given name', 'block-metadata'),
                                 ],
                                 [
                                     SchemaDefinition::ARGNAME_NAME => 'metaProperties',
                                     SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                                    SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Include only these block properties in the meta entry from the block', 'block-metadata'),
+                                    SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Include only these block properties in the meta entry from the block', 'block-metadata'),
                                 ]
                             ]
                         ],

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -51,9 +51,8 @@ class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'content' => $translationAPI->__('Post\'s content, formatted with its block metadata', 'pop-block-metadata'),
+            'content' => $this->translationAPI->__('Post\'s content, formatted with its block metadata', 'pop-block-metadata'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCategoryFieldResolver.php
@@ -49,14 +49,13 @@ abstract class AbstractCategoryFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'url' => $translationAPI->__('Category URL', 'pop-categories'),
-            'name' => $translationAPI->__('Category', 'pop-categories'),
-            'slug' => $translationAPI->__('Category slug', 'pop-categories'),
-            'description' => $translationAPI->__('Category description', 'pop-categories'),
-            'parent' => $translationAPI->__('Parent category (if this category is a child of another one)', 'pop-categories'),
-            'count' => $translationAPI->__('Number of custom posts containing this category', 'pop-categories'),
+            'url' => $this->translationAPI->__('Category URL', 'pop-categories'),
+            'name' => $this->translationAPI->__('Category', 'pop-categories'),
+            'slug' => $this->translationAPI->__('Category slug', 'pop-categories'),
+            'description' => $this->translationAPI->__('Category description', 'pop-categories'),
+            'parent' => $this->translationAPI->__('Parent category (if this category is a child of another one)', 'pop-categories'),
+            'count' => $this->translationAPI->__('Number of custom posts containing this category', 'pop-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostListCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostListCategoryFieldResolver.php
@@ -15,12 +15,11 @@ abstract class AbstractCustomPostListCategoryFieldResolver extends AbstractCusto
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'customPosts' => $translationAPI->__('Custom posts which contain this category', 'pop-categories'),
-            'customPostCount' => $translationAPI->__('Number of custom posts which contain this category', 'pop-categories'),
-            'unrestrictedCustomPosts' => $translationAPI->__('[Unrestricted] Custom posts which contain this category', 'pop-categories'),
-            'unrestrictedCustomPostCount' => $translationAPI->__('[Unrestricted] Number of custom posts which contain this category', 'pop-categories'),
+            'customPosts' => $this->translationAPI->__('Custom posts which contain this category', 'pop-categories'),
+            'customPostCount' => $this->translationAPI->__('Number of custom posts which contain this category', 'pop-categories'),
+            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts which contain this category', 'pop-categories'),
+            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts which contain this category', 'pop-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -52,11 +52,10 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'categories' => $translationAPI->__('Categories added to this custom post', 'pop-categories'),
-            'categoryCount' => $translationAPI->__('Number of categories added to this custom post', 'pop-categories'),
-            'categoryNames' => $translationAPI->__('Names of the categories added to this custom post', 'pop-categories'),
+            'categories' => $this->translationAPI->__('Categories added to this custom post', 'pop-categories'),
+            'categoryCount' => $this->translationAPI->__('Number of categories added to this custom post', 'pop-categories'),
+            'categoryNames' => $this->translationAPI->__('Names of the categories added to this custom post', 'pop-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/categories/src/TypeResolvers/AbstractCategoryTypeResolver.php
+++ b/layers/Schema/packages/categories/src/TypeResolvers/AbstractCategoryTypeResolver.php
@@ -14,8 +14,7 @@ abstract class AbstractCategoryTypeResolver extends AbstractTaxonomyTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a category, added to a custom post', 'categories');
+        return $this->translationAPI->__('Representation of a category, added to a custom post', 'categories');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/ModifyURLDirectiveResolver.php
+++ b/layers/Schema/packages/cdn-directive/src/DirectiveResolvers/ModifyURLDirectiveResolver.php
@@ -51,23 +51,21 @@ class ModifyURLDirectiveResolver extends AbstractTransformFieldStringValueDirect
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Replace the beginning path from the URL with another URL', 'basic-directives');
+        return $this->translationAPI->__('Replace the beginning path from the URL with another URL', 'basic-directives');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'from',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The domain to be replaced, including the protocol', 'basic-directives'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The domain to be replaced, including the protocol', 'basic-directives'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'to',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The domain to use as replacement, including the protocol', 'basic-directives'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The domain to use as replacement, including the protocol', 'basic-directives'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
         ];

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
@@ -29,9 +29,8 @@ class CommentFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'reply' => $translationAPI->__('Reply a comment with another comment', 'comment-mutations'),
+            'reply' => $this->translationAPI->__('Reply a comment with another comment', 'comment-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -30,9 +30,8 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'addComment' => $translationAPI->__('Add a comment to the custom post', 'comment-mutations'),
+            'addComment' => $this->translationAPI->__('Add a comment to the custom post', 'comment-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -34,10 +34,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'addCommentToCustomPost' => $translationAPI->__('Add a comment to a custom post', 'comment-mutations'),
-            'replyComment' => $translationAPI->__('Reply a comment with another comment', 'comment-mutations'),
+            'addCommentToCustomPost' => $this->translationAPI->__('Add a comment to a custom post', 'comment-mutations'),
+            'replyComment' => $this->translationAPI->__('Reply a comment with another comment', 'comment-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
@@ -43,7 +43,7 @@ class AddCommentToCustomPostMutationResolver extends AbstractMutationResolver
 
     protected function additionals(string | int $comment_id, array $form_data): void
     {
-        HooksAPIFacade::getInstance()->doAction('gd_addcomment', $comment_id, $form_data);
+        $this->hooksAPI->doAction('gd_addcomment', $comment_id, $form_data);
     }
 
     protected function getCommentData(array $form_data): array

--- a/layers/Schema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
@@ -33,10 +33,10 @@ class AddCommentToCustomPostMutationResolver extends AbstractMutationResolver
 
         // Either provide the customPostID, or retrieve it from the parent comment
         if ((!isset($form_data[MutationInputProperties::CUSTOMPOST_ID]) || !$form_data[MutationInputProperties::CUSTOMPOST_ID]) && (!isset($form_data[MutationInputProperties::PARENT_COMMENT_ID]) || !$form_data[MutationInputProperties::PARENT_COMMENT_ID])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The custom post ID is missing.', 'comment-mutations');
+            $errors[] = $this->translationAPI->__('The custom post ID is missing.', 'comment-mutations');
         }
         if (!isset($form_data[MutationInputProperties::COMMENT]) || !$form_data[MutationInputProperties::COMMENT]) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The comment is empty.', 'comment-mutations');
+            $errors[] = $this->translationAPI->__('The comment is empty.', 'comment-mutations');
         }
         return $errors;
     }

--- a/layers/Schema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/CommentUserFieldResolver.php
+++ b/layers/Schema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/CommentUserFieldResolver.php
@@ -35,9 +35,8 @@ class CommentUserFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'author' => $translationAPI->__('Comment\'s author', 'comments'),
+            'author' => $this->translationAPI->__('Comment\'s author', 'comments'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -20,8 +20,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
 
     public function getSchemaInterfaceDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('The entity can receive comments', 'comments');
+        return $this->translationAPI->__('The entity can receive comments', 'comments');
     }
 
     public function getFieldNamesToImplement(): array
@@ -59,12 +58,11 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
 
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'areCommentsOpen' => $translationAPI->__('Are comments open to be added to the custom post', 'pop-comments'),
-            'commentCount' => $translationAPI->__('Number of comments added to the custom post', 'pop-comments'),
-            'hasComments' => $translationAPI->__('Does the custom post have comments?', 'pop-comments'),
-            'comments' => $translationAPI->__('Comments added to the custom post', 'pop-comments'),
+            'areCommentsOpen' => $this->translationAPI->__('Are comments open to be added to the custom post', 'pop-comments'),
+            'commentCount' => $this->translationAPI->__('Number of comments added to the custom post', 'pop-comments'),
+            'hasComments' => $this->translationAPI->__('Does the custom post have comments?', 'pop-comments'),
+            'comments' => $this->translationAPI->__('Comments added to the custom post', 'pop-comments'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -76,19 +76,18 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'content' => $translationAPI->__('Comment\'s content', 'pop-comments'),
-            'authorName' => $translationAPI->__('Comment author\'s name', 'pop-comments'),
-            'authorURL' => $translationAPI->__('Comment author\'s URL', 'pop-comments'),
-            'authorEmail' => $translationAPI->__('Comment author\'s email', 'pop-comments'),
-            'customPost' => $translationAPI->__('Custom post to which the comment was added', 'pop-comments'),
-            'customPostID' => $translationAPI->__('ID of the custom post to which the comment was added', 'pop-comments'),
-            'approved' => $translationAPI->__('Is the comment approved?', 'pop-comments'),
-            'type' => $translationAPI->__('Type of comment', 'pop-comments'),
-            'parent' => $translationAPI->__('Parent comment (if this comment is a response to another one)', 'pop-comments'),
-            'date' => $translationAPI->__('Date when the comment was added', 'pop-comments'),
-            'responses' => $translationAPI->__('Responses to the comment', 'pop-comments'),
+            'content' => $this->translationAPI->__('Comment\'s content', 'pop-comments'),
+            'authorName' => $this->translationAPI->__('Comment author\'s name', 'pop-comments'),
+            'authorURL' => $this->translationAPI->__('Comment author\'s URL', 'pop-comments'),
+            'authorEmail' => $this->translationAPI->__('Comment author\'s email', 'pop-comments'),
+            'customPost' => $this->translationAPI->__('Custom post to which the comment was added', 'pop-comments'),
+            'customPostID' => $this->translationAPI->__('ID of the custom post to which the comment was added', 'pop-comments'),
+            'approved' => $this->translationAPI->__('Is the comment approved?', 'pop-comments'),
+            'type' => $this->translationAPI->__('Type of comment', 'pop-comments'),
+            'parent' => $this->translationAPI->__('Parent comment (if this comment is a response to another one)', 'pop-comments'),
+            'date' => $this->translationAPI->__('Date when the comment was added', 'pop-comments'),
+            'responses' => $this->translationAPI->__('Responses to the comment', 'pop-comments'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -163,7 +162,6 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         $cmsService = CMSServiceFacade::getInstance();
         switch ($fieldName) {
             case 'date':
@@ -174,7 +172,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
                             SchemaDefinition::ARGNAME_NAME => 'format',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                                $translationAPI->__('Date format, as defined in %s', 'pop-comments'),
+                                $this->translationAPI->__('Date format, as defined in %s', 'pop-comments'),
                                 'https://www.php.net/manual/en/function.date.php'
                             ),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => $cmsService->getOption(NameResolverFacade::getInstance()->getName('popcms:option:dateFormat')),

--- a/layers/Schema/packages/comments/src/TypeResolvers/CommentTypeResolver.php
+++ b/layers/Schema/packages/comments/src/TypeResolvers/CommentTypeResolver.php
@@ -17,8 +17,7 @@ class CommentTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Comments added to posts', 'comments');
+        return $this->translationAPI->__('Comments added to posts', 'comments');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/LowerCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/LowerCaseStringDirectiveResolver.php
@@ -33,7 +33,6 @@ class LowerCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Convert a string to lower case', 'convert-case-directives');
+        return $this->translationAPI->__('Convert a string to lower case', 'convert-case-directives');
     }
 }

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/TitleCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/TitleCaseStringDirectiveResolver.php
@@ -33,7 +33,6 @@ class TitleCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Convert a string to title case', 'convert-case-directives');
+        return $this->translationAPI->__('Convert a string to title case', 'convert-case-directives');
     }
 }

--- a/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/UpperCaseStringDirectiveResolver.php
+++ b/layers/Schema/packages/convert-case-directives/src/DirectiveResolvers/UpperCaseStringDirectiveResolver.php
@@ -33,7 +33,6 @@ class UpperCaseStringDirectiveResolver extends AbstractTransformFieldStringValue
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Convert a string to upper case', 'convert-case-directives');
+        return $this->translationAPI->__('Convert a string to upper case', 'convert-case-directives');
     }
 }

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -32,10 +32,9 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
             'setCategories' => sprintf(
-                $translationAPI->__('Set categories on the %s', 'custompost-category-mutations'),
+                $this->translationAPI->__('Set categories on the %s', 'custompost-category-mutations'),
                 $this->getEntityName()
             )
         ];
@@ -63,7 +62,6 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'setCategories':
                 $instanceManager = InstanceManagerFacade::getInstance();
@@ -75,7 +73,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::CATEGORY_IDS,
                         SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                            $translationAPI->__('The IDs of the categories to set, of type \'%s\'', 'custompost-category-mutations'),
+                            $this->translationAPI->__('The IDs of the categories to set, of type \'%s\'', 'custompost-category-mutations'),
                             $categoryTypeResolver->getTypeName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
@@ -83,7 +81,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::APPEND,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Append the categories to the existing ones?', 'custompost-category-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Append the categories to the existing ones?', 'custompost-category-mutations'),
                         SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                     ],
                 ];

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
@@ -37,10 +37,9 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
             $this->getSetCategoriesFieldName() => sprintf(
-                $translationAPI->__('Set categories on a %s', 'custompost-category-mutations'),
+                $this->translationAPI->__('Set categories on a %s', 'custompost-category-mutations'),
                 $this->getEntityName()
             ),
         ];
@@ -57,7 +56,6 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case $this->getSetCategoriesFieldName():
                 $instanceManager = InstanceManagerFacade::getInstance();
@@ -69,7 +67,7 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::CUSTOMPOST_ID,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                            $translationAPI->__('The ID of the %s', 'custompost-category-mutations'),
+                            $this->translationAPI->__('The ID of the %s', 'custompost-category-mutations'),
                             $this->getEntityName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
@@ -78,7 +76,7 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::CATEGORY_IDS,
                         SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                            $translationAPI->__('The IDs of the categories to set, of type \'%s\'', 'custompost-category-mutations'),
+                            $this->translationAPI->__('The IDs of the categories to set, of type \'%s\'', 'custompost-category-mutations'),
                             $categoryTypeResolver->getTypeName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
@@ -86,7 +84,7 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::APPEND,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Append the categories to the existing ones?', 'custompost-category-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Append the categories to the existing ones?', 'custompost-category-mutations'),
                         SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                     ],
                 ];

--- a/layers/Schema/packages/custompost-category-mutations/src/MutationResolvers/AbstractSetCategoriesOnCustomPostMutationResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/MutationResolvers/AbstractSetCategoriesOnCustomPostMutationResolver.php
@@ -35,10 +35,9 @@ abstract class AbstractSetCategoriesOnCustomPostMutationResolver extends Abstrac
             return $errors;
         }
 
-        $translationAPI = TranslationAPIFacade::getInstance();
         if (!$form_data[MutationInputProperties::CUSTOMPOST_ID]) {
             $errors[] = sprintf(
-                $translationAPI->__('The %s ID is missing.', 'custompost-category-mutations'),
+                $this->translationAPI->__('The %s ID is missing.', 'custompost-category-mutations'),
                 $this->getEntityName()
             );
         }
@@ -47,7 +46,6 @@ abstract class AbstractSetCategoriesOnCustomPostMutationResolver extends Abstrac
 
     protected function getEntityName(): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('custom post', 'custompost-category-mutations');
+        return $this->translationAPI->__('custom post', 'custompost-category-mutations');
     }
 }

--- a/layers/Schema/packages/custompost-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -22,9 +22,8 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'update' => $translationAPI->__('Update the custom post', 'custompost-mutations'),
+            'update' => $this->translationAPI->__('Update the custom post', 'custompost-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
+++ b/layers/Schema/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
@@ -137,8 +137,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         }
 
         // Allow plugins to add validation for their fields
-        $hooksAPI = HooksAPIFacade::getInstance();
-        $hooksAPI->doAction(
+        $this->hooksAPI->doAction(
             self::HOOK_VALIDATE_CONTENT,
             array(&$errors),
             $form_data
@@ -292,9 +291,8 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         $this->updateAdditionals($customPostID, $form_data, $log);
 
         // Inject Share profiles here
-        $hooksAPI = HooksAPIFacade::getInstance();
-        $hooksAPI->doAction(self::HOOK_EXECUTE_CREATE_OR_UPDATE, $customPostID, $form_data);
-        $hooksAPI->doAction(self::HOOK_EXECUTE_UPDATE, $customPostID, $log, $form_data);
+        $this->hooksAPI->doAction(self::HOOK_EXECUTE_CREATE_OR_UPDATE, $customPostID, $form_data);
+        $this->hooksAPI->doAction(self::HOOK_EXECUTE_UPDATE, $customPostID, $log, $form_data);
         return $customPostID;
     }
 
@@ -332,9 +330,8 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         $this->createAdditionals($customPostID, $form_data);
 
         // Inject Share profiles here
-        $hooksAPI = HooksAPIFacade::getInstance();
-        $hooksAPI->doAction(self::HOOK_EXECUTE_CREATE_OR_UPDATE, $customPostID, $form_data);
-        $hooksAPI->doAction(self::HOOK_EXECUTE_CREATE, $customPostID, $form_data);
+        $this->hooksAPI->doAction(self::HOOK_EXECUTE_CREATE_OR_UPDATE, $customPostID, $form_data);
+        $this->hooksAPI->doAction(self::HOOK_EXECUTE_CREATE, $customPostID, $form_data);
 
         return $customPostID;
     }

--- a/layers/Schema/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
+++ b/layers/Schema/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
@@ -82,7 +82,6 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         }
 
         $nameResolver = NameResolverFacade::getInstance();
-        $translationAPI = TranslationAPIFacade::getInstance();
 
         // Validate user permission
         $userRoleTypeDataResolver = UserRoleTypeDataResolverFacade::getInstance();
@@ -95,7 +94,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
                 $editCustomPostsCapability
             )
         ) {
-            $errors[] = $translationAPI->__('Your user doesn\'t have permission for editing custom posts.', 'custompost-mutations');
+            $errors[] = $this->translationAPI->__('Your user doesn\'t have permission for editing custom posts.', 'custompost-mutations');
             return;
         }
 
@@ -108,7 +107,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
                     $publishCustomPostsCapability
                 )
             ) {
-                $errors[] = $translationAPI->__('Your user doesn\'t have permission for publishing custom posts.', 'custompost-mutations');
+                $errors[] = $this->translationAPI->__('Your user doesn\'t have permission for publishing custom posts.', 'custompost-mutations');
                 return;
             }
         }
@@ -116,13 +115,11 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
 
     protected function getUserNotLoggedInErrorMessage(): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('You must be logged in to create or update custom posts', 'custompost-mutations');
+        return $this->translationAPI->__('You must be logged in to create or update custom posts', 'custompost-mutations');
     }
 
     protected function validateContent(array &$errors, array $form_data): void
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         // Validate that the status is valid
         $instanceManager = InstanceManagerFacade::getInstance();
         /**
@@ -133,7 +130,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
             $status = $form_data[MutationInputProperties::STATUS];
             if (!in_array($status, $customPostStatusEnum->getValues())) {
                 $errors[] = sprintf(
-                    $translationAPI->__('Status \'%s\' is not supported', 'custompost-mutations'),
+                    $this->translationAPI->__('Status \'%s\' is not supported', 'custompost-mutations'),
                     $status
                 );
             }
@@ -161,11 +158,10 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
 
     protected function validateUpdate(array &$errors, array $form_data): void
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
 
         $customPostID = $form_data[MutationInputProperties::ID] ?? null;
         if (!$customPostID) {
-            $errors[] = $translationAPI->__('The ID is missing', 'custompost-mutations');
+            $errors[] = $this->translationAPI->__('The ID is missing', 'custompost-mutations');
             return;
         }
 
@@ -173,7 +169,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         $post = $customPostTypeAPI->getCustomPost($customPostID);
         if (!$post) {
             $errors[] = sprintf(
-                $translationAPI->__('There is no entity with ID \'%s\'', 'custompost-mutations'),
+                $this->translationAPI->__('There is no entity with ID \'%s\'', 'custompost-mutations'),
                 $customPostID
             );
             return;
@@ -185,7 +181,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         $userID = $vars['global-userstate']['current-user-id'];
         if (!$customPostTypeMutationAPI->canUserEditCustomPost($userID, $customPostID)) {
             $errors[] = sprintf(
-                $translationAPI->__('You don\'t have permission to edit custom post with ID \'%s\'', 'custompost-mutations'),
+                $this->translationAPI->__('You don\'t have permission to edit custom post with ID \'%s\'', 'custompost-mutations'),
                 $customPostID
             );
             return;
@@ -270,7 +266,6 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
      */
     protected function update(array $form_data): string | int | Error
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $post_data = $this->getUpdateCustomPostData($form_data);
         $customPostID = $post_data['id'];
 
@@ -286,7 +281,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         } elseif ($result === null) {
             return new Error(
                 'update-error',
-                $translationAPI->__('Oops, there was a problem... this is embarrassing, huh?', 'custompost-mutations')
+                $this->translationAPI->__('Oops, there was a problem... this is embarrassing, huh?', 'custompost-mutations')
             );
         }
 
@@ -318,7 +313,6 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
      */
     protected function create(array $form_data): string | int | Error
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $post_data = $this->getCreateCustomPostData($form_data);
         $customPostID = $this->executeCreateCustomPost($post_data);
 
@@ -327,7 +321,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
         } elseif ($customPostID === null) {
             return new Error(
                 'create-error',
-                $translationAPI->__('Oops, there was a problem... this is embarrassing, huh?', 'custompost-mutations')
+                $this->translationAPI->__('Oops, there was a problem... this is embarrassing, huh?', 'custompost-mutations')
             );
         }
 

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -31,10 +31,9 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
             'setTags' => sprintf(
-                $translationAPI->__('Set tags on the %s', 'custompost-tag-mutations'),
+                $this->translationAPI->__('Set tags on the %s', 'custompost-tag-mutations'),
                 $this->getEntityName()
             )
         ];
@@ -62,20 +61,19 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'setTags':
                 return [
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::TAGS,
                         SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The tags to set', 'custompost-tag-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The tags to set', 'custompost-tag-mutations'),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
                     ],
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::APPEND,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Append the tags to the existing ones?', 'custompost-tag-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Append the tags to the existing ones?', 'custompost-tag-mutations'),
                         SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                     ],
                 ];

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
@@ -36,10 +36,9 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
             $this->getSetTagsFieldName() => sprintf(
-                $translationAPI->__('Set tags on a %s', 'custompost-tag-mutations'),
+                $this->translationAPI->__('Set tags on a %s', 'custompost-tag-mutations'),
                 $this->getEntityName()
             ),
         ];
@@ -56,7 +55,6 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case $this->getSetTagsFieldName():
                 return [
@@ -64,7 +62,7 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::CUSTOMPOST_ID,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                            $translationAPI->__('The ID of the %s', 'custompost-tag-mutations'),
+                            $this->translationAPI->__('The ID of the %s', 'custompost-tag-mutations'),
                             $this->getEntityName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
@@ -72,13 +70,13 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::TAGS,
                         SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The tags to set', 'custompost-tag-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The tags to set', 'custompost-tag-mutations'),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
                     ],
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::APPEND,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Append the tags to the existing ones?', 'custompost-tag-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Append the tags to the existing ones?', 'custompost-tag-mutations'),
                         SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                     ],
                 ];

--- a/layers/Schema/packages/custompost-tag-mutations/src/MutationResolvers/AbstractSetTagsOnCustomPostMutationResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/MutationResolvers/AbstractSetTagsOnCustomPostMutationResolver.php
@@ -35,10 +35,9 @@ abstract class AbstractSetTagsOnCustomPostMutationResolver extends AbstractMutat
             return $errors;
         }
 
-        $translationAPI = TranslationAPIFacade::getInstance();
         if (!$form_data[MutationInputProperties::CUSTOMPOST_ID]) {
             $errors[] = sprintf(
-                $translationAPI->__('The %s ID is missing.', 'custompost-tag-mutations'),
+                $this->translationAPI->__('The %s ID is missing.', 'custompost-tag-mutations'),
                 $this->getEntityName()
             );
         }
@@ -47,7 +46,6 @@ abstract class AbstractSetTagsOnCustomPostMutationResolver extends AbstractMutat
 
     protected function getEntityName(): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('custom post', 'custompost-tag-mutations');
+        return $this->translationAPI->__('custom post', 'custompost-tag-mutations');
     }
 }

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -40,10 +40,9 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'setFeaturedImage' => $translationAPI->__('Set the featured image on the custom post', 'custompostmedia-mutations'),
-            'removeFeaturedImage' => $translationAPI->__('Remove the featured image on the custom post', 'custompostmedia-mutations'),
+            'setFeaturedImage' => $this->translationAPI->__('Set the featured image on the custom post', 'custompostmedia-mutations'),
+            'removeFeaturedImage' => $this->translationAPI->__('Remove the featured image on the custom post', 'custompostmedia-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -71,7 +70,6 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'setFeaturedImage':
                 return [
@@ -79,7 +77,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::MEDIA_ITEM_ID,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                            $translationAPI->__('The ID of the featured image, of type \'%s\'', 'custompostmedia-mutations'),
+                            $this->translationAPI->__('The ID of the featured image, of type \'%s\'', 'custompostmedia-mutations'),
                             $this->mediaTypeResolver->getTypeName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMediaMutations\FieldResolvers;
 
+use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -20,9 +21,10 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
     function __construct(
         TranslationAPIInterface $translationAPI,
+        HooksAPIInterface $hooksAPI,
         protected MediaTypeResolver $mediaTypeResolver
     ) {
-        parent::__construct($translationAPI);
+        parent::__construct($translationAPI, $hooksAPI);
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMediaMutations\FieldResolvers;
 
+use PoP\Translation\TranslationAPIInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\MutationInputProperties;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\SetFeaturedImageOnCustomPostMutationResolver;
@@ -17,8 +18,11 @@ use PoPSchema\CustomPostMediaMutations\MutationResolvers\RemoveFeaturedImageOnCu
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
-    function __construct(protected MediaTypeResolver $mediaTypeResolver)
-    {
+    function __construct(
+        TranslationAPIInterface $translationAPI,
+        protected MediaTypeResolver $mediaTypeResolver
+    ) {
+        parent::__construct($translationAPI);
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMediaMutations\FieldResolvers;
 
+use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
@@ -21,9 +22,10 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 {
     function __construct(
         TranslationAPIInterface $translationAPI,
+        HooksAPIInterface $hooksAPI,
         protected MediaTypeResolver $mediaTypeResolver
     ) {
-        parent::__construct($translationAPI);
+        parent::__construct($translationAPI, $hooksAPI);
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMediaMutations\FieldResolvers;
 
+use PoP\Translation\TranslationAPIInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -11,15 +12,18 @@ use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
+use PoP\Engine\ComponentConfiguration as EngineComponentConfiguration;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\MutationInputProperties;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\SetFeaturedImageOnCustomPostMutationResolver;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\RemoveFeaturedImageOnCustomPostMutationResolver;
-use PoP\Engine\ComponentConfiguration as EngineComponentConfiguration;
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
-    function __construct(protected MediaTypeResolver $mediaTypeResolver)
-    {
+    function __construct(
+        TranslationAPIInterface $translationAPI,
+        protected MediaTypeResolver $mediaTypeResolver
+    ) {
+        parent::__construct($translationAPI);
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -44,10 +44,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'setFeaturedImageOnCustomPost' => $translationAPI->__('Set the featured image on a custom post', 'custompostmedia-mutations'),
-            'removeFeaturedImageFromCustomPost' => $translationAPI->__('Remove the featured image from a custom post', 'custompostmedia-mutations'),
+            'setFeaturedImageOnCustomPost' => $this->translationAPI->__('Set the featured image on a custom post', 'custompostmedia-mutations'),
+            'removeFeaturedImageFromCustomPost' => $this->translationAPI->__('Remove the featured image from a custom post', 'custompostmedia-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -63,12 +62,11 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $setRemoveFeaturedImageSchemaFieldArgs = [
             [
                 SchemaDefinition::ARGNAME_NAME => MutationInputProperties::CUSTOMPOST_ID,
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The ID of the custom post', 'custompostmedia-mutations'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The ID of the custom post', 'custompostmedia-mutations'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
         ];
@@ -81,7 +79,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
                             SchemaDefinition::ARGNAME_NAME => MutationInputProperties::MEDIA_ITEM_ID,
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                                $translationAPI->__('The ID of the featured image, of type \'%s\'', 'custompostmedia-mutations'),
+                                $this->translationAPI->__('The ID of the featured image, of type \'%s\'', 'custompostmedia-mutations'),
                                 $this->mediaTypeResolver->getTypeName()
                             ),
                             SchemaDefinition::ARGNAME_MANDATORY => true,

--- a/layers/Schema/packages/custompostmedia-mutations/src/MutationResolvers/RemoveFeaturedImageOnCustomPostMutationResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/MutationResolvers/RemoveFeaturedImageOnCustomPostMutationResolver.php
@@ -31,9 +31,8 @@ class RemoveFeaturedImageOnCustomPostMutationResolver extends AbstractMutationRe
             return $errors;
         }
 
-        $translationAPI = TranslationAPIFacade::getInstance();
         if (!$form_data[MutationInputProperties::CUSTOMPOST_ID]) {
-            $errors[] = $translationAPI->__('The custom post ID is missing.', 'custompostmedia-mutations');
+            $errors[] = $this->translationAPI->__('The custom post ID is missing.', 'custompostmedia-mutations');
         }
         return $errors;
     }

--- a/layers/Schema/packages/custompostmedia-mutations/src/MutationResolvers/SetFeaturedImageOnCustomPostMutationResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/MutationResolvers/SetFeaturedImageOnCustomPostMutationResolver.php
@@ -32,12 +32,11 @@ class SetFeaturedImageOnCustomPostMutationResolver extends AbstractMutationResol
             return $errors;
         }
 
-        $translationAPI = TranslationAPIFacade::getInstance();
         if (!$form_data[MutationInputProperties::CUSTOMPOST_ID]) {
-            $errors[] = $translationAPI->__('The custom post ID is missing.', 'custompostmedia-mutations');
+            $errors[] = $this->translationAPI->__('The custom post ID is missing.', 'custompostmedia-mutations');
         }
         if (!$form_data[MutationInputProperties::MEDIA_ITEM_ID]) {
-            $errors[] = $translationAPI->__('The media item ID is missing.', 'custompostmedia-mutations');
+            $errors[] = $this->translationAPI->__('The media item ID is missing.', 'custompostmedia-mutations');
         }
         return $errors;
     }

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -18,8 +18,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
 
     public function getSchemaInterfaceDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Fields concerning an entity\'s featured image', 'custompostmedia');
+        return $this->translationAPI->__('Fields concerning an entity\'s featured image', 'custompostmedia');
     }
 
     public function getFieldNamesToImplement(): array
@@ -52,10 +51,9 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
 
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'hasFeaturedImage' => $translationAPI->__('Does the custom post have a featured image?', 'custompostmedia'),
-            'featuredImage' => $translationAPI->__('Featured image from the custom post', 'custompostmedia'),
+            'hasFeaturedImage' => $this->translationAPI->__('Does the custom post have a featured image?', 'custompostmedia'),
+            'featuredImage' => $this->translationAPI->__('Featured image from the custom post', 'custompostmedia'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -34,8 +34,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
 
     public function getSchemaInterfaceDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Entities representing a custom post', 'customposts');
+        return $this->translationAPI->__('Entities representing a custom post', 'customposts');
     }
 
     public function getFieldNamesToImplement(): array
@@ -90,23 +89,21 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
 
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'content' => $translationAPI->__('Custom post content', 'customposts'),
-            'status' => $translationAPI->__('Custom post status', 'customposts'),
-            'isStatus' => $translationAPI->__('Is the custom post in the given status?', 'customposts'),
-            'date' => $translationAPI->__('Custom post published date', 'customposts'),
-            'datetime' => $translationAPI->__('Custom post published date and time', 'customposts'),
-            'title' => $translationAPI->__('Custom post title', 'customposts'),
-            'excerpt' => $translationAPI->__('Custom post excerpt', 'customposts'),
-            'customPostType' => $translationAPI->__('Custom post type', 'customposts'),
+            'content' => $this->translationAPI->__('Custom post content', 'customposts'),
+            'status' => $this->translationAPI->__('Custom post status', 'customposts'),
+            'isStatus' => $this->translationAPI->__('Is the custom post in the given status?', 'customposts'),
+            'date' => $this->translationAPI->__('Custom post published date', 'customposts'),
+            'datetime' => $this->translationAPI->__('Custom post published date and time', 'customposts'),
+            'title' => $this->translationAPI->__('Custom post title', 'customposts'),
+            'excerpt' => $this->translationAPI->__('Custom post excerpt', 'customposts'),
+            'customPostType' => $this->translationAPI->__('Custom post type', 'customposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }
     public function getSchemaFieldArgs(string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         $cmsService = CMSServiceFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         switch ($fieldName) {
@@ -118,7 +115,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
                             SchemaDefinition::ARGNAME_NAME => 'format',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                                $translationAPI->__('Date format, as defined in %s', 'customposts'),
+                                $this->translationAPI->__('Date format, as defined in %s', 'customposts'),
                                 'https://www.php.net/manual/en/function.date.php'
                             ),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => $cmsService->getOption(NameResolverFacade::getInstance()->getName('popcms:option:dateFormat')),
@@ -134,7 +131,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
                             SchemaDefinition::ARGNAME_NAME => 'format',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
                             SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                                $translationAPI->__('Date and time format, as defined in %s. Default value: \'%s\' (for current year date) or \'%s\' (otherwise)', 'customposts'),
+                                $this->translationAPI->__('Date and time format, as defined in %s. Default value: \'%s\' (for current year date) or \'%s\' (otherwise)', 'customposts'),
                                 'https://www.php.net/manual/en/function.date.php',
                                 'j M, H:i',
                                 'j M Y, H:i'
@@ -154,7 +151,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'status',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The status to check if the post has', 'customposts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The status to check if the post has', 'customposts'),
                             SchemaDefinition::ARGNAME_ENUM_NAME => $customPostStatusEnum->getName(),
                             SchemaDefinition::ARGNAME_ENUM_VALUES => [
                                 Status::PUBLISHED => [
@@ -174,10 +171,10 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
                                  */
                                 // 'trashed' => [
                                 //     SchemaDefinition::ARGNAME_NAME => 'trashed',
-                                //     SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Published content', 'customposts'),
+                                //     SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Published content', 'customposts'),
                                 //     SchemaDefinition::ARGNAME_DEPRECATED => true,
                                 //     SchemaDefinition::ARGNAME_DEPRECATIONDESCRIPTION => sprintf(
-                                //         $translationAPI->__('Use \'%s\' instead', 'customposts'),
+                                //         $this->translationAPI->__('Use \'%s\' instead', 'customposts'),
                                 //         Status::TRASH
                                 //     ),
                                 // ],
@@ -198,7 +195,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'format',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The format of the content', 'customposts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The format of the content', 'customposts'),
                             SchemaDefinition::ARGNAME_ENUM_NAME => $customPostContentFormatEnum->getName(),
                             SchemaDefinition::ARGNAME_ENUM_VALUES => SchemaHelpers::convertToSchemaFieldArgEnumValueDefinitions(
                                 $customPostContentFormatEnum->getValues()
@@ -258,12 +255,11 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
      */
     // protected function getSchemaDefinitionEnumValueDeprecationDescriptions(string $fieldName): ?array
     // {
-    //     $translationAPI = TranslationAPIFacade::getInstance();
     //     switch ($fieldName) {
     //         case 'status':
     //             return [
     //                 'trashed' => sprintf(
-    //                     $translationAPI->__('Using \'%s\' instead', 'customposts'),
+    //                     $this->translationAPI->__('Using \'%s\' instead', 'customposts'),
     //                     Status::TRASH
     //                 ),
     //             ];
@@ -273,18 +269,17 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
 
     protected function getSchemaDefinitionEnumValueDescriptions(string $fieldName): ?array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'status':
                 return [
-                    Status::PUBLISHED => $translationAPI->__('Published content', 'customposts'),
-                    Status::PENDING => $translationAPI->__('Pending content', 'customposts'),
-                    Status::DRAFT => $translationAPI->__('Draft content', 'customposts'),
-                    Status::TRASH => $translationAPI->__('Trashed content', 'customposts'),
+                    Status::PUBLISHED => $this->translationAPI->__('Published content', 'customposts'),
+                    Status::PENDING => $this->translationAPI->__('Pending content', 'customposts'),
+                    Status::DRAFT => $this->translationAPI->__('Draft content', 'customposts'),
+                    Status::TRASH => $this->translationAPI->__('Trashed content', 'customposts'),
                     /**
                      * @todo Extract to documentation before deleting this code
                      */
-                    // 'trashed' => $translationAPI->__('Trashed content', 'customposts'),
+                    // 'trashed' => $this->translationAPI->__('Trashed content', 'customposts'),
                 ];
         }
         return null;

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -61,7 +61,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
                 } elseif ($format == CustomPostContentFormatEnum::PLAIN_TEXT) {
                     $value = $customPostTypeAPI->getPlainTextContent($customPost);
                 }
-                return HooksAPIFacade::getInstance()->applyFilters(
+                return $this->hooksAPI->applyFilters(
                     'pop_content',
                     $value,
                     $typeResolver->getID($customPost)

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -62,12 +62,11 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'customPosts' => $translationAPI->__('Custom posts', 'pop-posts'),
-            'customPostCount' => $translationAPI->__('Number of custom posts', 'pop-posts'),
-            'unrestrictedCustomPosts' => $translationAPI->__('[Unrestricted] Custom posts', 'pop-posts'),
-            'unrestrictedCustomPostCount' => $translationAPI->__('[Unrestricted] Number of custom posts', 'pop-posts'),
+            'customPosts' => $this->translationAPI->__('Custom posts', 'pop-posts'),
+            'customPostCount' => $this->translationAPI->__('Number of custom posts', 'pop-posts'),
+            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts', 'pop-posts'),
+            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts', 'pop-posts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -49,10 +49,9 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'customPost' => $translationAPI->__('Custom post with a specific ID', 'customposts'),
-            'unrestrictedCustomPost' => $translationAPI->__('[Unrestricted] Custom post with a specific ID', 'customposts'),
+            'customPost' => $this->translationAPI->__('Custom post with a specific ID', 'customposts'),
+            'unrestrictedCustomPost' => $this->translationAPI->__('[Unrestricted] Custom post with a specific ID', 'customposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -69,7 +68,6 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'customPost':
             case 'unrestrictedCustomPost':
@@ -79,7 +77,7 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The custom post ID', 'customposts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The custom post ID', 'customposts'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/customposts/src/TypeResolvers/AbstractCustomPostTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/AbstractCustomPostTypeResolver.php
@@ -12,8 +12,7 @@ abstract class AbstractCustomPostTypeResolver extends AbstractTypeResolver
 {
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a custom post', 'customposts');
+        return $this->translationAPI->__('Representation of a custom post', 'customposts');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostTypeResolver.php
@@ -23,8 +23,7 @@ class CustomPostTypeResolver extends AbstractCustomPostTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a custom post', 'customposts');
+        return $this->translationAPI->__('Representation of a custom post', 'customposts');
     }
 
     public function getTypeDataLoaderClass(): string

--- a/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostUnionTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/CustomPostUnionTypeResolver.php
@@ -18,8 +18,7 @@ class CustomPostUnionTypeResolver extends AbstractUnionTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Union of \'custom post\' type resolvers', 'customposts');
+        return $this->translationAPI->__('Union of \'custom post\' type resolvers', 'customposts');
     }
 
     public function getTypeDataLoaderClass(): string

--- a/layers/Schema/packages/events/src/ConditionalOnComponent/Tags/FieldResolvers/EventTagFieldResolver.php
+++ b/layers/Schema/packages/events/src/ConditionalOnComponent/Tags/FieldResolvers/EventTagFieldResolver.php
@@ -25,10 +25,9 @@ abstract class EventTagFieldResolver extends AbstractEventFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'events' => $translationAPI->__('Events which contain this tag', 'events'),
-            'eventCount' => $translationAPI->__('Number of events which contain this tag', 'events'),
+            'events' => $this->translationAPI->__('Events which contain this tag', 'events'),
+            'eventCount' => $this->translationAPI->__('Number of events which contain this tag', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/events/src/ConditionalOnComponent/Users/FieldResolvers/EventUserFieldResolver.php
+++ b/layers/Schema/packages/events/src/ConditionalOnComponent/Users/FieldResolvers/EventUserFieldResolver.php
@@ -18,10 +18,9 @@ class EventUserFieldResolver extends AbstractEventFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'events' => $translationAPI->__('Events by the user', 'events'),
-            'eventCount' => $translationAPI->__('Number of events by the user', 'events'),
+            'events' => $this->translationAPI->__('Events by the user', 'events'),
+            'eventCount' => $this->translationAPI->__('Number of events by the user', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/events/src/FieldResolvers/AbstractEventFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/AbstractEventFieldResolver.php
@@ -47,10 +47,9 @@ abstract class AbstractEventFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'events' => $translationAPI->__('Events', 'events'),
-            'eventCount' => $translationAPI->__('Number of events', 'events'),
+            'events' => $this->translationAPI->__('Events', 'events'),
+            'eventCount' => $this->translationAPI->__('Number of events', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/events/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/EventFieldResolver.php
@@ -57,14 +57,13 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'location' => $translationAPI->__('Event\'s location', 'events'),
-            'startDate' => $translationAPI->__('Event\'s start ate', 'events'),
-            'endDate' => $translationAPI->__('Event\'s end date', 'events'),
-            'isAllDay' => $translationAPI->__('Is the event all day long?', 'events'),
-            'googleCalendarURL' => $translationAPI->__('Event\'s Google calendar URL', 'events'),
-            'icalURL' => $translationAPI->__('Event\'s Ical URL', 'events'),
+            'location' => $this->translationAPI->__('Event\'s location', 'events'),
+            'startDate' => $this->translationAPI->__('Event\'s start ate', 'events'),
+            'endDate' => $this->translationAPI->__('Event\'s end date', 'events'),
+            'isAllDay' => $this->translationAPI->__('Is the event all day long?', 'events'),
+            'googleCalendarURL' => $this->translationAPI->__('Event\'s Google calendar URL', 'events'),
+            'icalURL' => $this->translationAPI->__('Event\'s Ical URL', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/events/src/FieldResolvers/EventFunctionalFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/EventFunctionalFieldResolver.php
@@ -43,9 +43,8 @@ class EventFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'scope' => $translationAPI->__('Event\'s scope (future, current, past)', 'events'),
+            'scope' => $this->translationAPI->__('Event\'s scope (future, current, past)', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/events/src/FieldResolvers/RootEventFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/RootEventFieldResolver.php
@@ -32,9 +32,8 @@ class RootEventFieldResolver extends AbstractPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'event' => $translationAPI->__('Event with a specific ID', 'events'),
+            'event' => $this->translationAPI->__('Event with a specific ID', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -50,7 +49,6 @@ class RootEventFieldResolver extends AbstractPostFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'event':
                 return array_merge(
@@ -59,7 +57,7 @@ class RootEventFieldResolver extends AbstractPostFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The event ID', 'events'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The event ID', 'events'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/events/src/FieldResolvers/RootEventListFieldResolver.php
+++ b/layers/Schema/packages/events/src/FieldResolvers/RootEventListFieldResolver.php
@@ -18,9 +18,8 @@ class RootEventListFieldResolver extends AbstractEventFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'events' => $translationAPI->__('Events in the site', 'events'),
+            'events' => $this->translationAPI->__('Events in the site', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/events/src/TypeResolvers/EventTypeResolver.php
+++ b/layers/Schema/packages/events/src/TypeResolvers/EventTypeResolver.php
@@ -18,8 +18,7 @@ class EventTypeResolver extends AbstractCustomPostTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of an event', 'events');
+        return $this->translationAPI->__('Representation of an event', 'events');
     }
 
     // public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/AbstractLocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/AbstractLocationFunctionalFieldResolver.php
@@ -35,9 +35,8 @@ abstract class AbstractLocationFunctionalFieldResolver extends AbstractFunctiona
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'locationsmapURL' => $translationAPI->__('Locations map URL', 'pop-locations'),
+            'locationsmapURL' => $this->translationAPI->__('Locations map URL', 'pop-locations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -49,10 +49,9 @@ class CatEventFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'catSlugs' => $translationAPI->__('', ''),
-            'catName' => $translationAPI->__('', ''),
+            'catSlugs' => $this->translationAPI->__('', ''),
+            'catName' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CommentsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CommentsCustomPostFieldResolver.php
@@ -36,9 +36,8 @@ class CommentsCustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'commentsURL' => $translationAPI->__('URL of the comments section in the post page', 'pop-comments'),
+            'commentsURL' => $this->translationAPI->__('URL of the comments section in the post page', 'pop-comments'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -53,10 +53,9 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'hasLocation' => $translationAPI->__('Does the object have location?', 'pop-locations'),
-            'location' => $translationAPI->__('Object\'s location', 'pop-locations'),
+            'hasLocation' => $this->translationAPI->__('Does the object have location?', 'pop-locations'),
+            'location' => $this->translationAPI->__('Object\'s location', 'pop-locations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -49,9 +49,8 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'locations' => $translationAPI->__('Object\'s locations', 'pop-locations'),
+            'locations' => $this->translationAPI->__('Object\'s locations', 'pop-locations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -64,15 +64,14 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'locations' => $translationAPI->__('Event\'s locations', 'events'),
-            'categories' => $translationAPI->__('Event\'s categories', 'events'),
-            'dates' => $translationAPI->__('Event\'s dates', 'events'),
-            'times' => $translationAPI->__('Event\'s times', 'events'),
-            'startDateReadable' => $translationAPI->__('Event\'s start date in human-readable format', 'events'),
-            'daterange' => $translationAPI->__('Event\'s date range', 'events'),
-            'daterangetime' => $translationAPI->__('Event\'s date range and time', 'events'),
+            'locations' => $this->translationAPI->__('Event\'s locations', 'events'),
+            'categories' => $this->translationAPI->__('Event\'s categories', 'events'),
+            'dates' => $this->translationAPI->__('Event\'s dates', 'events'),
+            'times' => $this->translationAPI->__('Event\'s times', 'events'),
+            'startDateReadable' => $this->translationAPI->__('Event\'s start date in human-readable format', 'events'),
+            'daterange' => $this->translationAPI->__('Event\'s date range', 'events'),
+            'daterangetime' => $this->translationAPI->__('Event\'s date range and time', 'events'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFunctionalFieldResolver.php
@@ -42,10 +42,9 @@ class EventFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'multilayoutKeys' => $translationAPI->__('', ''),
-            'latestcountsTriggerValues' => $translationAPI->__('', ''),
+            'multilayoutKeys' => $this->translationAPI->__('', ''),
+            'latestcountsTriggerValues' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -49,9 +49,8 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'mapURL' => $translationAPI->__('Location map URL', 'pop-locations'),
+            'mapURL' => $this->translationAPI->__('Location map URL', 'pop-locations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/QueryableObjectPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/QueryableObjectPostFieldResolver.php
@@ -37,9 +37,8 @@ class QueryableObjectPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'endpoint' => $translationAPI->__('Endpoint to fetch the object\'s data', 'queriedobject'),
+            'endpoint' => $this->translationAPI->__('Endpoint to fetch the object\'s data', 'queriedobject'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagFunctionalFieldResolver.php
@@ -41,12 +41,11 @@ class TagFunctionalFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'symbol' => $translationAPI->__('Tag symbol', 'pop-everythingelse'),
-            'symbolnamedescription' => $translationAPI->__('Tag symbol and description', 'pop-everythingelse'),
-            'namedescription' => $translationAPI->__('Tag and description', 'pop-everythingelse'),
-            'symbolname' => $translationAPI->__('Symbol and tag', 'pop-everythingelse'),
+            'symbol' => $this->translationAPI->__('Tag symbol', 'pop-everythingelse'),
+            'symbolnamedescription' => $this->translationAPI->__('Tag symbol and description', 'pop-everythingelse'),
+            'namedescription' => $this->translationAPI->__('Tag and description', 'pop-everythingelse'),
+            'symbolname' => $this->translationAPI->__('Symbol and tag', 'pop-everythingelse'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -50,9 +50,8 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'tagNames' => $translationAPI->__('Names of the tags added to this post', 'pop-tags'),
+            'tagNames' => $this->translationAPI->__('Names of the tags added to this post', 'pop-tags'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -49,9 +49,8 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'locations' => $translationAPI->__('Locations', 'pop-locations'),
+            'locations' => $this->translationAPI->__('Locations', 'pop-locations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -40,11 +40,10 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'genericCustomPost' => $translationAPI->__('Custom post with a specific ID', 'generic-customposts'),
-            'genericCustomPosts' => $translationAPI->__('Custom posts', 'generic-customposts'),
-            'genericCustomPostCount' => $translationAPI->__('Number of custom posts', 'generic-customposts'),
+            'genericCustomPost' => $this->translationAPI->__('Custom post with a specific ID', 'generic-customposts'),
+            'genericCustomPosts' => $this->translationAPI->__('Custom posts', 'generic-customposts'),
+            'genericCustomPostCount' => $this->translationAPI->__('Number of custom posts', 'generic-customposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -74,7 +73,6 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'genericCustomPost':
                 return array_merge(
@@ -83,7 +81,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The page ID', 'generic-customposts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The page ID', 'generic-customposts'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/generic-customposts/src/TypeResolvers/GenericCustomPostTypeResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/TypeResolvers/GenericCustomPostTypeResolver.php
@@ -17,8 +17,7 @@ class GenericCustomPostTypeResolver extends AbstractCustomPostTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Any custom post, with or without its own type for the schema', 'customposts');
+        return $this->translationAPI->__('Any custom post, with or without its own type for the schema', 'customposts');
     }
 
     public function getTypeDataLoaderClass(): string

--- a/layers/Schema/packages/google-translate-directive/src/DirectiveResolvers/AbstractGoogleTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/google-translate-directive/src/DirectiveResolvers/AbstractGoogleTranslateDirectiveResolver.php
@@ -92,8 +92,7 @@ abstract class AbstractGoogleTranslateDirectiveResolver extends AbstractTranslat
             case self::PROVIDERS_GOOGLE:
                 // An array with the translations is found under data/translations
                 if (!$response['data']) {
-                    $translationAPI = TranslationAPIFacade::getInstance();
-                    return $translationAPI->__('There was an unidentified error when fetching data from the Google Translate API', 'google-translate-directive');
+                    return $this->translationAPI->__('There was an unidentified error when fetching data from the Google Translate API', 'google-translate-directive');
                 }
         }
         return parent::getErrorMessageFromResponse($provider, $response);

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -59,11 +59,10 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'highlights' => $translationAPI->__('', ''),
-            'hasHighlights' => $translationAPI->__('', ''),
-            'highlightsCount' => $translationAPI->__('', ''),
+            'highlights' => $this->translationAPI->__('', ''),
+            'hasHighlights' => $this->translationAPI->__('', ''),
+            'highlightsCount' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -49,9 +49,8 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'addhighlightURL' => $translationAPI->__('', ''),
+            'addhighlightURL' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -59,14 +59,13 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'title' => $translationAPI->__('', ''),
-            'excerpt' => $translationAPI->__('', ''),
-            'content' => $translationAPI->__('', ''),
-            'highlightedpost' => $translationAPI->__('', ''),
-            'highlightedPostURL' => $translationAPI->__('', ''),
-            'highlightedpost' => $translationAPI->__('', ''),
+            'title' => $this->translationAPI->__('', ''),
+            'excerpt' => $this->translationAPI->__('', ''),
+            'content' => $this->translationAPI->__('', ''),
+            'highlightedpost' => $this->translationAPI->__('', ''),
+            'highlightedPostURL' => $this->translationAPI->__('', ''),
+            'highlightedpost' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/highlights/src/TypeResolvers/HighlightTypeResolver.php
+++ b/layers/Schema/packages/highlights/src/TypeResolvers/HighlightTypeResolver.php
@@ -18,8 +18,7 @@ class HighlightTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('A highlighted piece of text, extracted from a post', 'highlights');
+        return $this->translationAPI->__('A highlighted piece of text, extracted from a post', 'highlights');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/locationposts/src/ConditionalOnComponent/Tags/FieldResolvers/LocationPostTagFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/ConditionalOnComponent/Tags/FieldResolvers/LocationPostTagFieldResolver.php
@@ -25,9 +25,8 @@ abstract class LocationPostTagFieldResolver extends AbstractLocationPostFieldRes
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'locationposts' => $translationAPI->__('Location Posts which contain this tag', 'locationposts'),
+            'locationposts' => $this->translationAPI->__('Location Posts which contain this tag', 'locationposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/locationposts/src/ConditionalOnComponent/Users/FieldResolvers/LocationPostUserFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/ConditionalOnComponent/Users/FieldResolvers/LocationPostUserFieldResolver.php
@@ -18,9 +18,8 @@ class LocationPostUserFieldResolver extends AbstractLocationPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'locationposts' => $translationAPI->__('Location Posts by the user', 'locationposts'),
+            'locationposts' => $this->translationAPI->__('Location Posts by the user', 'locationposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/locationposts/src/FieldResolvers/AbstractLocationPostFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/FieldResolvers/AbstractLocationPostFieldResolver.php
@@ -45,9 +45,8 @@ abstract class AbstractLocationPostFieldResolver extends AbstractQueryableFieldR
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'locationposts' => $translationAPI->__('Location Posts', 'locationposts'),
+            'locationposts' => $this->translationAPI->__('Location Posts', 'locationposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/locationposts/src/FieldResolvers/LocationPostFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/FieldResolvers/LocationPostFieldResolver.php
@@ -54,11 +54,10 @@ class LocationPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'categories' => $translationAPI->__('', ''),
-            'catSlugs' => $translationAPI->__('', ''),
-            'catName' => $translationAPI->__('', ''),
+            'categories' => $this->translationAPI->__('', ''),
+            'catSlugs' => $this->translationAPI->__('', ''),
+            'catName' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/locationposts/src/FieldResolvers/RootLocationPostFieldResolver.php
+++ b/layers/Schema/packages/locationposts/src/FieldResolvers/RootLocationPostFieldResolver.php
@@ -18,9 +18,8 @@ class RootLocationPostFieldResolver extends AbstractLocationPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'posts' => $translationAPI->__('Location Posts in the current site', 'locationposts'),
+            'posts' => $this->translationAPI->__('Location Posts in the current site', 'locationposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/locationposts/src/TypeResolvers/LocationPostTypeResolver.php
+++ b/layers/Schema/packages/locationposts/src/TypeResolvers/LocationPostTypeResolver.php
@@ -23,8 +23,7 @@ class LocationPostTypeResolver extends PostTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('A post which has locations', 'locationposts');
+        return $this->translationAPI->__('A post which has locations', 'locationposts');
     }
 
     public function getTypeDataLoaderClass(): string

--- a/layers/Schema/packages/locations/src/FieldResolvers/LocationFieldResolver.php
+++ b/layers/Schema/packages/locations/src/FieldResolvers/LocationFieldResolver.php
@@ -41,12 +41,11 @@ class LocationFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'coordinates' => $translationAPI->__('Location coordinates', 'pop-locations'),
-            'name' => $translationAPI->__('Location name', 'pop-locations'),
-            'address' => $translationAPI->__('Location address', 'pop-locations'),
-            'city' => $translationAPI->__('Location city', 'pop-locations'),
+            'coordinates' => $this->translationAPI->__('Location coordinates', 'pop-locations'),
+            'name' => $this->translationAPI->__('Location name', 'pop-locations'),
+            'address' => $this->translationAPI->__('Location address', 'pop-locations'),
+            'city' => $this->translationAPI->__('Location city', 'pop-locations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/locations/src/TypeResolvers/LocationTypeResolver.php
+++ b/layers/Schema/packages/locations/src/TypeResolvers/LocationTypeResolver.php
@@ -18,8 +18,7 @@ class LocationTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a location entity, with a name, address and coordinates', 'locations');
+        return $this->translationAPI->__('Representation of a location entity, with a name, address and coordinates', 'locations');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/MediaUserFieldResolver.php
+++ b/layers/Schema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/MediaUserFieldResolver.php
@@ -35,9 +35,8 @@ class MediaUserFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'author' => $translationAPI->__('Media element\'s author', 'pop-media'),
+            'author' => $this->translationAPI->__('Media element\'s author', 'pop-media'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -53,11 +53,10 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'src' => $translationAPI->__('Media element URL source', 'pop-media'),
-            'width' => $translationAPI->__('Media element\'s width', 'pop-media'),
-            'height' => $translationAPI->__('Media element\'s height', 'pop-media'),
+            'src' => $this->translationAPI->__('Media element URL source', 'pop-media'),
+            'width' => $this->translationAPI->__('Media element\'s width', 'pop-media'),
+            'height' => $this->translationAPI->__('Media element\'s height', 'pop-media'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -129,7 +128,6 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         $instanceManager = InstanceManagerFacade::getInstance();
         switch ($fieldName) {
             case 'src':
@@ -145,12 +143,12 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'size',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Size of the image', 'pop-media'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Size of the image', 'pop-media'),
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'device',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Device where to show the image', 'pop-media'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Device where to show the image', 'pop-media'),
                             SchemaDefinition::ARGNAME_ENUM_NAME => $mediaDeviceEnum->getName(),
                             SchemaDefinition::ARGNAME_ENUM_VALUES => SchemaHelpers::convertToSchemaFieldArgEnumValueDefinitions(
                                 $mediaDeviceEnum->getValues()

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Media\FieldResolvers;
 
+use PoP\Translation\TranslationAPIInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
@@ -16,8 +17,11 @@ use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 
 class RootFieldResolver extends AbstractQueryableFieldResolver
 {
-    function __construct(protected CustomPostTypeResolver $customPostTypeResolver)
-    {
+    function __construct(
+        TranslationAPIInterface $translationAPI,
+        protected CustomPostTypeResolver $customPostTypeResolver
+    ) {
+        parent::__construct($translationAPI);
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -39,10 +39,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'mediaItems' => $translationAPI->__('Get the media items', 'media'),
-            'mediaItem' => $translationAPI->__('Get a media item', 'media'),
+            'mediaItems' => $this->translationAPI->__('Get the media items', 'media'),
+            'mediaItem' => $this->translationAPI->__('Get a media item', 'media'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -58,7 +57,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'mediaItem':
                 return [
@@ -66,7 +64,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
                         SchemaDefinition::ARGNAME_NAME => 'id',
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
                         SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
-                            $translationAPI->__('The ID of the media element, of type \'%s\'', 'media'),
+                            $this->translationAPI->__('The ID of the media element, of type \'%s\'', 'media'),
                             $this->customPostTypeResolver->getTypeName()
                         ),
                         SchemaDefinition::ARGNAME_MANDATORY => true,

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Media\FieldResolvers;
 
+use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
@@ -19,9 +20,10 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 {
     function __construct(
         TranslationAPIInterface $translationAPI,
+        HooksAPIInterface $hooksAPI,
         protected CustomPostTypeResolver $customPostTypeResolver
     ) {
-        parent::__construct($translationAPI);
+        parent::__construct($translationAPI, $hooksAPI);
     }
 
     public function getClassesToAttachTo(): array

--- a/layers/Schema/packages/media/src/TypeResolvers/MediaTypeResolver.php
+++ b/layers/Schema/packages/media/src/TypeResolvers/MediaTypeResolver.php
@@ -17,8 +17,7 @@ class MediaTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Media elements (such as images, videos, etc), attached to a post or independent', 'media');
+        return $this->translationAPI->__('Media elements (such as images, videos, etc), attached to a post or independent', 'media');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -40,14 +40,13 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'itemDataEntries':
                 return [
                     [
                         SchemaDefinition::ARGNAME_NAME => 'flat',
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Flatten the items', 'menus'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Flatten the items', 'menus'),
                     ],
                 ];
         }
@@ -67,9 +66,8 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'itemDataEntries' => $translationAPI->__('The menu items', 'menus'),
+            'itemDataEntries' => $this->translationAPI->__('The menu items', 'menus'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
@@ -101,7 +101,7 @@ class MenuItemFieldResolver extends AbstractDBDataFieldResolver
                 if ($objectID = $menuItemTypeAPI->getMenuItemObjectID($menuItem)) {
                     $classes[] = 'menu-item-object-id-' . $objectID;
                 }
-                return join(' ', HooksAPIFacade::getInstance()->applyFilters('menuitem:classes', array_filter($classes), $menuItem, array()));
+                return join(' ', $this->hooksAPI->applyFilters('menuitem:classes', array_filter($classes), $menuItem, array()));
 
             case 'target':
                 return $menuItemTypeAPI->getMenuItemTarget($menuItem);

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
@@ -50,16 +50,15 @@ class MenuItemFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'title' => $translationAPI->__('Menu item title', 'menus'),
-            'alt' => $translationAPI->__('Menu item alt', 'menus'),
-            'url' => $translationAPI->__('Menu item URL', 'menus'),
-            'classes' => $translationAPI->__('Menu item classes', 'menus'),
-            'target' => $translationAPI->__('Menu item target', 'menus'),
-            'additionalAttrs' => $translationAPI->__('Menu item additional attributes', 'menus'),
-            'objectID' => $translationAPI->__('ID of the object linked to by the menu item ', 'menus'),
-            'parentID' => $translationAPI->__('Menu item\'s parent ID', 'menus'),
+            'title' => $this->translationAPI->__('Menu item title', 'menus'),
+            'alt' => $this->translationAPI->__('Menu item alt', 'menus'),
+            'url' => $this->translationAPI->__('Menu item URL', 'menus'),
+            'classes' => $this->translationAPI->__('Menu item classes', 'menus'),
+            'target' => $this->translationAPI->__('Menu item target', 'menus'),
+            'additionalAttrs' => $this->translationAPI->__('Menu item additional attributes', 'menus'),
+            'objectID' => $this->translationAPI->__('ID of the object linked to by the menu item ', 'menus'),
+            'parentID' => $this->translationAPI->__('Menu item\'s parent ID', 'menus'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/menus/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/RootFieldResolver.php
@@ -28,9 +28,8 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'menu' => $translationAPI->__('Get a menu', 'menus'),
+            'menu' => $this->translationAPI->__('Get a menu', 'menus'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -45,14 +44,13 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'menu':
                 return [
                     [
                         SchemaDefinition::ARGNAME_NAME => 'id',
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The ID of the menu', 'menus'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The ID of the menu', 'menus'),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
                     ],
                 ];

--- a/layers/Schema/packages/menus/src/TypeResolvers/MenuItemTypeResolver.php
+++ b/layers/Schema/packages/menus/src/TypeResolvers/MenuItemTypeResolver.php
@@ -18,8 +18,7 @@ class MenuItemTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Items (links, pages, etc) added to a menu', 'menus');
+        return $this->translationAPI->__('Items (links, pages, etc) added to a menu', 'menus');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/menus/src/TypeResolvers/MenuTypeResolver.php
+++ b/layers/Schema/packages/menus/src/TypeResolvers/MenuTypeResolver.php
@@ -18,8 +18,7 @@ class MenuTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a navigation menu', 'menus');
+        return $this->translationAPI->__('Representation of a navigation menu', 'menus');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
+++ b/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
@@ -17,8 +17,7 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
 
     public function getSchemaInterfaceDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Fields with meta values', 'custompostmeta');
+        return $this->translationAPI->__('Fields with meta values', 'custompostmeta');
     }
 
     public function getFieldNamesToImplement(): array
@@ -39,7 +38,6 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
     public function getSchemaFieldArgs(string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'meta':
                 return array_merge(
@@ -48,13 +46,13 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
                         [
                             SchemaDefinition::ARGNAME_NAME => 'key',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The meta key', 'meta'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The meta key', 'meta'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'single',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Whether to bring a single value', 'meta'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Whether to bring a single value', 'meta'),
                             SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                         ],
                     ]
@@ -66,9 +64,8 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
 
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'meta' => $translationAPI->__('Meta value', 'custompostmeta'),
+            'meta' => $this->translationAPI->__('Meta value', 'custompostmeta'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
@@ -75,4 +75,5 @@ class GD_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolve
 }
 
 // Static Initialization: Attach
-(new GD_DataLoad_FunctionalFieldResolver())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+$translationAPI = TranslationAPIFacade::getInstance();
+(new GD_DataLoad_FunctionalFieldResolver($translationAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
@@ -6,6 +6,7 @@ use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
+use PoP\Hooks\Facades\HooksAPIFacade;
 
 class GD_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
@@ -76,4 +77,5 @@ class GD_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolve
 
 // Static Initialization: Attach
 $translationAPI = TranslationAPIFacade::getInstance();
-(new GD_DataLoad_FunctionalFieldResolver($translationAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+$hooksAPI = HooksAPIFacade::getInstance();
+(new GD_DataLoad_FunctionalFieldResolver($translationAPI, $hooksAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -1,11 +1,12 @@
 <?php
 use PoP\Engine\Route\RouteUtils;
+use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
+use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 
 class PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
@@ -77,4 +78,5 @@ class PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver extends AbstractFu
 
 // Static Initialization: Attach
 $translationAPI = TranslationAPIFacade::getInstance();
-(new PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver($translationAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+$hooksAPI = HooksAPIFacade::getInstance();
+(new PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver($translationAPI, $hooksAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -76,4 +76,5 @@ class PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver extends AbstractFu
 }
 
 // Static Initialization: Attach
-(new PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+$translationAPI = TranslationAPIFacade::getInstance();
+(new PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver($translationAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -1,11 +1,12 @@
 <?php
 use PoP\Engine\Route\RouteUtils;
+use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
+use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 
 class PoP_EventsCreation_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
@@ -77,4 +78,5 @@ class PoP_EventsCreation_DataLoad_FunctionalFieldResolver extends AbstractFuncti
 
 // Static Initialization: Attach
 $translationAPI = TranslationAPIFacade::getInstance();
-(new PoP_EventsCreation_DataLoad_FunctionalFieldResolver($translationAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+$hooksAPI = HooksAPIFacade::getInstance();
+(new PoP_EventsCreation_DataLoad_FunctionalFieldResolver($translationAPI, $hooksAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -76,4 +76,5 @@ class PoP_EventsCreation_DataLoad_FunctionalFieldResolver extends AbstractFuncti
 }
 
 // Static Initialization: Attach
-(new PoP_EventsCreation_DataLoad_FunctionalFieldResolver())->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);
+$translationAPI = TranslationAPIFacade::getInstance();
+(new PoP_EventsCreation_DataLoad_FunctionalFieldResolver($translationAPI))->attach(\PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups::FIELDRESOLVERS);

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -117,34 +117,33 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'action' => $translationAPI->__('', ''),
-            'objectType' => $translationAPI->__('', ''),
-            'objectSubtype' => $translationAPI->__('', ''),
-            'objectName' => $translationAPI->__('', ''),
-            'objectID' => $translationAPI->__('', ''),
-            'userID' => $translationAPI->__('', ''),
-            'websiteURL' => $translationAPI->__('', ''),
-            'userCaps' => $translationAPI->__('', ''),
-            'histIp' => $translationAPI->__('', ''),
-            'histTime' => $translationAPI->__('', ''),
-            'histTimeNogmt' => $translationAPI->__('', ''),
-            'histTimeReadable' => $translationAPI->__('', ''),
-            'status' => $translationAPI->__('', ''),
-            'isStatusRead' => $translationAPI->__('', ''),
-            'isStatusNotRead' => $translationAPI->__('', ''),
-            'markAsReadURL' => $translationAPI->__('', ''),
-            'markAsUnreadURL' => $translationAPI->__('', ''),
-            'icon' => $translationAPI->__('', ''),
-            'url' => $translationAPI->__('', ''),
-            'target' => $translationAPI->__('', ''),
-            'message' => $translationAPI->__('', ''),
-            'isPostNotification' => $translationAPI->__('', ''),
-            'isUserNotification' => $translationAPI->__('', ''),
-            'isCommentNotification' => $translationAPI->__('', ''),
-            'isTaxonomyNotification' => $translationAPI->__('', ''),
-            'isAction' => $translationAPI->__('', ''),
+            'action' => $this->translationAPI->__('', ''),
+            'objectType' => $this->translationAPI->__('', ''),
+            'objectSubtype' => $this->translationAPI->__('', ''),
+            'objectName' => $this->translationAPI->__('', ''),
+            'objectID' => $this->translationAPI->__('', ''),
+            'userID' => $this->translationAPI->__('', ''),
+            'websiteURL' => $this->translationAPI->__('', ''),
+            'userCaps' => $this->translationAPI->__('', ''),
+            'histIp' => $this->translationAPI->__('', ''),
+            'histTime' => $this->translationAPI->__('', ''),
+            'histTimeNogmt' => $this->translationAPI->__('', ''),
+            'histTimeReadable' => $this->translationAPI->__('', ''),
+            'status' => $this->translationAPI->__('', ''),
+            'isStatusRead' => $this->translationAPI->__('', ''),
+            'isStatusNotRead' => $this->translationAPI->__('', ''),
+            'markAsReadURL' => $this->translationAPI->__('', ''),
+            'markAsUnreadURL' => $this->translationAPI->__('', ''),
+            'icon' => $this->translationAPI->__('', ''),
+            'url' => $this->translationAPI->__('', ''),
+            'target' => $this->translationAPI->__('', ''),
+            'message' => $this->translationAPI->__('', ''),
+            'isPostNotification' => $this->translationAPI->__('', ''),
+            'isUserNotification' => $this->translationAPI->__('', ''),
+            'isCommentNotification' => $this->translationAPI->__('', ''),
+            'isTaxonomyNotification' => $this->translationAPI->__('', ''),
+            'isAction' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -152,7 +151,6 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'isAction':
                 return array_merge(
@@ -161,7 +159,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'action',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The action to check against the notification', 'pop-posts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The action to check against the notification', 'pop-posts'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]
@@ -221,7 +219,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
             case 'histTimeReadable':
                 // Must convert date using GMT
                 return sprintf(
-                    TranslationAPIFacade::getInstance()->__('%s ago', 'pop-notifications'),
+                    $this->translationAPI->__('%s ago', 'pop-notifications'),
                     \humanTiming($notification->hist_time - ($cmsService->getOption(NameResolverFacade::getInstance()->getName('popcms:option:gmtOffset')) * 3600))
                 );
 

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFunctionalFieldResolver.php
@@ -35,9 +35,8 @@ class NotificationFunctionalFieldResolver extends AbstractFunctionalFieldResolve
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'multilayoutKeys' => $translationAPI->__('', ''),
+            'multilayoutKeys' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/notifications/src/TypeResolvers/NotificationTypeResolver.php
+++ b/layers/Schema/packages/notifications/src/TypeResolvers/NotificationTypeResolver.php
@@ -17,8 +17,7 @@ class NotificationTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Notifications for the user', 'notifications');
+        return $this->translationAPI->__('Notifications for the user', 'notifications');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -47,14 +47,13 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'page' => $translationAPI->__('Page with a specific ID', 'pages'),
-            'pages' => $translationAPI->__('Pages', 'pages'),
-            'pageCount' => $translationAPI->__('Number of pages', 'pages'),
-            'unrestrictedPage' => $translationAPI->__('[Unrestricted] Page with a specific ID', 'pages'),
-            'unrestrictedPages' => $translationAPI->__('[Unrestricted] Pages', 'pages'),
-            'unrestrictedPageCount' => $translationAPI->__('[Unrestricted] Number of pages', 'pages'),
+            'page' => $this->translationAPI->__('Page with a specific ID', 'pages'),
+            'pages' => $this->translationAPI->__('Pages', 'pages'),
+            'pageCount' => $this->translationAPI->__('Number of pages', 'pages'),
+            'unrestrictedPage' => $this->translationAPI->__('[Unrestricted] Page with a specific ID', 'pages'),
+            'unrestrictedPages' => $this->translationAPI->__('[Unrestricted] Pages', 'pages'),
+            'unrestrictedPageCount' => $this->translationAPI->__('[Unrestricted] Number of pages', 'pages'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -89,7 +88,6 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'page':
             case 'unrestrictedPage':
@@ -99,7 +97,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The page ID', 'pages'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The page ID', 'pages'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/pages/src/TypeResolvers/PageTypeResolver.php
+++ b/layers/Schema/packages/pages/src/TypeResolvers/PageTypeResolver.php
@@ -17,8 +17,7 @@ class PageTypeResolver extends AbstractCustomPostTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a page', 'pages');
+        return $this->translationAPI->__('Representation of a page', 'pages');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/PostCategoryListFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/PostCategoryListFieldResolver.php
@@ -18,12 +18,11 @@ class PostCategoryListFieldResolver extends AbstractPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'posts' => $translationAPI->__('Posts which contain this category', 'post-categories'),
-            'postCount' => $translationAPI->__('Number of posts which contain this category', 'post-categories'),
-            'unrestrictedPosts' => $translationAPI->__('[Unrestricted] Posts which contain this category', 'post-categories'),
-            'unrestrictedPostCount' => $translationAPI->__('[Unrestricted] Number of posts which contain this category', 'post-categories'),
+            'posts' => $this->translationAPI->__('Posts which contain this category', 'post-categories'),
+            'postCount' => $this->translationAPI->__('Number of posts which contain this category', 'post-categories'),
+            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts which contain this category', 'post-categories'),
+            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts which contain this category', 'post-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/PostQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/PostQueryableFieldResolver.php
@@ -23,11 +23,10 @@ class PostQueryableFieldResolver extends AbstractCustomPostQueryableFieldResolve
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'categories' => $translationAPI->__('Categories added to this post', 'post-categories'),
-            'categoryCount' => $translationAPI->__('Number of categories added to this post', 'post-categories'),
-            'categoryNames' => $translationAPI->__('Names of the categories added to this post', 'post-categories'),
+            'categories' => $this->translationAPI->__('Categories added to this post', 'post-categories'),
+            'categoryCount' => $this->translationAPI->__('Number of categories added to this post', 'post-categories'),
+            'categoryNames' => $this->translationAPI->__('Names of the categories added to this post', 'post-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -25,12 +25,11 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'postCategory' => $translationAPI->__('Post category with a specific ID', 'post-categories'),
-            'postCategories' => $translationAPI->__('Post categories', 'post-categories'),
-            'postCategoryCount' => $translationAPI->__('Number of post categories', 'post-categories'),
-            'postCategoryNames' => $translationAPI->__('Names of the post categories', 'post-categories'),
+            'postCategory' => $this->translationAPI->__('Post category with a specific ID', 'post-categories'),
+            'postCategories' => $this->translationAPI->__('Post categories', 'post-categories'),
+            'postCategoryCount' => $this->translationAPI->__('Number of post categories', 'post-categories'),
+            'postCategoryNames' => $this->translationAPI->__('Names of the post categories', 'post-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -72,7 +71,6 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'postCategory':
                 return array_merge(
@@ -81,7 +79,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The category ID', 'post-categories'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The category ID', 'post-categories'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/post-categories/src/TypeResolvers/PostCategoryTypeResolver.php
+++ b/layers/Schema/packages/post-categories/src/TypeResolvers/PostCategoryTypeResolver.php
@@ -20,8 +20,7 @@ class PostCategoryTypeResolver extends AbstractCategoryTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a category, added to a post', 'post-categories');
+        return $this->translationAPI->__('Representation of a category, added to a post', 'post-categories');
     }
 
     public function getTypeDataLoaderClass(): string

--- a/layers/Schema/packages/post-category-mutations/src/MutationResolvers/SetCategoriesOnPostMutationResolver.php
+++ b/layers/Schema/packages/post-category-mutations/src/MutationResolvers/SetCategoriesOnPostMutationResolver.php
@@ -18,7 +18,6 @@ class SetCategoriesOnPostMutationResolver extends AbstractSetCategoriesOnCustomP
 
     protected function getEntityName(): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('post', 'post-category-mutations');
+        return $this->translationAPI->__('post', 'post-category-mutations');
     }
 }

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/PostFieldResolver.php
@@ -22,9 +22,8 @@ class PostFieldResolver extends AbstractCustomPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'update' => $translationAPI->__('Update the post', 'post-mutations'),
+            'update' => $this->translationAPI->__('Update the post', 'post-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -37,10 +37,9 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'createPost' => $translationAPI->__('Create a post', 'post-mutations'),
-            'updatePost' => $translationAPI->__('Update a post', 'post-mutations'),
+            'createPost' => $this->translationAPI->__('Create a post', 'post-mutations'),
+            'updatePost' => $this->translationAPI->__('Update a post', 'post-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -61,11 +61,10 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'myPosts' => $translationAPI->__('Posts by the logged-in user', 'post-mutations'),
-            'myPostCount' => $translationAPI->__('Number of posts by the logged-in user', 'post-mutations'),
-            'myPost' => $translationAPI->__('Post with a specific ID', 'post-mutations'),
+            'myPosts' => $this->translationAPI->__('Posts by the logged-in user', 'post-mutations'),
+            'myPostCount' => $this->translationAPI->__('Number of posts by the logged-in user', 'post-mutations'),
+            'myPost' => $this->translationAPI->__('Post with a specific ID', 'post-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -73,7 +72,6 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'myPosts':
             case 'myPostCount':
@@ -88,7 +86,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The post ID', 'post-mutations'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The post ID', 'post-mutations'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/post-tag-mutations/src/MutationResolvers/SetTagsOnPostMutationResolver.php
+++ b/layers/Schema/packages/post-tag-mutations/src/MutationResolvers/SetTagsOnPostMutationResolver.php
@@ -18,7 +18,6 @@ class SetTagsOnPostMutationResolver extends AbstractSetTagsOnCustomPostMutationR
 
     protected function getEntityName(): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('post', 'post-tag-mutations');
+        return $this->translationAPI->__('post', 'post-tag-mutations');
     }
 }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/PostQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/PostQueryableFieldResolver.php
@@ -23,11 +23,10 @@ class PostQueryableFieldResolver extends AbstractCustomPostQueryableFieldResolve
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'tags' => $translationAPI->__('Tags added to this post', 'pop-post-tags'),
-            'tagCount' => $translationAPI->__('Number of tags added to this post', 'pop-post-tags'),
-            'tagNames' => $translationAPI->__('Names of the tags added to this post', 'pop-post-tags'),
+            'tags' => $this->translationAPI->__('Tags added to this post', 'pop-post-tags'),
+            'tagCount' => $this->translationAPI->__('Number of tags added to this post', 'pop-post-tags'),
+            'tagNames' => $this->translationAPI->__('Names of the tags added to this post', 'pop-post-tags'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagListFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagListFieldResolver.php
@@ -18,12 +18,11 @@ class PostTagListFieldResolver extends AbstractPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'posts' => $translationAPI->__('Posts which contain this tag', 'pop-taxonomies'),
-            'postCount' => $translationAPI->__('Number of posts which contain this tag', 'pop-taxonomies'),
-            'unrestrictedPosts' => $translationAPI->__('[Unrestricted] Posts which contain this tag', 'pop-taxonomies'),
-            'unrestrictedPostCount' => $translationAPI->__('[Unrestricted] Number of posts which contain this tag', 'pop-taxonomies'),
+            'posts' => $this->translationAPI->__('Posts which contain this tag', 'pop-taxonomies'),
+            'postCount' => $this->translationAPI->__('Number of posts which contain this tag', 'pop-taxonomies'),
+            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts which contain this tag', 'pop-taxonomies'),
+            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts which contain this tag', 'pop-taxonomies'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -25,12 +25,11 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'postTag' => $translationAPI->__('Post tag with a specific ID', 'pop-post-tags'),
-            'postTags' => $translationAPI->__('Post tags', 'pop-post-tags'),
-            'postTagCount' => $translationAPI->__('Number of post tags', 'pop-post-tags'),
-            'postTagNames' => $translationAPI->__('Names of the post tags', 'pop-post-tags'),
+            'postTag' => $this->translationAPI->__('Post tag with a specific ID', 'pop-post-tags'),
+            'postTags' => $this->translationAPI->__('Post tags', 'pop-post-tags'),
+            'postTagCount' => $this->translationAPI->__('Number of post tags', 'pop-post-tags'),
+            'postTagNames' => $this->translationAPI->__('Names of the post tags', 'pop-post-tags'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -72,7 +71,6 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'postTag':
                 return array_merge(
@@ -81,7 +79,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The tag ID', 'pop-post-tags'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The tag ID', 'pop-post-tags'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/post-tags/src/TypeResolvers/PostTagTypeResolver.php
+++ b/layers/Schema/packages/post-tags/src/TypeResolvers/PostTagTypeResolver.php
@@ -20,8 +20,7 @@ class PostTagTypeResolver extends AbstractTagTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a tag, added to a post', 'post-tags');
+        return $this->translationAPI->__('Representation of a tag, added to a post', 'post-tags');
     }
 
     public function getTypeDataLoaderClass(): string

--- a/layers/Schema/packages/posts/src/ConditionalOnComponent/Users/FieldResolvers/PostUserFieldResolver.php
+++ b/layers/Schema/packages/posts/src/ConditionalOnComponent/Users/FieldResolvers/PostUserFieldResolver.php
@@ -18,12 +18,11 @@ class PostUserFieldResolver extends AbstractPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'posts' => $translationAPI->__('Posts by the user', 'users'),
-            'postCount' => $translationAPI->__('Number of posts by the user', 'users'),
-            'unrestrictedPosts' => $translationAPI->__('[Unrestricted] Posts by the user', 'users'),
-            'unrestrictedPostCount' => $translationAPI->__('[Unrestricted] Number of posts by the user', 'users'),
+            'posts' => $this->translationAPI->__('Posts by the user', 'users'),
+            'postCount' => $this->translationAPI->__('Number of posts by the user', 'users'),
+            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts by the user', 'users'),
+            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts by the user', 'users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -63,12 +63,11 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'posts' => $translationAPI->__('Posts', 'pop-posts'),
-            'postCount' => $translationAPI->__('Number of posts', 'pop-posts'),
-            'unrestrictedPosts' => $translationAPI->__('[Unrestricted] Posts', 'pop-posts'),
-            'unrestrictedPostCount' => $translationAPI->__('[Unrestricted] Number of posts', 'pop-posts'),
+            'posts' => $this->translationAPI->__('Posts', 'pop-posts'),
+            'postCount' => $this->translationAPI->__('Number of posts', 'pop-posts'),
+            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts', 'pop-posts'),
+            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts', 'pop-posts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/ExperimentalBranchFieldResolver.php
@@ -52,7 +52,6 @@ class ExperimentalBranchFieldResolver extends CustomPostFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'excerpt':
                 return array_merge(
@@ -61,17 +60,17 @@ class ExperimentalBranchFieldResolver extends CustomPostFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'branch',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The branch name, set to value \'experimental\', enabling to use this fieldResolver', 'pop-posts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The branch name, set to value \'experimental\', enabling to use this fieldResolver', 'pop-posts'),
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'length',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_INT,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Maximum length for the except, in number of characters', 'pop-posts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Maximum length for the except, in number of characters', 'pop-posts'),
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'more',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('String to append at the end of the excerpt (if it is shortened by the \'length\' parameter)', 'pop-posts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('String to append at the end of the excerpt (if it is shortened by the \'length\' parameter)', 'pop-posts'),
                         ],
                     ]
                 );

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -49,17 +49,15 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'isPublished' => $translationAPI->__('Has the post been published?', 'content'),
+            'isPublished' => $this->translationAPI->__('Has the post been published?', 'content'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDeprecationDescription(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        $placeholder_status = $translationAPI->__('Use \'isStatus(status:%s)\' instead of \'%s\'', 'content');
+        $placeholder_status = $this->translationAPI->__('Use \'isStatus(status:%s)\' instead of \'%s\'', 'content');
         $descriptions = [
             'isPublished' => sprintf(
                 $placeholder_status,

--- a/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
@@ -44,10 +44,9 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'post' => $translationAPI->__('Post with a specific ID', 'posts'),
-            'unrestrictedPost' => $translationAPI->__('[Unrestricted] Post with a specific ID', 'posts'),
+            'post' => $this->translationAPI->__('Post with a specific ID', 'posts'),
+            'unrestrictedPost' => $this->translationAPI->__('[Unrestricted] Post with a specific ID', 'posts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -64,7 +63,6 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'post':
             case 'unrestrictedPost':
@@ -74,7 +72,7 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The post ID', 'pop-posts'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The post ID', 'pop-posts'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/posts/src/TypeResolvers/PostTypeResolver.php
+++ b/layers/Schema/packages/posts/src/TypeResolvers/PostTypeResolver.php
@@ -17,8 +17,7 @@ class PostTypeResolver extends AbstractCustomPostTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a post', 'posts');
+        return $this->translationAPI->__('Representation of a post', 'posts');
     }
 
     public function getTypeDataLoaderClass(): string

--- a/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
@@ -17,8 +17,7 @@ class QueryableFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
 
     public function getSchemaInterfaceDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Entities that can be queried through an URL', 'queriedobject');
+        return $this->translationAPI->__('Entities that can be queried through an URL', 'queriedobject');
     }
 
     public function getFieldNamesToImplement(): array
@@ -40,10 +39,9 @@ class QueryableFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
 
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'url' => $translationAPI->__('URL to query the object', 'queriedobject'),
-            'slug' => $translationAPI->__('URL\'s slug', 'queriedobject'),
+            'url' => $this->translationAPI->__('URL to query the object', 'queriedobject'),
+            'slug' => $this->translationAPI->__('URL\'s slug', 'queriedobject'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }

--- a/layers/Schema/packages/settings/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/RootFieldResolver.php
@@ -27,9 +27,8 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'option' => $translationAPI->__('Option saved in the DB', 'pop-settings'),
+            'option' => $this->translationAPI->__('Option saved in the DB', 'pop-settings'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -45,7 +44,6 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'option':
                 return array_merge(
@@ -54,7 +52,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'name',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The option name', 'pop-settings'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The option name', 'pop-settings'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -65,13 +65,12 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'stances' => $translationAPI->__('', ''),
-            'hasStances' => $translationAPI->__('', ''),
-            'stanceProCount' => $translationAPI->__('', ''),
-            'stanceNeutralCount' => $translationAPI->__('', ''),
-            'stanceAgainstCount' => $translationAPI->__('', ''),
+            'stances' => $this->translationAPI->__('', ''),
+            'hasStances' => $this->translationAPI->__('', ''),
+            'stanceProCount' => $this->translationAPI->__('', ''),
+            'stanceNeutralCount' => $this->translationAPI->__('', ''),
+            'stanceAgainstCount' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -63,19 +63,18 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'addStanceURL' => $translationAPI->__('', ''),
-            'loggedInUserStances' => $translationAPI->__('', ''),
-            'hasLoggedInUserStances' => $translationAPI->__('', ''),
-            'editStanceURL' => $translationAPI->__('', ''),
-            'postStancesProURL' => $translationAPI->__('', ''),
-            'postStancesNeutralURL' => $translationAPI->__('', ''),
-            'postStancesAgainstURL' => $translationAPI->__('', ''),
-            'createStanceButtonLazy' => $translationAPI->__('', ''),
-            'stancesLazy' => $translationAPI->__('', ''),
-            'stanceName' => $translationAPI->__('', ''),
-            'catName' => $translationAPI->__('', ''),
+            'addStanceURL' => $this->translationAPI->__('', ''),
+            'loggedInUserStances' => $this->translationAPI->__('', ''),
+            'hasLoggedInUserStances' => $this->translationAPI->__('', ''),
+            'editStanceURL' => $this->translationAPI->__('', ''),
+            'postStancesProURL' => $this->translationAPI->__('', ''),
+            'postStancesNeutralURL' => $this->translationAPI->__('', ''),
+            'postStancesAgainstURL' => $this->translationAPI->__('', ''),
+            'createStanceButtonLazy' => $this->translationAPI->__('', ''),
+            'stancesLazy' => $this->translationAPI->__('', ''),
+            'stanceName' => $this->translationAPI->__('', ''),
+            'catName' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -70,16 +70,15 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'categories' => $translationAPI->__('', ''),
-            'catSlugs' => $translationAPI->__('', ''),
-            'stance' => $translationAPI->__('', ''),
-            'title' => $translationAPI->__('', ''),
-            'excerpt' => $translationAPI->__('', ''),
-            'content' => $translationAPI->__('', ''),
-            'stancetarget' => $translationAPI->__('', ''),
-            'hasStanceTarget' => $translationAPI->__('', ''),
+            'categories' => $this->translationAPI->__('', ''),
+            'catSlugs' => $this->translationAPI->__('', ''),
+            'stance' => $this->translationAPI->__('', ''),
+            'title' => $this->translationAPI->__('', ''),
+            'excerpt' => $this->translationAPI->__('', ''),
+            'content' => $this->translationAPI->__('', ''),
+            'stancetarget' => $this->translationAPI->__('', ''),
+            'hasStanceTarget' => $this->translationAPI->__('', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/stances/src/TypeResolvers/StanceTypeResolver.php
+++ b/layers/Schema/packages/stances/src/TypeResolvers/StanceTypeResolver.php
@@ -18,8 +18,7 @@ class StanceTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('A stance by the user (from among “positive”, “neutral” or “negative”) and why', 'stances');
+        return $this->translationAPI->__('A stance by the user (from among “positive”, “neutral” or “negative”) and why', 'stances');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostListTagFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostListTagFieldResolver.php
@@ -15,12 +15,11 @@ abstract class AbstractCustomPostListTagFieldResolver extends AbstractCustomPost
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'customPosts' => $translationAPI->__('Custom posts which contain this tag', 'pop-tags'),
-            'customPostCount' => $translationAPI->__('Number of custom posts which contain this tag', 'pop-tags'),
-            'unrestrictedCustomPosts' => $translationAPI->__('[Unrestricted] Custom posts which contain this tag', 'pop-tags'),
-            'unrestrictedCustomPostCount' => $translationAPI->__('[Unrestricted] Number of custom posts which contain this tag', 'pop-tags'),
+            'customPosts' => $this->translationAPI->__('Custom posts which contain this tag', 'pop-tags'),
+            'customPostCount' => $this->translationAPI->__('Number of custom posts which contain this tag', 'pop-tags'),
+            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts which contain this tag', 'pop-tags'),
+            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts which contain this tag', 'pop-tags'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -52,11 +52,10 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'tags' => $translationAPI->__('Tags added to this custom post', 'pop-tags'),
-            'tagCount' => $translationAPI->__('Number of tags added to this custom post', 'pop-tags'),
-            'tagNames' => $translationAPI->__('Names of the tags added to this custom post', 'pop-tags'),
+            'tags' => $this->translationAPI->__('Tags added to this custom post', 'pop-tags'),
+            'tagCount' => $this->translationAPI->__('Number of tags added to this custom post', 'pop-tags'),
+            'tagNames' => $this->translationAPI->__('Names of the tags added to this custom post', 'pop-tags'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractTagFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractTagFieldResolver.php
@@ -47,13 +47,12 @@ abstract class AbstractTagFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'url' => $translationAPI->__('Tag URL', 'pop-tags'),
-            'name' => $translationAPI->__('Tag', 'pop-tags'),
-            'slug' => $translationAPI->__('Tag slug', 'pop-tags'),
-            'description' => $translationAPI->__('Tag description', 'pop-tags'),
-            'count' => $translationAPI->__('Number of custom posts containing this tag', 'pop-tags'),
+            'url' => $this->translationAPI->__('Tag URL', 'pop-tags'),
+            'name' => $this->translationAPI->__('Tag', 'pop-tags'),
+            'slug' => $this->translationAPI->__('Tag slug', 'pop-tags'),
+            'description' => $this->translationAPI->__('Tag description', 'pop-tags'),
+            'count' => $this->translationAPI->__('Number of custom posts containing this tag', 'pop-tags'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/tags/src/TypeResolvers/AbstractTagTypeResolver.php
+++ b/layers/Schema/packages/tags/src/TypeResolvers/AbstractTagTypeResolver.php
@@ -14,8 +14,7 @@ abstract class AbstractTagTypeResolver extends AbstractTaxonomyTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a tag, added to a custom post', 'tags');
+        return $this->translationAPI->__('Representation of a tag, added to a custom post', 'tags');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
+++ b/layers/Schema/packages/translate-directive/src/DirectiveResolvers/AbstractTranslateDirectiveResolver.php
@@ -76,7 +76,6 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
         array &$schemaTraces
     ): void {
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
-        $translationAPI = TranslationAPIFacade::getInstance();
 
         // Retrieve the provider from the directiveArgs. The provider is passed as a 'static' attribute (to decide the DirectiveResolver), so it can't be taken from the resultItem schema (as is the case with the from/to lang params)
         $provider = $this->getProvider($this->directiveArgsForSchema);
@@ -85,7 +84,7 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
         if (!$endpointURL) {
             // Give an error message for all failed fields
             $failureMessage = sprintf(
-                $translationAPI->__('Provider \'%s\' doesn\'t have an endpoint URL configured, so it can\'t proceed to do the translation', 'component-model'),
+                $this->translationAPI->__('Provider \'%s\' doesn\'t have an endpoint URL configured, so it can\'t proceed to do the translation', 'component-model'),
                 $provider
             );
             $this->processFailure($failureMessage, [], $idsDataFields, $succeedingPipelineIDsDataFields, $schemaErrors, $schemaWarnings);
@@ -123,7 +122,7 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
                     $dbErrors[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $translationAPI->__('The target language for object with ID \'%s\' is missing, so can\'t continue', 'component-model'),
+                            $this->translationAPI->__('The target language for object with ID \'%s\' is missing, so can\'t continue', 'component-model'),
                             $id
                         ),
                     ];
@@ -232,7 +231,7 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
                                 $dbErrors[(string)$id][] = [
                                     Tokens::PATH => [$this->directive],
                                     Tokens::MESSAGE => sprintf(
-                                        $translationAPI->__('Due to some previous error, this directive has not been executed on property \'%s\' for object with ID \'%s\'', 'component-model'),
+                                        $this->translationAPI->__('Due to some previous error, this directive has not been executed on property \'%s\' for object with ID \'%s\'', 'component-model'),
                                         $fieldOutputKey,
                                         $id
                                     ),
@@ -241,7 +240,7 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
                                 $dbWarnings[(string)$id][] = [
                                     Tokens::PATH => [$this->directive],
                                     Tokens::MESSAGE => sprintf(
-                                        $translationAPI->__('Due to some previous warning, property \'%s\' for object with ID \'%s\' has not been translated', 'component-model'),
+                                        $this->translationAPI->__('Due to some previous warning, property \'%s\' for object with ID \'%s\' has not been translated', 'component-model'),
                                         $fieldOutputKey,
                                         $id
                                     ),
@@ -256,7 +255,7 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
                 // Validate if the response is the translation, or some error from the service provider
                 if ($errorMessage = $this->getErrorMessageFromResponse($provider, $response)) {
                     $failureMessage = sprintf(
-                        $translationAPI->__('There was an error processing the response from the Provider API: %s', 'component-model'),
+                        $this->translationAPI->__('There was an error processing the response from the Provider API: %s', 'component-model'),
                         $errorMessage
                     );
                     $this->processFailure($failureMessage, [], $idsDataFields, $succeedingPipelineIDsDataFields, $schemaErrors, $schemaWarnings);
@@ -283,9 +282,8 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
      */
     protected function getClientFailureMessage(Error $error, string $provider): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return sprintf(
-            $translationAPI->__('There was an error requesting data from the Provider API: %s', 'component-model'),
+            $this->translationAPI->__('There was an error requesting data from the Provider API: %s', 'component-model'),
             $error->getErrorMessage()
         );
     }
@@ -308,42 +306,40 @@ abstract class AbstractTranslateDirectiveResolver extends AbstractSchemaDirectiv
     }
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Translate a string using the API from a certain provider', 'translate-directive');
+        return $this->translationAPI->__('Translate a string using the API from a certain provider', 'translate-directive');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $translationService = TranslationServiceFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'from',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Source language code', 'translate-directive'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Source language code', 'translate-directive'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'to',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Target language code (as a string) or codes (as an array) to translate to multiple languages', 'translate-directive'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Target language code (as a string) or codes (as an array) to translate to multiple languages', 'translate-directive'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'override',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Indicates if to override the field with the translation (valid only when argument \'to\' contains a single language code). If `false`, the translation is placed under the same entry plus adding \'-\' and the language code', 'translate-directive'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Indicates if to override the field with the translation (valid only when argument \'to\' contains a single language code). If `false`, the translation is placed under the same entry plus adding \'-\' and the language code', 'translate-directive'),
                 SchemaDefinition::ARGNAME_DEFAULT_VALUE => true,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'oneLanguagePerField',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Indicates if each field to translate receives its own \'to\' language. In this case, the \'to\' field must receive an array with the same amount of items as the fields, in the same order to be used', 'translate-directive'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Indicates if each field to translate receives its own \'to\' language. In this case, the \'to\' field must receive an array with the same amount of items as the fields, in the same order to be used', 'translate-directive'),
                 SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
             ],
             [
                 SchemaDefinition::ARGNAME_NAME => 'provider',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The name of the provider whose API to use for the translation', 'translate-directive'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The name of the provider whose API to use for the translation', 'translate-directive'),
                 SchemaDefinition::ARGNAME_DEFAULT_VALUE => $translationService->getDefaultProvider(),
             ],
         ];

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver.php
@@ -37,25 +37,24 @@ class ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver extends Abstrac
     protected function getValidationFailedMessage(TypeResolverInterface $typeResolver, array $failedDataFields): string
     {
         $capabilities = $this->directiveArgsForSchema['capabilities'];
-        $translationAPI = TranslationAPIFacade::getInstance();
         $isValidatingDirective = $this->isValidatingDirective();
         if (count($capabilities) == 1) {
             $errorMessage = $isValidatingDirective ?
-                $translationAPI->__('You must have capability \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
-                $translationAPI->__('You must have capability \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
+                $this->translationAPI->__('You must have capability \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
+                $this->translationAPI->__('You must have capability \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
         } else {
             $errorMessage = $isValidatingDirective ?
-                $translationAPI->__('You must have any capability from among \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
-                $translationAPI->__('You must have any capability from among \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
+                $this->translationAPI->__('You must have any capability from among \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
+                $this->translationAPI->__('You must have any capability from among \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
         }
         return sprintf(
             $errorMessage,
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $capabilities
             ),
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $failedDataFields
             ),
             $typeResolver->getMaybeNamespacedTypeName()
@@ -64,17 +63,15 @@ class ValidateDoesLoggedInUserHaveAnyCapabilityDirectiveResolver extends Abstrac
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('It validates if the user has any capability provided through directive argument \'capabilities\'', 'component-model');
+        return $this->translationAPI->__('It validates if the user has any capability provided through directive argument \'capabilities\'', 'component-model');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'capabilities',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Capabilities to validate if the logged-in user has (any of them)', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Capabilities to validate if the logged-in user has (any of them)', 'component-model'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
         ];

--- a/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver.php
+++ b/layers/Schema/packages/user-roles-access-control/src/DirectiveResolvers/ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver.php
@@ -37,25 +37,24 @@ class ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver extends AbstractValid
     protected function getValidationFailedMessage(TypeResolverInterface $typeResolver, array $failedDataFields): string
     {
         $roles = $this->directiveArgsForSchema['roles'];
-        $translationAPI = TranslationAPIFacade::getInstance();
         $isValidatingDirective = $this->isValidatingDirective();
         if (count($roles) == 1) {
             $errorMessage = $isValidatingDirective ?
-                $translationAPI->__('You must have role \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
-                $translationAPI->__('You must have role \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
+                $this->translationAPI->__('You must have role \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
+                $this->translationAPI->__('You must have role \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
         } else {
             $errorMessage = $isValidatingDirective ?
-                $translationAPI->__('You must have any role from among \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
-                $translationAPI->__('You must have any role from among \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
+                $this->translationAPI->__('You must have any role from among \'%s\' to access directives in field(s) \'%s\' for type \'%s\'', 'user-roles') :
+                $this->translationAPI->__('You must have any role from among \'%s\' to access field(s) \'%s\' for type \'%s\'', 'user-roles');
         }
         return sprintf(
             $errorMessage,
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $roles
             ),
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $failedDataFields
             ),
             $typeResolver->getMaybeNamespacedTypeName()
@@ -64,17 +63,15 @@ class ValidateDoesLoggedInUserHaveAnyRoleDirectiveResolver extends AbstractValid
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('It validates if the user has any of the roles provided through directive argument \'roles\'', 'component-model');
+        return $this->translationAPI->__('It validates if the user has any of the roles provided through directive argument \'roles\'', 'component-model');
     }
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         return [
             [
                 SchemaDefinition::ARGNAME_NAME => 'roles',
                 SchemaDefinition::ARGNAME_TYPE => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
-                SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Roles to validate if the logged-in user has (any of them)', 'component-model'),
+                SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Roles to validate if the logged-in user has (any of them)', 'component-model'),
                 SchemaDefinition::ARGNAME_MANDATORY => true,
             ],
         ];

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -61,10 +61,9 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      */
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'name' => $translationAPI->__('The role name', 'user-roles-wp'),
-            'capabilities' => $translationAPI->__('Capabilities granted by the role', 'user-roles-wp'),
+            'name' => $this->translationAPI->__('The role name', 'user-roles-wp'),
+            'capabilities' => $this->translationAPI->__('Capabilities granted by the role', 'user-roles-wp'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-roles-wp/src/TypeResolvers/UserRoleTypeResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/TypeResolvers/UserRoleTypeResolver.php
@@ -17,8 +17,7 @@ class UserRoleTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('User roles', 'user-roles');
+        return $this->translationAPI->__('User roles', 'user-roles');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -60,10 +60,9 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'roles' => $translationAPI->__('User roles', 'user-roles'),
-            'capabilities' => $translationAPI->__('User capabilities', 'user-roles'),
+            'roles' => $this->translationAPI->__('User roles', 'user-roles'),
+            'capabilities' => $this->translationAPI->__('User capabilities', 'user-roles'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-roles/src/TypeDataResolvers/AbstractUserRoleTypeDataResolver.php
+++ b/layers/Schema/packages/user-roles/src/TypeDataResolvers/AbstractUserRoleTypeDataResolver.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRoles\TypeDataResolvers;
 
-use PoP\Hooks\Facades\HooksAPIFacade;
+use PoP\Hooks\HooksAPIInterface;
 
 abstract class AbstractUserRoleTypeDataResolver implements UserRoleTypeDataResolverInterface
 {
+    function __construct(
+        protected HooksAPIInterface $hooksAPI
+    ) {
+    }
+
     public function getTheUserRole(string | int | object $userObjectOrID): string
     {
         $roles = $this->getUserRoles($userObjectOrID);
         $role = $roles[0];
         // Allow URE to override this function
-        return HooksAPIFacade::getInstance()->applyFilters(
+        return $this->hooksAPI->applyFilters(
             'getTheUserRole',
             $role,
             $userObjectOrID

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserLoggedInDirectiveResolver.php
@@ -23,14 +23,13 @@ class ValidateIsUserLoggedInDirectiveResolver extends AbstractValidateCheckpoint
 
     protected function getValidationFailedMessage(TypeResolverInterface $typeResolver, array $failedDataFields): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $errorMessage = $this->isValidatingDirective() ?
-            $translationAPI->__('You must be logged in to access directives in field(s) \'%s\' for type \'%s\'', 'user-state') :
-            $translationAPI->__('You must be logged in to access field(s) \'%s\' for type \'%s\'', 'user-state');
+            $this->translationAPI->__('You must be logged in to access directives in field(s) \'%s\' for type \'%s\'', 'user-state') :
+            $this->translationAPI->__('You must be logged in to access field(s) \'%s\' for type \'%s\'', 'user-state');
         return sprintf(
             $errorMessage,
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $failedDataFields
             ),
             $typeResolver->getMaybeNamespacedTypeName()
@@ -39,7 +38,6 @@ class ValidateIsUserLoggedInDirectiveResolver extends AbstractValidateCheckpoint
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('It validates if the user is logged-in', 'component-model');
+        return $this->translationAPI->__('It validates if the user is logged-in', 'component-model');
     }
 }

--- a/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInDirectiveResolver.php
+++ b/layers/Schema/packages/user-state-access-control/src/DirectiveResolvers/ValidateIsUserNotLoggedInDirectiveResolver.php
@@ -23,14 +23,13 @@ class ValidateIsUserNotLoggedInDirectiveResolver extends AbstractValidateCheckpo
 
     protected function getValidationFailedMessage(TypeResolverInterface $typeResolver, array $failedDataFields): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $errorMessage = $this->isValidatingDirective() ?
-            $translationAPI->__('You must not be logged in to access directives in field(s) \'%s\' for type \'%s\'', 'user-state') :
-            $translationAPI->__('You must not be logged in to access field(s) \'%s\' for type \'%s\'', 'user-state');
+            $this->translationAPI->__('You must not be logged in to access directives in field(s) \'%s\' for type \'%s\'', 'user-state') :
+            $this->translationAPI->__('You must not be logged in to access field(s) \'%s\' for type \'%s\'', 'user-state');
         return sprintf(
             $errorMessage,
             implode(
-                $translationAPI->__('\', \''),
+                $this->translationAPI->__('\', \''),
                 $failedDataFields
             ),
             $typeResolver->getMaybeNamespacedTypeName()
@@ -39,7 +38,6 @@ class ValidateIsUserNotLoggedInDirectiveResolver extends AbstractValidateCheckpo
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('It validates if the user is not logged-in', 'component-model');
+        return $this->translationAPI->__('It validates if the user is not logged-in', 'component-model');
     }
 }

--- a/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -31,10 +31,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'loginUser' => $translationAPI->__('Log the user in', 'user-state-mutations'),
-            'logoutUser' => $translationAPI->__('Log the user out', 'user-state-mutations'),
+            'loginUser' => $this->translationAPI->__('Log the user in', 'user-state-mutations'),
+            'logoutUser' => $this->translationAPI->__('Log the user out', 'user-state-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -50,20 +49,19 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'loginUser':
                 return [
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::USERNAME_OR_EMAIL,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The username or email', 'user-state-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The username or email', 'user-state-mutations'),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
                     ],
                     [
                         SchemaDefinition::ARGNAME_NAME => MutationInputProperties::PASSWORD,
                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
-                        SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The password', 'user-state-mutations'),
+                        SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The password', 'user-state-mutations'),
                         SchemaDefinition::ARGNAME_MANDATORY => true,
                     ],
                 ];

--- a/layers/Schema/packages/user-state-mutations/src/MutationResolvers/LoginMutationResolver.php
+++ b/layers/Schema/packages/user-state-mutations/src/MutationResolvers/LoginMutationResolver.php
@@ -82,7 +82,7 @@ class LoginMutationResolver extends AbstractMutationResolver
         ApplicationStateUtils::setUserStateVars(ApplicationState::$vars);
 
         $userID = $cmsusersresolver->getUserId($user);
-        HooksAPIFacade::getInstance()->doAction('gd:user:loggedin', $userID);
+        $this->hooksAPI->doAction('gd:user:loggedin', $userID);
         return $userID;
     }
 }

--- a/layers/Schema/packages/user-state-mutations/src/MutationResolvers/LoginMutationResolver.php
+++ b/layers/Schema/packages/user-state-mutations/src/MutationResolvers/LoginMutationResolver.php
@@ -22,10 +22,10 @@ class LoginMutationResolver extends AbstractMutationResolver
         $pwd = $form_data[MutationInputProperties::PASSWORD];
 
         if (!$username_or_email) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Please supply your username or email', 'user-state-mutations');
+            $errors[] = $this->translationAPI->__('Please supply your username or email', 'user-state-mutations');
         }
         if (!$pwd) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Please supply your password', 'user-state-mutations');
+            $errors[] = $this->translationAPI->__('Please supply your password', 'user-state-mutations');
         }
 
         $vars = ApplicationState::getVars();
@@ -37,8 +37,7 @@ class LoginMutationResolver extends AbstractMutationResolver
 
     protected function getUserAlreadyLoggedInErrorMessage(string | int $user_id): string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('You are already logged in', 'user-state-mutations');
+        return $this->translationAPI->__('You are already logged in', 'user-state-mutations');
     }
 
     public function execute(array $form_data): mixed
@@ -58,7 +57,7 @@ class LoginMutationResolver extends AbstractMutationResolver
             if (!$user) {
                 return new Error(
                     'no-user',
-                    TranslationAPIFacade::getInstance()->__('There is no user registered with that email address.')
+                    $this->translationAPI->__('There is no user registered with that email address.')
                 );
             }
             $username = $cmsusersresolver->getUserLogin($user);

--- a/layers/Schema/packages/user-state-mutations/src/MutationResolvers/LogoutMutationResolver.php
+++ b/layers/Schema/packages/user-state-mutations/src/MutationResolvers/LogoutMutationResolver.php
@@ -31,7 +31,7 @@ class LogoutMutationResolver extends AbstractMutationResolver
         // Modify the routing-state with the newly logged in user info
         ApplicationStateUtils::setUserStateVars(ApplicationState::$vars);
 
-        HooksAPIFacade::getInstance()->doAction('gd:user:loggedout', $user_id);
+        $this->hooksAPI->doAction('gd:user:loggedout', $user_id);
         return $user_id;
     }
 }

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -40,9 +40,8 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'isUserLoggedIn' => $translationAPI->__('Is the user logged-in?', 'user-state'),
+            'isUserLoggedIn' => $this->translationAPI->__('Is the user logged-in?', 'user-state'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -6,7 +6,6 @@ namespace PoPSchema\UserState\FieldResolvers;
 
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
 

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalUserStateFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalUserStateFieldResolver.php
@@ -29,9 +29,8 @@ class GlobalUserStateFieldResolver extends AbstractGlobalUserStateFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'loggedInUserID' => $translationAPI->__('The logged-in user\'s ID', 'user-state'),
+            'loggedInUserID' => $this->translationAPI->__('The logged-in user\'s ID', 'user-state'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
@@ -36,9 +36,8 @@ class RootMeFieldResolver extends AbstractUserStateFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'me' => $translationAPI->__('The logged-in user', 'user-state'),
+            'me' => $this->translationAPI->__('The logged-in user', 'user-state'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -58,9 +58,8 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'author' => $translationAPI->__('The post\'s author', ''),
+            'author' => $this->translationAPI->__('The post\'s author', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostListUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostListUserFieldResolver.php
@@ -18,12 +18,11 @@ class CustomPostListUserFieldResolver extends AbstractCustomPostListFieldResolve
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'customPosts' => $translationAPI->__('Custom posts by the user', 'pop-users'),
-            'customPostCount' => $translationAPI->__('Number of custom posts by the user', 'pop-users'),
-            'unrestrictedCustomPosts' => $translationAPI->__('[Unrestricted] Custom posts by the user', 'pop-users'),
-            'unrestrictedCustomPostCount' => $translationAPI->__('[Unrestricted] Number of custom posts by the user', 'pop-users'),
+            'customPosts' => $this->translationAPI->__('Custom posts by the user', 'pop-users'),
+            'customPostCount' => $this->translationAPI->__('Number of custom posts by the user', 'pop-users'),
+            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts by the user', 'pop-users'),
+            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts by the user', 'pop-users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostUserListFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostUserListFieldResolver.php
@@ -18,12 +18,11 @@ class CustomPostUserListFieldResolver extends AbstractCustomPostListFieldResolve
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'customPosts' => $translationAPI->__('Custom posts by the user', 'users'),
-            'customPostCount' => $translationAPI->__('Number of custom posts by the user', 'users'),
-            'unrestrictedCustomPosts' => $translationAPI->__('[Unrestricted] Custom posts by the user', 'users'),
-            'unrestrictedCustomPostCount' => $translationAPI->__('[Unrestricted] Number of custom posts by the user', 'users'),
+            'customPosts' => $this->translationAPI->__('Custom posts by the user', 'users'),
+            'customPostCount' => $this->translationAPI->__('Number of custom posts by the user', 'users'),
+            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts by the user', 'users'),
+            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts by the user', 'users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -18,8 +18,7 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
 
     public function getSchemaInterfaceDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Entities that have an author', 'queriedobject');
+        return $this->translationAPI->__('Entities that have an author', 'queriedobject');
     }
 
     public function getFieldNamesToImplement(): array
@@ -48,9 +47,8 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
 
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'author' => $translationAPI->__('The entity\'s author', 'queriedobject'),
+            'author' => $this->translationAPI->__('The entity\'s author', 'queriedobject'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -47,10 +47,9 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'users' => $translationAPI->__('Users', 'pop-users'),
-            'userCount' => $translationAPI->__('Number of users', 'pop-users'),
+            'users' => $this->translationAPI->__('Users', 'pop-users'),
+            'userCount' => $this->translationAPI->__('Number of users', 'pop-users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
@@ -31,10 +31,9 @@ class RootUserFieldResolver extends AbstractUserFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'user' => $translationAPI->__('User with a specific ID', 'pop-users'),
-            'users' => $translationAPI->__('Users in the current site', 'pop-users'),
+            'user' => $this->translationAPI->__('User with a specific ID', 'pop-users'),
+            'users' => $this->translationAPI->__('Users in the current site', 'pop-users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -50,7 +49,6 @@ class RootUserFieldResolver extends AbstractUserFieldResolver
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
-        $translationAPI = TranslationAPIFacade::getInstance();
         switch ($fieldName) {
             case 'user':
                 return array_merge(
@@ -59,7 +57,7 @@ class RootUserFieldResolver extends AbstractUserFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'id',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ID,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('The user ID', 'pop-users'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The user ID', 'pop-users'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Schema/packages/users/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/UserFieldResolver.php
@@ -64,20 +64,19 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'username' => $translationAPI->__('User\'s username handle', 'pop-users'),
-            'userNicename' => $translationAPI->__('User\'s nice name', 'pop-users'),
-            'nicename' => $translationAPI->__('User\'s nice name', 'pop-users'),
-            'name' => $translationAPI->__('Name of the user', 'pop-users'),
-            'displayName' => $translationAPI->__('Name of the user as displayed on the website', 'pop-users'),
-            'firstname' => $translationAPI->__('User\'s first name', 'pop-users'),
-            'lastname' => $translationAPI->__('User\'s last name', 'pop-users'),
-            'email' => $translationAPI->__('User\'s email', 'pop-users'),
-            'url' => $translationAPI->__('URL of the user\'s profile in the website', 'pop-users'),
-            'slug' => $translationAPI->__('Slug of the URL of the user\'s profile in the website', 'pop-users'),
-            'description' => $translationAPI->__('Description of the user', 'pop-users'),
-            'websiteURL' => $translationAPI->__('User\'s own website\'s URL', 'pop-users'),
+            'username' => $this->translationAPI->__('User\'s username handle', 'pop-users'),
+            'userNicename' => $this->translationAPI->__('User\'s nice name', 'pop-users'),
+            'nicename' => $this->translationAPI->__('User\'s nice name', 'pop-users'),
+            'name' => $this->translationAPI->__('Name of the user', 'pop-users'),
+            'displayName' => $this->translationAPI->__('Name of the user as displayed on the website', 'pop-users'),
+            'firstname' => $this->translationAPI->__('User\'s first name', 'pop-users'),
+            'lastname' => $this->translationAPI->__('User\'s last name', 'pop-users'),
+            'email' => $this->translationAPI->__('User\'s email', 'pop-users'),
+            'url' => $this->translationAPI->__('URL of the user\'s profile in the website', 'pop-users'),
+            'slug' => $this->translationAPI->__('Slug of the URL of the user\'s profile in the website', 'pop-users'),
+            'description' => $this->translationAPI->__('Description of the user', 'pop-users'),
+            'websiteURL' => $this->translationAPI->__('User\'s own website\'s URL', 'pop-users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/users/src/TypeResolvers/UserTypeResolver.php
+++ b/layers/Schema/packages/users/src/TypeResolvers/UserTypeResolver.php
@@ -17,8 +17,7 @@ class UserTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Representation of a user', 'users');
+        return $this->translationAPI->__('Representation of a user', 'users');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -50,10 +50,9 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'sites' => $translationAPI->__('All websites', 'multisite'),
-            'site' => $translationAPI->__('This website', 'multisite'),
+            'sites' => $this->translationAPI->__('All websites', 'multisite'),
+            'site' => $this->translationAPI->__('This website', 'multisite'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -48,10 +48,9 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
-            'domain' => $translationAPI->__('The site\'s domain', ''),
-            'host' => $translationAPI->__('The site\'s host', ''),
+            'domain' => $this->translationAPI->__('The site\'s domain', ''),
+            'host' => $this->translationAPI->__('The site\'s host', ''),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }

--- a/layers/SiteBuilder/packages/multisite/src/TypeResolvers/SiteTypeResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/TypeResolvers/SiteTypeResolver.php
@@ -17,8 +17,7 @@ class SiteTypeResolver extends AbstractTypeResolver
 
     public function getSchemaTypeDescription(): ?string
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
-        return $translationAPI->__('Obtain properties belonging to the site (name, domain, configuration options, etc)', 'multisite');
+        return $this->translationAPI->__('Obtain properties belonging to the site (name, domain, configuration options, etc)', 'multisite');
     }
 
     public function getID(object $resultItem): string | int

--- a/layers/Wassup/packages/contactus-mutations/src/MutationResolvers/ContactUsMutationResolver.php
+++ b/layers/Wassup/packages/contactus-mutations/src/MutationResolvers/ContactUsMutationResolver.php
@@ -15,15 +15,15 @@ class ContactUsMutationResolver extends AbstractMutationResolver
     {
         $errors = [];
         if (empty($form_data['name'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Your name cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Your name cannot be empty.', 'pop-genericforms');
         }
         if (empty($form_data['email'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email cannot be empty.', 'pop-genericforms');
         } elseif (!filter_var($form_data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email format is incorrect.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email format is incorrect.', 'pop-genericforms');
         }
         if (empty($form_data['message'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Message cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Message cannot be empty.', 'pop-genericforms');
         }
         return $errors;
     }
@@ -41,32 +41,32 @@ class ContactUsMutationResolver extends AbstractMutationResolver
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();
         $to = \PoP_EmailSender_Utils::getAdminNotificationsEmail();
         $subject = sprintf(
-            TranslationAPIFacade::getInstance()->__('[%s]: %s', 'pop-genericforms'),
+            $this->translationAPI->__('[%s]: %s', 'pop-genericforms'),
             $cmsapplicationapi->getSiteName(),
-            TranslationAPIFacade::getInstance()->__('Contact us', 'pop-genericforms')
+            $this->translationAPI->__('Contact us', 'pop-genericforms')
         );
         $placeholder = '<p><b>%s:</b> %s</p>';
         $msg = sprintf(
             '<p>%s</p>',
-            TranslationAPIFacade::getInstance()->__('New contact us submission', 'pop-genericforms')
+            $this->translationAPI->__('New contact us submission', 'pop-genericforms')
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Name', 'pop-genericforms'),
+            $this->translationAPI->__('Name', 'pop-genericforms'),
             $form_data['name']
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Email', 'pop-genericforms'),
+            $this->translationAPI->__('Email', 'pop-genericforms'),
             sprintf(
                 '<a href="mailto:%1$s">%1$s</a>',
                 $form_data['email']
             )
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Subject', 'pop-genericforms'),
+            $this->translationAPI->__('Subject', 'pop-genericforms'),
             $form_data['subject']
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Message', 'pop-genericforms'),
+            $this->translationAPI->__('Message', 'pop-genericforms'),
             $form_data['message']
         );
 

--- a/layers/Wassup/packages/contactus-mutations/src/MutationResolvers/ContactUsMutationResolver.php
+++ b/layers/Wassup/packages/contactus-mutations/src/MutationResolvers/ContactUsMutationResolver.php
@@ -33,7 +33,7 @@ class ContactUsMutationResolver extends AbstractMutationResolver
      */
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('pop_contactus', $form_data);
+        $this->hooksAPI->doAction('pop_contactus', $form_data);
     }
 
     protected function doExecute($form_data)

--- a/layers/Wassup/packages/contactuser-mutations/src/MutationResolvers/ContactUserMutationResolver.php
+++ b/layers/Wassup/packages/contactuser-mutations/src/MutationResolvers/ContactUserMutationResolver.php
@@ -45,7 +45,7 @@ class ContactUserMutationResolver extends AbstractMutationResolver
      */
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('pop_contactuser', $form_data);
+        $this->hooksAPI->doAction('pop_contactuser', $form_data);
     }
 
     protected function doExecute($form_data)

--- a/layers/Wassup/packages/contactuser-mutations/src/MutationResolvers/ContactUserMutationResolver.php
+++ b/layers/Wassup/packages/contactuser-mutations/src/MutationResolvers/ContactUserMutationResolver.php
@@ -16,25 +16,25 @@ class ContactUserMutationResolver extends AbstractMutationResolver
         $errors = [];
         $cmsusersapi = \PoPSchema\Users\FunctionAPIFactory::getInstance();
         if (empty($form_data['name'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Your name cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Your name cannot be empty.', 'pop-genericforms');
         }
 
         if (empty($form_data['email'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email cannot be empty.', 'pop-genericforms');
         } elseif (!filter_var($form_data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email format is incorrect.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email format is incorrect.', 'pop-genericforms');
         }
 
         if (empty($form_data['message'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Message cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Message cannot be empty.', 'pop-genericforms');
         }
 
         if (empty($form_data['target-id'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The requested user cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('The requested user cannot be empty.', 'pop-genericforms');
         } else {
             $target = $cmsusersapi->getUserById($form_data['target-id']);
             if (!$target) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The requested user does not exist.', 'pop-genericforms');
+                $errors[] = $this->translationAPI->__('The requested user does not exist.', 'pop-genericforms');
             }
         }
         return $errors;
@@ -53,10 +53,10 @@ class ContactUserMutationResolver extends AbstractMutationResolver
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();
         $websitename = $cmsapplicationapi->getSiteName();
         $subject = sprintf(
-            TranslationAPIFacade::getInstance()->__('[%s]: %s', 'pop-genericforms'),
+            $this->translationAPI->__('[%s]: %s', 'pop-genericforms'),
             $websitename,
             $form_data['subject'] ? $form_data['subject'] : sprintf(
-                TranslationAPIFacade::getInstance()->__('%s sends you a message', 'pop-genericforms'),
+                $this->translationAPI->__('%s sends you a message', 'pop-genericforms'),
                 $form_data['name']
             )
         );
@@ -64,27 +64,27 @@ class ContactUserMutationResolver extends AbstractMutationResolver
         $msg = sprintf(
             '<p>%s</p>',
             sprintf(
-                TranslationAPIFacade::getInstance()->__('You have been sent a message from a user in %s', 'pop-genericforms'),
+                $this->translationAPI->__('You have been sent a message from a user in %s', 'pop-genericforms'),
                 $websitename
             )
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Name', 'pop-genericforms'),
+            $this->translationAPI->__('Name', 'pop-genericforms'),
             $form_data['name']
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Email', 'pop-genericforms'),
+            $this->translationAPI->__('Email', 'pop-genericforms'),
             sprintf(
                 '<a href="mailto:%1$s">%1$s</a>',
                 $form_data['email']
             )
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Subject', 'pop-genericforms'),
+            $this->translationAPI->__('Subject', 'pop-genericforms'),
             $form_data['subject']
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Message', 'pop-genericforms'),
+            $this->translationAPI->__('Message', 'pop-genericforms'),
             $form_data['message']
         );
 

--- a/layers/Wassup/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
@@ -24,7 +24,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends \PoPSchema
 
     protected function addParentCategories()
     {
-        return HooksAPIFacade::getInstance()->applyFilters(
+        return $this->hooksAPI->applyFilters(
             'GD_CreateUpdate_Post:add-parent-categories',
             false,
             $this
@@ -51,7 +51,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends \PoPSchema
 
     protected function getCategoriesErrorMessages()
     {
-        return HooksAPIFacade::getInstance()->applyFilters(
+        return $this->hooksAPI->applyFilters(
             'GD_CreateUpdate_Post:categories-validation:error',
             array(
                 'empty-categories' => $this->translationAPI->__('The categories have not been set', 'pop-application'),

--- a/layers/Wassup/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
@@ -54,9 +54,9 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends \PoPSchema
         return HooksAPIFacade::getInstance()->applyFilters(
             'GD_CreateUpdate_Post:categories-validation:error',
             array(
-                'empty-categories' => TranslationAPIFacade::getInstance()->__('The categories have not been set', 'pop-application'),
-                'empty-category' => TranslationAPIFacade::getInstance()->__('The category has not been set', 'pop-application'),
-                'only-one' => TranslationAPIFacade::getInstance()->__('Only one category can be selected', 'pop-application'),
+                'empty-categories' => $this->translationAPI->__('The categories have not been set', 'pop-application'),
+                'empty-category' => $this->translationAPI->__('The category has not been set', 'pop-application'),
+                'only-one' => $this->translationAPI->__('Only one category can be selected', 'pop-application'),
             )
         );
     }
@@ -67,7 +67,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends \PoPSchema
         parent::validateContent($errors, $form_data);
 
         if ($this->supportsTitle() && empty($form_data[MutationInputProperties::TITLE])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The title cannot be empty', 'pop-application');
+            $errors[] = $this->translationAPI->__('The title cannot be empty', 'pop-application');
         }
 
         // Validate the following conditions only if status = pending/publish
@@ -76,11 +76,11 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends \PoPSchema
         }
 
         if (empty($form_data[MutationInputProperties::CONTENT])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The content cannot be empty', 'pop-application');
+            $errors[] = $this->translationAPI->__('The content cannot be empty', 'pop-application');
         }
 
         if ($this->isFeaturedImageMandatory() && empty($form_data[CustomPostMediaMutationInputProperties::FEATUREDIMAGE_ID])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The featured image has not been set', 'pop-application');
+            $errors[] = $this->translationAPI->__('The featured image has not been set', 'pop-application');
         }
 
         if ($validateCategories = $this->validateCategories($form_data)) {
@@ -102,7 +102,7 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends \PoPSchema
         parent::validateUpdateContent($errors, $form_data);
 
         if (isset($form_data[MutationInputProperties::REFERENCES]) && in_array($form_data[MutationInputProperties::ID], $form_data[MutationInputProperties::REFERENCES])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The post cannot be a response to itself', 'pop-postscreation');
+            $errors[] = $this->translationAPI->__('The post cannot be a response to itself', 'pop-postscreation');
         }
     }
 
@@ -116,20 +116,20 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends \PoPSchema
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
 
         if (!in_array($customPostTypeAPI->getStatus($customPostID), array(Status::DRAFT, Status::PENDING, Status::PUBLISHED))) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Hmmmmm, this post seems to have been deleted...', 'pop-application');
+            $errors[] = $this->translationAPI->__('Hmmmmm, this post seems to have been deleted...', 'pop-application');
             return;
         }
 
         // Validation below not needed, since this is done in the Checkpoint already
         // // Validate user permission
         // if (!gdCurrentUserCanEdit($customPostID)) {
-        //     $errors[] = TranslationAPIFacade::getInstance()->__('Your user doesn\'t have permission for editing.', 'pop-application');
+        //     $errors[] = $this->translationAPI->__('Your user doesn\'t have permission for editing.', 'pop-application');
         // }
 
         // // The nonce comes directly as a parameter in the request, it's not a form field
         // $nonce = $_REQUEST[POP_INPUTNAME_NONCE];
         // if (!gdVerifyNonce($nonce, GD_NONCE_EDITURL, $customPostID)) {
-        //     $errors[] = TranslationAPIFacade::getInstance()->__('Incorrect URL', 'pop-application');
+        //     $errors[] = $this->translationAPI->__('Incorrect URL', 'pop-application');
         //     return;
         // }
     }

--- a/layers/Wassup/packages/event-mutations/src/MutationResolvers/AbstractCreateUpdateEventMutationResolver.php
+++ b/layers/Wassup/packages/event-mutations/src/MutationResolvers/AbstractCreateUpdateEventMutationResolver.php
@@ -29,7 +29,7 @@ abstract class AbstractCreateUpdateEventMutationResolver extends AbstractCreateU
 
         // Validate for any status (even "draft"), since without date EM doesn't create the Event
         if (empty(array_filter(array_values($form_data['when'])))) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The dates/time cannot be empty', 'poptheme-wassup');
+            $errors[] = $this->translationAPI->__('The dates/time cannot be empty', 'poptheme-wassup');
         }
     }
 
@@ -72,10 +72,9 @@ abstract class AbstractCreateUpdateEventMutationResolver extends AbstractCreateU
         $EM_Event = new \EM_Event($post_data['id'], 'post_id');
         $eventPostID = $this->save($EM_Event, $post_data);
         if ($eventPostID === 0) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             return new Error(
                 'update-event',
-                $translationAPI->__('There was an error updating the event', 'event-mutations')
+                $this->translationAPI->__('There was an error updating the event', 'event-mutations')
             );
         }
         return $eventPostID;
@@ -86,10 +85,9 @@ abstract class AbstractCreateUpdateEventMutationResolver extends AbstractCreateU
         $EM_Event = new \EM_Event();
         $eventPostID = $this->save($EM_Event, $post_data);
         if ($eventPostID === 0) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             return new Error(
                 'create-event',
-                $translationAPI->__('There was an error creating the event', 'event-mutations')
+                $this->translationAPI->__('There was an error creating the event', 'event-mutations')
             );
         }
         return $eventPostID;

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/AbstractEmailInviteMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/AbstractEmailInviteMutationResolver.php
@@ -51,7 +51,7 @@ abstract class AbstractEmailInviteMutationResolver extends AbstractMutationResol
 
         $emails = $form_data['emails'];
         if (empty($emails)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email(s) cannot be empty.', 'pop-coreprocessors');
+            $errors[] = $this->translationAPI->__('Email(s) cannot be empty.', 'pop-coreprocessors');
         }
 
         return $errors;
@@ -74,7 +74,7 @@ abstract class AbstractEmailInviteMutationResolver extends AbstractMutationResol
         $emails = $form_data['emails'];
         if ($invalid_emails = $this->getInvalidEmails($emails)) {
             $warnings[] = sprintf(
-                TranslationAPIFacade::getInstance()->__('The following emails are invalid: <strong>%s</strong>', 'pop-coreprocessors'),
+                $this->translationAPI->__('The following emails are invalid: <strong>%s</strong>', 'pop-coreprocessors'),
                 implode(', ', $invalid_emails)
             );
         }

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/ChangeUserPasswordMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/ChangeUserPasswordMutationResolver.php
@@ -68,7 +68,7 @@ class ChangeUserPasswordMutationResolver extends AbstractMutationResolver
 
         $user_id = $user_data['ID'];
 
-        HooksAPIFacade::getInstance()->doAction('gd_changepassword_user', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_changepassword_user', $user_id, $form_data);
 
         return $user_id;
     }

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/ChangeUserPasswordMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/ChangeUserPasswordMutationResolver.php
@@ -22,20 +22,20 @@ class ChangeUserPasswordMutationResolver extends AbstractMutationResolver
         $repeatpassword =  $form_data['repeat_password'];
 
         if (!$current_password) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Please provide the current password.', 'pop-application');
+            $errors[] = $this->translationAPI->__('Please provide the current password.', 'pop-application');
         } elseif (!$cmsuseraccountapi->checkPassword($form_data['user_id'], $current_password)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Current password is incorrect.', 'pop-application');
+            $errors[] = $this->translationAPI->__('Current password is incorrect.', 'pop-application');
         }
 
         if (!$password) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The password cannot be emtpy.', 'pop-application');
+            $errors[] = $this->translationAPI->__('The password cannot be emtpy.', 'pop-application');
         } elseif (strlen($password) < 8) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The password must be at least 8 characters long.', 'pop-application');
+            $errors[] = $this->translationAPI->__('The password must be at least 8 characters long.', 'pop-application');
         } else {
             if (!$repeatpassword) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('Please confirm the password.', 'pop-application');
+                $errors[] = $this->translationAPI->__('Please confirm the password.', 'pop-application');
             } elseif ($password !== $repeatpassword) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('Passwords do not match.', 'pop-application');
+                $errors[] = $this->translationAPI->__('Passwords do not match.', 'pop-application');
             }
         }
         return $errors;

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateProfileMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateProfileMutationResolver.php
@@ -19,7 +19,7 @@ class CreateUpdateProfileMutationResolver extends CreateUpdateUserMutationResolv
         parent::validateContent($errors, $form_data);
 
         // Allow to validate the extra inputs
-        $hooked_errors = HooksAPIFacade::getInstance()->applyFilters('gd_createupdate_profile:validateContent', array(), $form_data);
+        $hooked_errors = $this->hooksAPI->applyFilters('gd_createupdate_profile:validateContent', array(), $form_data);
         foreach ($hooked_errors as $error) {
             $errors[] = $error;
         }
@@ -28,18 +28,18 @@ class CreateUpdateProfileMutationResolver extends CreateUpdateUserMutationResolv
     protected function additionals($user_id, $form_data)
     {
         parent::additionals($user_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_createupdate_profile:additionals', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_createupdate_profile:additionals', $user_id, $form_data);
     }
     protected function additionalsUpdate($user_id, $form_data)
     {
         parent::additionalsUpdate($user_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_createupdate_profile:additionalsUpdate', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_createupdate_profile:additionalsUpdate', $user_id, $form_data);
     }
     protected function additionalsCreate($user_id, $form_data)
     {
         parent::additionalsCreate($user_id, $form_data);
 
-        HooksAPIFacade::getInstance()->doAction('gd_createupdate_profile:additionalsCreate', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_createupdate_profile:additionalsCreate', $user_id, $form_data);
     }
     protected function createupdateuser($user_id, $form_data)
     {

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
@@ -21,22 +21,22 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
     protected function validateContent(array &$errors, array $form_data): void
     {
         if (empty($form_data['first_name'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The name cannot be empty', 'pop-application');
+            $errors[] = $this->translationAPI->__('The name cannot be empty', 'pop-application');
         }
 
         // Validate email
         $user_email = $form_data['user_email'];
         if ($user_email == '') {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The e-mail cannot be empty', 'pop-application');
+            $errors[] = $this->translationAPI->__('The e-mail cannot be empty', 'pop-application');
         } elseif (! is_email($user_email)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The email address isn&#8217;t correct.', 'pop-application');
+            $errors[] = $this->translationAPI->__('The email address isn&#8217;t correct.', 'pop-application');
         }
 
         $limited_email_domains = get_site_option('limited_email_domains');
         if (is_array($limited_email_domains) && empty($limited_email_domains) == false) {
             $emaildomain = substr($user_email, 1 + strpos($user_email, '@'));
             if (in_array($emaildomain, $limited_email_domains) == false) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('That email address is not allowed!', 'pop-application');
+                $errors[] = $this->translationAPI->__('That email address is not allowed!', 'pop-application');
             }
         }
     }
@@ -47,17 +47,17 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
         // Check the username
         $user_login = $form_data['username'];
         if ($user_login == '') {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The username cannot be empty.', 'pop-application');
+            $errors[] = $this->translationAPI->__('The username cannot be empty.', 'pop-application');
         } elseif (! validate_username($user_login)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('This username is invalid because it uses illegal characters. Please enter a valid username.', 'pop-application');
+            $errors[] = $this->translationAPI->__('This username is invalid because it uses illegal characters. Please enter a valid username.', 'pop-application');
         } elseif (username_exists($user_login)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('This username is already registered. Please choose another one.', 'pop-application');
+            $errors[] = $this->translationAPI->__('This username is already registered. Please choose another one.', 'pop-application');
         }
 
         // Check the e-mail address
         $user_email = $form_data['user_email'];
         if (email_exists($user_email)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('This email is already registered, please choose another one.', 'pop-application');
+            $errors[] = $this->translationAPI->__('This email is already registered, please choose another one.', 'pop-application');
         }
 
         // Validate Password
@@ -65,14 +65,14 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
         $repeatpassword =  $form_data['repeat_password'];
 
         if (!$password) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The password cannot be emtpy.', 'pop-application');
+            $errors[] = $this->translationAPI->__('The password cannot be emtpy.', 'pop-application');
         } elseif (strlen($password) < 8) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The password must be at least 8 characters long.', 'pop-application');
+            $errors[] = $this->translationAPI->__('The password must be at least 8 characters long.', 'pop-application');
         } else {
             if (!$repeatpassword) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('Please confirm the password.', 'pop-application');
+                $errors[] = $this->translationAPI->__('Please confirm the password.', 'pop-application');
             } elseif ($password !== $repeatpassword) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('Passwords do not match.', 'pop-application');
+                $errors[] = $this->translationAPI->__('Passwords do not match.', 'pop-application');
             }
         }
 
@@ -94,7 +94,7 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
 
         $email_user_id = email_exists($user_email);
         if ($email_user_id && $email_user_id !== $user_id) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('That email address already exists in our system!', 'pop-application');
+            $errors[] = $this->translationAPI->__('That email address already exists in our system!', 'pop-application');
         }
     }
 

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
@@ -192,15 +192,15 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
 
     protected function additionals($user_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_createupdate_user:additionals', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_createupdate_user:additionals', $user_id, $form_data);
     }
     protected function additionalsUpdate($user_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_createupdate_user:additionalsUpdate', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_createupdate_user:additionalsUpdate', $user_id, $form_data);
     }
     protected function additionalsCreate($user_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_createupdate_user:additionalsCreate', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_createupdate_user:additionalsCreate', $user_id, $form_data);
     }
 
     public function validateErrors(array $form_data): ?array

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateWithCommunityProfileMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateWithCommunityProfileMutationResolver.php
@@ -15,7 +15,7 @@ class CreateUpdateWithCommunityProfileMutationResolver extends CreateUpdateProfi
     }
     protected function usercommunitiesAdditionalsCreate($user_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_custom_createupdate_profile:additionalsCreate', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_custom_createupdate_profile:additionalsCreate', $user_id, $form_data);
     }
 
     protected function createuser($form_data)

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/EditMembershipMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/EditMembershipMutationResolver.php
@@ -86,19 +86,19 @@ class EditMembershipMutationResolver extends AbstractMutationResolver
         $errors = [];
         $user_id = $form_data['user_id'];
         if (!$user_id) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The user is missing', 'ure-pop');
+            $errors[] = $this->translationAPI->__('The user is missing', 'ure-pop');
             return $errors;
         }
 
         // $nonce = $form_data['nonce'];
         // if (!gdVerifyNonce( $nonce, GD_NONCE_EDITMEMBERSHIPURL, $user_id)) {
-        //     $errors[] = TranslationAPIFacade::getInstance()->__('Incorrect URL', 'ure-pop');
+        //     $errors[] = $this->translationAPI->__('Incorrect URL', 'ure-pop');
         //     return;
         // }
 
         $status = $form_data['status'];
         if (!$status) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The status has not been set', 'ure-pop');
+            $errors[] = $this->translationAPI->__('The status has not been set', 'ure-pop');
         }
         return $errors;
     }

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/EditMembershipMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/EditMembershipMutationResolver.php
@@ -76,7 +76,7 @@ class EditMembershipMutationResolver extends AbstractMutationResolver
         \PoPSchema\UserMeta\Utils::updateUserMeta($user_id, GD_URE_METAKEY_PROFILE_COMMUNITIES_MEMBERTAGS, $tags);
 
         // Allow ACF to also save the value in the DB
-        HooksAPIFacade::getInstance()->doAction('GD_EditMembership:update', $user_id, $community, $new_community_status, $new_community_privileges, $new_community_tags);
+        $this->hooksAPI->doAction('GD_EditMembership:update', $user_id, $community, $new_community_status, $new_community_privileges, $new_community_tags);
 
         return $user_id;
     }

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/InviteMembersMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/InviteMembersMutationResolver.php
@@ -24,7 +24,7 @@ class InviteMembersMutationResolver extends AbstractEmailInviteMutationResolver
         $website_html = \PoP_EmailTemplatesFactory::getInstance()->getWebsitehtml();//PoP_EmailUtils::get_website_html();
 
         $content = sprintf(
-            TranslationAPIFacade::getInstance()->__('<p><a href="%s">%s</a> is inviting you to <a href="%s">become their member</a>:</p>', 'ure-pop'),
+            $this->translationAPI->__('<p><a href="%s">%s</a> is inviting you to <a href="%s">become their member</a>:</p>', 'ure-pop'),
             $author_url,
             $author_name,
             RequestUtils::addRoute($author_url, POP_USERCOMMUNITIES_ROUTE_MEMBERS)
@@ -41,13 +41,13 @@ class InviteMembersMutationResolver extends AbstractEmailInviteMutationResolver
         $content .= sprintf(
             '<h3>%s</h3>',
             sprintf(
-                TranslationAPIFacade::getInstance()->__('How to become %s\'s member?', 'ure-pop'),
+                $this->translationAPI->__('How to become %s\'s member?', 'ure-pop'),
                 $author_name
             )
         );
         $content .= '<ul><li>';
         $content .= sprintf(
-            TranslationAPIFacade::getInstance()->__('If you have not registered in %s yet:<br/><a href="%s">Create your account</a>, and while doing so, select <strong>%s</strong> in section "%s".', 'ure-pop'),
+            $this->translationAPI->__('If you have not registered in %s yet:<br/><a href="%s">Create your account</a>, and while doing so, select <strong>%s</strong> in section "%s".', 'ure-pop'),
             $website_html,
             RouteUtils::getRouteURL(POP_USERPLATFORM_ROUTE_ADDPROFILE),
             $author_name,
@@ -55,7 +55,7 @@ class InviteMembersMutationResolver extends AbstractEmailInviteMutationResolver
         );
         $content .= '</li><li>';
         $content .= sprintf(
-            TranslationAPIFacade::getInstance()->__('<p>If you have already have an account in %s:<br/>Go to <a href="%s">%s</a>, select <strong>%s</strong> and submit.</p>', 'ure-pop'),
+            $this->translationAPI->__('<p>If you have already have an account in %s:<br/>Go to <a href="%s">%s</a>, select <strong>%s</strong> and submit.</p>', 'ure-pop'),
             $website_html,
             RouteUtils::getRouteURL(POP_USERCOMMUNITIES_ROUTE_MYCOMMUNITIES),
             RouteUtils::getRouteTitle(POP_USERCOMMUNITIES_ROUTE_MYCOMMUNITIES),
@@ -73,7 +73,7 @@ class InviteMembersMutationResolver extends AbstractEmailInviteMutationResolver
         $cmsusersapi = \PoPSchema\Users\FunctionAPIFactory::getInstance();
         $user_id = $form_data['user_id'];
         return sprintf(
-            TranslationAPIFacade::getInstance()->__('%s is inviting you to become their member!', 'ure-pop'),
+            $this->translationAPI->__('%s is inviting you to become their member!', 'ure-pop'),
             $cmsusersapi->getUserDisplayName($user_id)
         );
     }

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/InviteUsersMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/InviteUsersMutationResolver.php
@@ -23,13 +23,13 @@ class InviteUsersMutationResolver extends AbstractEmailInviteMutationResolver
                 $sender_html = $sender_name;
             }
             $content = sprintf(
-                TranslationAPIFacade::getInstance()->__('<p>%s is inviting you to join %s!</p>', 'pop-coreprocessors'),
+                $this->translationAPI->__('<p>%s is inviting you to join %s!</p>', 'pop-coreprocessors'),
                 $sender_html,
                 $website_html
             );
         } else {
             $content = sprintf(
-                TranslationAPIFacade::getInstance()->__('<p>You have been invited to join %s!</p>', 'pop-coreprocessors'),
+                $this->translationAPI->__('<p>You have been invited to join %s!</p>', 'pop-coreprocessors'),
                 $website_html
             );
         }
@@ -55,14 +55,14 @@ class InviteUsersMutationResolver extends AbstractEmailInviteMutationResolver
         $content .= sprintf(
             '<h3>%s</h3>',
             sprintf(
-                TranslationAPIFacade::getInstance()->__('What is %s?', 'pop-coreprocessors'),
+                $this->translationAPI->__('What is %s?', 'pop-coreprocessors'),
                 $cmsapplicationapi->getSiteName()
             )
         );
         $content .= gdGetWebsiteDescription();
         $content .= '<br/><br/>';
 
-        $btn_title = TranslationAPIFacade::getInstance()->__('Check it out here', 'pop-coreprocessors');
+        $btn_title = $this->translationAPI->__('Check it out here', 'pop-coreprocessors');
         $content .= \PoP_EmailTemplatesFactory::getInstance()->getButtonhtml($btn_title, $cmsengineapi->getSiteURL());
 
         return $content;
@@ -76,13 +76,13 @@ class InviteUsersMutationResolver extends AbstractEmailInviteMutationResolver
         // Maybe the user is logged in, maybe not
         if ($sender_name = $form_data['sender-name']) {
             $subject = sprintf(
-                TranslationAPIFacade::getInstance()->__('%s is inviting you to join %s!', 'pop-coreprocessors'),
+                $this->translationAPI->__('%s is inviting you to join %s!', 'pop-coreprocessors'),
                 $sender_name,
                 $cmsapplicationapi->getSiteName()
             );
         } else {
             $subject = sprintf(
-                TranslationAPIFacade::getInstance()->__('You have been invited to join %s!', 'pop-coreprocessors'),
+                $this->translationAPI->__('You have been invited to join %s!', 'pop-coreprocessors'),
                 $cmsapplicationapi->getSiteName()
             );
         }

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/InviteUsersMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/InviteUsersMutationResolver.php
@@ -35,7 +35,7 @@ class InviteUsersMutationResolver extends AbstractEmailInviteMutationResolver
         }
 
         // Allow Organik Fundraising to override the content
-        $content = HooksAPIFacade::getInstance()->applyFilters(
+        $content = $this->hooksAPI->applyFilters(
             'GD_InviteUsers:emailcontent',
             $content,
             $sender_html,
@@ -88,7 +88,7 @@ class InviteUsersMutationResolver extends AbstractEmailInviteMutationResolver
         }
 
         // Allow Organik Fundraising to override the message
-        return HooksAPIFacade::getInstance()->applyFilters(
+        return $this->hooksAPI->applyFilters(
             'GD_InviteUsers:emailsubject',
             $subject,
             $sender_name

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyCommunitiesMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyCommunitiesMutationResolver.php
@@ -44,7 +44,7 @@ class UpdateMyCommunitiesMutationResolver extends AbstractMutationResolver
         );
 
         // Allow to send an email before the update: get the current communities, so we know which ones are new
-        HooksAPIFacade::getInstance()->doAction('gd_update_mycommunities:update', $user_id, $form_data, $operationlog);
+        $this->hooksAPI->doAction('gd_update_mycommunities:update', $user_id, $form_data, $operationlog);
 
         return $user_id;
         // Update: either updated or no banned communities (even if nothing changed, tell the user update was successful)

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyCommunitiesMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyCommunitiesMutationResolver.php
@@ -58,7 +58,7 @@ class UpdateMyCommunitiesMutationResolver extends AbstractMutationResolver
 
         // Validate the Community doesn't belong to itself as a member
         if (in_array($user_id, $form_data['communities'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('You are not allowed to be a member of yourself!', 'ure-pop');
+            $errors[] = $this->translationAPI->__('You are not allowed to be a member of yourself!', 'ure-pop');
         }
         return $errors;
     }
@@ -92,7 +92,7 @@ class UpdateMyCommunitiesMutationResolver extends AbstractMutationResolver
                 );
             }
             $warnings[] = sprintf(
-                TranslationAPIFacade::getInstance()->__('The following Community(ies) will not be active, since they claim you are not their member: %s.', 'ure-pop'),
+                $this->translationAPI->__('The following Community(ies) will not be active, since they claim you are not their member: %s.', 'ure-pop'),
                 implode(', ', $banned_communities_html)
             );
         }

--- a/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateUserAvatarMutationResolver.php
+++ b/layers/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateUserAvatarMutationResolver.php
@@ -27,6 +27,6 @@ class UpdateUserAvatarMutationResolver extends AbstractMutationResolver
 
     protected function additionals($user_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_useravatar_update:additionals', $user_id, $form_data);
+        $this->hooksAPI->doAction('gd_useravatar_update:additionals', $user_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/flag-mutations/src/MutationResolvers/FlagCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/flag-mutations/src/MutationResolvers/FlagCustomPostMutationResolver.php
@@ -15,27 +15,27 @@ class FlagCustomPostMutationResolver extends AbstractMutationResolver
     {
         $errors = [];
         if (empty($form_data['name'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Your name cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Your name cannot be empty.', 'pop-genericforms');
         }
 
         if (empty($form_data['email'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email cannot be empty.', 'pop-genericforms');
         } elseif (!filter_var($form_data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email format is incorrect.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email format is incorrect.', 'pop-genericforms');
         }
 
         if (empty($form_data['whyflag'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Why flag cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Why flag cannot be empty.', 'pop-genericforms');
         }
 
         if (empty($form_data['target-id'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The requested post cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('The requested post cannot be empty.', 'pop-genericforms');
         } else {
             // Make sure the post exists
             $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
             $target = $customPostTypeAPI->getCustomPost($form_data['target-id']);
             if (!$target) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The requested post does not exist.', 'pop-genericforms');
+                $errors[] = $this->translationAPI->__('The requested post does not exist.', 'pop-genericforms');
             }
         }
         return $errors;
@@ -55,36 +55,36 @@ class FlagCustomPostMutationResolver extends AbstractMutationResolver
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
         $to = PoP_EmailSender_Utils::getAdminNotificationsEmail();
         $subject = sprintf(
-            TranslationAPIFacade::getInstance()->__('[%s]: %s', 'pop-genericforms'),
+            $this->translationAPI->__('[%s]: %s', 'pop-genericforms'),
             $cmsapplicationapi->getSiteName(),
-            TranslationAPIFacade::getInstance()->__('Flag post', 'pop-genericforms')
+            $this->translationAPI->__('Flag post', 'pop-genericforms')
         );
         $placeholder = '<p><b>%s:</b> %s</p>';
         $msg = sprintf(
             '<p>%s</p>',
-            TranslationAPIFacade::getInstance()->__('New post flagged by user', 'pop-genericforms')
+            $this->translationAPI->__('New post flagged by user', 'pop-genericforms')
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Name', 'pop-genericforms'),
+            $this->translationAPI->__('Name', 'pop-genericforms'),
             $form_data['name']
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Email', 'pop-genericforms'),
+            $this->translationAPI->__('Email', 'pop-genericforms'),
             sprintf(
                 '<a href="mailto:%1$s">%1$s</a>',
                 $form_data['email']
             )
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Post ID', 'pop-genericforms'),
+            $this->translationAPI->__('Post ID', 'pop-genericforms'),
             $form_data['target-id']
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Post title', 'pop-genericforms'),
+            $this->translationAPI->__('Post title', 'pop-genericforms'),
             $customPostTypeAPI->getTitle($form_data['target-id'])
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Why flag', 'pop-genericforms'),
+            $this->translationAPI->__('Why flag', 'pop-genericforms'),
             $form_data['whyflag']
         );
 

--- a/layers/Wassup/packages/flag-mutations/src/MutationResolvers/FlagCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/flag-mutations/src/MutationResolvers/FlagCustomPostMutationResolver.php
@@ -46,7 +46,7 @@ class FlagCustomPostMutationResolver extends AbstractMutationResolver
      */
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('pop_flag', $form_data);
+        $this->hooksAPI->doAction('pop_flag', $form_data);
     }
 
     protected function doExecute($form_data)

--- a/layers/Wassup/packages/highlight-mutations/src/MutationResolvers/AbstractCreateUpdateHighlightMutationResolver.php
+++ b/layers/Wassup/packages/highlight-mutations/src/MutationResolvers/AbstractCreateUpdateHighlightMutationResolver.php
@@ -22,17 +22,17 @@ abstract class AbstractCreateUpdateHighlightMutationResolver extends AbstractCre
         // Validate that the referenced post has been added (protection against hacking)
         // For highlights, we only add 1 reference, and not more.
         if (!$form_data['highlightedpost']) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('No post has been highlighted', 'poptheme-wassup');
+            $errors[] = $this->translationAPI->__('No post has been highlighted', 'poptheme-wassup');
         } else {
             // Highlights have no title input by the user. Instead, produce the title from the referenced post
             $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
             $referenced = $customPostTypeAPI->getCustomPost($form_data['highlightedpost']);
             if (!$referenced) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The highlighted post does not exist', 'poptheme-wassup');
+                $errors[] = $this->translationAPI->__('The highlighted post does not exist', 'poptheme-wassup');
             } else {
                 // If the referenced post has not been published yet, then error
                 if ($customPostTypeAPI->getStatus($referenced) != Status::PUBLISHED) {
-                    $errors[] = TranslationAPIFacade::getInstance()->__('The highlighted post is not published yet', 'poptheme-wassup');
+                    $errors[] = $this->translationAPI->__('The highlighted post is not published yet', 'poptheme-wassup');
                 }
             }
         }

--- a/layers/Wassup/packages/highlight-mutations/src/MutationResolvers/AbstractCreateUpdateHighlightMutationResolver.php
+++ b/layers/Wassup/packages/highlight-mutations/src/MutationResolvers/AbstractCreateUpdateHighlightMutationResolver.php
@@ -50,7 +50,7 @@ abstract class AbstractCreateUpdateHighlightMutationResolver extends AbstractCre
         \PoPSchema\CustomPostMeta\Utils::addCustomPostMeta($post_id, GD_METAKEY_POST_HIGHLIGHTEDPOST, $form_data['highlightedpost'], true);
 
         // Allow to create a Notification
-        HooksAPIFacade::getInstance()->doAction('GD_CreateUpdate_Highlight:createAdditionals', $post_id, $form_data);
+        $this->hooksAPI->doAction('GD_CreateUpdate_Highlight:createAdditionals', $post_id, $form_data);
     }
 
     protected function updateAdditionals(string | int $post_id, array $form_data, array $log): void
@@ -58,6 +58,6 @@ abstract class AbstractCreateUpdateHighlightMutationResolver extends AbstractCre
         parent::updateAdditionals($post_id, $form_data, $log);
 
         // Allow to create a Notification
-        HooksAPIFacade::getInstance()->doAction('GD_CreateUpdate_Highlight:updateAdditionals', $post_id, $form_data, $log);
+        $this->hooksAPI->doAction('GD_CreateUpdate_Highlight:updateAdditionals', $post_id, $form_data, $log);
     }
 }

--- a/layers/Wassup/packages/location-mutations/src/MutationResolvers/CreateLocationMutationResolver.php
+++ b/layers/Wassup/packages/location-mutations/src/MutationResolvers/CreateLocationMutationResolver.php
@@ -15,7 +15,7 @@ class CreateLocationMutationResolver extends AbstractMutationResolver
     {
         // Allow EM PoP to initialize the field names as it needs them to populate the object in function getPost($validate = true),
         // in file plugins/events-manager/classes/em-location.php
-        HooksAPIFacade::getInstance()->doAction('create_location');
+        $this->hooksAPI->doAction('create_location');
 
         $pluginapi = \PoP_Locations_APIFactory::getInstance();
         $location = $pluginapi->getNewLocationObject();

--- a/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterSubscriptionMutationResolver.php
+++ b/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterSubscriptionMutationResolver.php
@@ -26,7 +26,7 @@ class NewsletterSubscriptionMutationResolver extends AbstractMutationResolver
      */
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('pop_subscribetonewsletter', $form_data);
+        $this->hooksAPI->doAction('pop_subscribetonewsletter', $form_data);
     }
 
     protected function doExecute($form_data)

--- a/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterSubscriptionMutationResolver.php
+++ b/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterSubscriptionMutationResolver.php
@@ -14,9 +14,9 @@ class NewsletterSubscriptionMutationResolver extends AbstractMutationResolver
     {
         $errors = [];
         if (empty($form_data['email'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email cannot be empty.', 'pop-genericforms');
         } elseif (!filter_var($form_data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email format is incorrect.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email format is incorrect.', 'pop-genericforms');
         }
         return $errors;
     }
@@ -34,24 +34,24 @@ class NewsletterSubscriptionMutationResolver extends AbstractMutationResolver
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();
         $to = \PoP_EmailSender_Utils::getAdminNotificationsEmail();
         $subject = sprintf(
-            TranslationAPIFacade::getInstance()->__('[%s]: %s', 'pop-genericforms'),
+            $this->translationAPI->__('[%s]: %s', 'pop-genericforms'),
             $cmsapplicationapi->getSiteName(),
-            TranslationAPIFacade::getInstance()->__('Newsletter Subscription', 'pop-genericforms')
+            $this->translationAPI->__('Newsletter Subscription', 'pop-genericforms')
         );
         $placeholder = '<p><b>%s:</b> %s</p>';
         $msg = sprintf(
             '<p>%s</p>',
-            TranslationAPIFacade::getInstance()->__('User subscribed to newsletter', 'pop-genericforms')
+            $this->translationAPI->__('User subscribed to newsletter', 'pop-genericforms')
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Email', 'pop-genericforms'),
+            $this->translationAPI->__('Email', 'pop-genericforms'),
             sprintf(
                 '<a href="mailto:%1$s">%1$s</a>',
                 $form_data['email']
             )
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Name', 'pop-genericforms'),
+            $this->translationAPI->__('Name', 'pop-genericforms'),
             $form_data['name']
         );
 

--- a/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterUnsubscriptionMutationResolver.php
+++ b/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterUnsubscriptionMutationResolver.php
@@ -56,7 +56,7 @@ class NewsletterUnsubscriptionMutationResolver extends AbstractMutationResolver
      */
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('pop_unsubscribe_from_newsletter', $form_data);
+        $this->hooksAPI->doAction('pop_unsubscribe_from_newsletter', $form_data);
     }
 
     /**

--- a/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterUnsubscriptionMutationResolver.php
+++ b/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterUnsubscriptionMutationResolver.php
@@ -14,17 +14,17 @@ class NewsletterUnsubscriptionMutationResolver extends AbstractMutationResolver
     {
         $errors = [];
         if (empty($form_data['email'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email cannot be empty.', 'pop-genericforms');
         } elseif (!filter_var($form_data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email format is incorrect.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email format is incorrect.', 'pop-genericforms');
         }
 
-        $placeholder_string = TranslationAPIFacade::getInstance()->__('%s %s', 'pop-genericforms');
-        $makesure_string = TranslationAPIFacade::getInstance()->__('Please make sure you have clicked on the unsubscription link in the newsletter.', 'pop-genericforms');
+        $placeholder_string = $this->translationAPI->__('%s %s', 'pop-genericforms');
+        $makesure_string = $this->translationAPI->__('Please make sure you have clicked on the unsubscription link in the newsletter.', 'pop-genericforms');
         if (empty($form_data['verificationcode'])) {
             $errors[] = sprintf(
                 $placeholder_string,
-                TranslationAPIFacade::getInstance()->__('The verification code is missing.', 'pop-genericforms'),
+                $this->translationAPI->__('The verification code is missing.', 'pop-genericforms'),
                 $makesure_string
             );
         }
@@ -38,7 +38,7 @@ class NewsletterUnsubscriptionMutationResolver extends AbstractMutationResolver
         if ($verificationcode != $form_data['verificationcode']) {
             $errors[] = sprintf(
                 $placeholder_string,
-                TranslationAPIFacade::getInstance()->__('The verification code does not match the email.', 'pop-genericforms'),
+                $this->translationAPI->__('The verification code does not match the email.', 'pop-genericforms'),
                 $makesure_string
             );
         }
@@ -78,16 +78,16 @@ class NewsletterUnsubscriptionMutationResolver extends AbstractMutationResolver
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();
         $to = \PoP_EmailSender_Utils::getAdminNotificationsEmail();
         $subject = sprintf(
-            TranslationAPIFacade::getInstance()->__('[%s]: Newsletter unsubscription', 'pop-genericforms'),
+            $this->translationAPI->__('[%s]: Newsletter unsubscription', 'pop-genericforms'),
             $cmsapplicationapi->getSiteName()
         );
         $placeholder = '<p><b>%s:</b> %s</p>';
         $msg = sprintf(
             '<p>%s</p>',
-            TranslationAPIFacade::getInstance()->__('User unsubscribed from newsletter', 'pop-genericforms')
+            $this->translationAPI->__('User unsubscribed from newsletter', 'pop-genericforms')
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Email', 'pop-genericforms'),
+            $this->translationAPI->__('Email', 'pop-genericforms'),
             $newsletter_data['email']
         );
 

--- a/layers/Wassup/packages/notification-mutations/src/MutationResolvers/AbstractMarkAsReadOrUnreadNotificationMutationResolver.php
+++ b/layers/Wassup/packages/notification-mutations/src/MutationResolvers/AbstractMarkAsReadOrUnreadNotificationMutationResolver.php
@@ -28,7 +28,7 @@ abstract class AbstractMarkAsReadOrUnreadNotificationMutationResolver extends Ab
 
     protected function additionals($histid, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('GD_NotificationMarkAsReadUnread:additionals', $histid, $form_data);
+        $this->hooksAPI->doAction('GD_NotificationMarkAsReadUnread:additionals', $histid, $form_data);
     }
 
     abstract protected function getStatus();

--- a/layers/Wassup/packages/notification-mutations/src/MutationResolvers/AbstractMarkAsReadOrUnreadNotificationMutationResolver.php
+++ b/layers/Wassup/packages/notification-mutations/src/MutationResolvers/AbstractMarkAsReadOrUnreadNotificationMutationResolver.php
@@ -15,12 +15,12 @@ abstract class AbstractMarkAsReadOrUnreadNotificationMutationResolver extends Ab
         $errors = [];
         $histid = $form_data['histid'];
         if (!$histid) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('This URL is incorrect.', 'pop-notifications');
+            $errors[] = $this->translationAPI->__('This URL is incorrect.', 'pop-notifications');
         } else {
             // $notification = AAL_Main::instance()->api->getNotification($histid);
             $notification = \PoP_Notifications_API::getNotification($histid);
             if (!$notification) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('This notification does not exist.', 'pop-notifications');
+                $errors[] = $this->translationAPI->__('This notification does not exist.', 'pop-notifications');
             }
         }
         return $errors;

--- a/layers/Wassup/packages/notification-mutations/src/MutationResolvers/MarkAllAsReadNotificationMutationResolver.php
+++ b/layers/Wassup/packages/notification-mutations/src/MutationResolvers/MarkAllAsReadNotificationMutationResolver.php
@@ -11,7 +11,7 @@ class MarkAllAsReadNotificationMutationResolver extends AbstractMutationResolver
 {
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('GD_NotificationMarkAllAsRead:additionals', $form_data);
+        $this->hooksAPI->doAction('GD_NotificationMarkAllAsRead:additionals', $form_data);
     }
 
     protected function markAllAsRead($form_data)

--- a/layers/Wassup/packages/share-mutations/src/MutationResolvers/ShareByEmailMutationResolver.php
+++ b/layers/Wassup/packages/share-mutations/src/MutationResolvers/ShareByEmailMutationResolver.php
@@ -15,21 +15,21 @@ class ShareByEmailMutationResolver extends AbstractMutationResolver
     {
         $errors = [];
         if (empty($form_data['name'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Your name cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Your name cannot be empty.', 'pop-genericforms');
         }
 
         if (empty($form_data['email'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email cannot be empty.', 'pop-genericforms');
         } elseif (!filter_var($form_data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email format is incorrect.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email format is incorrect.', 'pop-genericforms');
         }
 
         if (empty($form_data['target-url'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The shared-page URL cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('The shared-page URL cannot be empty.', 'pop-genericforms');
         }
 
         if (empty($form_data['target-title'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The shared-page title cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('The shared-page title cannot be empty.', 'pop-genericforms');
         }
         return $errors;
     }
@@ -46,10 +46,10 @@ class ShareByEmailMutationResolver extends AbstractMutationResolver
     {
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();
         $subject = sprintf(
-            TranslationAPIFacade::getInstance()->__('[%s]: %s', 'pop-genericforms'),
+            $this->translationAPI->__('[%s]: %s', 'pop-genericforms'),
             $cmsapplicationapi->getSiteName(),
             sprintf(
-                TranslationAPIFacade::getInstance()->__('%s is sharing with you: %s', 'pop-genericforms'),
+                $this->translationAPI->__('%s is sharing with you: %s', 'pop-genericforms'),
                 $form_data['name'],
                 $form_data['target-title']
             )
@@ -58,14 +58,14 @@ class ShareByEmailMutationResolver extends AbstractMutationResolver
         $msg = sprintf(
             '<p>%s</p>',
             sprintf(
-                TranslationAPIFacade::getInstance()->__('%s is sharing with you: <a href="%s">%s</a>', 'pop-genericforms'),
+                $this->translationAPI->__('%s is sharing with you: <a href="%s">%s</a>', 'pop-genericforms'),
                 $form_data['name'],
                 $form_data['target-url'],
                 $form_data['target-title']
             )
         ) . ($form_data['message'] ? sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Additional message', 'pop-genericforms'),
+            $this->translationAPI->__('Additional message', 'pop-genericforms'),
             $form_data['message']
         ) : '');
 

--- a/layers/Wassup/packages/share-mutations/src/MutationResolvers/ShareByEmailMutationResolver.php
+++ b/layers/Wassup/packages/share-mutations/src/MutationResolvers/ShareByEmailMutationResolver.php
@@ -39,7 +39,7 @@ class ShareByEmailMutationResolver extends AbstractMutationResolver
      */
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('pop_sharebyemail', $form_data);
+        $this->hooksAPI->doAction('pop_sharebyemail', $form_data);
     }
 
     protected function doExecute($form_data)

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractCustomPostUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractCustomPostUpdateUserMetaValueMutationResolver.php
@@ -26,12 +26,12 @@ class AbstractCustomPostUpdateUserMetaValueMutationResolver extends AbstractUpda
             $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
             $target = $customPostTypeAPI->getCustomPost($target_id);
             if (!$target) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The requested post does not exist.', 'pop-coreprocessors');
+                $errors[] = $this->translationAPI->__('The requested post does not exist.', 'pop-coreprocessors');
             } else {
                 // Make sure this target accepts this functionality. Eg: Not all posts can be Recommended or Up/Down-voted.
                 // Discussion can be recommended only, Highlight up/down-voted only
                 if (!$this->eligible($target)) {
-                    $errors[] = TranslationAPIFacade::getInstance()->__('The requested functionality does not apply on this post.', 'pop-coreprocessors');
+                    $errors[] = $this->translationAPI->__('The requested functionality does not apply on this post.', 'pop-coreprocessors');
                 }
             }
         }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractCustomPostUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractCustomPostUpdateUserMetaValueMutationResolver.php
@@ -45,7 +45,7 @@ class AbstractCustomPostUpdateUserMetaValueMutationResolver extends AbstractUpda
 
     protected function additionals($target_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_updateusermetavalue:post', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_updateusermetavalue:post', $target_id, $form_data);
         parent::additionals($target_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractDownvoteOrUndoDownvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractDownvoteOrUndoDownvoteCustomPostMutationResolver.php
@@ -13,7 +13,7 @@ abstract class AbstractDownvoteOrUndoDownvoteCustomPostMutationResolver extends 
     {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
         $eligible = in_array($customPostTypeAPI->getCustomPostType($post), PoP_SocialNetwork_Utils::getUpdownvotePostTypes());
-        return HooksAPIFacade::getInstance()->applyFilters('GD_UpdownvoteUndoUpdownvotePost:eligible', $eligible, $post);
+        return $this->hooksAPI->applyFilters('GD_UpdownvoteUndoUpdownvotePost:eligible', $eligible, $post);
     }
 
     /**
@@ -22,6 +22,6 @@ abstract class AbstractDownvoteOrUndoDownvoteCustomPostMutationResolver extends 
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_downvoteundodownvote_post', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_downvoteundodownvote_post', $target_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractFollowOrUnfollowUserMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractFollowOrUnfollowUserMutationResolver.php
@@ -11,6 +11,6 @@ abstract class AbstractFollowOrUnfollowUserMutationResolver extends AbstractUser
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_followunfollow_user', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_followunfollow_user', $target_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractRecommendOrUnrecommendCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractRecommendOrUnrecommendCustomPostMutationResolver.php
@@ -14,7 +14,7 @@ abstract class AbstractRecommendOrUnrecommendCustomPostMutationResolver extends 
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
         $cmsapplicationpostsapi = \PoP\Application\PostsFunctionAPIFactory::getInstance();
         $eligible = in_array($customPostTypeAPI->getCustomPostType($post), $cmsapplicationpostsapi->getAllcontentPostTypes());
-        return HooksAPIFacade::getInstance()->applyFilters('GD_RecommendUnrecommendPost:eligible', $eligible, $post);
+        return $this->hooksAPI->applyFilters('GD_RecommendUnrecommendPost:eligible', $eligible, $post);
     }
 
     /**
@@ -23,6 +23,6 @@ abstract class AbstractRecommendOrUnrecommendCustomPostMutationResolver extends 
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_recommendunrecommend_post', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_recommendunrecommend_post', $target_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractSubscribeToOrUnsubscribeFromTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractSubscribeToOrUnsubscribeFromTagMutationResolver.php
@@ -20,7 +20,7 @@ abstract class AbstractSubscribeToOrUnsubscribeFromTagMutationResolver extends A
             $postTagTypeAPI = PostTagTypeAPIFacade::getInstance();
             $target = $postTagTypeAPI->getTag($target_id);
             if (!$target) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The requested topic/tag does not exist.', 'pop-coreprocessors');
+                $errors[] = $this->translationAPI->__('The requested topic/tag does not exist.', 'pop-coreprocessors');
             }
         }
         return $errors;

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractSubscribeToOrUnsubscribeFromTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractSubscribeToOrUnsubscribeFromTagMutationResolver.php
@@ -28,7 +28,7 @@ abstract class AbstractSubscribeToOrUnsubscribeFromTagMutationResolver extends A
 
     protected function additionals($target_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_subscritetounsubscribefrom_tag', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_subscritetounsubscribefrom_tag', $target_id, $form_data);
         parent::additionals($target_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
@@ -15,7 +15,7 @@ abstract class AbstractUpdateUserMetaValueMutationResolver extends AbstractMutat
         $errors = [];
         $target_id = $form_data['target_id'];
         if (!$target_id) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('This URL is incorrect.', 'pop-coreprocessors');
+            $errors[] = $this->translationAPI->__('This URL is incorrect.', 'pop-coreprocessors');
         }
         return $errors;
     }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
@@ -22,7 +22,7 @@ abstract class AbstractUpdateUserMetaValueMutationResolver extends AbstractMutat
 
     protected function additionals($target_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_updateusermetavalue', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_updateusermetavalue', $target_id, $form_data);
     }
 
     protected function update($form_data): string | int

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpvoteOrUndoUpvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpvoteOrUndoUpvoteCustomPostMutationResolver.php
@@ -13,7 +13,7 @@ abstract class AbstractUpvoteOrUndoUpvoteCustomPostMutationResolver extends Abst
     {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
         $eligible = in_array($customPostTypeAPI->getCustomPostType($post), PoP_SocialNetwork_Utils::getUpdownvotePostTypes());
-        return HooksAPIFacade::getInstance()->applyFilters('GD_UpdownvoteUndoUpdownvotePost:eligible', $eligible, $post);
+        return $this->hooksAPI->applyFilters('GD_UpdownvoteUndoUpdownvotePost:eligible', $eligible, $post);
     }
 
     /**
@@ -22,6 +22,6 @@ abstract class AbstractUpvoteOrUndoUpvoteCustomPostMutationResolver extends Abst
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_upvoteundoupvote_post', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_upvoteundoupvote_post', $target_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUserUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUserUpdateUserMetaValueMutationResolver.php
@@ -20,7 +20,7 @@ class AbstractUserUpdateUserMetaValueMutationResolver extends AbstractUpdateUser
             // Make sure the user exists
             $target = $cmsusersapi->getUserById($target_id);
             if (!$target) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The requested user does not exist.', 'pop-coreprocessors');
+                $errors[] = $this->translationAPI->__('The requested user does not exist.', 'pop-coreprocessors');
             }
         }
         return $errors;

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUserUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUserUpdateUserMetaValueMutationResolver.php
@@ -33,7 +33,7 @@ class AbstractUserUpdateUserMetaValueMutationResolver extends AbstractUpdateUser
 
     protected function additionals($target_id, $form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('gd_updateusermetavalue:user', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_updateusermetavalue:user', $target_id, $form_data);
         parent::additionals($target_id, $form_data);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/DownvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/DownvoteCustomPostMutationResolver.php
@@ -25,7 +25,7 @@ class DownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownvoteC
             $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_DOWNVOTESPOSTS);
             if (in_array($target_id, $value)) {
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You have already down-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You have already down-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $customPostTypeAPI->getTitle($target_id)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/DownvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/DownvoteCustomPostMutationResolver.php
@@ -39,7 +39,7 @@ class DownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownvoteC
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_downvotepost', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_downvotepost', $target_id, $form_data);
     }
 
     protected function getOppositeInstance()

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/FollowUserMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/FollowUserMutationResolver.php
@@ -20,13 +20,13 @@ class FollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationRes
             $target_id = $form_data['target_id'];
 
             if ($user_id == $target_id) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('You can\'t follow yourself!', 'pop-coreprocessors');
+                $errors[] = $this->translationAPI->__('You can\'t follow yourself!', 'pop-coreprocessors');
             } else {
                 // Check that the logged in user does not currently follow that user
                 $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_FOLLOWSUSERS);
                 if (in_array($target_id, $value)) {
                     $errors[] = sprintf(
-                        TranslationAPIFacade::getInstance()->__('You are already following <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                        $this->translationAPI->__('You are already following <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                         $cmsusersapi->getUserDisplayName($target_id)
                     );
                 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/FollowUserMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/FollowUserMutationResolver.php
@@ -41,7 +41,7 @@ class FollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationRes
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_followuser', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_followuser', $target_id, $form_data);
     }
 
     // protected function updateValue($value, $form_data) {

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/RecommendCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/RecommendCustomPostMutationResolver.php
@@ -24,7 +24,7 @@ class RecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecommend
             $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_RECOMMENDSPOSTS);
             if (in_array($target_id, $value)) {
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You have already recommended <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You have already recommended <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $customPostTypeAPI->getTitle($target_id)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/RecommendCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/RecommendCustomPostMutationResolver.php
@@ -38,7 +38,7 @@ class RecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecommend
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_recommendpost', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_recommendpost', $target_id, $form_data);
     }
 
     // protected function updateValue($value, $form_data) {

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/SubscribeToTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/SubscribeToTagMutationResolver.php
@@ -40,7 +40,7 @@ class SubscribeToTagMutationResolver extends AbstractSubscribeToOrUnsubscribeFro
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_subscribetotag', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_subscribetotag', $target_id, $form_data);
     }
 
     protected function update($form_data): string | int

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/SubscribeToTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/SubscribeToTagMutationResolver.php
@@ -26,7 +26,7 @@ class SubscribeToTagMutationResolver extends AbstractSubscribeToOrUnsubscribeFro
                 $applicationtaxonomyapi = \PoP\ApplicationTaxonomies\FunctionAPIFactory::getInstance();
                 $tag = $postTagTypeAPI->getTag($target_id);
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You have already subscribed to <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You have already subscribed to <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $applicationtaxonomyapi->getTagSymbolName($tag)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoDownvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoDownvoteCustomPostMutationResolver.php
@@ -24,7 +24,7 @@ class UndoDownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownv
             $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_DOWNVOTESPOSTS);
             if (!in_array($target_id, $value)) {
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You had not down-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You had not down-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $customPostTypeAPI->getTitle($target_id)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoDownvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoDownvoteCustomPostMutationResolver.php
@@ -38,7 +38,7 @@ class UndoDownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownv
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_undodownvotepost', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_undodownvotepost', $target_id, $form_data);
     }
 
     protected function update($form_data): string | int

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoUpvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoUpvoteCustomPostMutationResolver.php
@@ -38,7 +38,7 @@ class UndoUpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCus
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_undoupvotepost', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_undoupvotepost', $target_id, $form_data);
     }
 
     protected function update($form_data): string | int

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoUpvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoUpvoteCustomPostMutationResolver.php
@@ -24,7 +24,7 @@ class UndoUpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCus
             $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_UPVOTESPOSTS);
             if (!in_array($target_id, $value)) {
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You had not up-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You had not up-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $customPostTypeAPI->getTitle($target_id)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnfollowUserMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnfollowUserMutationResolver.php
@@ -37,7 +37,7 @@ class UnfollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationR
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_unfollowuser', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_unfollowuser', $target_id, $form_data);
     }
 
     // protected function updateValue($value, $form_data) {

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnfollowUserMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnfollowUserMutationResolver.php
@@ -23,7 +23,7 @@ class UnfollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationR
             $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_FOLLOWSUSERS);
             if (!in_array($target_id, $value)) {
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You were not following <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You were not following <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $cmsusersapi->getUserDisplayName($target_id)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnrecommendCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnrecommendCustomPostMutationResolver.php
@@ -24,7 +24,7 @@ class UnrecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecomme
             $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_RECOMMENDSPOSTS);
             if (!in_array($target_id, $value)) {
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You had not recommended <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You had not recommended <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $customPostTypeAPI->getTitle($target_id)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnrecommendCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnrecommendCustomPostMutationResolver.php
@@ -38,7 +38,7 @@ class UnrecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecomme
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_unrecommendpost', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_unrecommendpost', $target_id, $form_data);
     }
 
     // protected function updateValue($value, $form_data) {

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnsubscribeFromTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnsubscribeFromTagMutationResolver.php
@@ -40,7 +40,7 @@ class UnsubscribeFromTagMutationResolver extends AbstractSubscribeToOrUnsubscrib
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_unsubscribefromtag', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_unsubscribefromtag', $target_id, $form_data);
     }
 
     protected function update($form_data): string | int

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnsubscribeFromTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnsubscribeFromTagMutationResolver.php
@@ -26,7 +26,7 @@ class UnsubscribeFromTagMutationResolver extends AbstractSubscribeToOrUnsubscrib
                 $applicationtaxonomyapi = \PoP\ApplicationTaxonomies\FunctionAPIFactory::getInstance();
                 $tag = $postTagTypeAPI->getTag($target_id);
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You had not subscribed to <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You had not subscribed to <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $applicationtaxonomyapi->getTagSymbolName($tag)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UpvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UpvoteCustomPostMutationResolver.php
@@ -25,7 +25,7 @@ class UpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCustomP
             $value = \PoPSchema\UserMeta\Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_UPVOTESPOSTS);
             if (in_array($target_id, $value)) {
                 $errors[] = sprintf(
-                    TranslationAPIFacade::getInstance()->__('You have already up-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
+                    $this->translationAPI->__('You have already up-voted <em><strong>%s</strong></em>.', 'pop-coreprocessors'),
                     $customPostTypeAPI->getTitle($target_id)
                 );
             }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UpvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UpvoteCustomPostMutationResolver.php
@@ -39,7 +39,7 @@ class UpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCustomP
     protected function additionals($target_id, $form_data)
     {
         parent::additionals($target_id, $form_data);
-        HooksAPIFacade::getInstance()->doAction('gd_upvotepost', $target_id, $form_data);
+        $this->hooksAPI->doAction('gd_upvotepost', $target_id, $form_data);
     }
 
     protected function update($form_data): string | int

--- a/layers/Wassup/packages/stance-mutations/src/MutationResolvers/AbstractCreateUpdateStanceMutationResolver.php
+++ b/layers/Wassup/packages/stance-mutations/src/MutationResolvers/AbstractCreateUpdateStanceMutationResolver.php
@@ -22,11 +22,11 @@ abstract class AbstractCreateUpdateStanceMutationResolver extends AbstractCreate
             $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
             $referenced = $customPostTypeAPI->getCustomPost($form_data['stancetarget']);
             if (!$referenced) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The referenced post does not exist', 'poptheme-wassup');
+                $errors[] = $this->translationAPI->__('The referenced post does not exist', 'poptheme-wassup');
             } else {
                 // If the referenced post has not been published yet, then error
                 if ($customPostTypeAPI->getStatus($referenced) != Status::PUBLISHED) {
-                    $errors[] = TranslationAPIFacade::getInstance()->__('The referenced post is not published yet', 'poptheme-wassup');
+                    $errors[] = $this->translationAPI->__('The referenced post is not published yet', 'poptheme-wassup');
                 }
             }
         }
@@ -45,8 +45,8 @@ abstract class AbstractCreateUpdateStanceMutationResolver extends AbstractCreate
     protected function getCategoriesErrorMessages()
     {
         $category_error_msgs = parent::getCategoriesErrorMessages();
-        $category_error_msgs['empty-category'] = TranslationAPIFacade::getInstance()->__('The stance has not been set', 'pop-userstance');
-        $category_error_msgs['only-one'] = TranslationAPIFacade::getInstance()->__('Only one stance can be selected', 'pop-userstance');
+        $category_error_msgs['empty-category'] = $this->translationAPI->__('The stance has not been set', 'pop-userstance');
+        $category_error_msgs['only-one'] = $this->translationAPI->__('Only one stance can be selected', 'pop-userstance');
         return $category_error_msgs;
     }
 
@@ -81,19 +81,19 @@ abstract class AbstractCreateUpdateStanceMutationResolver extends AbstractCreate
         if ($stances = $customPostTypeAPI->getCustomPosts($query, ['return-type' => ReturnTypes::IDS])) {
             $stance_id = $stances[0];
             $error = sprintf(
-                TranslationAPIFacade::getInstance()->__('You have already added your %s', 'pop-userstance'),
+                $this->translationAPI->__('You have already added your %s', 'pop-userstance'),
                 \PoP_UserStance_PostNameUtils::getNameLc()
             );
             if ($referenced_id) {
                 $error = sprintf(
-                    TranslationAPIFacade::getInstance()->__('%s after reading “<a href="%s">%s</a>”', 'pop-userstance'),
+                    $this->translationAPI->__('%s after reading “<a href="%s">%s</a>”', 'pop-userstance'),
                     $error,
                     $customPostTypeAPI->getPermalink($referenced_id),
                     $customPostTypeAPI->getTitle($referenced_id)
                 );
             }
             $errors[] = sprintf(
-                TranslationAPIFacade::getInstance()->__('%s. <a href="%s" target="%s">Edit?</a>', 'pop-userstance'),
+                $this->translationAPI->__('%s. <a href="%s" target="%s">Edit?</a>', 'pop-userstance'),
                 $error,
                 urldecode($cmseditpostsapi->getEditPostLink($stance_id)),
                 POP_TARGET_ADDONS

--- a/layers/Wassup/packages/stance-mutations/src/MutationResolvers/AbstractCreateUpdateStanceMutationResolver.php
+++ b/layers/Wassup/packages/stance-mutations/src/MutationResolvers/AbstractCreateUpdateStanceMutationResolver.php
@@ -124,7 +124,7 @@ abstract class AbstractCreateUpdateStanceMutationResolver extends AbstractCreate
         }
 
         // Allow for URE to add the AuthorRole meta value
-        HooksAPIFacade::getInstance()->doAction('GD_CreateUpdate_Stance:createAdditionals', $post_id, $form_data);
+        $this->hooksAPI->doAction('GD_CreateUpdate_Stance:createAdditionals', $post_id, $form_data);
     }
 
     protected function updateAdditionals(string | int $post_id, array $form_data, array $log): void
@@ -132,6 +132,6 @@ abstract class AbstractCreateUpdateStanceMutationResolver extends AbstractCreate
         parent::updateAdditionals($post_id, $form_data, $log);
 
         // Allow for URE to add the AuthorRole meta value
-        HooksAPIFacade::getInstance()->doAction('GD_CreateUpdate_Stance:updateAdditionals', $post_id, $form_data, $log);
+        $this->hooksAPI->doAction('GD_CreateUpdate_Stance:updateAdditionals', $post_id, $form_data, $log);
     }
 }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/ActivatePluginsMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/ActivatePluginsMutationResolver.php
@@ -25,10 +25,10 @@ class ActivatePluginsMutationResolver extends AbstractMutationResolver
         if (!in_array($plugin, $current)) {
             $current[] = $plugin;
             sort($current);
-            HooksAPIFacade::getInstance()->doAction('activate_plugin', trim($plugin));
+            $this->hooksAPI->doAction('activate_plugin', trim($plugin));
             update_option('active_plugins', $current);
-            HooksAPIFacade::getInstance()->doAction('activate_' . trim($plugin));
-            HooksAPIFacade::getInstance()->doAction('activated_plugin', trim($plugin));
+            $this->hooksAPI->doAction('activate_' . trim($plugin));
+            $this->hooksAPI->doAction('activated_plugin', trim($plugin));
             return true;
         }
 
@@ -39,7 +39,7 @@ class ActivatePluginsMutationResolver extends AbstractMutationResolver
     {
         // Plugins needed by the website. Check the website version, if it's the one indicated,
         // then proceed to install the required plugin
-        $plugin_version = HooksAPIFacade::getInstance()->applyFilters(
+        $plugin_version = $this->hooksAPI->applyFilters(
             'PoP:system-activateplugins:plugins',
             array()
         );

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/BuildSystemMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/BuildSystemMutationResolver.php
@@ -11,7 +11,7 @@ class BuildSystemMutationResolver extends AbstractMutationResolver
 {
     public function execute(array $form_data): mixed
     {
-        HooksAPIFacade::getInstance()->doAction('PoP:system-build');
+        $this->hooksAPI->doAction('PoP:system-build');
         return true;
     }
 }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateSystemMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateSystemMutationResolver.php
@@ -11,7 +11,7 @@ class GenerateSystemMutationResolver extends AbstractMutationResolver
 {
     public function execute(array $form_data): mixed
     {
-        HooksAPIFacade::getInstance()->doAction('PoP:system-generate');
+        $this->hooksAPI->doAction('PoP:system-generate');
         return true;
     }
 }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateThemeMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateThemeMutationResolver.php
@@ -11,7 +11,7 @@ class GenerateThemeMutationResolver extends AbstractMutationResolver
 {
     public function execute(array $form_data): mixed
     {
-        HooksAPIFacade::getInstance()->doAction('PoP:system-generate:theme');
+        $this->hooksAPI->doAction('PoP:system-generate:theme');
         return true;
     }
 }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/InstallSystemMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/InstallSystemMutationResolver.php
@@ -16,7 +16,7 @@ class InstallSystemMutationResolver extends AbstractMutationResolver
         update_option('PoP:version', ApplicationInfoFacade::getInstance()->getVersion());
 
         // Execute install everywhere
-        HooksAPIFacade::getInstance()->doAction('PoP:system-install');
+        $this->hooksAPI->doAction('PoP:system-install');
         return true;
     }
 }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/SaveDefinitionFileMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/SaveDefinitionFileMutationResolver.php
@@ -11,7 +11,7 @@ class SaveDefinitionFileMutationResolver extends AbstractMutationResolver
 {
     public function execute(array $form_data): mixed
     {
-        HooksAPIFacade::getInstance()->doAction('PoP:system:save-definition-file');
+        $this->hooksAPI->doAction('PoP:system:save-definition-file');
         return true;
     }
 }

--- a/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LoginMutationResolver.php
+++ b/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LoginMutationResolver.php
@@ -13,7 +13,7 @@ class LoginMutationResolver extends \PoPSchema\UserStateMutations\MutationResolv
         $cmsusersapi = \PoPSchema\Users\FunctionAPIFactory::getInstance();
         $cmsuseraccountapi = \PoP\UserAccount\FunctionAPIFactory::getInstance();
         return sprintf(
-            TranslationAPIFacade::getInstance()->__('You are already logged in as <a href="%s">%s</a>, <a href="%s">logout</a>?', 'user-state-mutations'),
+            $this->translationAPI->__('You are already logged in as <a href="%s">%s</a>, <a href="%s">logout</a>?', 'user-state-mutations'),
             $cmsusersapi->getUserURL($user_id),
             $cmsusersapi->getUserDisplayName($user_id),
             $cmsuseraccountapi->getLogoutURL()

--- a/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LostPasswordMutationResolver.php
+++ b/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LostPasswordMutationResolver.php
@@ -115,9 +115,9 @@ class LostPasswordMutationResolver extends AbstractMutationResolver
         $user_id = $cmsusersresolver->getUserId($user);
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();
         $title = sprintf($this->translationAPI->__('[%s] Password Reset'), $cmsapplicationapi->getSiteName());
-        $title = HooksAPIFacade::getInstance()->applyFilters('popcms:retrievePasswordTitle', $title, $user_login, $user);
+        $title = $this->hooksAPI->applyFilters('popcms:retrievePasswordTitle', $title, $user_login, $user);
         $message = $this->retrievePasswordMessage($key, $user_login, $user_id);
-        $message = HooksAPIFacade::getInstance()->applyFilters('popcms:retrievePasswordMessage', $message, $key, $user_login, $user);
+        $message = $this->hooksAPI->applyFilters('popcms:retrievePasswordMessage', $message, $key, $user_login, $user);
 
         $user_email = $cmsusersresolver->getUserEmail($user);
         return PoP_EmailSender_Utils::sendEmail($user_email, htmlspecialchars_decode($title)/*wp_specialchars_decode($title)*/, $message);

--- a/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LostPasswordMutationResolver.php
+++ b/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LostPasswordMutationResolver.php
@@ -29,14 +29,14 @@ class LostPasswordMutationResolver extends AbstractMutationResolver
         $message = sprintf(
             '<p>%s</p><br/>',
             sprintf(
-                TranslationAPIFacade::getInstance()->__('Someone requested that the password be reset for your account on <a href="%s">%s</a>. If this was a mistake, or if it was not you who requested the password reset, just ignore this email and nothing will happen.', 'pop-application'),
+                $this->translationAPI->__('Someone requested that the password be reset for your account on <a href="%s">%s</a>. If this was a mistake, or if it was not you who requested the password reset, just ignore this email and nothing will happen.', 'pop-application'),
                 GeneralUtils::maybeAddTrailingSlash($cmsengineapi->getHomeURL()),
                 $cmsapplicationapi->getSiteName()
             )
         );
         $message .= sprintf(
             '<p>%s</p>',
-            TranslationAPIFacade::getInstance()->__('To reset your password, please click on the following link:</p>', 'pop-application')
+            $this->translationAPI->__('To reset your password, please click on the following link:</p>', 'pop-application')
         );
         $message .= sprintf(
             '<p>%s</p><br/>',
@@ -47,7 +47,7 @@ class LostPasswordMutationResolver extends AbstractMutationResolver
         );
         $message .= sprintf(
             '<p>%s</p>',
-            TranslationAPIFacade::getInstance()->__('Alternatively, please paste the following code in the "Code" input:', 'pop-application')
+            $this->translationAPI->__('Alternatively, please paste the following code in the "Code" input:', 'pop-application')
         );
         $message .= sprintf(
             // '<p><pre style="%s">%s</pre></p><br/>',
@@ -67,11 +67,11 @@ class LostPasswordMutationResolver extends AbstractMutationResolver
 
         // Code copied from file wp-login.php (We can't invoke it directly, since wp-login.php has not been loaded, and we can't do it since it executes a lot of unwanted code producing and output)
         if (empty($user_login)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Enter a username or e-mail address.');
+            $errors[] = $this->translationAPI->__('Enter a username or e-mail address.');
         } elseif (strpos($user_login, '@')) {
             $user = $cmsusersapi->getUserByEmail(trim($user_login));
             if (empty($user)) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('There is no user registered with that email address.');
+                $errors[] = $this->translationAPI->__('There is no user registered with that email address.');
             }
         } else {
             $login = trim($user_login);
@@ -79,7 +79,7 @@ class LostPasswordMutationResolver extends AbstractMutationResolver
         }
 
         if (!$user) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Invalid username or e-mail.');
+            $errors[] = $this->translationAPI->__('Invalid username or e-mail.');
         }
 
         return $errors;
@@ -111,10 +111,10 @@ class LostPasswordMutationResolver extends AbstractMutationResolver
         * in sanitize_option we want to reverse this for the plain text arena of emails.
         */
         // $site_name = wp_specialchars_decode($cmsapplicationapi->getSiteName(), ENT_QUOTES);
-        // $title = sprintf(TranslationAPIFacade::getInstance()->__('[%s] Password Reset'), $site_name);
+        // $title = sprintf($this->translationAPI->__('[%s] Password Reset'), $site_name);
         $user_id = $cmsusersresolver->getUserId($user);
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();
-        $title = sprintf(TranslationAPIFacade::getInstance()->__('[%s] Password Reset'), $cmsapplicationapi->getSiteName());
+        $title = sprintf($this->translationAPI->__('[%s] Password Reset'), $cmsapplicationapi->getSiteName());
         $title = HooksAPIFacade::getInstance()->applyFilters('popcms:retrievePasswordTitle', $title, $user_login, $user);
         $message = $this->retrievePasswordMessage($key, $user_login, $user_id);
         $message = HooksAPIFacade::getInstance()->applyFilters('popcms:retrievePasswordMessage', $message, $key, $user_login, $user);

--- a/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/ResetLostPasswordMutationResolver.php
+++ b/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/ResetLostPasswordMutationResolver.php
@@ -72,7 +72,7 @@ class ResetLostPasswordMutationResolver extends AbstractMutationResolver
 
         $cmsusersresolver = \PoPSchema\Users\ObjectPropertyResolverFactory::getInstance();
         $userID = $cmsusersresolver->getUserId($user);
-        HooksAPIFacade::getInstance()->doAction('gd_lostpasswordreset', $userID);
+        $this->hooksAPI->doAction('gd_lostpasswordreset', $userID);
         return $userID;
     }
 }

--- a/layers/Wassup/packages/volunteer-mutations/src/MutationResolvers/VolunteerMutationResolver.php
+++ b/layers/Wassup/packages/volunteer-mutations/src/MutationResolvers/VolunteerMutationResolver.php
@@ -15,28 +15,28 @@ class VolunteerMutationResolver extends AbstractMutationResolver
     {
         $errors = [];
         if (empty($form_data['name'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Your name cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Your name cannot be empty.', 'pop-genericforms');
         }
 
         if (empty($form_data['email'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email cannot be empty.', 'pop-genericforms');
         } elseif (!filter_var($form_data['email'], FILTER_VALIDATE_EMAIL)) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Email format is incorrect.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Email format is incorrect.', 'pop-genericforms');
         }
 
         if (empty($form_data['target-id'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('The requested post cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('The requested post cannot be empty.', 'pop-genericforms');
         } else {
             // Make sure the post exists
             $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
             $target = $customPostTypeAPI->getCustomPost($form_data['target-id']);
             if (!$target) {
-                $errors[] = TranslationAPIFacade::getInstance()->__('The requested post does not exist.', 'pop-genericforms');
+                $errors[] = $this->translationAPI->__('The requested post does not exist.', 'pop-genericforms');
             }
         }
 
         if (empty($form_data['whyvolunteer'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Why volunteer cannot be empty.', 'pop-genericforms');
+            $errors[] = $this->translationAPI->__('Why volunteer cannot be empty.', 'pop-genericforms');
         }
         return $errors;
     }
@@ -55,10 +55,10 @@ class VolunteerMutationResolver extends AbstractMutationResolver
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();
         $post_title = $customPostTypeAPI->getTitle($form_data['target-id']);
         $subject = sprintf(
-            TranslationAPIFacade::getInstance()->__('[%s]: %s', 'pop-genericforms'),
+            $this->translationAPI->__('[%s]: %s', 'pop-genericforms'),
             $cmsapplicationapi->getSiteName(),
             sprintf(
-                TranslationAPIFacade::getInstance()->__('%s applied to volunteer for %s', 'pop-genericforms'),
+                $this->translationAPI->__('%s applied to volunteer for %s', 'pop-genericforms'),
                 $form_data['name'],
                 $post_title
             )
@@ -66,29 +66,29 @@ class VolunteerMutationResolver extends AbstractMutationResolver
         $placeholder = '<p><b>%s:</b> %s</p>';
         $msg = sprintf(
             '<p>%s</p>',
-            TranslationAPIFacade::getInstance()->__('You have a new volunteer! Please contact the volunteer directly through the contact details below.', 'pop-genericforms')
+            $this->translationAPI->__('You have a new volunteer! Please contact the volunteer directly through the contact details below.', 'pop-genericforms')
         ) . sprintf(
             '<p>%s</p>',
             sprintf(
-                TranslationAPIFacade::getInstance()->__('%s applied to volunteer for: <a href="%s">%s</a>', 'pop-genericforms'),
+                $this->translationAPI->__('%s applied to volunteer for: <a href="%s">%s</a>', 'pop-genericforms'),
                 $form_data['name'],
                 $customPostTypeAPI->getPermalink($form_data['target-id']),
                 $post_title
             )
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Email', 'pop-genericforms'),
+            $this->translationAPI->__('Email', 'pop-genericforms'),
             sprintf(
                 '<a href="mailto:%1$s">%1$s</a>',
                 $form_data['email']
             )
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Phone', 'pop-genericforms'),
+            $this->translationAPI->__('Phone', 'pop-genericforms'),
             $form_data['phone']
         ) . sprintf(
             $placeholder,
-            TranslationAPIFacade::getInstance()->__('Why volunteer', 'pop-genericforms'),
+            $this->translationAPI->__('Why volunteer', 'pop-genericforms'),
             $form_data['whyvolunteer']
         );
 

--- a/layers/Wassup/packages/volunteer-mutations/src/MutationResolvers/VolunteerMutationResolver.php
+++ b/layers/Wassup/packages/volunteer-mutations/src/MutationResolvers/VolunteerMutationResolver.php
@@ -46,7 +46,7 @@ class VolunteerMutationResolver extends AbstractMutationResolver
      */
     protected function additionals($form_data)
     {
-        HooksAPIFacade::getInstance()->doAction('pop_volunteer', $form_data);
+        $this->hooksAPI->doAction('pop_volunteer', $form_data);
     }
 
     protected function doExecute($form_data)

--- a/layers/Wassup/packages/wassup/src/MutationResolvers/GravityFormsNewsletterUnsubscriptionMutationResolver.php
+++ b/layers/Wassup/packages/wassup/src/MutationResolvers/GravityFormsNewsletterUnsubscriptionMutationResolver.php
@@ -14,7 +14,7 @@ class GravityFormsNewsletterUnsubscriptionMutationResolver extends NewsletterUns
         parent::validateData($errors, $newsletter_data);
 
         if (empty($newsletter_data['entry-id'])) {
-            $errors[] = TranslationAPIFacade::getInstance()->__('Your email is not subscribed to our newsletter.', 'gravityforms-pop-genericforms');
+            $errors[] = $this->translationAPI->__('Your email is not subscribed to our newsletter.', 'gravityforms-pop-genericforms');
         }
     }
 


### PR DESCRIPTION
The following resolvers now have properties `$translationAPI` and `$hooksAPI`:

- `TypeResolver`s
- `FieldResolver`s
- `DirectiveResolver`s
- `FieldInterfaceResolver`s