### PR TITLE
Make `getSchemaFieldType` non-nullable

### DIFF
--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -32,7 +32,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'fullSchema' => SchemaDefinition::TYPE_OBJECT,

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -888,9 +888,14 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                 $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATIONDESCRIPTION] = $deprecationDescription;
             }
             if ($args = $schemaDefinitionResolver->getFilteredSchemaDirectiveArgs($typeResolver)) {
-                // Add the args under their name
+                // Add the args under their name.
+                // Watch out: the name is mandatory!
+                // If it hasn't been set, then skip the entry
                 $nameArgs = [];
                 foreach ($args as $arg) {
+                    if (!isset($arg[SchemaDefinition::ARGNAME_NAME])) {
+                        continue;
+                    }
                     $nameArgs[$arg[SchemaDefinition::ARGNAME_NAME]] = $arg;
                 }
                 $schemaDefinition[SchemaDefinition::ARGNAME_ARGS] = $nameArgs;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -26,7 +26,7 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
         ];
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
             'id' => SchemaDefinition::TYPE_ID,

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -7,7 +7,7 @@ namespace PoP\ComponentModel\FieldInterfaceResolvers;
 interface FieldInterfaceSchemaDefinitionResolverInterface
 {
     public function getFieldNamesToResolve(): array;
-    public function getSchemaFieldType(string $fieldName): ?string;
+    public function getSchemaFieldType(string $fieldName): string;
     public function isSchemaFieldResponseNonNullable(string $fieldName): bool;
     public function getSchemaFieldDescription(string $fieldName): ?string;
     public function getSchemaFieldArgs(string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -19,7 +19,7 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         return null;
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
             return $schemaDefinitionResolver->getSchemaFieldType($fieldName);

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -6,6 +6,7 @@ namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
 
 trait FieldInterfaceSchemaDefinitionResolverTrait
 {
@@ -24,7 +25,8 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
             return $schemaDefinitionResolver->getSchemaFieldType($fieldName);
         }
-        return null;
+        // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
+        return SchemaDefinition::TYPE_MIXED;
     }
 
     public function isSchemaFieldResponseNonNullable(string $fieldName): bool

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
+use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 
 trait FieldInterfaceSchemaDefinitionResolverTrait
 {
@@ -25,8 +25,9 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
             return $schemaDefinitionResolver->getSchemaFieldType($fieldName);
         }
-        // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
-        return SchemaDefinition::TYPE_MIXED;
+        
+        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
+        return $schemaDefinitionService->getDefaultType();
     }
 
     public function isSchemaFieldResponseNonNullable(string $fieldName): bool

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -21,7 +21,7 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
         return $this;
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
         return SchemaDefinition::TYPE_MIXED;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
 
@@ -23,8 +22,8 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
 
     public function getSchemaFieldType(string $fieldName): string
     {
-        // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
-        return SchemaDefinition::TYPE_MIXED;
+        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
+        return $schemaDefinitionService->getDefaultType();
     }
 
     public function isSchemaFieldResponseNonNullable(string $fieldName): bool

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -284,9 +284,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
 
             // If we found a resolver for this fieldName, get all its properties from it
             if ($schemaDefinitionResolver) {
-                if ($type = $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName)) {
-                    $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $type;
-                }
+                $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName);
                 if ($schemaDefinitionResolver->isSchemaFieldResponseNonNullable($typeResolver, $fieldName)) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] = true;
                 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -296,9 +296,14 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                     $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATIONDESCRIPTION] = $deprecationDescription;
                 }
                 if ($args = $schemaDefinitionResolver->getFilteredSchemaFieldArgs($typeResolver, $fieldName)) {
-                    // Add the args under their name
+                    // Add the args under their name.
+                    // Watch out: the name is mandatory!
+                    // If it hasn't been set, then skip the entry
                     $nameArgs = [];
                     foreach ($args as $arg) {
+                        if (!isset($arg[SchemaDefinition::ARGNAME_NAME])) {
+                            continue;
+                        }
                         $nameArgs[$arg[SchemaDefinition::ARGNAME_NAME]] = $arg;
                     }
                     $schemaDefinition[SchemaDefinition::ARGNAME_ARGS] = $nameArgs;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
@@ -116,7 +116,7 @@ abstract class AbstractReflectionPropertyFieldResolver extends AbstractDBDataFie
         );
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         // TODO: If we are running PHP 7.4, the properties may be typed,
         // so we can already get the type through reflection. Implement this!

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -190,7 +190,7 @@ trait AliasSchemaFieldResolverTrait
      * Proxy pattern: execute same function on the aliased FieldResolver,
      * for the aliased $fieldName
      */
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
         return $aliasedFieldResolver->getSchemaFieldType(

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -21,7 +21,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'typeName' => SchemaDefinition::TYPE_STRING,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -34,7 +34,7 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'id' => SchemaDefinition::TYPE_ID,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -10,7 +10,7 @@ interface FieldSchemaDefinitionResolverInterface
 {
     public function getFieldNamesToResolve(): array;
     public function getAdminFieldNames(): array;
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string;
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string;
     public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool;
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string;
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -20,7 +20,7 @@ trait FieldSchemaDefinitionResolverTrait
         return null;
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
             return $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName);

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
+use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
 use PoP\ComponentModel\Schema\SchemaDefinition;
@@ -26,8 +27,8 @@ trait FieldSchemaDefinitionResolverTrait
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
             return $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName);
         }
-        // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
-        return SchemaDefinition::TYPE_MIXED;
+        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
+        return $schemaDefinitionService->getDefaultType();
     }
 
     public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait FieldSchemaDefinitionResolverTrait
 {
@@ -25,7 +26,8 @@ trait FieldSchemaDefinitionResolverTrait
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
             return $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName);
         }
-        return null;
+        // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
+        return SchemaDefinition::TYPE_MIXED;
     }
 
     public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -21,7 +21,7 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return $this;
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
         return SchemaDefinition::TYPE_MIXED;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait SelfFieldSchemaDefinitionResolverTrait
 {
@@ -23,8 +24,8 @@ trait SelfFieldSchemaDefinitionResolverTrait
 
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
-        // By default, it can be of any type. Return this instead of null since the type is mandatory for GraphQL, so we avoid its non-implementation by the developer to throw errors
-        return SchemaDefinition::TYPE_MIXED;
+        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
+        return $schemaDefinitionService->getDefaultType();
     }
 
     public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsSchemaFilterInputModuleProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsSchemaFilterInputModuleProcessorInterface.php
