### PR TITLE
Handle error in response as per GraphQL spec

### DIFF
--- a/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -171,16 +171,16 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
         if ($name = $item[Tokens::NAME] ?? null) {
             $entry['name'] = $name;
         }
-        if ($this->addTopLevelExtensionsEntryToResponse()) {
-            if (
-                $extensions = array_merge(
-                    $this->getDBEntryExtensions($dbKey, $id, $item),
-                    $item[Tokens::EXTENSIONS] ?? []
-                )
-            ) {
-                $entry['extensions'] = $extensions;
-            }
+        // if ($this->addTopLevelExtensionsEntryToResponse()) {
+        if (
+            $extensions = array_merge(
+                $this->getDBEntryExtensions($dbKey, $id, $item),
+                $item[Tokens::EXTENSIONS] ?? []
+            )
+        ) {
+            $entry['extensions'] = $extensions;
         }
+        // }
         return $entry;
     }
 
@@ -214,16 +214,16 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
         if ($name = $item[Tokens::NAME] ?? null) {
             $entry['name'] = $name;
         }
-        if ($this->addTopLevelExtensionsEntryToResponse()) {
-            if (
-                $extensions = array_merge(
-                    $this->getSchemaEntryExtensions($dbKey, $item),
-                    $item[Tokens::EXTENSIONS] ?? []
-                )
-            ) {
-                $entry['extensions'] = $extensions;
-            }
+        // if ($this->addTopLevelExtensionsEntryToResponse()) {
+        if (
+            $extensions = array_merge(
+                $this->getSchemaEntryExtensions($dbKey, $item),
+                $item[Tokens::EXTENSIONS] ?? []
+            )
+        ) {
+            $entry['extensions'] = $extensions;
         }
+        // }
         return $entry;
     }
 
@@ -250,16 +250,16 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
         $entry = [
             'message' => $message,
         ];
-        if ($this->addTopLevelExtensionsEntryToResponse()) {
-            if (
-                $extensions = array_merge(
-                    $this->getQueryEntryExtensions(),
-                    $extensions
-                )
-            ) {
-                $entry['extensions'] = $extensions;
-            };
-        }
+        // if ($this->addTopLevelExtensionsEntryToResponse()) {
+        if (
+            $extensions = array_merge(
+                $this->getQueryEntryExtensions(),
+                $extensions
+            )
+        ) {
+            $entry['extensions'] = $extensions;
+        };
+        // }
         return $entry;
     }
 

