### PR TITLE
GraphQL API: Set the field to `null` when any applied directive has errors

### DIFF
--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -31,8 +31,8 @@ class ComponentConfiguration
     private static bool $treatTypeCoercingFailuresAsErrors = false;
     private static bool $treatUndefinedFieldOrDirectiveArgsAsErrors = false;
     private static bool $setFailingFieldResponseAsNull = false;
-    private static bool $stopDirectivePipelineExecutionIfDirectiveFailed = false;
     private static bool $removeFieldIfDirectiveFailed = false;
+    private static bool $stopDirectivePipelineExecutionIfDirectiveFailed = false;
 
     /**
      * Initialize component configuration
@@ -301,13 +301,13 @@ class ComponentConfiguration
     }
 
     /**
-     * Indicate: If a directive fails, then stop execution of the directive pipeline altogether
+     * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
      */
-    public static function stopDirectivePipelineExecutionIfDirectiveFailed(): bool
+    public static function removeFieldIfDirectiveFailed(): bool
     {
         // Define properties
-        $envVariable = Environment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED;
-        $selfProperty = &self::$stopDirectivePipelineExecutionIfDirectiveFailed;
+        $envVariable = Environment::REMOVE_FIELD_IF_DIRECTIVE_FAILED;
+        $selfProperty = &self::$removeFieldIfDirectiveFailed;
         $defaultValue = false;
         $callback = [EnvironmentValueHelpers::class, 'toBool'];
 
@@ -322,13 +322,13 @@ class ComponentConfiguration
     }
 
     /**
-     * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
+     * Indicate: If a directive fails, then stop execution of the directive pipeline altogether
      */