@@ -6,7 +6,7 @@ namespace PoP\ComponentModel\ModuleProcessors;
 
 interface DataloadQueryArgsSchemaFilterInputModuleProcessorInterface
 {
-    public function getSchemaFilterInputType(array $module): ?string;
+    public function getSchemaFilterInputType(array $module): string;
     public function getSchemaFilterInputDescription(array $module): ?string;
     public function getSchemaFilterInputDeprecationDescription(array $module): ?string;
     public function getSchemaFilterInputMandatory(array $module): bool;

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
@@ -41,9 +41,7 @@ trait FilterInputModuleProcessorTrait
             SchemaDefinition::ARGNAME_NAME => $this->getName($module),
         ];
         if ($filterSchemaDefinitionResolver = $this->getFilterInputSchemaDefinitionResolver($module)) {
-            if ($type = $filterSchemaDefinitionResolver->getSchemaFilterInputType($module)) {
-                $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $type;
-            }
+            $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $filterSchemaDefinitionResolver->getSchemaFilterInputType($module);
             if ($description = $filterSchemaDefinitionResolver->getSchemaFilterInputDescription($module)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $description;
             }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/SchemaFilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/SchemaFilterInputModuleProcessorTrait.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ModuleProcessors;
 
+use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
+
 trait SchemaFilterInputModuleProcessorTrait
 {
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
-        return null;
+        return $this->getDefaultSchemaFilterInputType();
+    }
+    protected function getDefaultSchemaFilterInputType(): string
+    {
+        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
+        return $schemaDefinitionService->getDefaultType();
     }
     public function getSchemaFilterInputDescription(array $module): ?string
     {

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -39,7 +39,7 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return [];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         return $this->fieldInterfaceResolver->getSchemaFieldType($fieldName);
     }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionService.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionService.php
@@ -19,4 +19,12 @@ class SchemaDefinitionService implements SchemaDefinitionServiceInterface
         // By default, use the type name
         return $typeResolver->getMaybeNamespacedTypeName();
     }
+    /**
+     * The `mixed` type is a wildcard type,
+     * representing *any* type (string, int, bool, etc)
+     */
+    public function getDefaultType(): string
+    {
+        return SchemaDefinition::TYPE_MIXED;
+    }
 }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionServiceInterface.php
