### PR TITLE
Use COMPOSER env var, to use `composer.local.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ composer.lock
 # to make sure the CI doesn't fail
 !/composer.lock
 .lando.local.yml
-composer.json.tmp
+composer.local.json
+composer.local.lock

--- a/webservers/graphql-api-for-wp/.gitignore
+++ b/webservers/graphql-api-for-wp/.gitignore
@@ -1,5 +1,5 @@
 /vendor/
 /wordpress/
 /defaults.local.env
-/localized-composer.json.tmp
 /wp-config.php.tmp
+/composer.local.json

--- a/webservers/graphql-api-for-wp/composer.json
+++ b/webservers/graphql-api-for-wp/composer.json
@@ -55,22 +55,19 @@
             "lando rebuild appserver -y"
         ],
         "symlink-vendor-for-graphql-api-for-wp-plugin": [
-            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json', '../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json",
-            "composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp",
-            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json.tmp', '../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json');\""
+            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json', '../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.local.json');\"",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.local.json",
+            "COMPOSER=composer.local.json composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp"
         ],
         "symlink-vendor-for-graphql-api-convert-case-directives-plugin": [
-            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json', '../../layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json.tmp');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json",
-            "composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/convert-case-directives",
-            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json.tmp', '../../layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json');\""
+            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.json', '../../layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.local.json');\"",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/convert-case-directives/composer.local.json",
+            "COMPOSER=composer.local.json composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/convert-case-directives"
         ],
         "symlink-vendor-for-graphql-api-events-manager-plugin": [
-            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/events-manager/composer.json', '../../layers/GraphQLAPIForWP/plugins/events-manager/composer.json.tmp');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/events-manager/composer.json",
-            "composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/events-manager",
-            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/events-manager/composer.json.tmp', '../../layers/GraphQLAPIForWP/plugins/events-manager/composer.json');\""
+            "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/events-manager/composer.json', '../../layers/GraphQLAPIForWP/plugins/events-manager/composer.local.json');\"",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/events-manager/composer.local.json",
+            "COMPOSER=composer.local.json composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/events-manager"
         ],
         "log-server-errors": "lando logs -t -f | grep \"php:error\"",
         "log-server-warnings": "lando logs -t -f | grep \"php:warn\"",

--- a/webservers/graphql-by-pop/.gitignore
+++ b/webservers/graphql-by-pop/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 /wordpress/
 /defaults.local.env
-/localized-composer.json.tmp
 /wp-config.php.tmp
+/composer.local.json
+/composer.local.json.tmp

--- a/webservers/graphql-by-pop/composer.json
+++ b/webservers/graphql-by-pop/composer.json
@@ -129,12 +129,10 @@
             "lando rebuild appserver -y"
         ],
         "symlink-vendor": [
-            "php -r \"copy('composer.json', 'composer.json.tmp');\"",
-            "php -r \"copy('composer.json', 'localized-composer.json.tmp');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package webservers/graphql-by-pop/localized-composer.json.tmp",
-            "sed -e 's#../../../../layers/#../../layers/#g' localized-composer.json.tmp > composer.json",
-            "composer update --no-dev",
-            "php -r \"copy('composer.json.tmp', 'composer.json');\""
+            "php -r \"copy('composer.json', 'composer.local.json.tmp');\"",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package webservers/graphql-by-pop/composer.local.json.tmp",
+            "sed -e 's#../../../../layers/#../../layers/#g' composer.local.json.tmp > composer.local.json",
+            "COMPOSER=composer.local.json composer update --no-dev"
         ],
         "log-server-errors": "lando logs -t -f | grep \"php:error\"",
         "log-server-warnings": "lando logs -t -f | grep \"php:warn\""

--- a/webservers/wassup/.gitignore
+++ b/webservers/wassup/.gitignore
@@ -1,5 +1,6 @@
 /vendor/
 /wordpress/
 /defaults.local.env
-/localized-composer.json.tmp
 /wp-config.php.tmp
+/composer.local.json
+/composer.local.json.tmp

--- a/webservers/wassup/composer.json
+++ b/webservers/wassup/composer.json
@@ -66,12 +66,10 @@
             "lando rebuild appserver -y"
         ],
         "symlink-vendor": [
-            "php -r \"copy('composer.json', 'composer.json.tmp');\"",
-            "php -r \"copy('composer.json', 'localized-composer.json.tmp');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package webservers/wassup/localized-composer.json.tmp",
-            "sed -e 's#../../../../layers/#../../layers/#g' localized-composer.json.tmp > composer.json",
-            "composer update --no-dev",
-            "php -r \"copy('composer.json.tmp', 'composer.json');\""
+            "php -r \"copy('composer.json', 'composer.local.json.tmp');\"",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package webservers/wassup/composer.local.json.tmp",
+            "sed -e 's#../../../../layers/#../../layers/#g' composer.local.json.tmp > composer.local.json",
+            "COMPOSER=composer.local.json composer update --no-dev"
         ],
         "log-server-errors": "lando logs -t -f | grep \"php:error\"",
         "log-server-warnings": "lando logs -t -f | grep \"php:warn\""


### PR DESCRIPTION
Passing environment variable `COMPOSER` to composer, we can switch to use `composer.local.json` for starting the development server, localizing it to symlink to the folders in the monorepo.