-    public static function removeFieldIfDirectiveFailed(): bool
+    public static function stopDirectivePipelineExecutionIfDirectiveFailed(): bool
     {
         // Define properties
-        $envVariable = Environment::REMOVE_FIELD_IF_DIRECTIVE_FAILED;
-        $selfProperty = &self::$removeFieldIfDirectiveFailed;
+        $envVariable = Environment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED;
+        $selfProperty = &self::$stopDirectivePipelineExecutionIfDirectiveFailed;
         $defaultValue = false;
         $callback = [EnvironmentValueHelpers::class, 'toBool'];
 

--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -32,6 +32,7 @@ class ComponentConfiguration
     private static bool $treatUndefinedFieldOrDirectiveArgsAsErrors = false;
     private static bool $setFailingFieldResponseAsNull = false;
     private static bool $stopDirectivePipelineExecutionIfDirectiveFailed = false;
+    private static bool $removeFieldIfDirectiveFailed = false;
 
     /**
      * Initialize component configuration
@@ -307,6 +308,27 @@ class ComponentConfiguration
         // Define properties
         $envVariable = Environment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED;
         $selfProperty = &self::$stopDirectivePipelineExecutionIfDirectiveFailed;
+        $defaultValue = false;
+        $callback = [EnvironmentValueHelpers::class, 'toBool'];
+
+        // Initialize property from the environment/hook
+        self::maybeInitializeConfigurationValue(
+            $envVariable,
+            $selfProperty,
+            $defaultValue,
+            $callback
+        );
+        return $selfProperty;
+    }
+
+    /**
+     * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
+     */
+    public static function removeFieldIfDirectiveFailed(): bool
+    {
+        // Define properties
+        $envVariable = Environment::REMOVE_FIELD_IF_DIRECTIVE_FAILED;
+        $selfProperty = &self::$removeFieldIfDirectiveFailed;
         $defaultValue = false;
         $callback = [EnvironmentValueHelpers::class, 'toBool'];
 

--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -31,6 +31,7 @@ class ComponentConfiguration
     private static bool $treatTypeCoercingFailuresAsErrors = false;
     private static bool $treatUndefinedFieldOrDirectiveArgsAsErrors = false;
     private static bool $setFailingFieldResponseAsNull = false;
+    private static bool $stopDirectivePipelineExecutionIfDirectiveFailed = false;
 
     /**
      * Initialize component configuration
@@ -285,6 +286,27 @@ class ComponentConfiguration
         // Define properties
         $envVariable = Environment::SET_FAILING_FIELD_RESPONSE_AS_NULL;
         $selfProperty = &self::$setFailingFieldResponseAsNull;
+        $defaultValue = false;
+        $callback = [EnvironmentValueHelpers::class, 'toBool'];
+
+        // Initialize property from the environment/hook
+        self::maybeInitializeConfigurationValue(
+            $envVariable,
+            $selfProperty,
+            $defaultValue,
+            $callback
+        );
+        return $selfProperty;
+    }
+
+    /**
+     * Indicate: If a directive fails, then stop execution of the directive pipeline altogether
+     */
+    public static function stopDirectivePipelineExecutionIfDirectiveFailed(): bool
+    {
+        // Define properties
+        $envVariable = Environment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED;
+        $selfProperty = &self::$stopDirectivePipelineExecutionIfDirectiveFailed;
         $defaultValue = false;
         $callback = [EnvironmentValueHelpers::class, 'toBool'];
 

--- a/layers/Engine/packages/component-model/src/ComponentConfiguration.php
+++ b/layers/Engine/packages/component-model/src/ComponentConfiguration.php
@@ -326,6 +326,10 @@ class ComponentConfiguration
      */
     public static function stopDirectivePipelineExecutionIfDirectiveFailed(): bool
     {
+        // If the field will be removed nevertheless, there's no point in executing the upcoming directives
+        if (static::removeFieldIfDirectiveFailed()) {
+            return true;
+        }
         // Define properties
         $envVariable = Environment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED;
         $selfProperty = &self::$stopDirectivePipelineExecutionIfDirectiveFailed;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -8,6 +8,7 @@ use Composer\Semver\Semver;
 use Exception;
 use League\Pipeline\StageInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
+use PoP\ComponentModel\ComponentConfiguration;
 use PoP\ComponentModel\DirectivePipeline\DirectivePipelineUtils;
 use PoP\ComponentModel\Directives\DirectiveTypes;
 use PoP\ComponentModel\Environment;
@@ -751,7 +752,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
             }
         }
         // If the failure must be processed as an error, we must also remove the fields from the directive pipeline
-        $removeFieldIfDirectiveFailed = Environment::removeFieldIfDirectiveFailed();
+        $removeFieldIfDirectiveFailed = ComponentConfiguration::removeFieldIfDirectiveFailed();
         if ($removeFieldIfDirectiveFailed) {
             $this->removeIDsDataFields($idsDataFieldsToRemove, $succeedingPipelineIDsDataFields);
         }

--- a/layers/Engine/packages/component-model/src/Environment.php
+++ b/layers/Engine/packages/component-model/src/Environment.php
@@ -19,14 +19,7 @@ class Environment
     public const TREAT_UNDEFINED_FIELD_OR_DIRECTIVE_ARGS_AS_ERRORS = 'TREAT_UNDEFINED_FIELD_OR_DIRECTIVE_ARGS_AS_ERRORS';
     public const SET_FAILING_FIELD_RESPONSE_AS_NULL = 'SET_FAILING_FIELD_RESPONSE_AS_NULL';
     public const STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED = 'STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED';
-
-    /**
-     * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
-     */
-    public static function removeFieldIfDirectiveFailed(): bool
-    {
-        return getenv('REMOVE_FIELD_IF_DIRECTIVE_FAILED') !== false ? strtolower(getenv('REMOVE_FIELD_IF_DIRECTIVE_FAILED')) == "true" : false;
-    }
+    public const REMOVE_FIELD_IF_DIRECTIVE_FAILED = 'REMOVE_FIELD_IF_DIRECTIVE_FAILED';
 
     /**
      * Indicate if to enable to restrict a field and directive by version,

--- a/layers/Engine/packages/component-model/src/Environment.php
+++ b/layers/Engine/packages/component-model/src/Environment.php
@@ -18,6 +18,7 @@ class Environment
     public const TREAT_TYPE_COERCING_FAILURES_AS_ERRORS = 'TREAT_TYPE_COERCING_FAILURES_AS_ERRORS';
     public const TREAT_UNDEFINED_FIELD_OR_DIRECTIVE_ARGS_AS_ERRORS = 'TREAT_UNDEFINED_FIELD_OR_DIRECTIVE_ARGS_AS_ERRORS';
     public const SET_FAILING_FIELD_RESPONSE_AS_NULL = 'SET_FAILING_FIELD_RESPONSE_AS_NULL';
+    public const STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED = 'STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED';
 
     /**
      * Indicate: If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
@@ -25,14 +26,6 @@ class Environment
     public static function removeFieldIfDirectiveFailed(): bool
     {
         return getenv('REMOVE_FIELD_IF_DIRECTIVE_FAILED') !== false ? strtolower(getenv('REMOVE_FIELD_IF_DIRECTIVE_FAILED')) == "true" : false;
-    }
-
-    /**
-     * Indicate: If a directive fails, then stop execution of the directive pipeline altogether
-     */
-    public static function stopDirectivePipelineExecutionIfDirectiveFailed(): bool
-    {
-        return getenv('STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED') !== false ? strtolower(getenv('STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED')) == "true" : false;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -407,7 +407,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         // Count how many times each directive is added
         $directiveFieldTrack = [];
         $directiveResolverInstanceFields = [];
-        for ($i = 0; $i < count($fieldDirectives); $i++) {
+        $fieldDirectivesCount = count($fieldDirectives);
+        for ($i = 0; $i < $fieldDirectivesCount; $i++) {
             // Because directives can be repeated inside a field (eg: <resize(50%),resize(50%)>),
             // then we deal with 2 variables:
             // 1. $fieldDirective: the actual directive

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -399,8 +399,10 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     ): array {
         // Check if, once a directive fails, the continuing directives must execute or not
         $stopDirectivePipelineExecutionIfDirectiveFailed = ComponentConfiguration::stopDirectivePipelineExecutionIfDirectiveFailed();
+        $showStopDirectivePipelineExecutionIfDirectiveFailedError = false;
         if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
             $stopDirectivePipelineExecutionPlaceholder = $this->translationAPI->__('Because directive \'%s\' failed, the succeeding directives in the pipeline have not been executed', 'pop-component-model');
+            $showStopDirectivePipelineExecutionIfDirectiveFailedError = !ComponentConfiguration::removeFieldIfDirectiveFailed();
         }
 
         $instances = [];
@@ -445,13 +447,15 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                     ),
                 ];
                 if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
-                    $schemaErrors[] = [
-                        Tokens::PATH => [$fieldDirective],
-                        Tokens::MESSAGE => sprintf(
-                            $stopDirectivePipelineExecutionPlaceholder,
-                            $fieldDirective
-                        ),
-                    ];
+                    if ($showStopDirectivePipelineExecutionIfDirectiveFailedError) {
+                        $schemaErrors[] = [
+                            Tokens::PATH => [$fieldDirective],
+                            Tokens::MESSAGE => sprintf(
+                                $stopDirectivePipelineExecutionPlaceholder,
+                                $fieldDirective
+                            ),
+                        ];
+                    }
                     break;
                 }
                 continue;
@@ -472,13 +476,15 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                     ),
                 ];
                 if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