--- a/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -64,13 +64,15 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
         }
 
         /**
-         * "Warnings", "deprecations", and "logEntries" top-level entries:
+         * "deprecations", and "logEntries" top-level entries:
          * since they are not part of the spec, place them under the top-level entry "extensions":
          *
          * > This entry is reserved for implementors to extend the protocol however they see fit,
          * > and hence there are no additional restrictions on its contents.
          *
          * @see http://spec.graphql.org/June2018/#sec-Response-Format
+         * 
+         * "warnings" are added always (see above)
          */
         if ($this->addTopLevelExtensionsEntryToResponse()) {
             // Add notices

--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -29,6 +29,7 @@ class ComponentConfiguration
     private static bool $enableAdminSchema = false;
     private static bool $validateFieldTypeResponseWithSchemaDefinition = false;
     private static bool $treatTypeCoercingFailuresAsErrors = false;
+    private static bool $setFailingFieldResponseAsNull = false;
 
     /**
      * Initialize component configuration
@@ -234,6 +235,32 @@ class ComponentConfiguration
         // Define properties
         $envVariable = Environment::TREAT_TYPE_COERCING_FAILURES_AS_ERRORS;
         $selfProperty = &self::$treatTypeCoercingFailuresAsErrors;
+        $defaultValue = false;
+        $callback = [EnvironmentValueHelpers::class, 'toBool'];
+
+        // Initialize property from the environment/hook
+        self::maybeInitializeConfigurationValue(
+            $envVariable,
+            $selfProperty,
+            $defaultValue,
+            $callback
+        );
+        return $selfProperty;
+    }
+
+    /**
+     * The GraphQL spec indicates that, when a field produces an error (during
+     * value resolution or coercion) then its response must be set as null:
+     * 
+     *   If a field error is raised while resolving a field, it is handled as though the field returned null, and the error must be added to the "errors" list in the response.
+     * 
+     * @see https://spec.graphql.org/draft/#sec-Handling-Field-Errors
+     */
+    public static function setFailingFieldResponseAsNull(): bool
+    {
+        // Define properties
+        $envVariable = Environment::SET_FAILING_FIELD_RESPONSE_AS_NULL;
+        $selfProperty = &self::$setFailingFieldResponseAsNull;
         $defaultValue = false;
         $callback = [EnvironmentValueHelpers::class, 'toBool'];
 

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -6,7 +6,6 @@ namespace PoP\ComponentModel\DirectiveResolvers;
 
 use PoP\ComponentModel\Container\ServiceTags\MandatoryDirectiveServiceTagInterface;
 use PoP\ComponentModel\Directives\DirectiveTypes;
-use PoP\ComponentModel\Facades\Schema\FeedbackMessageStoreFacade;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\TypeResolvers\PipelinePositions;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\DirectiveResolvers;
 
+use PoP\ComponentModel\ComponentConfiguration;
 use PoP\ComponentModel\Container\ServiceTags\MandatoryDirectiveServiceTagInterface;
 use PoP\ComponentModel\Directives\DirectiveTypes;
 use PoP\ComponentModel\Feedback\Tokens;
@@ -195,6 +196,11 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
                     Tokens::PATH => [$field],
                     Tokens::MESSAGE => $errorMessage,
                 ];
+            }
+            // For GraphQL, set the response for the failing field as null
+            if (ComponentConfiguration::setFailingFieldResponseAsNull()) {
+                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $dbItems[(string)$id][$fieldOutputKey] = null;
             }
         } else {
             // If there is an alias, store the results under this. Otherwise, on the fieldName+fieldArgs

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -1248,7 +1248,9 @@ class Engine implements EngineInterface
                 if ($entryHasId) {
                     foreach ($dbname_entries['primary'] as $id => $dbObject) {
                         $entry_data_fields_to_move = array_intersect(
-                            array_keys($dbObject),
+                            // If field "id" for this type has been disabled (eg: by ACL),
+                            // then $dbObject may be `null`
+                            array_keys($dbObject ?? []),
                             $data_fields
                         );
                         foreach ($entry_data_fields_to_move as $data_field) {
@@ -1748,7 +1750,9 @@ class Engine implements EngineInterface
                             foreach ($dbItems as $dbobject_id => $dbobject_values) {
                                 $combined_databases[$database_key][(string)$dbobject_id] = array_merge(
                                     $combined_databases[$database_key][(string)$dbobject_id] ?? [],
-                                    $dbobject_values
+                                    // If field "id" for this type has been disabled (eg: by ACL),
+                                    // then $dbObject may be `null`
+                                    $dbobject_values ?? []
                                 );
                             }
                         }

--- a/layers/Engine/packages/component-model/src/Environment.php
+++ b/layers/Engine/packages/component-model/src/Environment.php
@@ -16,6 +16,7 @@ class Environment
     public const ENABLE_ADMIN_SCHEMA = 'ENABLE_ADMIN_SCHEMA';
     public const VALIDATE_FIELD_TYPE_RESPONSE_WITH_SCHEMA_DEFINITION = 'VALIDATE_FIELD_TYPE_RESPONSE_WITH_SCHEMA_DEFINITION';
     public const TREAT_TYPE_COERCING_FAILURES_AS_ERRORS = 'TREAT_TYPE_COERCING_FAILURES_AS_ERRORS';
+    public const SET_FAILING_FIELD_RESPONSE_AS_NULL = 'SET_FAILING_FIELD_RESPONSE_AS_NULL';
 
     /**
      * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -34,19 +34,17 @@ class ErrorProvider implements ErrorProviderInterface
      * which is different than returning a null value.
      * Needed for compatibility with CustomPostUnionTypeResolver,
      * so that data-fields aimed for another post_type are not retrieved
-     *
-     * @param string $fieldName
-     * @return Error
      */
-    public function getNoFieldError(string $fieldName): Error
+    public function getNoFieldError(string $fieldName, string $typeName): Error
     {
         $translationAPI = TranslationAPIFacade::getInstance();
         return $this->getError(
             $fieldName,
             ErrorCodes::NO_FIELD,
             sprintf(
-                $translationAPI->__('No FieldResolver resolves field \'%s\'', 'pop-component-model'),
-                $fieldName
+                $translationAPI->__('No FieldResolver resolves field \'%s\' for type \'%s\'', 'pop-component-model'),
+                $fieldName,
+                $typeName
             )
         );
     }

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -42,7 +42,7 @@ class ErrorProvider implements ErrorProviderInterface
             $fieldName,
             ErrorCodes::NO_FIELD,
             sprintf(
-                $translationAPI->__('There is no resolver for field \'%s\' on type \'%s\' and ID type \'%s\'', 'pop-component-model'),
+                $translationAPI->__('There is no resolver for field \'%s\' on type \'%s\' and ID \'%s\'', 'pop-component-model'),
                 $fieldName,
                 $typeName,
                 $resultItemID

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -42,7 +42,7 @@ class ErrorProvider implements ErrorProviderInterface
             $fieldName,
             ErrorCodes::NO_FIELD,
             sprintf(
-                $translationAPI->__('No FieldResolver resolves field \'%s\' for type \'%s\'', 'pop-component-model'),
+                $translationAPI->__('There is no resolver for field \'%s\' on type \'%s\'', 'pop-component-model'),
                 $fieldName,
                 $typeName
             )

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -35,16 +35,17 @@ class ErrorProvider implements ErrorProviderInterface
      * Needed for compatibility with CustomPostUnionTypeResolver,
      * so that data-fields aimed for another post_type are not retrieved
      */
-    public function getNoFieldError(string $fieldName, string $typeName): Error
+    public function getNoFieldError(string | int $resultItemID, string $fieldName, string $typeName): Error
     {
         $translationAPI = TranslationAPIFacade::getInstance();
         return $this->getError(
             $fieldName,
             ErrorCodes::NO_FIELD,
             sprintf(
-                $translationAPI->__('There is no resolver for field \'%s\' on type \'%s\'', 'pop-component-model'),
+                $translationAPI->__('There is no resolver for field \'%s\' on type \'%s\' and ID type \'%s\'', 'pop-component-model'),
                 $fieldName,
-                $typeName
+                $typeName,
+                $resultItemID
             )
         );
     }

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
@@ -15,11 +15,8 @@ interface ErrorProviderInterface
      * which is different than returning a null value.
      * Needed for compatibility with CustomPostUnionTypeResolver,
      * so that data-fields aimed for another post_type are not retrieved
-     *
-     * @param string $fieldName
-     * @return Error
      */
-    public function getNoFieldError(string $fieldName): Error;
+    public function getNoFieldError(string $fieldName, string $typeName): Error;
 
     /**
      * Return an error to indicate that a non-nullable field is returning a `null` value

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
@@ -16,7 +16,7 @@ interface ErrorProviderInterface
      * Needed for compatibility with CustomPostUnionTypeResolver,
      * so that data-fields aimed for another post_type are not retrieved
      */
-    public function getNoFieldError(string $fieldName, string $typeName): Error;
+    public function getNoFieldError(string | int $resultItemID, string $fieldName, string $typeName): Error;
 
     /**
      * Return an error to indicate that a non-nullable field is returning a `null` value

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -655,8 +655,20 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                     )
                 )
             ) {
-                // Maybe cast the value to the appropriate type. Eg: from string to boolean
-                $fieldArgType = $fieldOrDirectiveArgNameTypes[$argName];
+                /**
+                 * Maybe cast the value to the appropriate type.
+                 * Eg: from string to boolean.
+                 * 
+                 * Handle also the case of executing a query with a fieldArg
+                 * that was not defined in the schema. Eg:
+                 * 
+                 * ```
+                 * { posts(thisArgIsNonExistent: "saloro") { id } }
+                 * ```
+                 * 
+                 * In that case, assign type `MIXED`, which implies "Do not cast"
+                 **/
+                $fieldArgType = $fieldOrDirectiveArgNameTypes[$argName] ?? SchemaDefinition::TYPE_MIXED;
                 // If not set, the return type is not an array
                 $fieldOrDirectiveArgIsArrayType = $fieldOrDirectiveArgNameIsArrayTypes[$argName] ?? false;
                 

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\ErrorHandling\ErrorDataTokens;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\Resolvers\ResolverTypes;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
@@ -187,7 +188,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                 $directiveArgumentNameTypes,
                 $directiveArgumentNameDefaultValues,
                 $variables,
-                $schemaWarnings
+                $schemaWarnings,
+                ResolverTypes::DIRECTIVE
             );
         }
 
@@ -204,7 +206,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         array $fieldOrDirectiveArgumentNameTypes,
         array $fieldArgumentNameDefaultValues,
         ?array $variables,
-        array &$schemaWarnings
+        array &$schemaWarnings,
+        string $resolverType
     ): array {
         if ($orderedFieldOrDirectiveArgNamesEnabled) {
             $orderedFieldOrDirectiveArgNames = array_keys($fieldOrDirectiveArgumentNameTypes);
@@ -259,7 +262,9 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                     $schemaWarnings[] = [
                         Tokens::PATH => [$fieldOrDirective],
                         Tokens::MESSAGE => sprintf(
-                            $this->translationAPI->__('Argument with name \'%s\' has not been documented in the schema, so it may have no effect (it has not been removed from the query, though)', 'pop-component-model'),
+                            $this->translationAPI->__('On %1$s \'%2$s\', argument with name \'%3$s\' has not been documented in the schema, so it may have no effect (it has not been removed from the query, though)', 'pop-component-model'),
+                            $resolverType == ResolverTypes::FIELD ? $this->translationAPI->__('field', 'component-model') : $this->translationAPI->__('directive', 'component-model'),
+                            $fieldOrDirective,
                             $fieldOrDirectiveArgName
                         ),
                     ];
@@ -318,7 +323,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                 $fieldArgumentNameTypes,
                 $fieldArgumentNameDefaultValues,
                 $variables,
-                $schemaWarnings
+                $schemaWarnings,
+                ResolverTypes::FIELD
             );
         }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1177,7 +1177,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             if ($versionConstraint = $fieldArgs[SchemaDefinition::ARGNAME_VERSION_CONSTRAINT] ?? null) {
                 $errorMessage = sprintf(
                     $this->translationAPI->__(
-                        'No FieldResolver resolves field \'%s\' and version constraint \'%s\' for type \'%s\'',
+                        'There is no resolver for field \'%s\' and version constraint \'%s\' on type \'%s\'',
                         'pop-component-model'
                     ),
                     $fieldName,
@@ -1189,7 +1189,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         if (!isset($errorMessage)) {
             $errorMessage = sprintf(
                 $this->translationAPI->__(
-                    'No FieldResolver resolves field \'%s\' for type \'%s\'',
+                    'There is no resolver for field \'%s\' on type \'%s\'',
                     'pop-component-model'
                 ),
                 $fieldName,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -42,7 +42,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     /**
      * Cache of which fieldResolvers will process the given field
      *
-     * @var array<string, FieldResolverInterface>
+     * @var array<string, FieldResolverInterface[]>
      */
     protected array $fieldResolvers = [];
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1455,7 +1455,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         // Return an error to indicate that no fieldResolver processes this field, which is different than returning a null value.
         // Needed for compatibility with CustomPostUnionTypeResolver (so that data-fields aimed for another post_type are not retrieved)
         $fieldName = $this->fieldQueryInterpreter->getFieldName($field);
-        return $this->errorProvider->getNoFieldError($fieldName, $this->getTypeName());
+        return $this->errorProvider->getNoFieldError($fieldName, $this->getMaybeNamespacedTypeName());
     }
 
     protected function processFlatShapeSchemaDefinition(array $options = [])

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1455,7 +1455,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         // Return an error to indicate that no fieldResolver processes this field, which is different than returning a null value.
         // Needed for compatibility with CustomPostUnionTypeResolver (so that data-fields aimed for another post_type are not retrieved)
         $fieldName = $this->fieldQueryInterpreter->getFieldName($field);
-        return $this->errorProvider->getNoFieldError($fieldName);
+        return $this->errorProvider->getNoFieldError($fieldName, $this->getTypeName());
     }
 
     protected function processFlatShapeSchemaDefinition(array $options = [])

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -42,7 +42,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     /**
      * Cache of which fieldResolvers will process the given field
      *
-     * @var FieldResolverInterface[]
+     * @var array<string, FieldResolverInterface>
      */
     protected array $fieldResolvers = [];
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1324,13 +1324,13 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $fieldName,
                 $fieldArgs,
                 $schemaErrors,
-                // $schemaWarnings,
+                $schemaWarnings,
             ) = $this->dissectFieldForSchema($field);
 
-            // // Store the warnings to be read if needed
-            // if ($schemaWarnings) {
-            //     $this->feedbackMessageStore->addSchemaWarnings($schemaWarnings);
-            // }
+            // Store the warnings to be read if needed
+            if ($schemaWarnings) {
+                $this->feedbackMessageStore->addSchemaWarnings($schemaWarnings);
+            }
             if ($schemaErrors) {
                 return $this->errorProvider->getNestedSchemaErrorsFieldError($schemaErrors, $fieldName);
             }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1455,7 +1455,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         // Return an error to indicate that no fieldResolver processes this field, which is different than returning a null value.
         // Needed for compatibility with CustomPostUnionTypeResolver (so that data-fields aimed for another post_type are not retrieved)
         $fieldName = $this->fieldQueryInterpreter->getFieldName($field);
-        return $this->errorProvider->getNoFieldError($fieldName, $this->getMaybeNamespacedTypeName());
+        return $this->errorProvider->getNoFieldError($this->getID($resultItem), $fieldName, $this->getMaybeNamespacedTypeName());
     }
 
     protected function processFlatShapeSchemaDefinition(array $options = [])

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -732,6 +732,10 @@ class PluginConfiguration
              * Treat casting failures as errors, not warnings
              */
             ComponentModelEnvironment::TREAT_TYPE_COERCING_FAILURES_AS_ERRORS => true,
+            /**
+             * Show a `null` entry in the response for failing fields
+             */
+            ComponentModelEnvironment::SET_FAILING_FIELD_RESPONSE_AS_NULL => true,
         ];
         $componentClassConfiguration[\GraphQLByPoP\GraphQLClientsForWP\Component::class] = [
             \GraphQLByPoP\GraphQLClientsForWP\Environment::GRAPHQL_CLIENTS_COMPONENT_URL => $mainPluginURL . 'vendor/graphql-by-pop/graphql-clients-for-wp',

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/Services/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/Services/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -121,16 +121,16 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
             unset($extensions['location']);
             $entry['location'] = $location;
         }
-        if ($this->addTopLevelExtensionsEntryToResponse()) {
-            if (
-                $extensions = array_merge(
-                    $this->getQueryEntryExtensions(),
-                    $extensions
-                )
-            ) {
-                $entry['extensions'] = $extensions;
-            };
-        }
+        // if ($this->addTopLevelExtensionsEntryToResponse()) {
+        if (
+            $extensions = array_merge(
+                $this->getQueryEntryExtensions(),
+                $extensions
+            )
+        ) {
+            $entry['extensions'] = $extensions;
+        };
+        // }
         return $entry;
     }
 


### PR DESCRIPTION
The [GraphQL spec indicates that](https://spec.graphql.org/draft/#sec-Handling-Field-Errors), when a field produces an error (during value resolution or coercion) then its response must be set as `null`:

> If a field error is raised while resolving a field, it is handled as though the field returned null, and the error must be added to the "errors" list in the response.

Implemented this behavior.