### PR TITLE
Changed field `meta` to `metaValue` + `metaValues`

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-comment-meta.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-comment-meta.md
@@ -1,14 +1,14 @@
 # Schema Comment Meta
 
-Retrieve meta values for comments, by querying field `meta`.
+Retrieve meta values for comments, by querying fields `metaValue` and `metaValues`.
 
 For security reasons, which meta keys can be queried must be explicitly configured. By default, the list is empty.
 
-Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the `meta` field in the GraphQL schema) only if needed.
+Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the meta fields in the GraphQL schema) only if needed.
 
 ## How to use
 
-Query field `meta` on a comment, passing the required meta key as field argument `key`.
+Query fields `metaValue` and `metaValues` on a comment, passing the required meta key as field argument `key`.
 
 For instance, this query retrieves the comment's `description` meta value (as long as allowed by configuration):
 
@@ -18,7 +18,7 @@ For instance, this query retrieves the comment's `description` meta value (as lo
     id
     comments {
       id
-      description: meta(key: "description", single: true)
+      description: metaValue(key: "description")
     }
   }
 }
@@ -26,7 +26,7 @@ For instance, this query retrieves the comment's `description` meta value (as lo
 
 ## Configure the allowed meta keys
 
-In the "Schema Comment Meta" tab from the Settings, we must configure the list of meta keys that can be queried via `meta`.
+In the "Schema Comment Meta" tab from the Settings, we must configure the list of meta keys that can be queried via the meta fields.
 
 Each entry can either be:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-custompost-meta.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-custompost-meta.md
@@ -1,14 +1,14 @@
 # Schema Custom Post Meta
 
-Retrieve meta values for custom posts, by querying field `meta`.
+Retrieve meta values for custom posts, by querying fields `metaValue` and `metaValues`.
 
 For security reasons, which meta keys can be queried must be explicitly configured. By default, the list is empty.
 
-Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the `meta` field in the GraphQL schema) only if needed.
+Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the meta fields in the GraphQL schema) only if needed.
 
 ## How to use
 
-Query field `meta` on a custom post, passing the required meta key as field argument `key`.
+Query fields `metaValue` and `metaValues` on a custom post, passing the required meta key as field argument `key`.
 
 For instance, this query retrieves the post's `_edit_last` meta value (as long as allowed by configuration):
 
@@ -16,14 +16,14 @@ For instance, this query retrieves the post's `_edit_last` meta value (as long a
 {
   posts {
     id
-    editLast: meta(key: "_edit_last", single: true)
+    editLast: metaValue(key: "_edit_last")
   }
 }
 ```
 
 ## Configure the allowed meta keys
 
-In the "Schema Custom Post Meta" tab from the Settings, we must configure the list of meta keys that can be queried via `meta`.
+In the "Schema Custom Post Meta" tab from the Settings, we must configure the list of meta keys that can be queried via the meta fields.
 
 Each entry can either be:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-taxonomy-meta.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-taxonomy-meta.md
@@ -1,14 +1,14 @@
 # Schema Taxonomy Meta
 
-Retrieve meta values for taxonomies (i.e. tags and categories), by querying field `meta`.
+Retrieve meta values for taxonomies (i.e. tags and categories), by querying fields `metaValue` and `metaValues`.
 
 For security reasons, which meta keys can be queried must be explicitly configured. By default, the list is empty.
 
-Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the `meta` field in the GraphQL schema) only if needed.
+Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the meta fields in the GraphQL schema) only if needed.
 
 ## How to use
 
-Query field `meta` on a tag or category, passing the required meta key as field argument `key`.
+Query fields `metaValue` and `metaValues` on a tag or category, passing the required meta key as field argument `key`.
 
 For instance, this query retrieves the category's `description` meta value (as long as allowed by configuration):
 
@@ -18,7 +18,7 @@ For instance, this query retrieves the category's `description` meta value (as l
     id
     categories {
       id
-      description: meta(key: "description", single: true)
+      description: metaValue(key: "description")
     }
   }
 }
@@ -26,7 +26,7 @@ For instance, this query retrieves the category's `description` meta value (as l
 
 ## Configure the allowed meta keys
 
-In the "Schema Taxonomy Meta" tab from the Settings, we must configure the list of meta keys that can be queried via `meta`.
+In the "Schema Taxonomy Meta" tab from the Settings, we must configure the list of meta keys that can be queried via the meta fields.
 
 Each entry can either be:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-user-meta.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-user-meta.md
@@ -1,14 +1,14 @@
 # Schema User Meta
 
-Retrieve meta values for users, by querying field `meta`.
+Retrieve meta values for users, by querying fields `metaValue` and `metaValues`.
 
 For security reasons, which meta keys can be queried must be explicitly configured. By default, the list is empty.
 
-Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the `meta` field in the GraphQL schema) only if needed.
+Querying meta values is an expensive operation, requiring a call to the database per object and meta key, so enable this module (as to expose the meta fields in the GraphQL schema) only if needed.
 
 ## How to use
 
-Query field `meta` on a user, passing the required meta key as field argument `key`.
+Query fields `metaValue` and `metaValues` on a user, passing the required meta key as field argument `key`.
 
 For instance, this query retrieves the user's `last_name` meta value (as long as allowed by configuration):
 
@@ -16,14 +16,14 @@ For instance, this query retrieves the user's `last_name` meta value (as long as
 {
   users {
     id
-    lastName: meta(key: "last_name", single: true)
+    lastName: metaValue(key: "last_name")
   }
 }
 ```
 
 ## Configure the allowed meta keys
 
