### PR TITLE
Rework basic types - Manage when/how to use types `Mixed`, `Object` and `ANY_SCALAR`

### DIFF
--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -313,27 +313,6 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                 if ($schemaTypeModifiers & SchemaTypeModifiers::IS_ARRAY) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] = true;
                 }
-                /**
-                 * This value will not be used with GraphQL, but can be used by PoP.
-                 * 
-                 * While GraphQL has a strong type system, PoP takes a more lenient approach,
-                 * enabling fields to maybe be an array, maybe not.
-                 * 
-                 * Eg: `echo(object: ...)` will print back whatever provided,
-                 * whether `String` or `[String]`. Its input is `Mixed`, which can comprise
-                 * an `Object`, so it could be provided as an array, or also `String`, which
-                 * will not be an array.
-                 * 
-                 * Whenever `MAY_BE_ARRAY` flag is on, the server will skip validations
-                 * concerning an input being array or not.
-                 */
-                if (in_array($type, [
-                    SchemaDefinition::TYPE_INPUT_OBJECT,
-                    SchemaDefinition::TYPE_OBJECT,
-                    SchemaDefinition::TYPE_MIXED,
-                ])) {
-                    $schemaDefinition[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] = true;
-                }
                 if ($description = $schemaDefinitionResolver->getSchemaFieldDescription($typeResolver, $fieldName)) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $description;
                 }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsSchemaFilterInputModuleProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsSchemaFilterInputModuleProcessorInterface.php
@@ -10,10 +10,6 @@ interface DataloadQueryArgsSchemaFilterInputModuleProcessorInterface
     public function getSchemaFilterInputDescription(array $module): ?string;
     public function getSchemaFilterInputDeprecationDescription(array $module): ?string;
     public function getSchemaFilterInputIsArrayType(array $module): bool;
-    /**
-     * This function is needed by PoP API, not by GraphQL
-     */
-    public function getSchemaFilterInputMayBeArrayType(array $module): bool;
     public function getSchemaFilterInputMandatory(array $module): bool;
     public function addSchemaDefinitionForFilter(array &$schemaDefinition, array $module): void;
 }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
@@ -41,14 +41,33 @@ trait FilterInputModuleProcessorTrait
             SchemaDefinition::ARGNAME_NAME => $this->getName($module),
         ];
         if ($filterSchemaDefinitionResolver = $this->getFilterInputSchemaDefinitionResolver($module)) {
-            $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $filterSchemaDefinitionResolver->getSchemaFilterInputType($module);
+            $type = $filterSchemaDefinitionResolver->getSchemaFilterInputType($module);
+            $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $type;
             if ($description = $filterSchemaDefinitionResolver->getSchemaFilterInputDescription($module)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $description;
             }
             if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsArrayType($module)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] = true;
             }
-            if ($filterSchemaDefinitionResolver->getSchemaFilterInputMayBeArrayType($module)) {
+            /**
+             * This value will not be used with GraphQL, but can be used by PoP.
+             * 
+             * While GraphQL has a strong type system, PoP takes a more lenient approach,
+             * enabling fields to maybe be an array, maybe not.
+             * 
+             * Eg: `echo(object: ...)` will print back whatever provided,
+             * whether `String` or `[String]`. Its input is `Mixed`, which can comprise
+             * an `Object`, so it could be provided as an array, or also `String`, which
+             * will not be an array.
+             * 
+             * Whenever `MAY_BE_ARRAY` flag is on, the server will skip validations
+             * concerning an input being array or not.
+             */
+            if (in_array($type, [
+                SchemaDefinition::TYPE_INPUT_OBJECT,
+                SchemaDefinition::TYPE_OBJECT,
+                SchemaDefinition::TYPE_MIXED,
+            ])) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] = true;
             }
             if ($filterSchemaDefinitionResolver->getSchemaFilterInputMandatory($module)) {

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
@@ -49,27 +49,6 @@ trait FilterInputModuleProcessorTrait
             if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsArrayType($module)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] = true;
             }
-            /**
-             * This value will not be used with GraphQL, but can be used by PoP.
-             * 
-             * While GraphQL has a strong type system, PoP takes a more lenient approach,
-             * enabling fields to maybe be an array, maybe not.
-             * 
-             * Eg: `echo(object: ...)` will print back whatever provided,
-             * whether `String` or `[String]`. Its input is `Mixed`, which can comprise
-             * an `Object`, so it could be provided as an array, or also `String`, which
-             * will not be an array.
-             * 
-             * Whenever `MAY_BE_ARRAY` flag is on, the server will skip validations
-             * concerning an input being array or not.
-             */
-            if (in_array($type, [
-                SchemaDefinition::TYPE_INPUT_OBJECT,
-                SchemaDefinition::TYPE_OBJECT,
-                SchemaDefinition::TYPE_MIXED,
-            ])) {
-                $schemaDefinition[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] = true;
-            }
             if ($filterSchemaDefinitionResolver->getSchemaFilterInputMandatory($module)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] = true;
             }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/SchemaFilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/SchemaFilterInputModuleProcessorTrait.php
@@ -29,13 +29,6 @@ trait SchemaFilterInputModuleProcessorTrait
     {
         return false;
     }
-    /**
-     * This function is needed by PoP API, not by GraphQL
-     */
-    public function getSchemaFilterInputMayBeArrayType(array $module): bool
-    {
-        return false;
-    }
     public function getSchemaFilterInputMandatory(array $module): bool
     {
         return false;

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -103,7 +103,7 @@ trait FieldOrDirectiveResolverTrait
                 $fieldOrDirectiveArgSchemaDefinition = $fieldOrDirectiveArgsSchemaDefinition[$fieldOrDirectiveArgumentName];
                 // If the value may be array, may be not, then there's nothing to validate
                 $fieldOrDirectiveArgMayBeArray = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] ?? false;
