### PR TITLE
Validate main plugin version when registering an extension

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
+++ b/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
@@ -39,6 +39,7 @@ add_action('plugins_loaded', function (): void {
      */
     $extensionVersion = '0.8.0';
     $extensionName = \__('GraphQL API - Extension Demo', 'graphql-api-extension-demo');
+    $mainPluginVersionConstraint = '^0.8';
     
     /**
      * Validate the GraphQL API plugin is active
@@ -61,7 +62,9 @@ add_action('plugins_loaded', function (): void {
 
     if (ExtensionManager::assertIsValid(
         GraphQLAPIExtension::class,
-        $extensionVersion
+        $extensionVersion,
+        $extensionName,
+        $mainPluginVersionConstraint
     )) {
         // Load Composer’s autoloader
         require_once(__DIR__ . '/vendor/autoload.php');

--- a/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
+++ b/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
@@ -59,7 +59,7 @@ add_action('plugins_loaded', function (): void {
         return;
     }
 
-    if (ExtensionManager::assertNotRegistered(
+    if (ExtensionManager::assertIsValid(
         GraphQLAPIExtension::class,
         $extensionVersion
     )) {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/graphql-api.php
@@ -36,7 +36,7 @@ $pluginName = __('GraphQL API for WordPress', 'graphql-api');
 /**
  * If the plugin is already registered, print an error and halt loading
  */
-if (class_exists(Plugin::class) && !MainPluginManager::assertNotRegistered($pluginVersion)) {
+if (class_exists(Plugin::class) && !MainPluginManager::assertIsValid($pluginVersion)) {
     return;
 }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\PluginManagement;
 
+use Composer\Semver\Semver;
 use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractExtension;
 
 class ExtensionManager extends AbstractPluginManager
@@ -39,13 +40,24 @@ class ExtensionManager extends AbstractPluginManager
     }
 
     /**
-     * Validate that the extension is not registered yet.
-     * If it is, print an error and return false
+     * Validate that the extension can be registered:
+     * 
+     * 1. It hasn't been registered yet (eg: the plugin is not duplicated)
+     * 2. The required version of the main plugin is the one installed
+     * 
+     * If the assertion fails, it prints an error on the WP admin and returns false
+     * 
+     * @param $mainPluginVersionConstraint the semver version constraint required for the plugin (eg: "^1.0" means >=1.0.0 and <2.0.0)
+     * @return `true` if the extension can be registered, `false` otherwise
+     * @see https://getcomposer.org/doc/articles/versions.md#versions-and-constraints
      */
     public static function assertIsValid(
         string $extensionClass,
-        string $extensionVersion
+        string $extensionVersion,
+        ?string $extensionName = null,
+        ?string $mainPluginVersionConstraint = null,
     ): bool {
+        // Validate that the extension is not registered yet.
         if (isset(self::$extensionClassInstances[$extensionClass])) {
             self::printAdminNoticeErrorMessage(
                 sprintf(
@@ -53,6 +65,23 @@ class ExtensionManager extends AbstractPluginManager
                     self::$extensionClassInstances[$extensionClass]->getConfig('name'),
                     self::$extensionClassInstances[$extensionClass]->getConfig('version'),
                     $extensionVersion,
+                )
+            );
+            return false;
+        }
+
+        // Validate that the required version of the GraphQL API for WP plugin is installed
+        if ($mainPluginVersionConstraint !== null && !Semver::satisfies(
+            MainPluginManager::getConfig('version'),
+            $mainPluginVersionConstraint
+        )) {
+            self::printAdminNoticeErrorMessage(
+                sprintf(
+                    __('Extension <strong>%s</strong> requires plugin <strong>%s</strong> to satisfy version constraint <code>%s</code>, but the current version <code>%s</code> does not. The extension has not been loaded.', 'graphql-api'),
+                    $extensionName ?? $extensionClass,
+                    MainPluginManager::getConfig('name'),
+                    $mainPluginVersionConstraint,
+                    MainPluginManager::getConfig('version'),
                 )
             );
             return false;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
@@ -42,7 +42,7 @@ class ExtensionManager extends AbstractPluginManager
      * Validate that the extension is not registered yet.
      * If it is, print an error and return false
      */
-    public static function assertNotRegistered(
+    public static function assertIsValid(
         string $extensionClass,
         string $extensionVersion
     ): bool {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
@@ -62,7 +62,7 @@ class ExtensionManager extends AbstractPluginManager
             self::printAdminNoticeErrorMessage(
                 sprintf(
                     __('Extension <strong>%s</strong> is already installed with version <code>%s</code>, so version <code>%s</code> has not been loaded. Please deactivate all versions, remove the older version, and activate again the latest version of the plugin.', 'graphql-api'),
-                    self::$extensionClassInstances[$extensionClass]->getConfig('name'),
+                    $extensionName ?? self::$extensionClassInstances[$extensionClass]->getConfig('name'),
                     self::$extensionClassInstances[$extensionClass]->getConfig('version'),
                     $extensionVersion,
                 )

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/MainPluginManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/MainPluginManager.php
@@ -20,7 +20,7 @@ class MainPluginManager extends AbstractPluginManager
      * Validate that the plugin is not registered yet.
      * If it is, print an error and return false
      */
-    public static function assertNotRegistered(
+    public static function assertIsValid(
         string $pluginVersion
     ): bool {
         if (self::$mainPlugin !== null) {


### PR DESCRIPTION
Pass the semver constraint required for the main plugin, when installing an extension:

```php
// Main plugin must have version: >= 1.1.0 and < 2.0.0
$mainPluginVersionConstraint = '^1.1';

ExtensionManager::assertIsValid(
  GraphQLAPIExtension::class,
  $extensionVersion,
  $extensionName,
  $mainPluginVersionConstraint // Pass here
)
```

If the version constraint is not satisfied, the extension is not loaded, and an error notice is shown in the wp-admin:

![Screenshot 2021-06-10 at 13-22-18 Plugins ‹ GraphQL API — WordPress](https://user-images.githubusercontent.com/1981996/121469378-f719e180-c9ee-11eb-8649-06b279e75272.png)