@@ -11,4 +11,9 @@ interface SchemaDefinitionServiceInterface
 {
     public function getInterfaceSchemaKey(FieldInterfaceResolverInterface $interfaceResolver): string;
     public function getTypeSchemaKey(TypeResolverInterface $typeResolver): string;
+    /**
+     * Field types, and field/directive argument types are mandatory.
+     * When not defined, the default type will be used.
+     */
+    public function getDefaultType(): string;
 }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -43,7 +43,7 @@ class SchemaHelpers
         return array_filter(
             $schemaFieldArgs,
             function ($schemaFieldArg) {
-                return isset($schemaFieldArg[SchemaDefinition::ARGNAME_TYPE]) && $schemaFieldArg[SchemaDefinition::ARGNAME_TYPE] == SchemaDefinition::TYPE_ENUM;
+                return ($schemaFieldArg[SchemaDefinition::ARGNAME_TYPE] ?? null) == SchemaDefinition::TYPE_ENUM;
             }
         );
     }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -42,9 +42,7 @@ class SchemaHelpers
     {
         return array_filter(
             $schemaFieldArgs,
-            function ($schemaFieldArg) {
-                return ($schemaFieldArg[SchemaDefinition::ARGNAME_TYPE] ?? null) == SchemaDefinition::TYPE_ENUM;
-            }
+            fn ($schemaFieldArg) => ($schemaFieldArg[SchemaDefinition::ARGNAME_TYPE] ?? null) == SchemaDefinition::TYPE_ENUM
         );
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1416,8 +1416,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
 
     protected function processFlatShapeSchemaDefinition(array $options = [])
     {
-        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
-        $typeSchemaKey = $schemaDefinitionService->getTypeSchemaKey($this);
+        $typeSchemaKey = $this->schemaDefinitionService->getTypeSchemaKey($this);
 
         // By now, we have the schema definition
         if (isset($this->schemaDefinition[$typeSchemaKey][SchemaDefinition::ARGNAME_CONNECTIONS])) {
@@ -1434,8 +1433,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
 
     public function getSchemaDefinition(array $stackMessages, array &$generalMessages, array $options = []): array
     {
-        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
-        $typeSchemaKey = $schemaDefinitionService->getTypeSchemaKey($this);
+        $typeSchemaKey = $this->schemaDefinitionService->getTypeSchemaKey($this);
 
         // Stop recursion
         $class = get_called_class();
@@ -1483,8 +1481,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
 
     protected function addSchemaDefinition(array $stackMessages, array &$generalMessages, array $options = [])
     {
-        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
-        $typeSchemaKey = $schemaDefinitionService->getTypeSchemaKey($this);
+        $typeSchemaKey = $this->schemaDefinitionService->getTypeSchemaKey($this);
         $typeName = $this->getMaybeNamespacedTypeName();
         $this->schemaDefinition[$typeSchemaKey][SchemaDefinition::ARGNAME_NAME] = $typeName;
         $this->schemaDefinition[$typeSchemaKey][SchemaDefinition::ARGNAME_NAMESPACED_NAME] = $this->getNamespacedTypeName();
@@ -1510,10 +1507,9 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         }
 
         // Add all the implemented interfaces
-        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
         $typeInterfaceDefinitions = [];
         foreach ($this->getAllImplementedInterfaceResolverInstances() as $interfaceInstance) {
-            $interfaceSchemaKey = $schemaDefinitionService->getInterfaceSchemaKey($interfaceInstance);
+            $interfaceSchemaKey = $this->schemaDefinitionService->getInterfaceSchemaKey($interfaceInstance);
 
             // Conveniently get the fields from the schema, which have already been calculated above
             // since they also include their interface fields
@@ -1681,8 +1677,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         if ($isConnection) {
             unset($fieldSchemaDefinition[SchemaDefinition::ARGNAME_RELATIONAL]);
         }
-        $schemaDefinitionService = SchemaDefinitionServiceFacade::getInstance();
-        $typeSchemaKey = $schemaDefinitionService->getTypeSchemaKey($this);
+        $typeSchemaKey = $this->schemaDefinitionService->getTypeSchemaKey($this);
         $this->schemaDefinition[$typeSchemaKey][$entry][$fieldName] = $fieldSchemaDefinition;
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -14,7 +14,6 @@ use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\ComponentModel\ErrorHandling\ErrorProviderInterface;
 use PoP\ComponentModel\Facades\AttachableExtensions\AttachableExtensionManagerFacade;
 use PoP\ComponentModel\Facades\Engine\DataloadingEngineFacade;
-use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
 use PoP\ComponentModel\FieldResolvers\FieldResolverInterface;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers;
 
-use Exception;
 use League\Pipeline\PipelineBuilder;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
 use PoP\ComponentModel\ComponentConfiguration;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -24,6 +24,7 @@ use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\Schema\SchemaHelpers;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolverDecorators\TypeResolverDecoratorInterface;
@@ -110,7 +111,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         protected InstanceManagerInterface $instanceManager,
         protected FeedbackMessageStoreInterface $feedbackMessageStore,
         protected FieldQueryInterpreterInterface $fieldQueryInterpreter,
-        protected ErrorProviderInterface $errorProvider
+        protected ErrorProviderInterface $errorProvider,
+        protected SchemaDefinitionServiceInterface $schemaDefinitionService,
     ) {
     }
 
@@ -1647,14 +1649,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         }
         // Convert the field type from its internal representation (eg: "array:id") to the type (eg: "array:Post")
         if ($options['useTypeName'] ?? null) {
-            $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? null;
-            // The type is mandatory. If not provided, throw an error
-            if ($type === null) {
-                throw new Exception(sprintf(
-                    $this->translationAPI->__('The field schema definition must always declare a type. Missing in \'%s\'', 'component-model'),
-                    \json_encode($fieldSchemaDefinition)
-                ));
-            }
+            // The type is mandatory. If not provided, use the default one
+            $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? $this->schemaDefinitionService->getDefaultType();
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::convertTypeIDToTypeName($type, $this, $fieldName);
         } else {
             // Display the type under entry "referencedType"

--- a/layers/Engine/packages/engine/src/ConditionalOnContext/Guzzle/SchemaServices/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnContext/Guzzle/SchemaServices/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -20,7 +20,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'getJSON' => SchemaDefinition::TYPE_OBJECT,

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -19,7 +19,7 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'getSelfProp' => SchemaDefinition::TYPE_MIXED,

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -39,7 +39,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'if' => SchemaDefinition::TYPE_MIXED,

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -33,7 +33,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'concat' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/CPTFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/CPTFieldResolver.php
@@ -51,7 +51,7 @@ class CPTFieldResolver extends AbstractQueryableFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $ret = match($fieldName) {
             'accessControlLists' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/EmbeddableFields/SchemaServices/FieldResolvers/EchoOperatorGlobalFieldResolver.php
@@ -47,7 +47,7 @@ class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
     /**
      * Change the type from mixed to string
      */
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'echoStr' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -29,7 +29,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'exportedVariables' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_MIXED),

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -33,7 +33,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'name' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -26,7 +26,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'name' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -42,7 +42,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return $fieldName == 'name' && isset($fieldArgs['namespaced']);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'name' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -32,7 +32,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'name' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -17,7 +17,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             '__typename' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -27,7 +27,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'name' => SchemaDefinition::TYPE_STRING,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
@@ -54,7 +54,7 @@ class RegisterQueryAndMutationRootsRootFieldResolver extends AbstractDBDataField
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'queryRoot' => SchemaDefinition::TYPE_ID,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -35,7 +35,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             '__schema' => SchemaDefinition::TYPE_ID,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -31,7 +31,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'queryType' => SchemaDefinition::TYPE_ID,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -46,7 +46,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'kind' => SchemaDefinition::TYPE_ENUM,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -353,12 +353,11 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     protected function introduceSDLNotationToFieldSchemaDefinition(array $fieldSchemaDefinitionPath): void
     {
         $fieldSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinition, $fieldSchemaDefinitionPath);
-        if ($type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? null) {
-            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
-                $type,
-                $fieldSchemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] ?? null
-            );
-        }
+        $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+        $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
+            $type,
+            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] ?? null
+        );
         $this->introduceSDLNotationToFieldOrDirectiveArgs($fieldSchemaDefinitionPath);
     }
     protected function introduceSDLNotationToFieldOrDirectiveArgs(array $fieldOrDirectiveSchemaDefinitionPath): void