-In the "Schema User Meta" tab from the Settings, we must configure the list of meta keys that can be queried via `meta`.
+In the "Schema User Meta" tab from the Settings, we must configure the list of meta keys that can be queried via the meta fields.
 
 Each entry can either be:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.8.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.8.md
@@ -50,11 +50,16 @@ Menus have been mapped, via the new `Menu` type, and the new field `Root.menu`.
 
 Custom post, user, comment and taxonomy meta values can now be queried, via the new fields:
 
-- `Post.meta: Mixed`
-- `User.meta: Mixed`
-- `Comment.meta: Mixed`
-- `PostCategory.meta: Mixed`
-- `PostTag.meta: Mixed`
+- `Post.metaValue: Mixed`
+- `Post.metaValues: [Mixed]`
+- `User.metaValue: Mixed`
+- `User.metaValues: [Mixed]`
+- `Comment.metaValue: Mixed`
+- `Comment.metaValues: [Mixed]`
+- `PostCategory.metaValue: Mixed`
+- `PostCategory.metaValues: [Mixed]`
+- `PostTag.metaValue: Mixed`
+- `PostTag.metaValues: [Mixed]`
 
 For instance, this query retrieves the meta `last_name` for the users:
 
@@ -62,14 +67,14 @@ For instance, this query retrieves the meta `last_name` for the users:
 {
   users {
     id
-    lastName: meta(key: "last_name", single: true)
+    lastName: metaValue(key: "last_name")
   }
 }
 ```
 
 Since meta value can be anything (string, integer, float, boolean, array, or null) they have been mapped via the generic type `Mixed`.
 
-The modules adding field `meta` to the GraphQL schema are disabled by default, so they must be enabled:
+The modules adding the meta fields to the GraphQL schema are disabled by default, so they must be enabled:
 
 - Schema Custom Post Meta
 - Schema User Meta

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -376,25 +376,25 @@ class SchemaTypeModuleResolver extends AbstractSchemaTypeModuleResolver
             case self::SCHEMA_CUSTOMPOST_META:
                 return sprintf(
                     \__('Add the <code>%1$s</code> field to custom posts, such as type <code>%2$s</code>', 'graphql-api'),
-                    'meta',
+                    'metaValue',
                     $this->postTypeResolver->getTypeName()
                 );
             case self::SCHEMA_USER_META:
                 return sprintf(
                     \__('Add the <code>%1$s</code> field to type <code>%2$s</code>', 'graphql-api'),
-                    'meta',
+                    'metaValue',
                     $this->userTypeResolver->getTypeName()
                 );
             case self::SCHEMA_COMMENT_META:
                 return sprintf(
                     \__('Add the <code>%1$s</code> field to type <code>%2$s</code>', 'graphql-api'),
-                    'meta',
+                    'metaValue',
                     $this->commentTypeResolver->getTypeName()
                 );
             case self::SCHEMA_TAXONOMY_META:
                 return sprintf(
                     \__('Add the <code>%1$s</code> field to taxonomies, such as types <code>%2$s</code> and <code>%3$s</code>', 'graphql-api'),
-                    'meta',
+                    'metaValue',
                     $this->postTagTypeResolver->getTypeName(),
                     $this->postCategoryTypeResolver->getTypeName()
                 );

--- a/layers/Schema/packages/commentmeta/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/commentmeta/src/FieldResolvers/CommentFieldResolver.php
@@ -30,7 +30,8 @@ class CommentFieldResolver extends AbstractDBDataFieldResolver
     public function getFieldNamesToResolve(): array
     {
         return [
-            'meta',
+            'metaValue',
+            'metaValues',
         ];
     }
 
@@ -60,11 +61,12 @@ class CommentFieldResolver extends AbstractDBDataFieldResolver
         $commentMetaAPI = CommentMetaTypeAPIFacade::getInstance();
         $comment = $resultItem;
         switch ($fieldName) {
-            case 'meta':
+            case 'metaValue':
+            case 'metaValues':
                 return $commentMetaAPI->getCommentMeta(
                     $typeResolver->getID($comment),
                     $fieldArgs['key'],
-                    $fieldArgs['single']
+                    $fieldName === 'metaValue'
                 );
         }
 

--- a/layers/Schema/packages/custompostmeta/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmeta/src/FieldResolvers/CustomPostFieldResolver.php
@@ -30,7 +30,8 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
     public function getFieldNamesToResolve(): array
     {
         return [
-            'meta',
+            'metaValue',
+            'metaValues',
         ];
     }
 
@@ -60,11 +61,12 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         $customPostMetaAPI = CustomPostMetaTypeAPIFacade::getInstance();
         $customPost = $resultItem;
         switch ($fieldName) {
-            case 'meta':
+            case 'metaValue':
+            case 'metaValues':
                 return $customPostMetaAPI->getCustomPostMeta(
                     $typeResolver->getID($customPost),
                     $fieldArgs['key'],
-                    $fieldArgs['single']
+                    $fieldName === 'metaValue'
                 );
         }
 

--- a/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
+++ b/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace PoPSchema\Meta\FieldInterfaceResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
 
 class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
@@ -22,14 +23,16 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
     public function getFieldNamesToImplement(): array
     {
         return [
-            'meta',
+            'metaValue',
+            'metaValues',
         ];
     }
 
     public function getSchemaFieldType(string $fieldName): ?string
     {
         $types = [
-            'meta' => SchemaDefinition::TYPE_MIXED,
+            'metaValue' => SchemaDefinition::TYPE_MIXED,
+            'metaValues' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
@@ -38,7 +41,8 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($fieldName);
         switch ($fieldName) {
-            case 'meta':
+            case 'metaValue':
+            case 'metaValues':
                 return array_merge(
                     $schemaFieldArgs,
                     [
@@ -47,12 +51,6 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The meta key', 'meta'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
-                        ],
-                        [
-                            SchemaDefinition::ARGNAME_NAME => 'single',
-                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_BOOL,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Whether to bring a single value', 'meta'),
-                            SchemaDefinition::ARGNAME_DEFAULT_VALUE => false,
                         ],
                     ]
                 );
@@ -64,7 +62,8 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
         $descriptions = [
-            'meta' => $this->translationAPI->__('Meta value', 'custompostmeta'),
+            'metaValue' => $this->translationAPI->__('Single meta value', 'custompostmeta'),
+            'metaValues' => $this->translationAPI->__('List of meta values', 'custompostmeta'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }

--- a/layers/Schema/packages/taxonomymeta/src/FieldResolvers/TaxonomyFieldResolver.php
+++ b/layers/Schema/packages/taxonomymeta/src/FieldResolvers/TaxonomyFieldResolver.php
@@ -30,7 +30,8 @@ class TaxonomyFieldResolver extends AbstractDBDataFieldResolver
     public function getFieldNamesToResolve(): array
     {
         return [
-            'meta',
+            'metaValue',
+            'metaValues',
         ];
     }
 
@@ -60,11 +61,12 @@ class TaxonomyFieldResolver extends AbstractDBDataFieldResolver
         $taxonomyMetaAPI = TaxonomyMetaTypeAPIFacade::getInstance();
         $taxonomy = $resultItem;
         switch ($fieldName) {
-            case 'meta':
+            case 'metaValue':
+            case 'metaValues':
                 return $taxonomyMetaAPI->getTaxonomyMeta(
                     $typeResolver->getID($taxonomy),
                     $fieldArgs['key'],
-                    $fieldArgs['single']
+                    $fieldName === 'metaValue'
                 );
         }
 

--- a/layers/Schema/packages/usermeta/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/usermeta/src/FieldResolvers/UserFieldResolver.php
@@ -30,7 +30,8 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
     public function getFieldNamesToResolve(): array
     {
         return [
-            'meta',
+            'metaValue',
+            'metaValues',
         ];
     }
 
@@ -60,11 +61,12 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         $userMetaAPI = UserMetaTypeAPIFacade::getInstance();
         $user = $resultItem;
         switch ($fieldName) {
-            case 'meta':
+            case 'metaValue':
+            case 'metaValues':
                 return $userMetaAPI->getUserMeta(
                     $typeResolver->getID($user),
                     $fieldArgs['key'],
-                    $fieldArgs['single']
+                    $fieldName === 'metaValue'
                 );
         }
 


### PR DESCRIPTION
Instead of a single `meta` field that can return both array or single values, as defined via the `single` field argument, for GraphQL it makes more sense to have 2 fields, with `metaValue` returning `Mixed`, and `metaValues` returning `[Mixed]`.