-                if ($fieldOrDirectiveArgMayBeArray === true) {
+                if ($fieldOrDirectiveArgMayBeArray) {
                     continue;
                 }
                 $fieldOrDirectiveArgIsArray = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -101,8 +101,27 @@ trait FieldOrDirectiveResolverTrait
             if ($fieldOrDirectiveArgumentValue !== null) {
                 // Check if it's an array or not from the schema definition
                 $fieldOrDirectiveArgSchemaDefinition = $fieldOrDirectiveArgsSchemaDefinition[$fieldOrDirectiveArgumentName];
+                /**
+                 * This value will not be used with GraphQL, but can be used by PoP.
+                 * 
+                 * While GraphQL has a strong type system, PoP takes a more lenient approach,
+                 * enabling fields to maybe be an array, maybe not.
+                 * 
+                 * Eg: `echo(object: ...)` will print back whatever provided,
+                 * whether `String` or `[String]`. Its input is `Mixed`, which can comprise
+                 * an `Object`, so it could be provided as an array, or also `String`, which
+                 * will not be an array.
+                 * 
+                 * Whenever the value may be an array, the server will skip those validations
+                 * to check if an input is array or not (and throw an error).
+                 */
+                $fieldOrDirectiveArgType = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+                $fieldOrDirectiveArgMayBeArray = in_array($fieldOrDirectiveArgType, [
+                    SchemaDefinition::TYPE_INPUT_OBJECT,
+                    SchemaDefinition::TYPE_OBJECT,
+                    SchemaDefinition::TYPE_MIXED,
+                ]);
                 // If the value may be array, may be not, then there's nothing to validate
-                $fieldOrDirectiveArgMayBeArray = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] ?? false;
                 if ($fieldOrDirectiveArgMayBeArray) {
                     continue;
                 }
@@ -165,7 +184,26 @@ trait FieldOrDirectiveResolverTrait
                 // Check if it's an array or not from the schema definition
                 $enumTypeFieldOrDirectiveArgSchemaDefinition = $enumTypeFieldOrDirectiveArgsSchemaDefinition[$fieldOrDirectiveArgumentName];
                 // If the value may be array, may be not, then there's nothing to validate
-                $enumTypeFieldOrDirectiveArgMayBeArray = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] ?? false;
+                /**
+                 * This value will not be used with GraphQL, but can be used by PoP.
+                 * 
+                 * While GraphQL has a strong type system, PoP takes a more lenient approach,
+                 * enabling fields to maybe be an array, maybe not.
+                 * 
+                 * Eg: `echo(value: ...)` will print back whatever provided,
+                 * whether `String` or `[String]`. Its input is `Mixed`, which can comprise
+                 * an `Object`, so it could be provided as an array, or also `String`, which
+                 * will not be an array.
+                 * 
+                 * Whenever the value may be an array, the server will skip those validations
+                 * to check if an input is array or not (and throw an error).
+                 */
+                $enumTypeFieldOrDirectiveArgType = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+                $enumTypeFieldOrDirectiveArgMayBeArray = in_array($enumTypeFieldOrDirectiveArgType, [
+                    SchemaDefinition::TYPE_INPUT_OBJECT,
+                    SchemaDefinition::TYPE_OBJECT,
+                    SchemaDefinition::TYPE_MIXED,
+                ]);
                 $enumTypeFieldOrDirectiveArgIsArray = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
                 // Each fieldArgumentEnumValue is an array with item "name" for sure, and maybe also "description", "deprecated" and "deprecationDescription"
                 $schemaFieldOrDirectiveArgumentEnumValues = $schemaFieldArgumentEnumValueDefinitions[$fieldOrDirectiveArgumentName];

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -651,7 +651,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                 // If not set, the return type is not an array
                 $fieldArgIsArrayType = $fieldOrDirectiveArgNameIsArrayTypes[$argName] ?? false;
                 $fieldArgMayBeArrayType = $fieldOrDirectiveArgNameMayBeArrayTypes[$argName] ?? false;