@@ -368,14 +367,13 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
         // Also for the fieldOrDirective arguments
         if ($fieldOrDirectiveArgs = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? null) {
             foreach ($fieldOrDirectiveArgs as $fieldOrDirectiveArgName => $fieldOrDirectiveArgSchemaDefinition) {
-                if ($type = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? null) {
-                    $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema($type, $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null);
-                    // If it is an input object, it may have its own args to also convert
-                    if ($type == SchemaDefinition::TYPE_INPUT_OBJECT) {
-                        foreach (($fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? []) as $inputFieldArgName => $inputFieldArgDefinition) {
-                            $inputFieldType = $inputFieldArgDefinition[SchemaDefinition::ARGNAME_TYPE];
-                            $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_ARGS][$inputFieldArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema($inputFieldType, $inputFieldArgDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null);
-                        }
+                $type = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+                $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema($type, $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null);
+                // If it is an input object, it may have its own args to also convert
+                if ($type == SchemaDefinition::TYPE_INPUT_OBJECT) {
+                    foreach (($fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? []) as $inputFieldArgName => $inputFieldArgDefinition) {
+                        $inputFieldType = $inputFieldArgDefinition[SchemaDefinition::ARGNAME_TYPE];
+                        $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_ARGS][$inputFieldArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema($inputFieldType, $inputFieldArgDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null);
                     }
                 }
             }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\Registries;
 
-use Exception;
 use GraphQLByPoP\GraphQLQuery\ComponentConfiguration as GraphQLQueryComponentConfiguration;
 use GraphQLByPoP\GraphQLQuery\Schema\SchemaElements;
 use GraphQLByPoP\GraphQLServer\Cache\CacheTypes;
@@ -25,6 +24,7 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\Translation\TranslationAPIInterface;
 
 class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegistryInterface
 {
@@ -42,6 +42,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     protected array $dynamicTypes = [];
 
     public function __construct(
+        protected TranslationAPIInterface $translationAPI,
         protected SchemaDefinitionServiceInterface $schemaDefinitionService,
     ) {
     }
@@ -399,12 +400,11 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
         if (isset($vars['edit-schema']) && $vars['edit-schema']) {
             $directiveSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinition, $directiveSchemaDefinitionPath);
             if ($directiveSchemaDefinition[SchemaDefinition::ARGNAME_DIRECTIVE_TYPE] == DirectiveTypes::SCHEMA) {
-                $translationAPI = TranslationAPIFacade::getInstance();
                 $directiveSchemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = sprintf(
-                    $translationAPI->__('%s %s', 'graphql-server'),
+                    $this->translationAPI->__('%s %s', 'graphql-server'),
                     sprintf(
                         '_%s_', // Make it italic using markdown
-                        $translationAPI->__('("Schema" type directive)', 'graphql-server')
+                        $this->translationAPI->__('("Schema" type directive)', 'graphql-server')
                     ),
                     $directiveSchemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION]
                 );
@@ -419,11 +419,10 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     {
         $fieldOrDirectiveSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinition, $fieldOrDirectiveSchemaDefinitionPath);
         if ($schemaFieldVersion = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_VERSION] ?? null) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] .= sprintf(
                 sprintf(
-                    $translationAPI->__(' _%s_', 'graphql-server'), // Make it italic using markdown
-                    $translationAPI->__('(Version: %s)', 'graphql-server')
+                    $this->translationAPI->__(' _%s_', 'graphql-server'), // Make it italic using markdown
+                    $this->translationAPI->__('(Version: %s)', 'graphql-server')
                 ),
                 $schemaFieldVersion
             );
@@ -435,13 +434,12 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
      */
     protected function addNestedDirectiveDataToSchemaDirectiveArgs(array $directiveSchemaDefinitionPath): void
     {
-        $translationAPI = TranslationAPIFacade::getInstance();
         $directiveSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinition, $directiveSchemaDefinitionPath);
         $directiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ??= [];
         $directiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][] = [
             SchemaDefinition::ARGNAME_NAME => SchemaElements::DIRECTIVE_PARAM_NESTED_UNDER,
             SchemaDefinition::ARGNAME_TYPE => GraphQLServerSchemaDefinition::TYPE_INT,
-            SchemaDefinition::ARGNAME_DESCRIPTION => $translationAPI->__('Nest the directive under another one, indicated as a relative position from this one (a negative int)', 'graphql-server'),
+            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Nest the directive under another one, indicated as a relative position from this one (a negative int)', 'graphql-server'),
         ];
     }
 
@@ -452,9 +450,8 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     {
         $fieldSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinition, $fieldSchemaDefinitionPath);
         if ($fieldSchemaDefinition[SchemaDefinition::ARGNAME_FIELD_IS_MUTATION] ?? null) {
-            $translationAPI = TranslationAPIFacade::getInstance();
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = sprintf(
-                $translationAPI->__('[Mutation] %s', 'graphql-server'),
+                $this->translationAPI->__('[Mutation] %s', 'graphql-server'),
                 $fieldSchemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION]
             );
         }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -23,7 +23,6 @@ use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\State\ApplicationState;
-use PoP\Translation\Facades\TranslationAPIFacade;
 use PoP\Translation\TranslationAPIInterface;
 
 class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegistryInterface

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -28,7 +28,7 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'blockMetadata' => SchemaDefinition::TYPE_OBJECT,

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -30,7 +30,7 @@ class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'content' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCategoryFieldResolver.php
@@ -33,7 +33,7 @@ abstract class AbstractCategoryFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'url' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -26,7 +26,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'categories' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
@@ -60,7 +60,7 @@ class CommentFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'reply' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'addComment' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -40,7 +40,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'addCommentToCustomPost' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/CommentUserFieldResolver.php
+++ b/layers/Schema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/CommentUserFieldResolver.php
@@ -50,7 +50,7 @@ class CommentUserFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'author' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -31,7 +31,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
         ];
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
             'areCommentsOpen' => SchemaDefinition::TYPE_BOOL,

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -65,7 +65,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'content' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/comments/src/TypeResolvers/CommentTypeResolver.php
+++ b/layers/Schema/packages/comments/src/TypeResolvers/CommentTypeResolver.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\ErrorHandling\ErrorProviderInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
@@ -23,6 +24,7 @@ class CommentTypeResolver extends AbstractTypeResolver
         FeedbackMessageStoreInterface $feedbackMessageStore,
         FieldQueryInterpreterInterface $fieldQueryInterpreter,
         ErrorProviderInterface $errorProvider,
+        SchemaDefinitionServiceInterface $schemaDefinitionService,
         protected CommentTypeAPIInterface $commentTypeAPI,
     ) {
         parent::__construct(
@@ -31,7 +33,8 @@ class CommentTypeResolver extends AbstractTypeResolver
             $instanceManager,
             $feedbackMessageStore,
             $fieldQueryInterpreter,
-            $errorProvider
+            $errorProvider,
+            $schemaDefinitionService,
         );
     }
 

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -39,7 +39,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'setCategories' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
@@ -44,7 +44,7 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             $this->getSetCategoriesFieldName() => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/custompost-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -27,7 +27,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'update' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -39,7 +39,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'setTags' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
@@ -44,7 +44,7 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             $this->getSetTagsFieldName() => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -63,7 +63,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'setFeaturedImage' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -67,7 +67,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'setFeaturedImageOnCustomPost' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -28,7 +28,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
         ];
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
             'hasFeaturedImage' => SchemaDefinition::TYPE_BOOL,

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -50,7 +50,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
         );
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
             'content' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'customPosts' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -55,7 +55,7 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'customPost' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/customposts/src/ModuleProcessors/FormInputs/FilterInputModuleProcessor.php
