### PR TITLE
Execute JSON template last

### DIFF
--- a/layers/Engine/packages/engine-wp/src/Hooks/TemplateHookSet.php
+++ b/layers/Engine/packages/engine-wp/src/Hooks/TemplateHookSet.php
@@ -13,7 +13,9 @@ class TemplateHookSet extends AbstractHookSet
     {
         $this->hooksAPI->addFilter(
             'template_include',
-            [$this, 'setTemplate']
+            [$this, 'setTemplate'],
+            // Execute last
+            PHP_INT_MAX
         );
     }
     public function setTemplate(string $template): string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-htmlcssplatform-wp/library/functions/templates.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-htmlcssplatform-wp/library/functions/templates.php
@@ -11,5 +11,6 @@ HooksAPIFacade::getInstance()->addFilter(
 	    return $template;
 	},
 	// Priority: execute before PoP Engine
-	PHP_INT_MAX-1
+	// @todo Revise if this is still correct
+	PHP_INT_MAX - 1
 );

--- a/layers/SiteBuilder/packages/site-wp/src/Hooks/TemplateHookSet.php
+++ b/layers/SiteBuilder/packages/site-wp/src/Hooks/TemplateHookSet.php
@@ -13,7 +13,9 @@ class TemplateHookSet extends AbstractHookSet
     {
         $this->hooksAPI->addFilter(
             'template_include',
-            [$this, 'setTemplate']
+            [$this, 'setTemplate'],
+            // Execute last
+            PHP_INT_MAX
         );
     }
     public function setTemplate(string $template): string


### PR DESCRIPTION
The `json.php` template to display the response the API must be set at the very end of hook `template_include`, to avoid Oxygen Page Builder (and potentially others) from overriding it.