### PR TITLE
Install importer-plugin last in Lando

### DIFF
--- a/webservers/graphql-api-for-wp/.lando.yml
+++ b/webservers/graphql-api-for-wp/.lando.yml
@@ -290,15 +290,15 @@ services:
       - cp assets/.htaccess wordpress
       - wp rewrite structure '/%postname%/' --hard --path=wordpress
       - wp plugin activate graphql-api --path=wordpress
-      - wp plugin install wordpress-importer --activate --path=wordpress
-      - >-
-        wp import assets/graphql-api-sample-data.xml --authors=create
-        --path=wordpress
       - >-
         sed 's/__DIR__/dirname(__DIR__)/' wordpress/index.php >
         wordpress/Schema/index.php
       - cp wordpress/Schema/index.php wordpress/API/index.php
       - cp wordpress/Schema/index.php wordpress/Engine/index.php
       - cp wordpress/Schema/index.php wordpress/GraphQLByPoP/index.php
+      - wp plugin install wordpress-importer --activate --path=wordpress
+      - >-
+        wp import assets/graphql-api-sample-data.xml --authors=create
+        --path=wordpress
 env_file:
   - ../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/lando/defaults.env


### PR DESCRIPTION
Because of the [IPv6 error happening in Lando](https://github.com/lando/lando/issues/2913), after executing this line in `.lando.yml`, the installation fails:

```yml
wp plugin install wordpress-importer --activate --path=wordpress
```

So move it to the bottom, so that everything else is executed (after it fails, the script halts execution)