+++ b/layers/Schema/packages/customposts/src/ModuleProcessors/FormInputs/FilterInputModuleProcessor.php
@@ -71,14 +71,14 @@ class FilterInputModuleProcessor extends AbstractFormInputModuleProcessor implem
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_CUSTOMPOSTSTATUS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ENUM),
             self::MODULE_FILTERINPUT_GENERICPOSTTYPES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
             self::MODULE_FILTERINPUT_UNIONCUSTOMPOSTTYPES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function addSchemaDefinitionForFilter(array &$schemaDefinition, array $module): void

--- a/layers/Schema/packages/customposts/src/ModuleProcessors/FormInputs/FilterMultipleInputModuleProcessor.php
+++ b/layers/Schema/packages/customposts/src/ModuleProcessors/FormInputs/FilterMultipleInputModuleProcessor.php
@@ -62,12 +62,12 @@ class FilterMultipleInputModuleProcessor extends AbstractFormInputModuleProcesso
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_CUSTOMPOSTDATES => SchemaDefinition::TYPE_DATE,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/AbstractLocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/AbstractLocationFunctionalFieldResolver.php
@@ -24,7 +24,7 @@ abstract class AbstractLocationFunctionalFieldResolver extends AbstractFunctiona
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'locationsmapURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -28,7 +28,7 @@ class CatEventFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'catSlugs' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CommentsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CommentsCustomPostFieldResolver.php
@@ -25,7 +25,7 @@ class CommentsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'commentsURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -30,7 +30,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'hasLocation' => SchemaDefinition::TYPE_BOOL,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -27,7 +27,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'locations' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -33,7 +33,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'locations' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFunctionalFieldResolver.php
@@ -30,7 +30,7 @@ class EventFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'multilayoutKeys' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -27,7 +27,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'mapURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/QueryableObjectPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/QueryableObjectPostFieldResolver.php
@@ -26,7 +26,7 @@ class QueryableObjectPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'endpoint' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagFunctionalFieldResolver.php
@@ -27,7 +27,7 @@ class TagFunctionalFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'symbol' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -28,7 +28,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'tagNames' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -27,7 +27,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'locations' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'genericCustomPost' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -32,7 +32,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'highlights' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -27,7 +27,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'addhighlightURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -32,7 +32,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'title' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/MediaUserFieldResolver.php
+++ b/layers/Schema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/MediaUserFieldResolver.php
@@ -50,7 +50,7 @@ class MediaUserFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'author' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -53,7 +53,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'src' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -64,7 +64,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'mediaItems' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/media/src/TypeResolvers/MediaTypeResolver.php
+++ b/layers/Schema/packages/media/src/TypeResolvers/MediaTypeResolver.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\ErrorHandling\ErrorProviderInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
@@ -23,6 +24,7 @@ class MediaTypeResolver extends AbstractTypeResolver
         FeedbackMessageStoreInterface $feedbackMessageStore,
         FieldQueryInterpreterInterface $fieldQueryInterpreter,
         ErrorProviderInterface $errorProvider,
+        SchemaDefinitionServiceInterface $schemaDefinitionService,
         protected MediaTypeAPIInterface $mediaTypeAPI,
     ) {
         parent::__construct(
@@ -32,6 +34,7 @@ class MediaTypeResolver extends AbstractTypeResolver
             $feedbackMessageStore,
             $fieldQueryInterpreter,
             $errorProvider,
+            $schemaDefinitionService,
         );
     }
 

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -27,7 +27,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             // 'items' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
@@ -31,7 +31,7 @@ class MenuItemFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'title' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/menus/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/RootFieldResolver.php
@@ -33,7 +33,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'menu' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
+++ b/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
@@ -28,7 +28,7 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
         ];
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
             'metaValue' => SchemaDefinition::TYPE_MIXED,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -23,7 +23,7 @@ class PS_POP_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'thumbFullDimensions' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -30,7 +30,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'commentObjectID' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -24,7 +24,7 @@ class PoPTheme_Wassup_AAL_PoP_DataLoad_FieldResolver_Notifications extends Abstr
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -21,7 +21,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'isLinkEmbeddable' => SchemaDefinition::TYPE_BOOL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -23,7 +23,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'link' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/multiselect-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/multiselect-filterinputs.php
@@ -99,7 +99,7 @@ class PoP_Module_Processor_CreateUpdatePostMultiSelectFilterInputs extends PoP_M
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_APPLIESTO => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
@@ -107,7 +107,7 @@ class PoP_Module_Processor_CreateUpdatePostMultiSelectFilterInputs extends PoP_M
             self::MODULE_FILTERINPUT_CONTENTSECTIONS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             self::MODULE_FILTERINPUT_POSTSECTIONS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/volunteers-multiselect-forminputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/volunteers-multiselect-forminputs.php
@@ -67,12 +67,12 @@ class PoPTheme_Wassup_Module_Processor_MultiSelectFilterInputs extends PoP_Modul
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_VOLUNTEERSNEEDED_MULTISELECT => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_BOOL),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -24,7 +24,7 @@ class GD_ApplicationProcessors_DataLoad_FieldResolver_Posts extends AbstractDBDa
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'highlightsLazy' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -23,7 +23,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'contentClipped' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -33,7 +33,7 @@ class PoP_Application_DataLoad_FieldResolver_FunctionalPosts extends AbstractFun
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'multilayoutKeys' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -53,7 +53,7 @@ class PoP_Application_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldRe
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'favicon' => SchemaDefinition::TYPE_OBJECT,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -26,7 +26,7 @@ class PoP_Application_DataLoad_FieldResolver_FunctionalUsers extends AbstractFun
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'multilayoutKeys' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -19,7 +19,7 @@ class PoP_Application_UserAvatar_DataLoad_FieldResolver_Users extends AbstractDB
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'avatar' => SchemaDefinition::TYPE_OBJECT,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -19,7 +19,7 @@ class PoP_Application_DataLoad_FieldResolver_Tags extends AbstractDBDataFieldRes
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'mentionQueryby' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -19,7 +19,7 @@ class PoP_Avatar_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolve
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'userphoto' => SchemaDefinition::TYPE_OBJECT,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/forminputs/daterange-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/forminputs/daterange-filterinputs.php
@@ -61,12 +61,12 @@ class PoP_Module_Processor_DateRangeComponentFilterInputs extends PoP_Module_Pro
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_CUSTOMPOSTDATES => SchemaDefinition::TYPE_DATE,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/forminputs/multiselect-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/forminputs/multiselect-filterinputs.php
@@ -81,13 +81,13 @@ class PoP_Module_Processor_MultiSelectFilterInputs extends PoP_Module_Processor_
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_MODERATEDPOSTSTATUS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ENUM),
             self::MODULE_FILTERINPUT_UNMODERATEDPOSTSTATUS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ENUM),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles-processors/plugins/pop-bootstrap-processors/pop-library/processors/forminputs/multiselect-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles-processors/plugins/pop-bootstrap-processors/pop-library/processors/forminputs/multiselect-filterinputs.php
