### PR TITLE
Treat failing casting as either warnings or errors

### DIFF
--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -28,6 +28,7 @@ class ComponentConfiguration
     private static bool $useSingleTypeInsteadOfUnionType = false;
     private static bool $enableAdminSchema = false;
     private static bool $validateFieldTypeResponseWithSchemaDefinition = false;
+    private static bool $treatTypeCoercingFailuresAsErrors = false;
 
     /**
      * Initialize component configuration
@@ -212,6 +213,28 @@ class ComponentConfiguration
         $envVariable = Environment::VALIDATE_FIELD_TYPE_RESPONSE_WITH_SCHEMA_DEFINITION;
         $selfProperty = &self::$validateFieldTypeResponseWithSchemaDefinition;
         $defaultValue = RootEnvironment::isApplicationEnvironmentDev();
+        $callback = [EnvironmentValueHelpers::class, 'toBool'];
+
+        // Initialize property from the environment/hook
+        self::maybeInitializeConfigurationValue(
+            $envVariable,
+            $selfProperty,
+            $defaultValue,
+            $callback
+        );
+        return $selfProperty;
+    }
+
+    /**
+     * By default, errors produced from casting a type (eg: "3.5 to int")
+     * are treated as warnings, not errors
+     */
+    public static function treatTypeCoercingFailuresAsErrors(): bool
+    {
+        // Define properties
+        $envVariable = Environment::TREAT_TYPE_COERCING_FAILURES_AS_ERRORS;
+        $selfProperty = &self::$treatTypeCoercingFailuresAsErrors;
+        $defaultValue = false;
         $callback = [EnvironmentValueHelpers::class, 'toBool'];
 
         // Initialize property from the environment/hook

--- a/layers/Engine/packages/component-model/src/Environment.php
+++ b/layers/Engine/packages/component-model/src/Environment.php
@@ -15,6 +15,7 @@ class Environment
     public const USE_SINGLE_TYPE_INSTEAD_OF_UNION_TYPE = 'USE_SINGLE_TYPE_INSTEAD_OF_UNION_TYPE';
     public const ENABLE_ADMIN_SCHEMA = 'ENABLE_ADMIN_SCHEMA';
     public const VALIDATE_FIELD_TYPE_RESPONSE_WITH_SCHEMA_DEFINITION = 'VALIDATE_FIELD_TYPE_RESPONSE_WITH_SCHEMA_DEFINITION';
+    public const TREAT_TYPE_COERCING_FAILURES_AS_ERRORS = 'TREAT_TYPE_COERCING_FAILURES_AS_ERRORS';
 
     /**
      * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -937,7 +937,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         ) {
             $directiveName = $this->getFieldDirectiveName($fieldDirective);
             $directiveArgNameTypes = $this->getDirectiveArgumentNameTypes($directiveResolver, $typeResolver);
-            $treatCastingFailuresAsErrors = ComponentConfiguration::treatTypeCoercingFailuresAsErrors();
+            $treatTypeCoercingFailuresAsErrors = ComponentConfiguration::treatTypeCoercingFailuresAsErrors();
             foreach (array_keys($failedCastingDirectiveArgs) as $failedCastingDirectiveArgName) {
                 // If it is Error, also show the error message
                 if ($directiveArgErrorMessage = $failedCastingDirectiveArgErrorMessages[$failedCastingDirectiveArgName] ?? null) {
@@ -959,7 +959,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                     );
                 }
                 // Either treat it as an error or a warning
-                if ($treatCastingFailuresAsErrors) {
+                if ($treatTypeCoercingFailuresAsErrors) {
                     $schemaErrors[] = [
                         Tokens::PATH => [$fieldDirective],
                         Tokens::MESSAGE => $errorMessage,
@@ -995,7 +995,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             $fieldName = $this->getFieldName($field);
             $fieldArgNameTypes = $this->getFieldArgumentNameTypes($typeResolver, $field);
             $fieldArgNameIsArrayTypes = $this->getFieldArgumentNameIsArrayTypes($typeResolver, $field);
-            $treatCastingFailuresAsErrors = ComponentConfiguration::treatTypeCoercingFailuresAsErrors();
+            $treatTypeCoercingFailuresAsErrors = ComponentConfiguration::treatTypeCoercingFailuresAsErrors();
             foreach (array_keys($failedCastingFieldArgs) as $failedCastingFieldArgName) {
                 // If it is Error, also show the error message
                 $fieldOrDirectiveArgIsArrayType = $fieldArgNameIsArrayTypes[$failedCastingFieldArgName];
@@ -1024,7 +1024,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                         $composedFieldArgType
                     );
                 }
-                if ($treatCastingFailuresAsErrors) {
+                if ($treatTypeCoercingFailuresAsErrors) {
                     $schemaErrors[] = [
                         Tokens::PATH => [$field],
                         Tokens::MESSAGE => $errorMessage,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -722,12 +722,16 @@ class PluginConfiguration
         $isDev = RootEnvironment::isApplicationEnvironmentDev();
         $mainPluginURL = (string) MainPluginManager::getConfig('url');
 
-        /**
-         * Enable the schema entity registries, as to retrieve the type/directive resolver classes
-         * from the type/directive names, saved in the DB in the ACL/CCL Custom Post Types
-         */
         $componentClassConfiguration[\PoP\ComponentModel\Component::class] = [
+            /**
+             * Enable the schema entity registries, as to retrieve the type/directive resolver classes
+             * from the type/directive names, saved in the DB in the ACL/CCL Custom Post Types
+             */
             ComponentModelEnvironment::ENABLE_SCHEMA_ENTITY_REGISTRIES => true,
+            /**
+             * Treat casting failures as errors, not warnings
+             */
+            ComponentModelEnvironment::TREAT_TYPE_COERCING_FAILURES_AS_ERRORS => true,
         ];
         $componentClassConfiguration[\GraphQLByPoP\GraphQLClientsForWP\Component::class] = [
             \GraphQLByPoP\GraphQLClientsForWP\Environment::GRAPHQL_CLIENTS_COMPONENT_URL => $mainPluginURL . 'vendor/graphql-by-pop/graphql-clients-for-wp',


### PR DESCRIPTION
Added env var `TREAT_TYPE_COERCING_FAILURES_AS_ERRORS`, to indicate if casting (or "coercing") failures (such as casting value `3.5` to `Integer`) must be treated as a warning (default for PoP) or error (default for GraphQL).