### PR TITLE
Create `getSchemaFieldTypeModifiers`

### DIFF
--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -40,13 +40,13 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'fullSchema':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -40,7 +40,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'fullSchema':

--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -7,16 +7,17 @@ namespace PoP\API\FieldResolvers;
 use PoP\API\Cache\CacheTypes;
 use PoP\API\Cache\CacheUtils;
 use PoP\API\ComponentConfiguration;
-use PoP\API\Schema\SchemaDefinition;
 use PoP\API\Enums\SchemaFieldShapeEnum;
-use PoP\ComponentModel\Schema\SchemaHelpers;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
-use PoP\API\Facades\PersistedQueryManagerFacade;
 use PoP\API\Facades\PersistedFragmentManagerFacade;
+use PoP\API\Facades\PersistedQueryManagerFacade;
+use PoP\API\Schema\SchemaDefinition;
 use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaHelpers;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -44,7 +45,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
     {
         switch ($fieldName) {
             case 'fullSchema':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -40,7 +40,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'fullSchema':

--- a/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/RootFieldResolver.php
@@ -40,13 +40,13 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'fullSchema':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 
 class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
@@ -38,7 +39,7 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
     {
         switch ($fieldName) {
             case 'id':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($fieldName);
     }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -34,7 +34,7 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'id':

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -34,13 +34,13 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool
     {
         switch ($fieldName) {
             case 'id':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($fieldName);
+        return parent::getSchemaFieldTypeModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -34,13 +34,13 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool
     {
         switch ($fieldName) {
             case 'id':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($fieldName);
+        return parent::getSchemaFieldResponseModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -8,7 +8,7 @@ interface FieldInterfaceSchemaDefinitionResolverInterface
 {
     public function getFieldNamesToResolve(): array;
     public function getSchemaFieldType(string $fieldName): string;
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool;
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool;
     public function getSchemaFieldDescription(string $fieldName): ?string;
     public function getSchemaFieldArgs(string $fieldName): array;
     public function getFilteredSchemaFieldArgs(string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -8,7 +8,7 @@ interface FieldInterfaceSchemaDefinitionResolverInterface
 {
     public function getFieldNamesToResolve(): array;
     public function getSchemaFieldType(string $fieldName): string;
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool;
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int;
     public function getSchemaFieldDescription(string $fieldName): ?string;
     public function getSchemaFieldArgs(string $fieldName): array;
     public function getFilteredSchemaFieldArgs(string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -8,7 +8,7 @@ interface FieldInterfaceSchemaDefinitionResolverInterface
 {
     public function getFieldNamesToResolve(): array;
     public function getSchemaFieldType(string $fieldName): string;
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool;
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool;
     public function getSchemaFieldDescription(string $fieldName): ?string;
     public function getSchemaFieldArgs(string $fieldName): array;
     public function getFilteredSchemaFieldArgs(string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -30,10 +30,10 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
-            return $schemaDefinitionResolver->isSchemaFieldResponseNonNullable($fieldName);
+            return $schemaDefinitionResolver->getSchemaFieldResponseModifiers($fieldName);
         }
         return false;
     }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -30,10 +30,10 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
-            return $schemaDefinitionResolver->getSchemaFieldResponseModifiers($fieldName);
+            return $schemaDefinitionResolver->getSchemaFieldTypeModifiers($fieldName);
         }
         return false;
     }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -30,7 +30,7 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
             return $schemaDefinitionResolver->getSchemaFieldTypeModifiers($fieldName);

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -35,7 +35,7 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
             return $schemaDefinitionResolver->getSchemaFieldTypeModifiers($fieldName);
         }
-        return false;
+        return null;
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -28,8 +28,7 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
 
     public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
-        // By default, types are nullable
-        return false;
+        return null;
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -26,7 +26,7 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool
     {
         // By default, types are nullable
         return false;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -26,7 +26,7 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool
     {
         // By default, types are nullable
         return false;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -26,7 +26,7 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         // By default, types are nullable
         return false;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -285,7 +285,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
             // If we found a resolver for this fieldName, get all its properties from it
             if ($schemaDefinitionResolver) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName);
-                if ($schemaDefinitionResolver->isSchemaFieldResponseNonNullable($typeResolver, $fieldName)) {
+                if ($schemaDefinitionResolver->getSchemaFieldResponseModifiers($typeResolver, $fieldName)) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] = true;
                 }
                 if ($description = $schemaDefinitionResolver->getSchemaFieldDescription($typeResolver, $fieldName)) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -285,7 +285,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
             // If we found a resolver for this fieldName, get all its properties from it
             if ($schemaDefinitionResolver) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName);
-                if ($schemaDefinitionResolver->getSchemaFieldResponseModifiers($typeResolver, $fieldName)) {
+                if ($schemaDefinitionResolver->getSchemaFieldTypeModifiers($typeResolver, $fieldName)) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] = true;
                 }
                 if ($description = $schemaDefinitionResolver->getSchemaFieldDescription($typeResolver, $fieldName)) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -28,6 +28,7 @@ use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\LooseContracts\NameResolverInterface;
 
@@ -285,7 +286,8 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
             // If we found a resolver for this fieldName, get all its properties from it
             if ($schemaDefinitionResolver) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $schemaDefinitionResolver->getSchemaFieldType($typeResolver, $fieldName);
-                if ($schemaDefinitionResolver->getSchemaFieldTypeModifiers($typeResolver, $fieldName)) {
+                $schemaTypeModifiers = $schemaDefinitionResolver->getSchemaFieldTypeModifiers($typeResolver, $fieldName);
+                if ($schemaTypeModifiers & SchemaTypeModifiers::NON_NULLABLE) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] = true;
                 }
                 if ($description = $schemaDefinitionResolver->getSchemaFieldDescription($typeResolver, $fieldName)) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
@@ -123,7 +123,7 @@ abstract class AbstractReflectionPropertyFieldResolver extends AbstractDBDataFie
         return parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         // TODO: If we are running PHP 7.4, the properties may be typed,
         // so we can already get the type through reflection. Implement this!

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
@@ -123,11 +123,11 @@ abstract class AbstractReflectionPropertyFieldResolver extends AbstractDBDataFie
         return parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         // TODO: If we are running PHP 7.4, the properties may be typed,
         // so we can already get the type through reflection. Implement this!
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
@@ -123,11 +123,11 @@ abstract class AbstractReflectionPropertyFieldResolver extends AbstractDBDataFie
         return parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         // TODO: If we are running PHP 7.4, the properties may be typed,
         // so we can already get the type through reflection. Implement this!
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractReflectionPropertyFieldResolver.php
@@ -123,7 +123,7 @@ abstract class AbstractReflectionPropertyFieldResolver extends AbstractDBDataFie
         return parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         // TODO: If we are running PHP 7.4, the properties may be typed,
         // so we can already get the type through reflection. Implement this!

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -203,10 +203,10 @@ trait AliasSchemaFieldResolverTrait
      * Proxy pattern: execute same function on the aliased FieldResolver,
      * for the aliased $fieldName
      */
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
-        return $aliasedFieldResolver->isSchemaFieldResponseNonNullable(
+        return $aliasedFieldResolver->getSchemaFieldResponseModifiers(
             $typeResolver,
             $this->getAliasedFieldName($fieldName)
         );

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -203,7 +203,7 @@ trait AliasSchemaFieldResolverTrait
      * Proxy pattern: execute same function on the aliased FieldResolver,
      * for the aliased $fieldName
      */
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
         return $aliasedFieldResolver->getSchemaFieldResponseModifiers(

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -203,10 +203,10 @@ trait AliasSchemaFieldResolverTrait
      * Proxy pattern: execute same function on the aliased FieldResolver,
      * for the aliased $fieldName
      */
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
-        return $aliasedFieldResolver->getSchemaFieldResponseModifiers(
+        return $aliasedFieldResolver->getSchemaFieldTypeModifiers(
             $typeResolver,
             $this->getAliasedFieldName($fieldName)
         );

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -203,7 +203,7 @@ trait AliasSchemaFieldResolverTrait
      * Proxy pattern: execute same function on the aliased FieldResolver,
      * for the aliased $fieldName
      */
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
         return $aliasedFieldResolver->getSchemaFieldResponseModifiers(

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -33,7 +33,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'typeName':

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -6,6 +6,7 @@ namespace PoP\ComponentModel\FieldResolvers;
 
 use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
@@ -41,7 +42,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
             case 'qualifiedTypeName':
             case 'isType':
             case 'implements':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -33,7 +33,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'typeName':

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -33,7 +33,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'typeName':
@@ -43,7 +43,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
             case 'implements':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/CoreGlobalFieldResolver.php
@@ -33,7 +33,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'typeName':
@@ -43,7 +43,7 @@ class CoreGlobalFieldResolver extends AbstractGlobalFieldResolver
             case 'implements':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -43,14 +43,14 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'id':
             case 'self':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -43,14 +43,14 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'id':
             case 'self':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
+use PoP\ComponentModel\FieldInterfaceResolvers\ElementalFieldInterfaceResolver;
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\FieldInterfaceResolvers\ElementalFieldInterfaceResolver;
 
 class ElementalFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -48,7 +49,7 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
         switch ($fieldName) {
             case 'id':
             case 'self':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -43,7 +43,7 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'id':

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -43,7 +43,7 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'id':

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -11,7 +11,7 @@ interface FieldSchemaDefinitionResolverInterface
     public function getFieldNamesToResolve(): array;
     public function getAdminFieldNames(): array;
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string;
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool;
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int;
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string;
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;
     public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -11,7 +11,7 @@ interface FieldSchemaDefinitionResolverInterface
     public function getFieldNamesToResolve(): array;
     public function getAdminFieldNames(): array;
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string;
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool;
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool;
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string;
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;
     public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -11,7 +11,7 @@ interface FieldSchemaDefinitionResolverInterface
     public function getFieldNamesToResolve(): array;
     public function getAdminFieldNames(): array;
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string;
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int;
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int;
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string;
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;
     public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -11,7 +11,7 @@ interface FieldSchemaDefinitionResolverInterface
     public function getFieldNamesToResolve(): array;
     public function getAdminFieldNames(): array;
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string;
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int;
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int;
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string;
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;
     public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -31,7 +31,7 @@ trait FieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
             return $schemaDefinitionResolver->getSchemaFieldResponseModifiers($typeResolver, $fieldName);

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -31,10 +31,10 @@ trait FieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
-            return $schemaDefinitionResolver->getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+            return $schemaDefinitionResolver->getSchemaFieldTypeModifiers($typeResolver, $fieldName);
         }
         return false;
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -36,7 +36,7 @@ trait FieldSchemaDefinitionResolverTrait
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
             return $schemaDefinitionResolver->getSchemaFieldTypeModifiers($typeResolver, $fieldName);
         }
-        return false;
+        return null;
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -31,10 +31,10 @@ trait FieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
-            return $schemaDefinitionResolver->isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+            return $schemaDefinitionResolver->getSchemaFieldResponseModifiers($typeResolver, $fieldName);
         }
         return false;
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -31,7 +31,7 @@ trait FieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
             return $schemaDefinitionResolver->getSchemaFieldResponseModifiers($typeResolver, $fieldName);

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -28,7 +28,7 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         // By default, types are nullable
         return false;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -28,7 +28,7 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         // By default, types are nullable
         return false;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -28,10 +28,12 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
+    /**
+     * By default types are nullable, and not an array
+     */
     public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
-        // By default, types are nullable
-        return false;
+        return null;
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -28,7 +28,7 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         // By default, types are nullable
         return false;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -28,7 +28,7 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return $schemaDefinitionService->getDefaultType();
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         // By default, types are nullable
         return false;

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -44,9 +44,9 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
-        return $this->fieldInterfaceResolver->getSchemaFieldResponseModifiers($fieldName);
+        return $this->fieldInterfaceResolver->getSchemaFieldTypeModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -44,9 +44,9 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->getSchemaFieldType($fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
-        return $this->fieldInterfaceResolver->isSchemaFieldResponseNonNullable($fieldName);
+        return $this->fieldInterfaceResolver->getSchemaFieldResponseModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -44,7 +44,7 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         return $this->fieldInterfaceResolver->getSchemaFieldResponseModifiers($fieldName);
     }

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -44,7 +44,7 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         return $this->fieldInterfaceResolver->getSchemaFieldResponseModifiers($fieldName);
     }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Schema;
+
+class SchemaTypeModifiers
+{
+    public const NON_NULLABLE = 1;
+}

--- a/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Schema;
 
+/**
+ * Values to extract using a bitwise operation
+ * 
+ * @see https://www.php.net/manual/en/language.operators.bitwise.php#91291
+ */
 class SchemaTypeModifiers
 {
     public const NON_NULLABLE = 1;

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\Engine\FieldResolvers;
 
-use PoP\FieldQuery\QueryHelpers;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Engine\Dataloading\Expressions;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\Dataloading\Expressions;
+use PoP\FieldQuery\QueryHelpers;
 
 class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
 {
@@ -31,7 +32,7 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
     {
         switch ($fieldName) {
             case 'getSelfProp':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -27,7 +27,7 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'getSelfProp':

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -27,13 +27,13 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'getSelfProp':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -27,13 +27,13 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'getSelfProp':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -27,7 +27,7 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'getSelfProp':

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -59,7 +59,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'not':
@@ -73,7 +73,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
             case 'sprintf':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -59,7 +59,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'not':
@@ -73,7 +73,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
             case 'sprintf':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -59,7 +59,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'not':

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -59,7 +59,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'not':

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\Engine\FieldResolvers;
 
-use PoP\Engine\Misc\Extract;
-use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
+use PoP\Engine\Misc\Extract;
 
 class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
 {
@@ -71,7 +72,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
             case 'context':
             case 'time':
             case 'sprintf':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -55,7 +55,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'concat',

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\FunctionFields\FieldResolvers;
 
+use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
 
 class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
 {
@@ -75,7 +76,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
             'titleCase',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -55,7 +55,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'concat',
@@ -77,7 +77,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -55,7 +55,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'concat',
@@ -77,7 +77,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -55,7 +55,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'concat',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -39,7 +39,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'exportedVariables',
@@ -47,7 +47,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -39,7 +39,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'exportedVariables',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -39,7 +39,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'exportedVariables',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -39,7 +39,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'exportedVariables',
@@ -47,7 +47,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/VariablesAsExpressions/SchemaServices/FieldResolvers/VariablesAsExpressionsRootFieldResolver.php
@@ -9,6 +9,7 @@ use GraphQLByPoP\GraphQLServer\ConditionalOnContext\MultipleQueryExecution\Schem
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
@@ -45,7 +46,7 @@ class VariablesAsExpressionsRootFieldResolver extends AbstractDBDataFieldResolve
             'exportedVariables',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -45,7 +45,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'name',
@@ -56,7 +56,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     protected function getSchemaDefinitionEnumName(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -45,7 +45,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -45,7 +45,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
 use GraphQLByPoP\GraphQLServer\Enums\DirectiveLocationEnum;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\DirectiveTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\InputValueTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\FieldResolvers\EnumTypeFieldSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class DirectiveFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -54,7 +55,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
             'isRepeatable',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -45,7 +45,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',
@@ -56,7 +56,7 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     protected function getSchemaDefinitionEnumName(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -37,7 +37,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'name',
@@ -46,7 +46,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumValueTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class EnumValueFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -44,7 +45,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
             'isDeprecated',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -37,7 +37,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -37,7 +37,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',
@@ -46,7 +46,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EnumValueFieldResolver.php
@@ -37,7 +37,7 @@ class EnumValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\Extensions;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\FieldResolvers\EnumTypeFieldSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -56,7 +57,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
             'name',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -50,7 +50,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'name',
@@ -58,7 +58,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -50,7 +50,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',
@@ -58,7 +58,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -50,7 +50,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/NamespacedTypeFieldResolver.php
@@ -50,7 +50,7 @@ class NamespacedTypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -46,7 +46,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',
@@ -57,7 +57,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\FieldTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\InputValueTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 
 class FieldFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -55,7 +56,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
             'isDeprecated',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -46,7 +46,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'name',
@@ -57,7 +57,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -46,7 +46,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -46,7 +46,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -25,7 +25,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             '__typename',
@@ -33,7 +33,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -25,7 +25,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             '__typename',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -25,7 +25,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             '__typename',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
 use PoP\API\Schema\SchemaDefinition;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class GlobalFieldResolver extends AbstractGlobalFieldResolver
 {
@@ -31,7 +32,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
             '__typename',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/GlobalFieldResolver.php
@@ -25,7 +25,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             '__typename',
@@ -33,7 +33,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -38,7 +38,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'name',
@@ -47,7 +47,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\InputValueTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class InputValueFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -45,7 +46,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
             'type',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -38,7 +38,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',
@@ -47,7 +47,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -38,7 +38,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -38,7 +38,7 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -44,7 +44,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             '__schema',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -44,7 +44,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             '__schema',
@@ -53,7 +53,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
-use PoP\API\Schema\SchemaDefinition;
-use PoP\ComponentModel\Misc\GeneralUtils;
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\SchemaTypeResolver;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use GraphQLByPoP\GraphQLServer\TypeDataLoaders\SchemaTypeDataLoader;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\SchemaTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
+use PoP\API\Schema\SchemaDefinition;
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -51,7 +52,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
             '__type',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -44,7 +44,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             '__schema',
@@ -53,7 +53,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -44,7 +44,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             '__schema',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -44,7 +44,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'queryType',
@@ -54,7 +54,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
-use PoP\API\Schema\SchemaDefinition;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\SchemaTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\DirectiveTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\SchemaTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
+use PoP\API\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class SchemaFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -52,7 +53,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
             'directives',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -44,7 +44,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'queryType',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -44,7 +44,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'queryType',
@@ -54,7 +54,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -44,7 +44,7 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'queryType',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -5,21 +5,22 @@ declare(strict_types=1);
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
 use GraphQLByPoP\GraphQLServer\Enums\TypeKindEnum;
-use GraphQLByPoP\GraphQLServer\ObjectModels\EnumType;
-use GraphQLByPoP\GraphQLServer\ObjectModels\InputObjectType;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\FieldTypeResolver;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use GraphQLByPoP\GraphQLServer\ObjectModels\AbstractNestableType;
+use GraphQLByPoP\GraphQLServer\ObjectModels\EnumType;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasFieldsTypeInterface;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumValueTypeResolver;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\InputValueTypeResolver;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasInterfacesTypeInterface;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasPossibleTypesTypeInterface;
+use GraphQLByPoP\GraphQLServer\ObjectModels\InputObjectType;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumValueTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\FieldTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\InputValueTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\FieldResolvers\EnumTypeFieldSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class TypeFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -69,7 +70,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
             'kind',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -63,7 +63,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'kind',
@@ -71,7 +71,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     protected function getSchemaDefinitionEnumName(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -63,7 +63,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'kind',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -63,7 +63,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'kind',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -63,7 +63,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'kind',
@@ -71,7 +71,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     protected function getSchemaDefinitionEnumName(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -36,13 +36,13 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'blockMetadata':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -36,13 +36,13 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'blockMetadata':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -36,7 +36,7 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'blockMetadata':

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -36,7 +36,7 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'blockMetadata':

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/PostFieldResolver.php
@@ -6,10 +6,11 @@ namespace PoPSchema\BlockMetadataWP\FieldResolvers;
 
 use Leoloso\BlockMetadata\Data;
 use Leoloso\BlockMetadata\Metadata;
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 
 class PostFieldResolver extends AbstractDBDataFieldResolver
@@ -40,7 +41,7 @@ class PostFieldResolver extends AbstractDBDataFieldResolver
     {
         switch ($fieldName) {
             case 'blockMetadata':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -38,13 +38,13 @@ class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'content':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -38,13 +38,13 @@ class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'content':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -38,7 +38,7 @@ class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'content':

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoPSchema\BlockMetadataWP\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 
 class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
@@ -42,7 +43,7 @@ class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
     {
         switch ($fieldName) {
             case 'content':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/TryNewFeaturesPostFieldResolver.php
@@ -38,7 +38,7 @@ class TryNewFeaturesPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'content':

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace PoPSchema\Categories\FieldResolvers;
 
-use PoPSchema\Categories\ComponentConfiguration;
+use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
+use PoPSchema\Categories\ComponentConfiguration;
 use PoPSchema\Categories\ComponentContracts\CategoryAPIRequestedContractTrait;
-use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 use PoPSchema\Categories\ModuleProcessors\FieldDataloadModuleProcessor;
+use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryableFieldResolver
 {
@@ -44,7 +45,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
             'categoryNames',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'categories',

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'categories',

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'categories',
@@ -46,7 +46,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'categories',
@@ -46,7 +46,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -42,7 +42,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool
     {
         switch ($fieldName) {
             case 'areCommentsOpen':
@@ -51,7 +51,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             case 'comments':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($fieldName);
+        return parent::getSchemaFieldTypeModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -42,7 +42,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'areCommentsOpen':

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSchema\Comments\FieldInterfaceResolvers;
 
+use PoP\ComponentModel\FieldInterfaceResolvers\AbstractQueryableSchemaFieldInterfaceResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoPSchema\Comments\TypeDataLoaders\CommentTypeDataLoader;
-use PoP\ComponentModel\FieldInterfaceResolvers\AbstractQueryableSchemaFieldInterfaceResolver;
 
 class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInterfaceResolver
 {
@@ -49,7 +50,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             case 'commentCount':
             case 'hasComments':
             case 'comments':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($fieldName);
     }

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -42,7 +42,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool
     {
         switch ($fieldName) {
             case 'areCommentsOpen':
@@ -51,7 +51,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             case 'comments':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($fieldName);
+        return parent::getSchemaFieldResponseModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
@@ -93,7 +94,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             case 'type':
             case 'date':
             case 'responses':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -83,7 +83,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'content':
@@ -95,7 +95,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             case 'responses':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -83,7 +83,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'content':

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -83,7 +83,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'content':

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -83,7 +83,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'content':
@@ -95,7 +95,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             case 'responses':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'setCategories',

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -6,6 +6,7 @@ namespace PoPSchema\CustomPostCategoryMutations\FieldResolvers;
 
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPostCategoryMutations\MutationResolvers\MutationInputProperties;
@@ -53,7 +54,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
             'setCategories',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'setCategories',
@@ -55,7 +55,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'setCategories',

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'setCategories',
@@ -55,7 +55,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'setTags',

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'setTags',

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'setTags',
@@ -55,7 +55,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -6,6 +6,7 @@ namespace PoPSchema\CustomPostTagMutations\FieldResolvers;
 
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPostTagMutations\MutationResolvers\MutationInputProperties;
@@ -53,7 +54,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
             'setTags',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'setTags',
@@ -55,7 +55,7 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -72,7 +72,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'setFeaturedImage',
@@ -81,7 +81,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -72,7 +72,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'setFeaturedImage',

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -72,7 +72,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'setFeaturedImage',
@@ -81,7 +81,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMediaMutations\FieldResolvers;
 
-use PoP\Hooks\HooksAPIInterface;
-use PoP\Engine\CMS\CMSServiceInterface;
-use PoP\Translation\TranslationAPIInterface;
-use PoP\LooseContracts\NameResolverInterface;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
-use PoP\ComponentModel\Instances\InstanceManagerInterface;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
+use PoP\ComponentModel\Instances\InstanceManagerInterface;
+use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\CMS\CMSServiceInterface;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\LooseContracts\NameResolverInterface;
+use PoP\Translation\TranslationAPIInterface;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\MutationInputProperties;
-use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
-use PoPSchema\CustomPostMediaMutations\MutationResolvers\SetFeaturedImageOnCustomPostMutationResolver;
 use PoPSchema\CustomPostMediaMutations\MutationResolvers\RemoveFeaturedImageOnCustomPostMutationResolver;
+use PoPSchema\CustomPostMediaMutations\MutationResolvers\SetFeaturedImageOnCustomPostMutationResolver;
+use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
+use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -79,7 +80,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
             'removeFeaturedImage',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -72,7 +72,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'setFeaturedImage',

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -37,7 +37,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'hasFeaturedImage',
@@ -45,7 +45,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($fieldName);
+        return parent::getSchemaFieldResponseModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -37,7 +37,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasFeaturedImage',

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -37,7 +37,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'hasFeaturedImage',
@@ -45,7 +45,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($fieldName);
+        return parent::getSchemaFieldTypeModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMedia\FieldInterfaceResolvers;
 
-use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
 
 class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
@@ -43,7 +44,7 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
             'hasFeaturedImage',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($fieldName);
     }

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -65,7 +65,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         /**
          * Please notice that the URL, slug, title and excerpt are nullable,

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -65,7 +65,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool
     {
         /**
          * Please notice that the URL, slug, title and excerpt are nullable,
@@ -80,7 +80,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
             case 'customPostType':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($fieldName);
+        return parent::getSchemaFieldTypeModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -65,7 +65,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool
     {
         /**
          * Please notice that the URL, slug, title and excerpt are nullable,
@@ -80,7 +80,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
             case 'customPostType':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($fieldName);
+        return parent::getSchemaFieldResponseModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\FieldInterfaceResolvers;
 
-use PoPSchema\CustomPosts\Types\Status;
-use PoP\ComponentModel\Schema\SchemaHelpers;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoPSchema\CustomPosts\Enums\CustomPostStatusEnum;
-use PoPSchema\CustomPosts\Enums\CustomPostContentFormatEnum;
 use PoP\ComponentModel\FieldInterfaceResolvers\EnumTypeFieldInterfaceSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaHelpers;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoPSchema\CustomPosts\Enums\CustomPostContentFormatEnum;
+use PoPSchema\CustomPosts\Enums\CustomPostStatusEnum;
+use PoPSchema\CustomPosts\Types\Status;
 use PoPSchema\QueriedObject\FieldInterfaceResolvers\QueryableFieldInterfaceResolver;
 
 class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
@@ -78,7 +79,7 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
             case 'date':
             case 'datetime':
             case 'customPostType':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($fieldName);
     }

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\FieldResolvers;
 
-use PoPSchema\CustomPosts\ComponentConfiguration;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
-use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\CustomPosts\ComponentConfiguration;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 use PoPSchema\CustomPosts\ModuleProcessors\CustomPostRelationalFieldDataloadModuleProcessor;
+use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoPSchema\CustomPosts\Types\Status;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
@@ -54,7 +55,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
             case 'customPostCount':
             case 'unrestrictedCustomPosts':
             case 'unrestrictedCustomPostCount':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'customPosts':

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'customPosts':
@@ -56,7 +56,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
             case 'unrestrictedCustomPostCount':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'customPosts':
@@ -56,7 +56,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
             case 'unrestrictedCustomPostCount':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -47,7 +47,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'customPosts':

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -37,13 +37,13 @@ class CatEventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'catSlugs':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -37,7 +37,7 @@ class CatEventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'catSlugs':

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -37,7 +37,7 @@ class CatEventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'catSlugs':

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace PoPSchema\EverythingElse\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Events\Facades\EventTypeAPIFacade;
+use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 use PoPSchema\EventTags\Facades\EventTagTypeAPIFacade;
 
 class CatEventFieldResolver extends AbstractDBDataFieldResolver
@@ -41,7 +42,7 @@ class CatEventFieldResolver extends AbstractDBDataFieldResolver
     {
         switch ($fieldName) {
             case 'catSlugs':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CatEventFieldResolver.php
@@ -37,13 +37,13 @@ class CatEventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'catSlugs':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -39,7 +39,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'hasLocation',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace PoPSchema\Locations\FieldResolvers;
 
-use PoP\ComponentModel\Misc\GeneralUtils;
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
+use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -45,7 +46,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
             'hasLocation',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -39,7 +39,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasLocation',
@@ -47,7 +47,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -39,7 +39,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'hasLocation',
@@ -47,7 +47,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -39,7 +39,7 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasLocation',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'locations',
@@ -43,7 +43,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'locations',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\Locations\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
+use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -41,7 +42,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
             'locations',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'locations',
@@ -43,7 +43,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'locations',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -47,7 +47,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'categories':

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace PoPSchema\Events\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
-use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Events\Facades\EventTypeAPIFacade;
+use PoPSchema\Events\TypeResolvers\EventTypeResolver;
+use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
 
 class EventFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -56,7 +57,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
             case 'startDateReadable':
             case 'daterange':
             case 'daterangetime':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -47,7 +47,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'categories':

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -47,7 +47,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'categories':
@@ -58,7 +58,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
             case 'daterangetime':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -47,7 +47,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'categories':
@@ -58,7 +58,7 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
             case 'daterangetime':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'mapURL',
@@ -43,7 +43,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'mapURL',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'mapURL',
@@ -43,7 +43,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'mapURL',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/LocationFunctionalFieldResolver.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSchema\Locations\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\Route\RouteUtils;
 use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
 
@@ -41,7 +42,7 @@ class LocationFunctionalFieldResolver extends AbstractFunctionalFieldResolver
             'mapURL',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -36,7 +36,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'tagNames',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -36,7 +36,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'tagNames',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -36,7 +36,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'tagNames',
@@ -44,7 +44,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -36,7 +36,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'tagNames',
@@ -44,7 +44,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/TagsCustomPostFieldResolver.php
@@ -6,6 +6,7 @@ namespace PoPSchema\EverythingElse\FieldResolvers;
 
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
@@ -42,7 +43,7 @@ class TagsCustomPostFieldResolver extends AbstractDBDataFieldResolver
             'tagNames',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -35,7 +35,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'locations',
@@ -43,7 +43,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\Locations\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Locations\TypeResolvers\LocationTypeResolver;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class UserFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -41,7 +42,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
             'locations',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -35,7 +35,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'locations',
@@ -43,7 +43,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -35,7 +35,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'locations',

--- a/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -35,7 +35,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'locations',

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -57,7 +57,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'genericCustomPosts',
@@ -66,7 +66,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -57,7 +57,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'genericCustomPosts',

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\GenericCustomPosts\FieldResolvers;
 
-use PoPSchema\CustomPosts\Types\Status;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\GenericCustomPosts\ComponentConfiguration;
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
-use PoPSchema\GenericCustomPosts\TypeResolvers\GenericCustomPostTypeResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
+use PoPSchema\CustomPosts\Types\Status;
+use PoPSchema\GenericCustomPosts\ComponentConfiguration;
 use PoPSchema\GenericCustomPosts\ModuleProcessors\GenericCustomPostRelationalFieldDataloadModuleProcessor;
+use PoPSchema\GenericCustomPosts\TypeResolvers\GenericCustomPostTypeResolver;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 /**
@@ -64,7 +65,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
             'genericCustomPostCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -57,7 +57,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'genericCustomPosts',
@@ -66,7 +66,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -57,7 +57,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'genericCustomPosts',

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -42,7 +42,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'highlights',
@@ -52,7 +52,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -42,7 +42,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'highlights',

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -42,7 +42,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'highlights',

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace PoPSchema\Highlights\FieldResolvers;
 
-use PoP\ComponentModel\Misc\GeneralUtils;
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\Highlights\TypeResolvers\HighlightTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
+use PoPSchema\Highlights\TypeResolvers\HighlightTypeResolver;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
@@ -50,7 +51,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
             'highlightsCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -42,7 +42,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'highlights',
@@ -52,7 +52,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'addhighlightURL',
@@ -43,7 +43,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\Highlights\FieldResolvers;
 
-use PoP\Engine\Route\RouteUtils;
+use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\Route\RouteUtils;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
-use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
 
 class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
 {
@@ -41,7 +42,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
             'addhighlightURL',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'addhighlightURL',

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'addhighlightURL',
@@ -43,7 +43,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/CustomPostFunctionalFieldResolver.php
@@ -35,7 +35,7 @@ class CustomPostFunctionalFieldResolver extends AbstractFunctionalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'addhighlightURL',

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -44,7 +44,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -44,7 +44,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace PoPSchema\Highlights\FieldResolvers;
 
-use PoP\ComponentModel\Misc\GeneralUtils;
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
-use PoPSchema\Highlights\TypeResolvers\HighlightTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
+use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
+use PoPSchema\Highlights\TypeResolvers\HighlightTypeResolver;
 
 class HighlightFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -51,7 +52,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
             'highlightedpost',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -44,7 +44,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',
@@ -53,7 +53,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -44,7 +44,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'content',
@@ -53,7 +53,7 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaHelpers;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\Hooks\HooksAPIInterface;
@@ -69,7 +70,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'src',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -63,7 +63,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'src',

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -63,7 +63,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'src',

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -63,7 +63,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'src',
@@ -71,7 +71,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -63,7 +63,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'src',
@@ -71,7 +71,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -92,7 +92,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'mediaItems',
@@ -100,7 +100,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -92,7 +92,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'mediaItems',

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -92,7 +92,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'mediaItems',

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -92,7 +92,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'mediaItems',
@@ -100,7 +100,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
@@ -98,7 +99,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
             'mediaItems',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -51,7 +51,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'itemDataEntries',

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -51,7 +51,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'itemDataEntries',
@@ -59,7 +59,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -7,6 +7,7 @@ namespace PoPSchema\Menus\FieldResolvers;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\Menus\Facades\MenuTypeAPIFacade;
@@ -57,7 +58,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
             'itemDataEntries',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -51,7 +51,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'itemDataEntries',

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -51,7 +51,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
         return parent::getSchemaFieldArgs($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'itemDataEntries',
@@ -59,7 +59,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -41,7 +41,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'commentObjectID',
@@ -49,7 +49,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -2,6 +2,7 @@
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Hooks\Facades\HooksAPIFacade;
@@ -47,7 +48,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
             'commentObjectID',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -41,7 +41,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'commentObjectID',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -41,7 +41,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'commentObjectID',
@@ -49,7 +49,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -41,7 +41,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'commentObjectID',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -29,7 +29,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'isLinkEmbeddable',
@@ -37,7 +37,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -29,7 +29,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isLinkEmbeddable',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -29,7 +29,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isLinkEmbeddable',
@@ -37,7 +37,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -29,7 +29,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'isLinkEmbeddable',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -1,9 +1,10 @@
 <?php
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractFunctionalFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
+use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 
 class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFunctionalFieldResolver
 {
@@ -35,7 +36,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_FunctionalPosts extends AbstractFu
             'isLinkEmbeddable',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -1,9 +1,10 @@
 <?php
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 
 class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
@@ -38,7 +39,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
             'hasLink',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -32,7 +32,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'hasLink',
@@ -40,7 +40,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -32,7 +32,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasLink',
@@ -40,7 +40,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -32,7 +32,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'hasLink',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -32,7 +32,7 @@ class PoP_AddPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasLink',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -1,12 +1,13 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
-use PoP\Engine\Route\RouteUtils;
-use PoPSchema\Comments\TypeResolvers\CommentTypeResolver;
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\Route\RouteUtils;
+use PoP\Translation\Facades\TranslationAPIFacade;
+use PoPSchema\Comments\TypeResolvers\CommentTypeResolver;
 
 class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
 {
@@ -38,7 +39,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
             'contentClipped',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -32,7 +32,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'contentClipped',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -32,7 +32,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'contentClipped',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -32,7 +32,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'contentClipped',
@@ -40,7 +40,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -32,7 +32,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'contentClipped',
@@ -40,7 +40,7 @@ class PoPGenericForms_DataLoad_FieldResolver_Comments extends AbstractDBDataFiel
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'hasIndividualDetails',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasIndividualDetails',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasIndividualDetails',
@@ -40,7 +40,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -1,9 +1,10 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
@@ -38,7 +39,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
             'hasIndividualDetails',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'hasIndividualDetails',
@@ -40,7 +40,7 @@ class FieldResolver_IndividualUsers extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -38,7 +38,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasOrganizationDetails',
@@ -46,7 +46,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -38,7 +38,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasOrganizationDetails',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -38,7 +38,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'hasOrganizationDetails',
@@ -46,7 +46,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -1,9 +1,10 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
@@ -44,7 +45,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
             'hasOrganizationDetails',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -38,7 +38,7 @@ class FieldResolver_OrganizationUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'hasOrganizationDetails',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -1,11 +1,12 @@
 <?php
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoP\ComponentModel\FieldResolvers\EnumTypeFieldSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
+use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoPSchema\PostCategories\Facades\PostCategoryTypeAPIFacade;
 
 class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
@@ -55,7 +56,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
             'hasLinkCategories',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -48,7 +48,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -48,7 +48,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'content',
@@ -57,7 +57,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -48,7 +48,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -48,7 +48,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',
@@ -57,7 +57,7 @@ class PoP_ContentPostLinks_DataLoad_FieldResolver_Posts extends AbstractDBDataFi
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -1,8 +1,9 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 
 class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
@@ -37,7 +38,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
             'content',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',
@@ -39,7 +39,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'content',
@@ -39,7 +39,7 @@ class GD_EM_DataLoad_FieldResolver_Events extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -1,9 +1,10 @@
 <?php
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoPSchema\Events\TypeResolvers\EventTypeResolver;
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
+use PoPSchema\Events\TypeResolvers\EventTypeResolver;
 
 class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
@@ -37,7 +38,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
             'content',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',
@@ -39,7 +39,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -31,7 +31,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'content',
@@ -39,7 +39,7 @@ class GD_EM_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -1,8 +1,9 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\LocationPosts\TypeResolvers\LocationPostTypeResolver;
 use PoPSchema\PostCategories\Facades\PostCategoryTypeAPIFacade;
 
@@ -36,7 +37,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
             'content',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -30,7 +30,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -30,7 +30,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'content',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -30,7 +30,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'content',
@@ -38,7 +38,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -30,7 +30,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'content',
@@ -38,7 +38,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_FieldResolver_Posts extends 
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'references',
@@ -53,7 +53,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'references',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'references',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -1,13 +1,14 @@
 <?php
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
+use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 
 class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
 {
@@ -51,7 +52,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
             'referencedByCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'references',
@@ -53,7 +53,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -38,7 +38,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'taggedusers',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -38,7 +38,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'taggedusers',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -38,7 +38,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'taggedusers',
@@ -46,7 +46,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -38,7 +38,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'taggedusers',
@@ -46,7 +46,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -1,9 +1,10 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Comments\TypeResolvers\CommentTypeResolver;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
@@ -44,7 +45,7 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
             'taggedusers',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'taggedusers',
@@ -53,7 +53,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'taggedusers',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -1,6 +1,7 @@
 <?php
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -51,7 +52,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
             'downvotePostCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'taggedusers',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -41,7 +41,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'taggedusers',
@@ -53,7 +53,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -39,7 +39,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'recommendsCustomPosts',
@@ -50,7 +50,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -39,7 +39,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'recommendsCustomPosts',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -39,7 +39,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'recommendsCustomPosts',
@@ -50,7 +50,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -1,6 +1,7 @@
 <?php
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -48,7 +49,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
             'followersCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -39,7 +39,7 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'recommendsCustomPosts',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'members',
@@ -41,7 +41,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -1,9 +1,10 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
@@ -39,7 +40,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
             'hasMembers',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'members',
@@ -41,7 +41,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'members',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -32,7 +32,7 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'members',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'communities',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -1,15 +1,16 @@
 <?php
-use PoPSchema\EverythingElse\Enums\MemberTagEnum;
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
-use PoPSchema\EverythingElse\Enums\MemberStatusEnum;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\EverythingElse\Enums\MemberPrivilegeEnum;
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\FieldResolvers\EnumTypeFieldSchemaDefinitionResolverTrait;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
+use PoPSchema\EverythingElse\Enums\MemberPrivilegeEnum;
+use PoPSchema\EverythingElse\Enums\MemberStatusEnum;
+use PoPSchema\EverythingElse\Enums\MemberTagEnum;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolver
 {
@@ -55,7 +56,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
             'hasActiveCommunities',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'communities',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'communities',
@@ -57,7 +57,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'communities',
@@ -57,7 +57,7 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isProfile',
@@ -55,7 +55,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'isProfile',
@@ -55,7 +55,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -1,8 +1,9 @@
 <?php
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldResolver
@@ -53,7 +54,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
             'isProfile',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isProfile',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -47,7 +47,7 @@ class GD_UserPlatform_DataLoad_FieldResolver_Users extends AbstractDBDataFieldRe
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'isProfile',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -1,14 +1,15 @@
 <?php
 namespace PoPSchema\UserRoles;
 
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
-use PoP\Hooks\Facades\HooksAPIFacade;
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Hooks\Facades\HooksAPIFacade;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\UserRoles\Facades\UserRoleTypeDataResolverFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class FieldResolver_Users extends AbstractDBDataFieldResolver
 {
@@ -40,7 +41,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
             'hasRole',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -34,7 +34,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasRole',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -34,7 +34,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'hasRole',
@@ -42,7 +42,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -34,7 +34,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'hasRole',
@@ -42,7 +42,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -34,7 +34,7 @@ class FieldResolver_Users extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'hasRole',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -29,7 +29,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'volunteersNeeded',
@@ -37,7 +37,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -1,8 +1,9 @@
 <?php
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 
 class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldResolver
@@ -35,7 +36,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
             'volunteersNeeded',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -29,7 +29,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'volunteersNeeded',
@@ -37,7 +37,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -29,7 +29,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'volunteersNeeded',

--- a/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -29,7 +29,7 @@ class PoP_Volunteering_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'volunteersNeeded',

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -114,7 +114,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'action',

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -114,7 +114,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'action',
@@ -136,7 +136,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -114,7 +114,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'action',
@@ -136,7 +136,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
@@ -134,7 +135,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
             'isAction',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -114,7 +114,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'action',

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -70,7 +70,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'pages',
@@ -81,7 +81,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\Pages\FieldResolvers;
 
+use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoPSchema\CustomPosts\ModuleProcessors\CustomPostRelationalFieldDataloadModuleProcessor;
 use PoPSchema\CustomPosts\Types\Status;
 use PoPSchema\Pages\ComponentConfiguration;
 use PoPSchema\Pages\Facades\PageTypeAPIFacade;
 use PoPSchema\Pages\TypeResolvers\PageTypeResolver;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
-use PoPSchema\CustomPosts\ModuleProcessors\CustomPostRelationalFieldDataloadModuleProcessor;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class RootPageFieldResolver extends AbstractQueryableFieldResolver
@@ -79,7 +80,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
             'unrestrictedPageCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -70,7 +70,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'pages',

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -70,7 +70,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'pages',

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -70,7 +70,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'pages',
@@ -81,7 +81,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'postCategories',

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'postCategories',

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\PostCategories\FieldResolvers;
 
-use PoPSchema\Categories\ComponentConfiguration;
-use PoPSchema\PostCategories\TypeResolvers\PostCategoryTypeResolver;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
-use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
-use PoPSchema\PostCategories\ModuleProcessors\PostCategoryFieldDataloadModuleProcessor;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoPSchema\Categories\ComponentConfiguration;
 use PoPSchema\PostCategories\Facades\PostCategoryTypeAPIFacade;
+use PoPSchema\PostCategories\ModuleProcessors\PostCategoryFieldDataloadModuleProcessor;
+use PoPSchema\PostCategories\TypeResolvers\PostCategoryTypeResolver;
+use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
 {
@@ -62,7 +63,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
             'postCategoryNames',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'postCategories',
@@ -64,7 +64,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'postCategories',
@@ -64,7 +64,7 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -6,14 +6,15 @@ namespace PoPSchema\PostMutations\FieldResolvers;
 
 use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoPSchema\CustomPosts\Types\Status;
+use PoPSchema\PostMutations\ModuleProcessors\FieldDataloadModuleProcessor;
 use PoPSchema\Posts\ComponentConfiguration;
 use PoPSchema\Posts\Facades\PostTypeAPIFacade;
-use PoPSchema\PostMutations\ModuleProcessors\FieldDataloadModuleProcessor;
 use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 use PoPSchema\UserState\FieldResolvers\UserStateFieldResolverTrait;
@@ -53,7 +54,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
             'myPostCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -46,7 +46,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'myPosts',
@@ -55,7 +55,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -46,7 +46,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'myPosts',

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -46,7 +46,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'myPosts',

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -46,7 +46,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'myPosts',
@@ -55,7 +55,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'postTags',
@@ -64,7 +64,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'postTags',
@@ -64,7 +64,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'postTags',

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -54,7 +54,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'postTags',

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\PostTags\FieldResolvers;
 
-use PoPSchema\Tags\ComponentConfiguration;
-use PoPSchema\PostTags\TypeResolvers\PostTagTypeResolver;
-use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
-use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
-use PoPSchema\PostTags\ModuleProcessors\PostTagFieldDataloadModuleProcessor;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
 use PoPSchema\PostTags\Facades\PostTagTypeAPIFacade;
+use PoPSchema\PostTags\ModuleProcessors\PostTagFieldDataloadModuleProcessor;
+use PoPSchema\PostTags\TypeResolvers\PostTagTypeResolver;
+use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
+use PoPSchema\Tags\ComponentConfiguration;
 
 class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
 {
@@ -62,7 +63,7 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
             'postTagNames',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace PoPSchema\Posts\FieldResolvers;
 
+use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoPSchema\CustomPosts\Types\Status;
 use PoPSchema\Posts\ComponentConfiguration;
 use PoPSchema\Posts\Facades\PostTypeAPIFacade;
-use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoPSchema\Posts\ModuleProcessors\FieldDataloadModuleProcessor;
+use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
 abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
@@ -55,7 +56,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
             'unrestrictedPostCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -46,7 +46,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'posts',

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -46,7 +46,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'posts',
@@ -57,7 +57,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -46,7 +46,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'posts',

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -46,7 +46,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'posts',
@@ -57,7 +57,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -35,7 +35,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isPublished',
@@ -43,7 +43,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\Posts\FieldResolvers;
 
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
-use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 use PoPSchema\CustomPosts\Types\Status;
+use PoPSchema\Posts\TypeResolvers\PostTypeResolver;
 
 class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -41,7 +42,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
             'isPublished',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -35,7 +35,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'isPublished',
@@ -43,7 +43,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -35,7 +35,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'isPublished',

--- a/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/PostLegacyContentFieldResolver.php
@@ -35,7 +35,7 @@ class PostLegacyContentFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isPublished',

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -46,7 +46,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'stances',
@@ -58,7 +58,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace PoPSchema\Stances\FieldResolvers;
 
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\Stances\TypeResolvers\StanceTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
-use PoPSchema\Stances\ComponentConfiguration;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
+use PoPSchema\Stances\ComponentConfiguration;
+use PoPSchema\Stances\TypeResolvers\StanceTypeResolver;
 
 class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -56,7 +57,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
             'stanceAgainstCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -46,7 +46,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'stances',
@@ -58,7 +58,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -46,7 +46,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'stances',

--- a/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -46,7 +46,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'stances',

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -53,7 +53,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'categories',
@@ -64,7 +64,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -53,7 +53,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'categories',

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -53,7 +53,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'categories',

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -53,7 +53,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'categories',
@@ -64,7 +64,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace PoPSchema\Stances\FieldResolvers;
 
-use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\Stances\TypeResolvers\StanceTypeResolver;
-use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
+use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
+use PoPSchema\Stances\TypeResolvers\StanceTypeResolver;
 use PoPSchema\Taxonomies\Facades\TaxonomyTypeAPIFacade;
 
 class StanceFieldResolver extends AbstractDBDataFieldResolver
@@ -62,7 +63,7 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
             'hasStanceTarget',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'tags',
@@ -46,7 +46,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace PoPSchema\Tags\FieldResolvers;
 
-use PoPSchema\Tags\ComponentConfiguration;
+use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
-use PoPSchema\Tags\ComponentContracts\TagAPIRequestedContractTrait;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
+use PoPSchema\Tags\ComponentConfiguration;
+use PoPSchema\Tags\ComponentContracts\TagAPIRequestedContractTrait;
 use PoPSchema\Tags\ModuleProcessors\FieldDataloadModuleProcessor;
 
 abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryableFieldResolver
@@ -44,7 +45,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
             'tagNames',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'tags',

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'tags',
@@ -46,7 +46,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -36,7 +36,7 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'tags',

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRolesWP\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\UserRolesWP\TypeResolvers\UserRoleTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractReflectionPropertyFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\UserRolesWP\TypeResolvers\UserRoleTypeResolver;
 
 class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
 {
@@ -48,7 +49,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
             'capabilities',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -41,7 +41,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      *
      * @see https://github.com/getpop/component-model/issues/1
      */
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'name',
@@ -50,7 +50,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -41,7 +41,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      *
      * @see https://github.com/getpop/component-model/issues/1
      */
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -41,7 +41,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      *
      * @see https://github.com/getpop/component-model/issues/1
      */
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',

--- a/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
+++ b/layers/Schema/packages/user-roles-wp/src/FieldResolvers/UserRoleFieldResolver.php
@@ -41,7 +41,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
      *
      * @see https://github.com/getpop/component-model/issues/1
      */
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'name',
@@ -50,7 +50,7 @@ class UserRoleFieldResolver extends AbstractReflectionPropertyFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
@@ -37,7 +37,7 @@ trait RolesFieldResolverTrait
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'roles',

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
@@ -37,7 +37,7 @@ trait RolesFieldResolverTrait
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'roles',
@@ -46,7 +46,7 @@ trait RolesFieldResolverTrait
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
@@ -37,7 +37,7 @@ trait RolesFieldResolverTrait
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'roles',
@@ -46,7 +46,7 @@ trait RolesFieldResolverTrait
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
@@ -37,7 +37,7 @@ trait RolesFieldResolverTrait
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'roles',

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/RolesFieldResolverTrait.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace PoPSchema\UserRoles\FieldResolvers;
 
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Translation\Facades\TranslationAPIFacade;
 use PoPSchema\UserRoles\Facades\UserRoleTypeDataResolverFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait RolesFieldResolverTrait
 {
@@ -44,7 +45,7 @@ trait RolesFieldResolverTrait
             'capabilities',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -45,7 +45,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'roles',

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRoles\FieldResolvers;
 
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoPSchema\UserRoles\Facades\UserRoleTypeDataResolverFacade;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoPSchema\UserRoles\Facades\UserRoleTypeDataResolverFacade;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class UserFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -52,7 +53,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
             'capabilities',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -45,7 +45,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'roles',

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -45,7 +45,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'roles',
@@ -54,7 +54,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-roles/src/FieldResolvers/UserFieldResolver.php
@@ -45,7 +45,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'roles',
@@ -54,7 +54,7 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -26,7 +26,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isUserLoggedIn',

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -26,7 +26,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'isUserLoggedIn',

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -26,7 +26,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'isUserLoggedIn',
@@ -34,7 +34,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserState\FieldResolvers;
 
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractGlobalFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\State\ApplicationState;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class GlobalFieldResolver extends AbstractGlobalFieldResolver
 {
@@ -32,7 +33,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
             'isUserLoggedIn',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/GlobalFieldResolver.php
@@ -26,7 +26,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'isUserLoggedIn',
@@ -34,7 +34,7 @@ class GlobalFieldResolver extends AbstractGlobalFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -61,7 +61,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         switch ($fieldName) {
             case 'author':

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -61,14 +61,14 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'author':
                 $fieldInterfaceResolver = $this->getWithAuthorFieldInterfaceResolverInstance();
-                return $fieldInterfaceResolver->getSchemaFieldResponseModifiers($fieldName);
+                return $fieldInterfaceResolver->getSchemaFieldTypeModifiers($fieldName);
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -61,7 +61,7 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'author':

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -61,14 +61,14 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         switch ($fieldName) {
             case 'author':
                 $fieldInterfaceResolver = $this->getWithAuthorFieldInterfaceResolverInstance();
-                return $fieldInterfaceResolver->isSchemaFieldResponseNonNullable($fieldName);
+                return $fieldInterfaceResolver->getSchemaFieldResponseModifiers($fieldName);
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     /**

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -35,7 +35,7 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldTypeModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         switch ($fieldName) {
             case 'author':

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoPSchema\Users\FieldInterfaceResolvers;
 
-use PoPSchema\Users\TypeResolvers\UserTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldInterfaceResolvers\AbstractSchemaFieldInterfaceResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoPSchema\Users\TypeResolvers\UserTypeResolver;
 
 class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolver
 {
@@ -39,7 +40,7 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
     {
         switch ($fieldName) {
             case 'author':
-                return true;
+                return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($fieldName);
     }

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -35,13 +35,13 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(string $fieldName): bool
     {
         switch ($fieldName) {
             case 'author':
                 return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($fieldName);
+        return parent::getSchemaFieldResponseModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -35,13 +35,13 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(string $fieldName): bool
+    public function getSchemaFieldTypeModifiers(string $fieldName): bool
     {
         switch ($fieldName) {
             case 'author':
                 return true;
         }
-        return parent::getSchemaFieldResponseModifiers($fieldName);
+        return parent::getSchemaFieldTypeModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(string $fieldName): ?string

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -58,7 +58,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'users',
@@ -67,7 +67,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -58,7 +58,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'users',

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -58,7 +58,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'users',
@@ -67,7 +67,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -58,7 +58,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'users',

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\FieldResolvers\AbstractQueryableFieldResolver;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Schema\TypeCastingHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
@@ -65,7 +66,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
             'userCount',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -35,7 +35,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'sites',

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -35,7 +35,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'sites',
@@ -44,7 +44,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -35,7 +35,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'sites',
@@ -44,7 +44,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -35,7 +35,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'sites',

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\Multisite\FieldResolvers;
 
-use PoP\Engine\TypeResolvers\RootTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\TypeCastingHelpers;
-use PoP\Multisite\TypeResolvers\SiteTypeResolver;
-use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\Schema\TypeCastingHelpers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\TypeResolvers\RootTypeResolver;
+use PoP\Multisite\TypeResolvers\SiteTypeResolver;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
 {
@@ -42,7 +43,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
             'site',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -33,7 +33,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'domain',
@@ -42,7 +42,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -33,7 +33,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function isSchemaFieldResponseNonNullable(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
     {
         $nonNullableFieldNames = [
             'domain',
@@ -42,7 +42,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
         if (in_array($fieldName, $nonNullableFieldNames)) {
             return true;
         }
-        return parent::isSchemaFieldResponseNonNullable($typeResolver, $fieldName);
+        return parent::getSchemaFieldResponseModifiers($typeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -33,7 +33,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
             'domain',

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\Multisite\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 use PoP\Multisite\TypeResolvers\SiteTypeResolver;
 
@@ -40,7 +41,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
             'host',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
-            return true;
+            return SchemaTypeModifiers::NON_NULLABLE;
         }
         return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
     }

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/SiteFieldResolver.php
@@ -33,7 +33,7 @@ class SiteFieldResolver extends AbstractDBDataFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): bool
+    public function getSchemaFieldResponseModifiers(TypeResolverInterface $typeResolver, string $fieldName): int
     {
         $nonNullableFieldNames = [
             'domain',


### PR DESCRIPTION
Replace `isSchemaFieldResponseNonNullable` with `getSchemaFieldTypeModifiers`, allowing to retrieve all properties for a field type's response through a single function:

- `String`
- `String!`
- `[String]`
- `[String]!`
- `[String!]!`

To find out which property is activated, we use bitwise operations, like described [here](https://www.php.net/manual/en/language.operators.bitwise.php#91291).

In this PR, only `SchemaTypeModifiers::NON_NULLABLE` is completed. The other ones will come in other PRs.