@@ -102,14 +102,14 @@ class GD_URE_Module_Processor_MultiSelectFilterInputs extends PoP_Module_Process
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_URE_FILTERINPUT_INDIVIDUALINTERESTS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
             self::MODULE_URE_FILTERINPUT_ORGANIZATIONCATEGORIES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
             self::MODULE_URE_FILTERINPUT_ORGANIZATIONTYPES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
@@ -22,7 +22,7 @@ class GD_URE_Custom_DataLoad_FieldResolver_FunctionalIndividualUsers extends Abs
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'individualInterestsByName' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -23,7 +23,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'individualinterests' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
@@ -23,7 +23,7 @@ class GD_URE_Custom_DataLoad_FieldResolver_FunctionalOrganizationUsers extends A
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'organizationTypesByName' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -26,7 +26,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'contactPerson' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -24,7 +24,7 @@ class GD_ContentCreation_DataLoad_FieldResolver_FunctionalPosts extends Abstract
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'flagURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -32,7 +32,7 @@ class GD_ContentCreation_DataLoad_FieldResolver_Posts extends AbstractDBDataFiel
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'titleEdit' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -23,7 +23,7 @@ class GD_ContentCreation_Media_DataLoad_FieldResolver_FunctionalPosts extends Ab
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'featuredImageAttrs' => SchemaDefinition::TYPE_OBJECT,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -25,7 +25,7 @@ class PoP_ContentCreation_DataLoad_FieldResolver_Notifications extends AbstractD
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/multiselect-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/multiselect-filterinputs.php
@@ -90,13 +90,13 @@ class PoP_ContentPostLinksCreation_Module_Processor_CreateUpdatePostMultiSelectF
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_LINKCATEGORIES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
-            self::MODULE_FILTERINPUT_LINKACCESS => TYPE_SEARCH,
+            self::MODULE_FILTERINPUT_LINKACCESS => SchemaDefinition::TYPE_STRING,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -33,7 +33,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'excerpt' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -23,7 +23,7 @@ class GD_ContentPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts extends
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'addContentPostLinkURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-functionalhook.php
@@ -27,7 +27,7 @@ class GD_DataLoad_FunctionalFieldResolver extends AbstractFunctionalFieldResolve
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'printURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -22,7 +22,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'excerpt' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -22,7 +22,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'excerpt' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -24,7 +24,7 @@ class PoP_EventLinksCreation_DataLoad_FunctionalFieldResolver extends AbstractFu
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'addEventLinkURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/forminputs/daterange-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/forminputs/daterange-filterinputs.php
@@ -60,12 +60,12 @@ class PoP_Events_Module_Processor_DateRangeComponentFilterInputs extends PoP_Mod
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_EVENTSCOPE => SchemaDefinition::TYPE_DATE,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -24,7 +24,7 @@ class PoP_EventsCreation_DataLoad_FunctionalFieldResolver extends AbstractFuncti
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'addEventURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/formcomponents/typeaheads/user-typeahead-formcomponents.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/formcomponents/typeaheads/user-typeahead-formcomponents.php
@@ -95,12 +95,12 @@ class PoP_Module_Processor_UserSelectableTypeaheadFilterInputs extends PoP_Modul
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERCOMPONENT_SELECTABLETYPEAHEAD_PROFILES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/forminputs/select-forminputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/forminputs/select-forminputs.php
@@ -94,7 +94,7 @@ class PoP_Module_Processor_SelectFilterInputs extends PoP_Module_Processor_Selec
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_ORDERUSER => SchemaDefinition::TYPE_STRING,
@@ -102,7 +102,7 @@ class PoP_Module_Processor_SelectFilterInputs extends PoP_Module_Processor_Selec
             self::MODULE_FILTERINPUT_ORDERTAG => SchemaDefinition::TYPE_STRING,
             self::MODULE_FILTERINPUT_ORDERCOMMENT => SchemaDefinition::TYPE_STRING,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/forminputs/text-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-forms-processors/library/processors/forminputs/text-filterinputs.php