-                    $schemaErrors[] = [
-                        Tokens::PATH => [$fieldDirective],
-                        Tokens::MESSAGE => sprintf(
-                            $stopDirectivePipelineExecutionPlaceholder,
-                            $fieldDirective
-                        ),
-                    ];
+                    if ($showStopDirectivePipelineExecutionIfDirectiveFailedError) {
+                        $schemaErrors[] = [
+                            Tokens::PATH => [$fieldDirective],
+                            Tokens::MESSAGE => sprintf(
+                                $stopDirectivePipelineExecutionPlaceholder,
+                                $fieldDirective
+                            ),
+                        ];
+                    }
                     break;
                 }
                 continue;
@@ -497,13 +503,15 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                         ),
                     ];
                     if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
-                        $schemaErrors[] = [
-                            Tokens::PATH => [$fieldDirective],
-                            Tokens::MESSAGE => sprintf(
-                                $stopDirectivePipelineExecutionPlaceholder,
-                                $fieldDirective
-                            ),
-                        ];
+                        if ($showStopDirectivePipelineExecutionIfDirectiveFailedError) {
+                            $schemaErrors[] = [
+                                Tokens::PATH => [$fieldDirective],
+                                Tokens::MESSAGE => sprintf(
+                                    $stopDirectivePipelineExecutionPlaceholder,
+                                    $fieldDirective
+                                ),
+                            ];
+                        }
                         break;
                     }
                     continue;
@@ -566,13 +574,15 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                     );
                     // Because there were schema errors, skip this directive
                     if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
-                        $schemaErrors[] = [
-                            Tokens::PATH => [$fieldDirective],
-                            Tokens::MESSAGE => sprintf(
-                                $stopDirectivePipelineExecutionPlaceholder,
-                                $fieldDirective
-                            ),
-                        ];
+                        if ($showStopDirectivePipelineExecutionIfDirectiveFailedError) {
+                            $schemaErrors[] = [
+                                Tokens::PATH => [$fieldDirective],
+                                Tokens::MESSAGE => sprintf(
+                                    $stopDirectivePipelineExecutionPlaceholder,
+                                    $fieldDirective
+                                ),
+                            ];
+                        }
                         break;
                     }
                     continue;