-                if ($fieldArgMayBeArrayType === false) {
+                if (!$fieldArgMayBeArrayType) {
                     // Validate that the expected array/non-array input is provided
                     $errorMessage = null;
                     if ($fieldArgIsArrayType && !is_array($argValue)) {

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -53,19 +53,11 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     /**
      * @var array<string, array>
      */
-    private array $fieldArgumentNameMayBeArrayTypesCache = [];
-    /**
-     * @var array<string, array>
-     */
     private array $directiveArgumentNameTypesCache = [];
     /**
      * @var array<string, array>
      */
     private array $directiveArgumentNameIsArrayTypesCache = [];
-    /**
-     * @var array<string, array>
-     */
-    private array $directiveArgumentNameMayBeArrayTypesCache = [];
     /**
      * @var array<string, array>
      */
@@ -587,12 +579,10 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         // Get the field argument types, to know to what type it will cast the value
         if ($directiveArgNameTypes = $this->getDirectiveArgumentNameTypes($directiveResolver, $typeResolver)) {
             $directiveArgNameIsArrayTypes = $this->getDirectiveArgumentNameIsArrayTypes($directiveResolver, $typeResolver);
-            $directiveArgNameMayBeArrayTypes = $this->getDirectiveArgumentNameMayBeArrayTypes($directiveResolver, $typeResolver);
             return $this->castFieldOrDirectiveArguments(
                 $directiveArgs,
                 $directiveArgNameTypes,
                 $directiveArgNameIsArrayTypes,
-                $directiveArgNameMayBeArrayTypes,
                 $failedCastingDirectiveArgErrorMessages,
                 $forSchema
             );
@@ -610,12 +600,10 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         // Get the field argument types, to know to what type it will cast the value
         if ($fieldArgNameTypes = $this->getFieldArgumentNameTypes($typeResolver, $field)) {
             $fieldArgNameIsArrayTypes = $this->getFieldArgumentNameIsArrayTypes($typeResolver, $field);
-            $fieldArgNameMayBeArrayTypes = $this->getFieldArgumentNameMayBeArrayTypes($typeResolver, $field);
             return $this->castFieldOrDirectiveArguments(
                 $fieldArgs,
                 $fieldArgNameTypes,
                 $fieldArgNameIsArrayTypes,
-                $fieldArgNameMayBeArrayTypes,
                 $failedCastingFieldArgErrorMessages,
                 $forSchema
             );
@@ -627,7 +615,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         array $fieldOrDirectiveArgs,
         array $fieldOrDirectiveArgNameTypes,
         array $fieldOrDirectiveArgNameIsArrayTypes,
-        array $fieldOrDirectiveArgNameMayBeArrayTypes,
         array &$failedCastingFieldOrDirectiveArgErrorMessages,
         bool $forSchema
     ): array {
@@ -649,18 +636,37 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                 // Maybe cast the value to the appropriate type. Eg: from string to boolean
                 $fieldArgType = $fieldOrDirectiveArgNameTypes[$argName];
                 // If not set, the return type is not an array
-                $fieldArgIsArrayType = $fieldOrDirectiveArgNameIsArrayTypes[$argName] ?? false;
-                $fieldArgMayBeArrayType = $fieldOrDirectiveArgNameMayBeArrayTypes[$argName] ?? false;
-                if (!$fieldArgMayBeArrayType) {
+                $fieldOrDirectiveArgIsArrayType = $fieldOrDirectiveArgNameIsArrayTypes[$argName] ?? false;
+                
+                /**
+                 * This value will not be used with GraphQL, but can be used by PoP.
+                 * 
+                 * While GraphQL has a strong type system, PoP takes a more lenient approach,
+                 * enabling fields to maybe be an array, maybe not.
+                 * 
+                 * Eg: `echo(value: ...)` will print back whatever provided,
+                 * whether `String` or `[String]`. Its input is `Mixed`, which can comprise
+                 * an `Object`, so it could be provided as an array, or also `String`, which
+                 * will not be an array.
+                 * 
+                 * Whenever the value may be an array, the server will skip those validations
+                 * to check if an input is array or not (and throw an error).
+                 */
+                $fieldOrDirectiveArgMayBeArrayType = in_array($fieldArgType, [
+                    SchemaDefinition::TYPE_INPUT_OBJECT,
+                    SchemaDefinition::TYPE_OBJECT,
+                    SchemaDefinition::TYPE_MIXED,
+                ]);
+                if (!$fieldOrDirectiveArgMayBeArrayType) {
                     // Validate that the expected array/non-array input is provided
                     $errorMessage = null;
-                    if ($fieldArgIsArrayType && !is_array($argValue)) {
+                    if ($fieldOrDirectiveArgIsArrayType && !is_array($argValue)) {
                         $errorMessage = sprintf(
                             $this->translationAPI->__('Argument \'%s\' expects an array, but value \'%s\' was provided', 'pop-component-model'),
                             $argName,
                             $argValue
                         );
-                    } elseif (!$fieldArgIsArrayType && is_array($argValue)) {
+                    } elseif (!$fieldOrDirectiveArgIsArrayType && is_array($argValue)) {
                         $errorMessage = sprintf(
                             $this->translationAPI->__('Argument \'%s\' does not expect an array, but array \'%s\' was provided', 'pop-component-model'),
                             $argName,
@@ -677,8 +683,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                 // Cast (or "coerce" in GraphQL terms) the value
                 // If the value is an array, then cast each element to the item type
                 if (
-                    (!$fieldArgMayBeArrayType && $fieldArgIsArrayType)
-                    || ($fieldArgMayBeArrayType && is_array($argValue))
+                    (!$fieldOrDirectiveArgMayBeArrayType && $fieldOrDirectiveArgIsArrayType)
+                    || ($fieldOrDirectiveArgMayBeArrayType && is_array($argValue))
                 ) {
                     $argValue = array_map(
                         fn ($arrayArgValueElem) => $this->typeCastingExecuter->cast($fieldArgType, $arrayArgValueElem),
@@ -762,26 +768,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             }
         }
         return $directiveArgNameIsArrayTypes;
-    }
-
-    protected function getDirectiveArgumentNameMayBeArrayTypes(DirectiveResolverInterface $directiveResolver, TypeResolverInterface $typeResolver): array
-    {
-        if (!isset($this->directiveArgumentNameMayBeArrayTypesCache[get_class($directiveResolver)][get_class($typeResolver)])) {
-            $this->directiveArgumentNameMayBeArrayTypesCache[get_class($directiveResolver)][get_class($typeResolver)] = $this->doGetDirectiveArgumentNameMayBeArrayTypes($directiveResolver, $typeResolver);
-        }
-        return $this->directiveArgumentNameMayBeArrayTypesCache[get_class($directiveResolver)][get_class($typeResolver)];
-    }
-
-    protected function doGetDirectiveArgumentNameMayBeArrayTypes(DirectiveResolverInterface $directiveResolver, TypeResolverInterface $typeResolver): array
-    {
-        // Get the fieldDirective argument types, to know to what type it will cast the value
-        $directiveArgNameMayBeArrayTypes = [];
-        if ($directiveSchemaDefinitionArgs = $this->getDirectiveSchemaDefinitionArgs($directiveResolver, $typeResolver)) {
-            foreach ($directiveSchemaDefinitionArgs as $directiveSchemaDefinitionArg) {
-                $directiveArgNameMayBeArrayTypes[$directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] ?? false;
-            }
-        }
-        return $directiveArgNameMayBeArrayTypes;
     }
 
     protected function getDirectiveArgumentNameDefaultValues(DirectiveResolverInterface $directiveResolver, TypeResolverInterface $typeResolver): array
@@ -868,26 +854,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             }
         }
         return $fieldArgNameIsArrayTypes;
-    }
-
-    protected function getFieldArgumentNameMayBeArrayTypes(TypeResolverInterface $typeResolver, string $field): array
-    {
-        if (!isset($this->fieldArgumentNameMayBeArrayTypesCache[get_class($typeResolver)][$field])) {
-            $this->fieldArgumentNameMayBeArrayTypesCache[get_class($typeResolver)][$field] = $this->doGetFieldArgumentNameMayBeArrayTypes($typeResolver, $field);
-        }
-        return $this->fieldArgumentNameMayBeArrayTypesCache[get_class($typeResolver)][$field];
-    }
-
-    protected function doGetFieldArgumentNameMayBeArrayTypes(TypeResolverInterface $typeResolver, string $field): array
-    {
-        // Get the field argument types, to know to what type it will cast the value
-        $fieldArgNameMayBeArrayTypes = [];
-        if ($fieldSchemaDefinitionArgs = $this->getFieldSchemaDefinitionArgs($typeResolver, $field)) {
-            foreach ($fieldSchemaDefinitionArgs as $fieldSchemaDefinitionArg) {
-                $fieldArgNameMayBeArrayTypes[$fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_MAY_BE_ARRAY] ?? false;
-            }
-        }
-        return $fieldArgNameMayBeArrayTypes;
     }
 
     protected function getFieldArgumentNameDefaultValues(TypeResolverInterface $typeResolver, string $field): array
@@ -1007,9 +973,9 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             $fieldArgNameIsArrayTypes = $this->getFieldArgumentNameIsArrayTypes($typeResolver, $field);
             foreach (array_keys($failedCastingFieldArgs) as $failedCastingFieldArgName) {
                 // If it is Error, also show the error message
-                $fieldArgIsArrayType = $fieldArgNameIsArrayTypes[$failedCastingFieldArgName];
+                $fieldOrDirectiveArgIsArrayType = $fieldArgNameIsArrayTypes[$failedCastingFieldArgName];
                 $composedFieldArgType = $fieldArgNameTypes[$failedCastingFieldArgName];
-                if ($fieldArgIsArrayType) {
+                if ($fieldOrDirectiveArgIsArrayType) {
                     $composedFieldArgType = sprintf(
                         $this->translationAPI->__('array of %s', 'pop-component-model'),
                         $composedFieldArgType

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -94,6 +94,15 @@ class SchemaDefinition
      * on the server-side via PHP
      */
     const TYPE_MIXED = 'mixed';
+    /**
+     * This custom scalar type comprises the 2 atomic types by GraphQL:
+     * 
+     * - String
+     * - Int
+     * 
+     * It is used to represent array keys, which can only be numeric or strings.
+     */
+    const TYPE_KEY = 'key';
 
     /**
      * One of the 5 atomic scalars in GraphQL

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -55,15 +55,72 @@ class SchemaDefinition
     const ARGVALUE_SCHEMA_SHAPE_NESTED = 'nested';
 
     // Field/Directive Argument Types
+
+    /**
+     * Custom scalar type "comprising" the 5 atomic scalar types by GraphQL:
+     * 
+     * - String
+     * - Int
+     * - Float
+     * - Bool
+     * - ID
+     * 
+     * In GraphQL there is no union of scalars, hence this type comes to represent
+     * any of all the scalars. It can be used when we cannot know of what type will
+     * the value be. Eg: when calling `get_option` or `get_post_meta` in WordPress.
+     * 
+     * In GraphQL clients, errors will be shown when providing a `String` to an input
+     * of type `ANY_SCALAR`, but the GraphQL server will process the value correctly.
+     * 
+     * @see https://spec.graphql.org/draft/#sec-Scalars
+     * @see https://github.com/graphql/graphql-spec/issues/215
+     */
+    const TYPE_ANY_SCALAR = 'any_scalar';
+    /**
+     * Custom scalar type representing an `object` from PHP:
+     * some instance from a class or stdClass.
+     * 
+     * It also represents a JSONObject input.
+     * 
+     * Please notice: this type is not an `array`, however it can be represented
+     * through an array on the server-side via PHP. The distinction is important,
+     * because an `array` is not a type in GraphQL, but an `object` can be, as a custom scalar
+     */
+    const TYPE_OBJECT = 'object';
+    /**
+     * This custom scalar type comprises the 5 atomic types by GraphQL, plus the Object.
+     * 
+     * As a consequence, this type can also be represented through an array
+     * on the server-side via PHP
+     */
     const TYPE_MIXED = 'mixed';
-    const TYPE_ID = 'id';
+
+    /**
+     * One of the 5 atomic scalars in GraphQL
+     */
     const TYPE_STRING = 'string';
+    /**
+     * One of the 5 atomic scalars in GraphQL
+     */
     const TYPE_INT = 'int';
+    /**
+     * One of the 5 atomic scalars in GraphQL
+     */
     const TYPE_FLOAT = 'float';
+    /**
+     * One of the 5 atomic scalars in GraphQL
+     */
     const TYPE_BOOL = 'bool';
+    /**
+     * One of the 5 atomic scalars in GraphQL
+     */
+    const TYPE_ID = 'id';
+
+    /**
+     * Custom scalars
+     */
     const TYPE_DATE = 'date';
     const TYPE_TIME = 'time';
-    const TYPE_OBJECT = 'object';
     const TYPE_URL = 'url';
     const TYPE_EMAIL = 'email';
     const TYPE_IP = 'ip';

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -13,7 +13,6 @@ class SchemaDefinition
     const ARGNAME_TYPE = 'type';
     const ARGNAME_NON_NULLABLE = 'nonNullable';
     const ARGNAME_IS_ARRAY = 'isArray';
-    const ARGNAME_MAY_BE_ARRAY = 'mayBeArray';
     const ARGNAME_REFERENCED_TYPE = 'referencedType';
     const ARGNAME_DESCRIPTION = 'description';
     const ARGNAME_VERSION = 'version';

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -102,7 +102,7 @@ class SchemaDefinition
      * 
      * It is used to represent array keys, which can only be numeric or strings.
      */
-    const TYPE_KEY = 'key';
+    const TYPE_ARRAY_KEY = 'array_key';
 
     /**
      * One of the 5 atomic scalars in GraphQL

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionService.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionService.php
@@ -25,6 +25,6 @@ class SchemaDefinitionService implements SchemaDefinitionServiceInterface
      */
     public function getDefaultType(): string
     {
-        return SchemaDefinition::TYPE_MIXED;
+        return SchemaDefinition::TYPE_ANY_SCALAR;
     }
 }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
@@ -13,15 +13,4 @@ class SchemaTypeModifiers
 {
     public const NON_NULLABLE = 1;
     public const IS_ARRAY = 2;
-
-    /**
-     * This value will not be used with GraphQL, but can be used by PoP.
-     * 
-     * While GraphQL has a strong type system, PoP takes a more lenient approach,
-     * enabling fields to maybe be an array, maybe not.
-     * 
-     * Eg: `echo(value: ...)` will print back whatever provided,
-     * whether `String` or `[String]`
-     */
-    public const MAY_BE_ARRAY = 4;
 }

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -66,7 +66,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
             case SchemaDefinition::TYPE_FLOAT:
             case SchemaDefinition::TYPE_BOOL:
             case SchemaDefinition::TYPE_TIME:
-                if (is_array($value)) {
+                if (is_object($value)) {
                     return new Error(
                         'object-cast',
                         sprintf(

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -24,11 +24,54 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
      */
     public function cast(string $type, mixed $value): mixed
     {
-        if (is_array($value)) {
-            return new Error(
-                'array-cast',
-                $this->translationAPI->__('An array is not considered a type. Consider converting it into an object')
-            );
+        // Fail if passing an array for unsupporting types
+        switch ($type) {
+            case SchemaDefinition::TYPE_ID:
+            case SchemaDefinition::TYPE_STRING:
+            case SchemaDefinition::TYPE_URL:
+            case SchemaDefinition::TYPE_EMAIL:
+            case SchemaDefinition::TYPE_IP:
+            case SchemaDefinition::TYPE_ENUM:
+            case SchemaDefinition::TYPE_DATE:
+            case SchemaDefinition::TYPE_INT:
+            case SchemaDefinition::TYPE_FLOAT:
+            case SchemaDefinition::TYPE_BOOL:
+            case SchemaDefinition::TYPE_TIME:
+                if (is_array($value)) {
+                    return new Error(
+                        'array-cast',
+                        sprintf(
+                            $this->translationAPI->__('An array cannot be casted to type \'%s\'', 'component-model'),
+                            $type
+                        )
+                    );
+                }
+                break;
+        }
+
+        // Fail if passing an object for unsupporting types
+        switch ($type) {
+            case SchemaDefinition::TYPE_ID:
+            case SchemaDefinition::TYPE_STRING:
+            case SchemaDefinition::TYPE_URL:
+            case SchemaDefinition::TYPE_EMAIL:
+            case SchemaDefinition::TYPE_IP:
+            case SchemaDefinition::TYPE_ENUM:
+            case SchemaDefinition::TYPE_DATE:
+            case SchemaDefinition::TYPE_INT:
+            case SchemaDefinition::TYPE_FLOAT:
+            case SchemaDefinition::TYPE_BOOL:
+            case SchemaDefinition::TYPE_TIME:
+                if (is_array($value)) {
+                    return new Error(
+                        'object-cast',
+                        sprintf(
+                            $this->translationAPI->__('An object cannot be casted to type \'%s\'', 'component-model'),
+                            $type
+                        )
+                    );
+                }
+                break;
         }
         
         switch ($type) {

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -26,6 +26,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
     {
         // Fail if passing an array for unsupporting types
         switch ($type) {
+            case SchemaDefinition::TYPE_ANY_SCALAR:
             case SchemaDefinition::TYPE_ID:
             case SchemaDefinition::TYPE_STRING:
             case SchemaDefinition::TYPE_URL:
@@ -51,6 +52,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
 
         // Fail if passing an object for unsupporting types
         switch ($type) {
+            case SchemaDefinition::TYPE_ANY_SCALAR:
             case SchemaDefinition::TYPE_ID:
             case SchemaDefinition::TYPE_STRING:
             case SchemaDefinition::TYPE_URL:
@@ -78,12 +80,15 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
             case SchemaDefinition::TYPE_MIXED:
                 // Accept anything and everything
                 return $value;
+            case SchemaDefinition::TYPE_ANY_SCALAR:
+                // Accept anything and everything
+                return $value;
             case SchemaDefinition::TYPE_ID:
-                // An array or an object cannot be an ID
-                if (is_object($value)) {
+                // GraphQL spec: only String or Int allowed.
+                // @see https://spec.graphql.org/draft/#sec-ID.Input-Coercion
+                if (is_float($value) && is_bool($value)) {
                     return null;
                 }
-                // Accept anything and everything
                 return $value;
             case SchemaDefinition::TYPE_STRING:
                 return (string)$value;
@@ -106,7 +111,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 return $value;
             case SchemaDefinition::TYPE_OBJECT:
             case SchemaDefinition::TYPE_INPUT_OBJECT:
-                if (!is_object($value)) {
+                if (!is_object($value) || !is_array($value)) {
                     return null;
                 }
                 return $value;

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -28,6 +28,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
         switch ($type) {
             case SchemaDefinition::TYPE_ANY_SCALAR:
             case SchemaDefinition::TYPE_ID:
+            case SchemaDefinition::TYPE_KEY:
             case SchemaDefinition::TYPE_STRING:
             case SchemaDefinition::TYPE_URL:
             case SchemaDefinition::TYPE_EMAIL:
@@ -54,6 +55,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
         switch ($type) {
             case SchemaDefinition::TYPE_ANY_SCALAR:
             case SchemaDefinition::TYPE_ID:
+            case SchemaDefinition::TYPE_KEY:
             case SchemaDefinition::TYPE_STRING:
             case SchemaDefinition::TYPE_URL:
             case SchemaDefinition::TYPE_EMAIL:
@@ -78,13 +80,12 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
         
         switch ($type) {
             case SchemaDefinition::TYPE_MIXED:
-                // Accept anything and everything
                 return $value;
             case SchemaDefinition::TYPE_ANY_SCALAR:
-                // Accept anything and everything
                 return $value;
             case SchemaDefinition::TYPE_ID:
-                // GraphQL spec: only String or Int allowed.
+            case SchemaDefinition::TYPE_KEY:
+                // Type ID in GraphQL spec: only String or Int allowed.
                 // @see https://spec.graphql.org/draft/#sec-ID.Input-Coercion
                 if (is_float($value) && is_bool($value)) {
                     return null;

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -112,7 +112,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 return $value;
             case SchemaDefinition::TYPE_OBJECT:
             case SchemaDefinition::TYPE_INPUT_OBJECT:
-                if (!is_object($value) || !is_array($value)) {
+                if (!(is_object($value) || is_array($value))) {
                     return null;
                 }
                 return $value;

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -28,7 +28,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
         switch ($type) {
             case SchemaDefinition::TYPE_ANY_SCALAR:
             case SchemaDefinition::TYPE_ID:
-            case SchemaDefinition::TYPE_KEY:
+            case SchemaDefinition::TYPE_ARRAY_KEY:
             case SchemaDefinition::TYPE_STRING:
             case SchemaDefinition::TYPE_URL:
             case SchemaDefinition::TYPE_EMAIL:
@@ -55,7 +55,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
         switch ($type) {
             case SchemaDefinition::TYPE_ANY_SCALAR:
             case SchemaDefinition::TYPE_ID:
-            case SchemaDefinition::TYPE_KEY:
+            case SchemaDefinition::TYPE_ARRAY_KEY:
             case SchemaDefinition::TYPE_STRING:
             case SchemaDefinition::TYPE_URL:
             case SchemaDefinition::TYPE_EMAIL:
@@ -84,7 +84,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
             case SchemaDefinition::TYPE_ANY_SCALAR:
                 return $value;
             case SchemaDefinition::TYPE_ID:
-            case SchemaDefinition::TYPE_KEY:
+            case SchemaDefinition::TYPE_ARRAY_KEY:
                 // Type ID in GraphQL spec: only String or Int allowed.
                 // @see https://spec.graphql.org/draft/#sec-ID.Input-Coercion
                 if (is_float($value) && is_bool($value)) {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
@@ -11,7 +11,6 @@ use PoP\Engine\Dataloading\Expressions;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
-use PoP\ComponentModel\Facades\Schema\FeedbackMessageStoreFacade;
 use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
 use PoP\ComponentModel\Feedback\Tokens;
 
@@ -28,7 +27,6 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
             [
                 SchemaDefinition::ARGNAME_NAME => 'addExpressions',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                SchemaDefinition::ARGNAME_IS_ARRAY => true,
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                     $this->translationAPI->__('Expressions to inject to the composed directive. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)
@@ -37,7 +35,6 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
             [
                 SchemaDefinition::ARGNAME_NAME => 'appendExpressions',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                SchemaDefinition::ARGNAME_IS_ARRAY => true,
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                     $this->translationAPI->__('Append a value to an expression which must be an array, to inject to the composed directive. If the array has not been set, it is initialized as an empty array. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
@@ -27,6 +27,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
             [
                 SchemaDefinition::ARGNAME_NAME => 'addExpressions',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
+                SchemaDefinition::ARGNAME_IS_ARRAY => true,
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                     $this->translationAPI->__('Expressions to inject to the composed directive. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)
@@ -35,6 +36,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
             [
                 SchemaDefinition::ARGNAME_NAME => 'appendExpressions',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
+                SchemaDefinition::ARGNAME_IS_ARRAY => true,
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                     $this->translationAPI->__('Append a value to an expression which must be an array, to inject to the composed directive. If the array has not been set, it is initialized as an empty array. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -42,6 +42,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
             [
                 SchemaDefinition::ARGNAME_NAME => 'addArguments',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
+                SchemaDefinition::ARGNAME_IS_ARRAY => true,
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                     $this->translationAPI->__('Arguments to inject to the function. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -42,7 +42,6 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
             [
                 SchemaDefinition::ARGNAME_NAME => 'addArguments',
                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                SchemaDefinition::ARGNAME_IS_ARRAY => true,
                 SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
                     $this->translationAPI->__('Arguments to inject to the function. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                     QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -49,7 +49,7 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
                     [
                         [
                             SchemaDefinition::ARGNAME_NAME => 'self',
-                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
+                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_OBJECT,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The `$self` object containing all data for the current object', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -50,7 +50,6 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'self',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_IS_ARRAY => true,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The `$self` object containing all data for the current object', 'component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],

--- a/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/FunctionGlobalFieldResolver.php
@@ -28,15 +28,6 @@ class FunctionGlobalFieldResolver extends AbstractGlobalFieldResolver
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
 
-    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
-    {
-        switch ($fieldName) {
-            case 'getSelfProp':
-                return SchemaTypeModifiers::MAY_BE_ARRAY;
-        }
-        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
-    }
-
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
     {
         $descriptions = [

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -238,7 +238,6 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         [
                             SchemaDefinition::ARGNAME_NAME => 'value',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_MAY_BE_ARRAY => true,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The input to be echoed back', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],

--- a/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -218,8 +218,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                     [
                         [
                             SchemaDefinition::ARGNAME_NAME => 'object',
-                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
-                            SchemaDefinition::ARGNAME_IS_ARRAY => true,
+                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_OBJECT,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The object to retrieve the data from', 'pop-component-model'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -310,7 +310,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'key',
-                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_KEY,
+                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ARRAY_KEY,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Key (string or integer) under which to add the value to the array. If not provided, the value is added without key', 'function-fields'),
                         ],
                     ]

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -310,7 +310,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'key',
-                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
+                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ANY_SCALAR,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Key (string or integer) under which to add the value to the array. If not provided, the value is added without key', 'function-fields'),
                         ],
                     ]
@@ -324,7 +324,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                             SchemaDefinition::ARGNAME_NAME => 'array',
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_MIXED,
                             SchemaDefinition::ARGNAME_IS_ARRAY => true,
-                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The array to represented as a string', 'function-fields'),
+                            SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('The array to be represented as a string', 'function-fields'),
                             SchemaDefinition::ARGNAME_MANDATORY => true,
                         ],
                     ]

--- a/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
+++ b/layers/Engine/packages/function-fields/src/FieldResolvers/OperatorGlobalFieldResolver.php
@@ -310,7 +310,7 @@ class OperatorGlobalFieldResolver extends AbstractGlobalFieldResolver
                         ],
                         [
                             SchemaDefinition::ARGNAME_NAME => 'key',
-                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ANY_SCALAR,
+                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_KEY,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Key (string or integer) under which to add the value to the array. If not provided, the value is added without key', 'function-fields'),
                         ],
                     ]

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
+use GraphQLByPoP\GraphQLServer\ObjectModels\Field;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\FieldTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\InputValueTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\TypeTypeResolver;
@@ -41,7 +42,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
             'type' => SchemaDefinition::TYPE_STRING,
             'isDeprecated' => SchemaDefinition::TYPE_BOOL,
             'deprecationReason' => SchemaDefinition::TYPE_STRING,
-            'extensions' => SchemaDefinition::TYPE_MIXED,
+            'extensions' => SchemaDefinition::TYPE_OBJECT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -53,8 +54,6 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
             'type',
             'isDeprecated'
                 => SchemaTypeModifiers::NON_NULLABLE,
-            'extensions'
-                => SchemaTypeModifiers::IS_ARRAY,
             'args'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
@@ -91,6 +90,7 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         ?array $expressions = null,
         array $options = []
     ): mixed {
+        /** @var Field */
         $field = $resultItem;
         switch ($fieldName) {
             case 'name':

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -52,7 +52,8 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
         return match($fieldName) {
             'name',
             'type',
-            'isDeprecated'
+            'isDeprecated',
+            'extensions'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'args'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -6,6 +6,7 @@ namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
 use GraphQLByPoP\GraphQLServer\Enums\TypeKindEnum;
 use GraphQLByPoP\GraphQLServer\ObjectModels\AbstractNestableType;
+use GraphQLByPoP\GraphQLServer\ObjectModels\AbstractType;
 use GraphQLByPoP\GraphQLServer\ObjectModels\EnumType;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasFieldsTypeInterface;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasInterfacesTypeInterface;
@@ -58,7 +59,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
             'enumValues' => SchemaDefinition::TYPE_ID,
             'inputFields' => SchemaDefinition::TYPE_ID,
             'ofType' => SchemaDefinition::TYPE_ID,
-            'extensions' => SchemaDefinition::TYPE_MIXED,
+            'extensions' => SchemaDefinition::TYPE_OBJECT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -72,8 +73,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
             'interfaces',
             'possibleTypes',
             'enumValues',
-            'inputFields',
-            'extensions'
+            'inputFields'
                 => SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
@@ -160,6 +160,7 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
         ?array $expressions = null,
         array $options = []
     ): mixed {
+        /** @var AbstractType */
         $type = $resultItem;
         switch ($fieldName) {
             case 'kind':

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -67,7 +67,8 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
     {
         return match($fieldName) {
-            'kind'
+            'kind',
+            'extensions'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'fields',
             'interfaces',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
@@ -49,7 +49,7 @@ class Schema
             GraphQLServerSchemaDefinition::TYPE_OBJECT,
             GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             GraphQLServerSchemaDefinition::TYPE_MIXED,
-            GraphQLServerSchemaDefinition::TYPE_KEY,
+            GraphQLServerSchemaDefinition::TYPE_ARRAY_KEY,
             GraphQLServerSchemaDefinition::TYPE_DATE,
             GraphQLServerSchemaDefinition::TYPE_TIME,
             GraphQLServerSchemaDefinition::TYPE_URL,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
@@ -47,6 +47,7 @@ class Schema
             GraphQLServerSchemaDefinition::TYPE_FLOAT,
             GraphQLServerSchemaDefinition::TYPE_BOOL,
             GraphQLServerSchemaDefinition::TYPE_OBJECT,
+            GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             GraphQLServerSchemaDefinition::TYPE_MIXED,
             GraphQLServerSchemaDefinition::TYPE_DATE,
             GraphQLServerSchemaDefinition::TYPE_TIME,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
@@ -49,6 +49,7 @@ class Schema
             GraphQLServerSchemaDefinition::TYPE_OBJECT,
             GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             GraphQLServerSchemaDefinition::TYPE_MIXED,
+            GraphQLServerSchemaDefinition::TYPE_KEY,
             GraphQLServerSchemaDefinition::TYPE_DATE,
             GraphQLServerSchemaDefinition::TYPE_TIME,
             GraphQLServerSchemaDefinition::TYPE_URL,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -336,6 +336,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
             GraphQLServerSchemaDefinition::TYPE_OBJECT,
             GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             GraphQLServerSchemaDefinition::TYPE_MIXED,
+            GraphQLServerSchemaDefinition::TYPE_KEY,
             GraphQLServerSchemaDefinition::TYPE_DATE,
             GraphQLServerSchemaDefinition::TYPE_TIME,
             GraphQLServerSchemaDefinition::TYPE_URL,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -334,6 +334,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
             GraphQLServerSchemaDefinition::TYPE_FLOAT,
             GraphQLServerSchemaDefinition::TYPE_BOOL,
             GraphQLServerSchemaDefinition::TYPE_OBJECT,
+            GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             GraphQLServerSchemaDefinition::TYPE_MIXED,
             GraphQLServerSchemaDefinition::TYPE_DATE,
             GraphQLServerSchemaDefinition::TYPE_TIME,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -336,7 +336,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
             GraphQLServerSchemaDefinition::TYPE_OBJECT,
             GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             GraphQLServerSchemaDefinition::TYPE_MIXED,
-            GraphQLServerSchemaDefinition::TYPE_KEY,
+            GraphQLServerSchemaDefinition::TYPE_ARRAY_KEY,
             GraphQLServerSchemaDefinition::TYPE_DATE,
             GraphQLServerSchemaDefinition::TYPE_TIME,
             GraphQLServerSchemaDefinition::TYPE_URL,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinition.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinition.php
@@ -8,6 +8,7 @@ class SchemaDefinition
 {
     const TYPE_ANY_SCALAR = 'AnyScalar';
     const TYPE_MIXED = 'Mixed';
+    const TYPE_KEY = 'Key';
     const TYPE_ID = 'ID';
     const TYPE_STRING = 'String';
     const TYPE_INT = 'Int';

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinition.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinition.php
@@ -6,6 +6,7 @@ namespace GraphQLByPoP\GraphQLServer\Schema;
 
 class SchemaDefinition
 {
+    const TYPE_ANY_SCALAR = 'AnyScalar';
     const TYPE_MIXED = 'Mixed';
     const TYPE_ID = 'ID';
     const TYPE_STRING = 'String';

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinition.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaDefinition.php
@@ -8,7 +8,7 @@ class SchemaDefinition
 {
     const TYPE_ANY_SCALAR = 'AnyScalar';
     const TYPE_MIXED = 'Mixed';
-    const TYPE_KEY = 'Key';
+    const TYPE_ARRAY_KEY = 'ArrayKey';
     const TYPE_ID = 'ID';
     const TYPE_STRING = 'String';
     const TYPE_INT = 'Int';

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
@@ -38,7 +38,7 @@ class SchemaHelpers
             SchemaDefinition::TYPE_OBJECT => GraphQLServerSchemaDefinition::TYPE_OBJECT,
             SchemaDefinition::TYPE_ANY_SCALAR => GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             SchemaDefinition::TYPE_MIXED => GraphQLServerSchemaDefinition::TYPE_MIXED,
-            SchemaDefinition::TYPE_KEY => GraphQLServerSchemaDefinition::TYPE_KEY,
+            SchemaDefinition::TYPE_ARRAY_KEY => GraphQLServerSchemaDefinition::TYPE_ARRAY_KEY,
             SchemaDefinition::TYPE_DATE => GraphQLServerSchemaDefinition::TYPE_DATE,
             SchemaDefinition::TYPE_TIME => GraphQLServerSchemaDefinition::TYPE_TIME,
             SchemaDefinition::TYPE_URL => GraphQLServerSchemaDefinition::TYPE_URL,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
@@ -38,6 +38,7 @@ class SchemaHelpers
             SchemaDefinition::TYPE_OBJECT => GraphQLServerSchemaDefinition::TYPE_OBJECT,
             SchemaDefinition::TYPE_ANY_SCALAR => GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             SchemaDefinition::TYPE_MIXED => GraphQLServerSchemaDefinition::TYPE_MIXED,
+            SchemaDefinition::TYPE_KEY => GraphQLServerSchemaDefinition::TYPE_KEY,
             SchemaDefinition::TYPE_DATE => GraphQLServerSchemaDefinition::TYPE_DATE,
             SchemaDefinition::TYPE_TIME => GraphQLServerSchemaDefinition::TYPE_TIME,
             SchemaDefinition::TYPE_URL => GraphQLServerSchemaDefinition::TYPE_URL,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
@@ -36,6 +36,7 @@ class SchemaHelpers
             SchemaDefinition::TYPE_FLOAT => GraphQLServerSchemaDefinition::TYPE_FLOAT,
             SchemaDefinition::TYPE_BOOL => GraphQLServerSchemaDefinition::TYPE_BOOL,
             SchemaDefinition::TYPE_OBJECT => GraphQLServerSchemaDefinition::TYPE_OBJECT,
+            SchemaDefinition::TYPE_ANY_SCALAR => GraphQLServerSchemaDefinition::TYPE_ANY_SCALAR,
             SchemaDefinition::TYPE_MIXED => GraphQLServerSchemaDefinition::TYPE_MIXED,
             SchemaDefinition::TYPE_DATE => GraphQLServerSchemaDefinition::TYPE_DATE,
             SchemaDefinition::TYPE_TIME => GraphQLServerSchemaDefinition::TYPE_TIME,

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -31,7 +31,7 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
     {
         $types = [
             // 'items' => SchemaDefinition::TYPE_ID,
-            'itemDataEntries' => SchemaDefinition::TYPE_MIXED,
+            'itemDataEntries' => SchemaDefinition::TYPE_OBJECT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }

--- a/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
+++ b/layers/Schema/packages/meta/src/FieldInterfaceResolvers/WithMetaFieldInterfaceResolver.php
@@ -31,8 +31,8 @@ class WithMetaFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolve
     public function getSchemaFieldType(string $fieldName): string
     {
         $types = [
-            'metaValue' => SchemaDefinition::TYPE_MIXED,
-            'metaValues' => SchemaDefinition::TYPE_MIXED,
+            'metaValue' => SchemaDefinition::TYPE_ANY_SCALAR,
+            'metaValues' => SchemaDefinition::TYPE_ANY_SCALAR,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }

--- a/layers/Schema/packages/settings/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/RootFieldResolver.php
@@ -35,7 +35,7 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
     {
         $types = [
-            'option' => SchemaDefinition::TYPE_MIXED,
+            'option' => SchemaDefinition::TYPE_ANY_SCALAR,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }


### PR DESCRIPTION
Re-create the basic scalar types used in the server, both to power GraphQL and also the PoP API, and manage when to use or another throughout the codebase.

---

```php
const TYPE_ANY_SCALAR = 'any_scalar';
```

Custom scalar type "comprising" the 5 atomic scalar types by GraphQL:

- String
- Int
- Float
- Bool
- ID

In GraphQL there is no union of scalars, hence this type comes to represent any of all the scalars. It can be used when we cannot know of what type will the value be. Eg: when calling `get_option` or `get_post_meta` in WordPress.

In GraphQL clients, errors will be shown when providing a `String` to an input of type `ANY_SCALAR`, but the GraphQL server will process the value correctly.

See:

- https://spec.graphql.org/draft/#sec-Scalars
- https://github.com/graphql/graphql-spec/issues/215

---

```php
const TYPE_OBJECT = 'object';
```

Custom scalar type representing an `object` from PHP: some instance from a class or stdClass. It also represents a JSONObject input.

Please notice: this type is not an `array`, however it can be represented through an array on the server-side via PHP. The distinction is important, because an `array` is not a type in GraphQL, but an `object` can be, as a custom scalar

---

```php
const TYPE_MIXED = 'mixed';
```

This custom scalar type comprises the 5 atomic types by GraphQL, plus the Object.

As a consequence, this type can also be represented through an array on the server-side via PHP