@@ -80,14 +80,14 @@ class PoP_Module_Processor_TextFilterInputs extends PoP_Module_Processor_TextFor
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_SEARCH => SchemaDefinition::TYPE_STRING,
             self::MODULE_FILTERINPUT_HASHTAGS => SchemaDefinition::TYPE_STRING,
             self::MODULE_FILTERINPUT_NAME => SchemaDefinition::TYPE_STRING,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -21,7 +21,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'excerpt' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -23,7 +23,7 @@ class PoP_LocationPostLinksCreation_DataLoad_FieldResolver_FunctionalPosts exten
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'addLocationPostLinkURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -23,7 +23,7 @@ class PoP_LocationPostsCreation_DataLoad_FieldResolver_FunctionalPosts extends A
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'addLocationPostURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -22,7 +22,7 @@ class PoP_Notifications_UserLogin_DataLoad_FieldResolver_Notifications extends A
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -22,7 +22,7 @@ class PoP_Notifications_UserPlatform_DataLoad_FieldResolver_Notifications extend
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -23,7 +23,7 @@ class GD_PostsCreation_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'addpostURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -21,7 +21,7 @@ class PPPPoP_DataLoad_FieldResolver_FunctionalProfiles extends AbstractFunctiona
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'previewURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts-processors/library/processors/formcomponents/typeaheads/post-typeahead-filtercomponents.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts-processors/library/processors/formcomponents/typeaheads/post-typeahead-filtercomponents.php
@@ -69,12 +69,12 @@ class PoP_Module_Processor_PostSelectableTypeaheadFilterComponents extends PoP_M
         return parent::getTriggerLayoutSubmodule($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERCOMPONENT_SELECTABLETYPEAHEAD_REFERENCES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -29,7 +29,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'references' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -24,7 +24,7 @@ class PoP_RelatedPosts_AAL_PoP_DataLoad_FieldResolver_Notifications extends Abst
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -23,7 +23,7 @@ class WSL_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFie
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
@@ -20,7 +20,7 @@ class GD_WSL_FieldResolver_Users extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'url' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-socialmediaitems-base.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-socialmediaitems-base.php
@@ -29,7 +29,7 @@ abstract class PoP_SocialMediaProviders_DataLoad_FieldResolver_FunctionalSocialM
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'shareURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -21,7 +21,7 @@ class PoPGenericForms_DataLoad_FieldResolver_FunctionalUsers extends AbstractFun
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'contactURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -24,7 +24,7 @@ class PoP_SocialNetwork_DataLoad_FieldResolver_Notifications extends AbstractDBD
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -21,7 +21,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'taggedusers' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -31,7 +31,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'recommendPostURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -29,7 +29,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'taggedusers' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -22,7 +22,7 @@ class GD_DataLoad_FieldResolver_Tags extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'subscribeToTagURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -22,7 +22,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_FunctionalUsers extends AbstractFu
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'followUserURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -28,7 +28,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'recommendsCustomPosts' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -21,7 +21,7 @@ class PoP_UserAvatar_DataLoad_FieldResolver_FunctionalUsers extends AbstractFunc
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'fileUploadPictureURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -22,7 +22,7 @@ class PoP_AAL_UserAvatar_DataLoad_FieldResolver_Notification extends AbstractDBD
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/formcomponents/typeaheads/user-typeahead-filtercomponents.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/formcomponents/typeaheads/user-typeahead-filtercomponents.php
@@ -90,14 +90,14 @@ class GD_URE_Module_Processor_UserSelectableTypeaheadFilterInputs extends PoP_Mo
         return parent::getTriggerLayoutSubmodule($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_URE_FILTERCOMPONENT_SELECTABLETYPEAHEAD_COMMUNITIES_POST => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             self::MODULE_URE_FILTERCOMPONENT_SELECTABLETYPEAHEAD_COMMUNITIES_USER => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             self::MODULE_URE_FILTERCOMPONENT_SELECTABLETYPEAHEAD_COMMUNITYPLUSMEMBERS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/multiselect-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/plugins/pop-bootstrap-processors/library/processors/forminputs/multiselect-filterinputs.php
@@ -98,14 +98,14 @@ class GD_URE_Module_Processor_ProfileMultiSelectFilterInputs extends PoP_Module_
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_URE_FILTERINPUT_MEMBERPRIVILEGES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ENUM),
             self::MODULE_URE_FILTERINPUT_MEMBERTAGS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ENUM),
             self::MODULE_URE_FILTERINPUT_MEMBERSTATUS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ENUM),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -23,7 +23,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'members' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -24,7 +24,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_FunctionalUsers extends Abstract
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
 			'editMembershipURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -33,7 +33,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'memberstatus' => SchemaDefinition::TYPE_ENUM,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -41,7 +41,7 @@ class URE_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDBDataFie
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'editUserMembershipURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform-processors/pop-library/processors/createupdatepost/forminputs/buttongroup-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform-processors/pop-library/processors/createupdatepost/forminputs/buttongroup-filterinputs.php
@@ -94,14 +94,14 @@ class PoP_Module_Processor_CreateUpdatePostButtonGroupFilterInputs extends PoP_M
         return parent::isMultiple($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_BUTTONGROUP_CATEGORIES => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             self::MODULE_FILTERINPUT_BUTTONGROUP_CONTENTSECTIONS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             self::MODULE_FILTERINPUT_BUTTONGROUP_POSTSECTIONS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -22,7 +22,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_FunctionalUsers extends AbstractFun
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'shortDescriptionFormatted' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -29,7 +29,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'shortDescription' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -25,7 +25,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'role' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/processors/forminputs/multiselect-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/processors/forminputs/multiselect-filterinputs.php
@@ -67,12 +67,12 @@ class UserStance_Module_Processor_MultiSelectFilterInputs extends PoP_Module_Pro
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_STANCE_MULTISELECT => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/plugins/pop-userroles/library/processors/forminputs/multiselect-filterinputs.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/plugins/pop-userroles/library/processors/forminputs/multiselect-filterinputs.php
@@ -67,12 +67,12 @@ class UserStance_URE_Module_Processor_MultiSelectFilterInputs extends PoP_Module
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_AUTHORROLE_MULTISELECT => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -24,7 +24,7 @@ class UserStance_AAL_PoP_DataLoad_FieldResolver_Notifications extends AbstractDB
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'icon' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -24,7 +24,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'volunteerURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -21,7 +21,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'volunteersNeeded' => SchemaDefinition::TYPE_BOOL,

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -81,7 +81,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'action' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFunctionalFieldResolver.php
@@ -24,7 +24,7 @@ class NotificationFunctionalFieldResolver extends AbstractFunctionalFieldResolve
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'multilayoutKeys' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -57,7 +57,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'page' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/pages/src/TypeResolvers/PageTypeResolver.php
+++ b/layers/Schema/packages/pages/src/TypeResolvers/PageTypeResolver.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\ErrorHandling\ErrorProviderInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
 use PoPSchema\CustomPosts\TypeResolvers\AbstractCustomPostTypeResolver;
@@ -23,6 +24,7 @@ class PageTypeResolver extends AbstractCustomPostTypeResolver
         FeedbackMessageStoreInterface $feedbackMessageStore,
         FieldQueryInterpreterInterface $fieldQueryInterpreter,
         ErrorProviderInterface $errorProvider,
+        SchemaDefinitionServiceInterface $schemaDefinitionService,
         protected PageTypeAPIInterface $pageTypeAPI,
     ) {
         parent::__construct(
@@ -32,6 +34,7 @@ class PageTypeResolver extends AbstractCustomPostTypeResolver
             $feedbackMessageStore,
             $fieldQueryInterpreter,
             $errorProvider,
+            $schemaDefinitionService,
         );
     }
 

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -43,7 +43,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'postCategory' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -43,7 +43,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'createPost' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -36,7 +36,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'myPosts' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -43,7 +43,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'postTag' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -35,7 +35,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'posts' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -27,7 +27,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'isPublished' => SchemaDefinition::TYPE_BOOL,