@@ -587,13 +597,15 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                         ];
                     }
                     if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
-                        $schemaErrors[] = [
-                            Tokens::PATH => [$fieldDirective],
-                            Tokens::MESSAGE => sprintf(
-                                $stopDirectivePipelineExecutionPlaceholder,
-                                $fieldDirective
-                            ),
-                        ];
+                        if ($showStopDirectivePipelineExecutionIfDirectiveFailedError) {
+                            $schemaErrors[] = [
+                                Tokens::PATH => [$fieldDirective],
+                                Tokens::MESSAGE => sprintf(
+                                    $stopDirectivePipelineExecutionPlaceholder,
+                                    $fieldDirective
+                                ),
+                            ];
+                        }
                         break;
                     }
                     continue;
@@ -643,13 +655,15 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                         ),
                     ];
                     if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
-                        $schemaErrors[] = [
-                            Tokens::PATH => [$fieldDirective],
-                            Tokens::MESSAGE => sprintf(
-                                $stopDirectivePipelineExecutionPlaceholder,
-                                $fieldDirective
-                            ),
-                        ];
+                        if ($showStopDirectivePipelineExecutionIfDirectiveFailedError) {
+                            $schemaErrors[] = [
+                                Tokens::PATH => [$fieldDirective],
+                                Tokens::MESSAGE => sprintf(
+                                    $stopDirectivePipelineExecutionPlaceholder,
+                                    $fieldDirective
+                                ),
+                            ];
+                        }
                         break;
                     }
                     // If after removing the duplicated fields there are still others, process them

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -398,7 +398,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         array &$schemaTraces
     ): array {
         // Check if, once a directive fails, the continuing directives must execute or not
-        $stopDirectivePipelineExecutionIfDirectiveFailed = Environment::stopDirectivePipelineExecutionIfDirectiveFailed();
+        $stopDirectivePipelineExecutionIfDirectiveFailed = ComponentConfiguration::stopDirectivePipelineExecutionIfDirectiveFailed();
         if ($stopDirectivePipelineExecutionIfDirectiveFailed) {
             $stopDirectivePipelineExecutionPlaceholder = $this->translationAPI->__('Because directive \'%s\' failed, the succeeding directives in the pipeline have not been executed', 'pop-component-model');
         }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -740,6 +740,10 @@ class PluginConfiguration
              * Show a `null` entry in the response for failing fields
              */
             ComponentModelEnvironment::SET_FAILING_FIELD_RESPONSE_AS_NULL => true,
+            /**
+             * If a directive fails, then stop execution of the directive pipeline altogether
+             */
+            ComponentModelEnvironment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED => true,
         ];
         $componentClassConfiguration[\GraphQLByPoP\GraphQLClientsForWP\Component::class] = [
             \GraphQLByPoP\GraphQLClientsForWP\Environment::GRAPHQL_CLIENTS_COMPONENT_URL => $mainPluginURL . 'vendor/graphql-by-pop/graphql-clients-for-wp',

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -741,10 +741,6 @@ class PluginConfiguration
              */
             ComponentModelEnvironment::SET_FAILING_FIELD_RESPONSE_AS_NULL => true,
             /**
-             * If a directive fails, then stop execution of the directive pipeline altogether
-             */
-            ComponentModelEnvironment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED => true,
-            /**
              * If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
              */
             ComponentModelEnvironment::REMOVE_FIELD_IF_DIRECTIVE_FAILED => true,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -744,6 +744,10 @@ class PluginConfiguration
              * If a directive fails, then stop execution of the directive pipeline altogether
              */
             ComponentModelEnvironment::STOP_DIRECTIVE_PIPELINE_EXECUTION_IF_DIRECTIVE_FAILED => true,
+            /**
+             * If a directive fails, then remove the affected IDs/fields from the upcoming stages of the directive pipeline execution
+             */
+            ComponentModelEnvironment::REMOVE_FIELD_IF_DIRECTIVE_FAILED => true,
         ];
         $componentClassConfiguration[\GraphQLByPoP\GraphQLClientsForWP\Component::class] = [
             \GraphQLByPoP\GraphQLClientsForWP\Environment::GRAPHQL_CLIENTS_COMPONENT_URL => $mainPluginURL . 'vendor/graphql-by-pop/graphql-clients-for-wp',


### PR DESCRIPTION
Implemented functionality, and set on plugin via environment variable `ComponentModelEnvironment::REMOVE_FIELD_IF_DIRECTIVE_FAILED`