--- a/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
@@ -50,7 +50,7 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'post' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
@@ -27,7 +27,7 @@ class QueryableFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
         ];
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
             'url' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/schema-commons/src/ModuleProcessors/FormInputs/CommonFilterInputModuleProcessor.php
+++ b/layers/Schema/packages/schema-commons/src/ModuleProcessors/FormInputs/CommonFilterInputModuleProcessor.php
@@ -80,7 +80,7 @@ class CommonFilterInputModuleProcessor extends AbstractFormInputModuleProcessor 
         return $names[$module[1]] ?? parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_ORDER => SchemaDefinition::TYPE_STRING,
@@ -90,7 +90,7 @@ class CommonFilterInputModuleProcessor extends AbstractFormInputModuleProcessor 
             self::MODULE_FILTERINPUT_IDS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),
             self::MODULE_FILTERINPUT_ID => SchemaDefinition::TYPE_ID,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/schema-commons/src/ModuleProcessors/FormInputs/CommonFilterMultipleInputModuleProcessor.php
+++ b/layers/Schema/packages/schema-commons/src/ModuleProcessors/FormInputs/CommonFilterMultipleInputModuleProcessor.php
@@ -100,12 +100,12 @@ class CommonFilterMultipleInputModuleProcessor extends AbstractFormInputModulePr
         }
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_DATES => SchemaDefinition::TYPE_DATE,
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/settings/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/RootFieldResolver.php
@@ -32,7 +32,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'option' => SchemaDefinition::TYPE_MIXED,

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -34,7 +34,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'stances' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -42,7 +42,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'addStanceURL' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -38,7 +38,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'categories' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -26,7 +26,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'tags' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractTagFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractTagFieldResolver.php
@@ -32,7 +32,7 @@ abstract class AbstractTagFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'url' => SchemaDefinition::TYPE_URL,

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -27,7 +27,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      *
      * @see https://github.com/getpop/component-model/issues/1
      */
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'name' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/user-roles-wp/src/Overrides/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles-wp/src/Overrides/FieldResolvers/RolesFieldResolverTrait.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait RolesFieldResolverTrait
 {
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'roles' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
@@ -28,7 +28,7 @@ trait RolesFieldResolverTrait
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'roles' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -36,7 +36,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'roles' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_STRING),

--- a/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -37,7 +37,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'loginUser' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -18,7 +18,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'isUserLoggedIn' => SchemaDefinition::TYPE_BOOL,

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalUserStateFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalUserStateFieldResolver.php
@@ -18,7 +18,7 @@ class GlobalUserStateFieldResolver extends AbstractGlobalUserStateFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'loggedInUserID' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
@@ -25,7 +25,7 @@ class RootMeFieldResolver extends AbstractUserStateFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'me' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -43,7 +43,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $resolver;
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         switch ($fieldName) {
             case 'author':

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -27,7 +27,7 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
         ];
     }
 
-    public function getSchemaFieldType(string $fieldName): ?string
+    public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
             'author' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -49,7 +49,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'users' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
@@ -37,7 +37,7 @@ class RootUserFieldResolver extends AbstractUserFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'user' => SchemaDefinition::TYPE_ID,

--- a/layers/Schema/packages/users/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/UserFieldResolver.php
@@ -66,7 +66,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'username' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/users/src/ModuleProcessors/FilterInputModuleProcessor.php
+++ b/layers/Schema/packages/users/src/ModuleProcessors/FilterInputModuleProcessor.php
@@ -52,13 +52,13 @@ class FilterInputModuleProcessor extends AbstractFormInputModuleProcessor implem
         return parent::getName($module);
     }
 
-    public function getSchemaFilterInputType(array $module): ?string
+    public function getSchemaFilterInputType(array $module): string
     {
         $types = [
             self::MODULE_FILTERINPUT_NAME => SchemaDefinition::TYPE_STRING,
             self::MODULE_FILTERINPUT_EMAILS => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_EMAIL),
         ];
-        return $types[$module[1]] ?? null;
+        return $types[$module[1]] ?? $this->getDefaultSchemaFilterInputType();
     }
 
     public function getSchemaFilterInputDescription(array $module): ?string

--- a/layers/Schema/packages/users/src/TypeResolvers/UserTypeResolver.php
+++ b/layers/Schema/packages/users/src/TypeResolvers/UserTypeResolver.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\ErrorHandling\ErrorProviderInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\Translation\TranslationAPIInterface;
@@ -23,6 +24,7 @@ class UserTypeResolver extends AbstractTypeResolver
         FeedbackMessageStoreInterface $feedbackMessageStore,
         FieldQueryInterpreterInterface $fieldQueryInterpreter,
         ErrorProviderInterface $errorProvider,
+        SchemaDefinitionServiceInterface $schemaDefinitionService,
         protected UserTypeAPIInterface $userTypeAPI,
     ) {
         parent::__construct(
@@ -32,6 +34,7 @@ class UserTypeResolver extends AbstractTypeResolver
             $feedbackMessageStore,
             $fieldQueryInterpreter,
             $errorProvider,
+            $schemaDefinitionService,
         );
     }
 

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -26,7 +26,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'sites' => TypeCastingHelpers::makeArray(SchemaDefinition::TYPE_ID),

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -24,7 +24,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
             'domain' => SchemaDefinition::TYPE_STRING,


### PR DESCRIPTION
To have the same behavior as in GraphQL, and emulating the strict typing afforded by PHP 8.0.

Now, all types in the schema must be typed always. If not provided, the default type `MIXED` is used.