### PR TITLE
Prepend path on schemaDB error

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1095,6 +1095,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $directiveResolverInstances[] = $directiveResolverInstance;
             }
 
+            $directivePipelineSchemaErrors = $directivePipelineIDDBErrors = [];
+
             // We can finally resolve the pipeline, passing along an array with the ID and fields for each directive
             $directivePipeline = $this->getDirectivePipeline($directiveResolverInstances);
             $directivePipeline->resolveDirectivePipeline(
@@ -1107,17 +1109,53 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $previousDBItems,
                 $variables,
                 $messages,
-                $dbErrors,
+                $directivePipelineIDDBErrors,
                 $dbWarnings,
                 $dbDeprecations,
                 $dbNotices,
                 $dbTraces,
-                $schemaErrors,
+                $directivePipelineSchemaErrors,
                 $schemaWarnings,
                 $schemaDeprecations,
                 $schemaNotices,
                 $schemaTraces
             );
+            
+            // If any directive failed execution, then prepend the path on the error
+            if ($directivePipelineSchemaErrors) {
+                // Extract the failing fields from the path of the thrown error
+                foreach ($directivePipelineSchemaErrors as $directivePipelineSchemaError) {
+                    $schemaErrorFailingField = $directivePipelineSchemaError[Tokens::PATH][0];
+                    if ($failingFields = $fieldDirectiveFields[$schemaErrorFailingField] ?? []) {
+                        foreach ($failingFields as $failingField) {
+                            $schemaError = $directivePipelineSchemaError;
+                            array_unshift($schemaError[Tokens::PATH], $failingField);
+                            $this->prependPathOnNestedErrors($schemaError, $failingField);
+                            $schemaErrors[] = $schemaError;
+                        }
+                    } else {
+                        $schemaErrors[] = $directivePipelineSchemaError;
+                    }
+                }                
+            }
+            if ($directivePipelineIDDBErrors) {
+                // Extract the failing fields from the path of the thrown error
+                foreach ($directivePipelineIDDBErrors as $id => $directivePipelineDBErrors) {
+                    foreach ($directivePipelineDBErrors as $directivePipelineDBError) {
+                        $dbErrorFailingField = $directivePipelineDBError[Tokens::PATH][0];
+                        if ($failingFields = $fieldDirectiveFields[$dbErrorFailingField] ?? []) {
+                            foreach ($failingFields as $failingField) {
+                                $dbError = $directivePipelineDBError;
+                                array_unshift($dbError[Tokens::PATH], $failingField);
+                                $this->prependPathOnNestedErrors($dbError, $failingField);
+                                $dbErrors[$id][] = $dbError;
+                            }
+                        } else {
+                            $dbErrors[$id][] = $directivePipelineDBError;
+                        }
+                    }
+                }                
+            }
         }
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1141,7 +1141,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 foreach ($failingFieldSchemaErrors as $failingField => $failingSchemaErrors) {
                     $schemaErrors[] = [
                         Tokens::PATH => [$failingField],
-                        Tokens::MESSAGE => $this->translationAPI->__('This field can\'t be executed due to errors from its composed directives', 'component-model'),
+                        Tokens::MESSAGE => $this->translationAPI->__('This field can\'t be executed due to errors from its directives', 'component-model'),
                         Tokens::EXTENSIONS => [
                             Tokens::NESTED => $failingSchemaErrors,
                         ],
@@ -1170,7 +1170,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                     foreach ($failingIDDBErrors as $id => $failingDBErrors) {
                         $dbErrors[$id][] = [
                             Tokens::PATH => [$failingField],
-                            Tokens::MESSAGE => $this->translationAPI->__('This field can\'t be executed due to errors from its composed directives', 'component-model'),
+                            Tokens::MESSAGE => $this->translationAPI->__('This field can\'t be executed due to errors from its directives', 'component-model'),
                             Tokens::EXTENSIONS => [
                                 Tokens::NESTED => $failingDBErrors,
                             ],


### PR DESCRIPTION
Complete the whole path to the field/directive where the error was produced.

To test, disable directive `translate` and remove the users on the site (or at least have them different to the testing email list), and then execute <a href="https://graphql-by-pop.lndo.site/api/graphql/?postId=1&query=postId=1&query=post($postId)@post.content|date(d/m/Y)@date,getJSON(%22https://newapi.getpop.org/wp-json/newsletter/v1/subscriptions%22)@userList|arrayUnique(extract(getSelfProp(%25self%25,%20userList),lang))@userLangs|extract(getSelfProp(%25self%25,%20userList),email)@userEmails|arrayFill(getJSON(sprintf(%22https://newapi.getpop.org/users/api/rest/?query=name|email%26emails[]=%25s%22,[arrayJoin(getSelfProp(%25self%25,%20userEmails),%22%26emails[]=%22)])),getSelfProp(%25self%25,%20userList),email)@userData;post($postId)@post%3CcopyRelationalResults([content,%20date],[postContent,%20postDate])%3E;getSelfProp(%25self%25,%20postContent)@postContent%3Ctranslate(from:%20en,to:%20arrayDiff([getSelfProp(%25self%25,%20userLangs),[en]])),renameProperty(postContent-en)%3E|getSelfProp(%25self%25,%20userData)@userPostData%3CforEach%3CapplyFunction(function:%20arrayAddItem(array:%20[],value:%20%22%22),addArguments:%20[key:%20postContent,array:%20%25value%25,value:%20getSelfProp(%25self%25,sprintf(postContent-%25s,[extract(%25value%25,%20lang)]))]),applyFunction(function:%20arrayAddItem(array:%20[],value:%20%22%22),addArguments:%20[key:%20header,array:%20%25value%25,value:%20sprintf(string:%20%22%3Cp%3EHi%20%25s,%20we%20published%20this%20post%20on%20%25s,%20enjoy!%3C/p%3E%22,values:%20[extract(%25value%25,%20name),getSelfProp(%25self%25,%20postDate)])])%3E%3E;getSelfProp(%25self%25,%20userPostData)@translatedUserPostProps%3CforEach(if:%20not(equals(extract(%25value%25,%20lang),en)))%3CadvancePointerInArray(path:%20header,appendExpressions:%20[toLang:%20extract(%25value%25,%20lang)])%3Ctranslate(from:%20en,to:%20%25toLang%25,oneLanguagePerField:%20true,override:%20true)%3E%3E%3E;getSelfProp(%25self%25,translatedUserPostProps)@emails%3CforEach%3CapplyFunction(function:%20arrayAddItem(array:%20[],value:%20[]),addArguments:%20[key:%20content,array:%20%25value%25,value:%20concat([extract(%25value%25,%20header),extract(%25value%25,%20postContent)])]),applyFunction(function:%20arrayAddItem(array:%20[],value:%20[]),addArguments:%20[key:%20to,array:%20%25value%25,value:%20extract(%25value%25,%20email)]),applyFunction(function:%20arrayAddItem(array:%20[],value:%20[]),addArguments:%20[key:%20subject,array:%20%25value%25,value:%20%22PoP%20API%20example%20:)%22]),sendByEmail%3E%3E">this PoP query</a>.

This should produce this response:

```json
{
  "errors": [
    {
      "message": "Argument 'copyFromFields' cannot be empty, so directive 'copyRelationalResults' has been ignored",
      "extensions": {
        "type": "schema",
        "entityDBKey": "Root",
        "path": [
          "post($postId)@post<copyRelationalResults([content, date],[postContent, postDate])>",
          "copyRelationalResults([content, date],[postContent, postDate])"
        ]
      }
    },
    {
      "message": "No DirectiveResolver resolves directive with name 'translate'",
      "extensions": {
        "type": "schema",
        "entityDBKey": "Root",
        "path": [
          "getSelfProp(%self%, postContent)@postContent<translate(from: en,to: arrayDiff([getSelfProp(%self%, userLangs),[en]])),renameProperty(postContent-en)>",
          "translate(from: en,to: arrayDiff([getSelfProp(%self%, userLangs),[en]]))"
        ]
      }
    },
    {
      "message": "This directive can't be executed due to errors from its composed directives",
      "extensions": {
        "type": "schema",
        "entityDBKey": "Root",
        "path": [
          "getSelfProp(%self%, userPostData)@translatedUserPostProps<forEach(if: not(equals(extract(%value%, lang),en)))<advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>>>",
          "forEach(if: not(equals(extract(%value%, lang),en)))<advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>>"
        ],
        "nested": [
          {
            "path": [
              "getSelfProp(%self%, userPostData)@translatedUserPostProps<forEach(if: not(equals(extract(%value%, lang),en)))<advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>>>",
              "forEach(if: not(equals(extract(%value%, lang),en)))<advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>>",
              "advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>"
            ],
            "message": "This directive can't be executed due to errors from its composed directives",
            "extensions": {
              "nested": [
                {
                  "path": [
                    "getSelfProp(%self%, userPostData)@translatedUserPostProps<forEach(if: not(equals(extract(%value%, lang),en)))<advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>>>",
                    "forEach(if: not(equals(extract(%value%, lang),en)))<advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>>",
                    "advancePointerInArray(path: header,appendExpressions: [toLang: extract(%value%, lang)])<translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)>",
                    "translate(from: en,to: %toLang%,oneLanguagePerField: true,override: true)"
                  ],
                  "message": "No DirectiveResolver resolves directive with name 'translate'"
                }
              ]
            }
          }
        ]
      }
    },
    {
      "message": "This directive can't be executed due to errors from its composed directives",
      "extensions": {
        "type": "schema",
        "entityDBKey": "Root",
        "path": [
          "getSelfProp(%self%,translatedUserPostProps)@emails<forEach<applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: content,array: %value%,value: concat([extract(%value%, header),extract(%value%, postContent)])]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: to,array: %value%,value: extract(%value%, email)]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: subject,array: %value%,value: \\\"PoP API example :)\\\"]),sendByEmail>>",
          "forEach<applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: content,array: %value%,value: concat([extract(%value%, header),extract(%value%, postContent)])]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: to,array: %value%,value: extract(%value%, email)]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: subject,array: %value%,value: \\\"PoP API example :)\\\"]),sendByEmail>"
        ],
        "nested": [
          {
            "path": [
              "getSelfProp(%self%,translatedUserPostProps)@emails<forEach<applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: content,array: %value%,value: concat([extract(%value%, header),extract(%value%, postContent)])]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: to,array: %value%,value: extract(%value%, email)]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: subject,array: %value%,value: \\\"PoP API example :)\\\"]),sendByEmail>>",
              "forEach<applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: content,array: %value%,value: concat([extract(%value%, header),extract(%value%, postContent)])]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: to,array: %value%,value: extract(%value%, email)]),applyFunction(function: arrayAddItem(array: [],value: []),addArguments: [key: subject,array: %value%,value: \\\"PoP API example :)\\\"]),sendByEmail>",
              "sendByEmail"
            ],
            "message": "No DirectiveResolver resolves directive with name 'sendByEmail'"
          }
        ]
      }
    },
    {
      "message": "This field can't be executed due to errors from its directives",
      "extensions": {
        "type": "dataObject",
        "entityDBKey": "Root",
        "id": "root",
        "path": [
          "getSelfProp(%self%, userData)@userPostData<forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>>"
        ],
        "nested": [
          {
            "path": [
              "getSelfProp(%self%, userData)@userPostData<forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>>",
              "forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>",
              "applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))])"
            ],
            "message": "Applying function on 'userPostData.0' on object with ID 'root' failed due to error: Argument 'value' cannot be empty, so field 'arrayAddItem' has been ignored"
          },
          {
            "path": [
              "getSelfProp(%self%, userData)@userPostData<forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>>",
              "forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>",
              "applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))])"
            ],
            "message": "Applying function on 'userPostData.1' on object with ID 'root' failed due to error: Argument 'value' cannot be empty, so field 'arrayAddItem' has been ignored"
          },
          {
            "path": [
              "getSelfProp(%self%, userData)@userPostData<forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>>",
              "forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>",
              "applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))])"
            ],
            "message": "Applying function on 'userPostData.2' on object with ID 'root' failed due to error: Argument 'value' cannot be empty, so field 'arrayAddItem' has been ignored"
          },
          {
            "path": [
              "getSelfProp(%self%, userData)@userPostData<forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>>",
              "forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>",
              "applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))])"
            ],
            "message": "Applying function on 'userPostData.3' on object with ID 'root' failed due to error: Argument 'value' cannot be empty, so field 'arrayAddItem' has been ignored"
          },
          {
            "path": [
              "getSelfProp(%self%, userData)@userPostData<forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>>",
              "forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>",
              "applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))])"
            ],
            "message": "Applying function on 'userPostData.4' on object with ID 'root' failed due to error: Argument 'value' cannot be empty, so field 'arrayAddItem' has been ignored"
          },
          {
            "path": [
              "getSelfProp(%self%, userData)@userPostData<forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>>",
              "forEach<applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))]),applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: header,array: %value%,value: sprintf(string: \\\"<p>Hi %s, we published this post on %s, enjoy!<\/p>\\\",values: [extract(%value%, name),getSelfProp(%self%, postDate)])])>",
              "applyFunction(function: arrayAddItem(array: [],value: \\\"\\\"),addArguments: [key: postContent,array: %value%,value: getSelfProp(%self%,sprintf(postContent-%s,[extract(%value%, lang)]))])"
            ],
            "message": "Applying function on 'userPostData.5' on object with ID 'root' failed due to error: Argument 'value' cannot be empty, so field 'arrayAddItem' has been ignored"
          }
        ]
      }
    }
  ],
  "extensions": {
    "warnings": [
      {
        "message": "For directive 'copyRelationalResults', casting value '[\"content\",\"date\"]' for argument 'copyFromFields' to type 'string' failed: Argument 'copyFromFields' does not expect an array, but array '[\"content\",\"date\"]' was provided. It has been ignored",
        "extensions": {
          "type": "schema",
          "entityDBKey": "Root",
          "path": [
            "post($postId)@post<copyRelationalResults([content, date],[postContent, postDate])>",
            "copyRelationalResults([content, date],[postContent, postDate])"
          ]
        }
      },
      {
        "message": "For directive 'copyRelationalResults', casting value '[\"postContent\",\"postDate\"]' for argument 'copyToFields' to type 'string' failed: Argument 'copyToFields' does not expect an array, but array '[\"postContent\",\"postDate\"]' was provided. It has been ignored",
        "extensions": {
          "type": "schema",
          "entityDBKey": "Root",
          "path": [
            "post($postId)@post<copyRelationalResults([content, date],[postContent, postDate])>",
            "copyRelationalResults([content, date],[postContent, postDate])"
          ]
        }
      }
    ]
  },
  "data": {
    "userList": [
      {
        "email": "abracadabra@ganga.com",
        "lang": "de"
      },
      {
        "email": "longon@caramanon.com",
        "lang": "es"
      },
      {
        "email": "rancotanto@parabara.com",
        "lang": "en"
      },
      {
        "email": "quezarapadon@quebrulacha.net",
        "lang": "fr"
      },
      {
        "email": "test@test.com",
        "lang": "de"
      },
      {
        "email": "emilanga@pedrola.com",
        "lang": "fr"
      }
    ],
    "userLangs": [
      "de",
      "es",
      "en",
      "fr"
    ],
    "userEmails": [
      "abracadabra@ganga.com",
      "longon@caramanon.com",
      "rancotanto@parabara.com",
      "quezarapadon@quebrulacha.net",
      "test@test.com",
      "emilanga@pedrola.com"
    ],
    "userData": [
      {
        "name": "Abrigail Ataluncha",
        "email": "quezarapadon@quebrulacha.net",
        "lang": "fr"
      },
      {
        "name": "chipbennett",
        "email": "abracadabra@ganga.com",
        "lang": "de"
      },
      {
        "name": "emiluzelac",
        "email": "longon@caramanon.com",
        "lang": "es"
      },
      {
        "name": "lance",
        "email": "rancotanto@parabara.com",
        "lang": "en"
      },
      {
        "name": "Test",
        "email": "test@test.com",
        "lang": "de"
      },
      {
        "name": "themedemos",
        "email": "emilanga@pedrola.com",
        "lang": "fr"
      }
    ],
    "post": {
      "id": 1,
      "content": "\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!<\/p>\n",
      "date": "30\/04\/2021"
    },
    "userPostData": [
      {
        "name": "Abrigail Ataluncha",
        "email": "quezarapadon@quebrulacha.net",
        "lang": "fr",
        "header": "<p>Hi Abrigail Ataluncha, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "chipbennett",
        "email": "abracadabra@ganga.com",
        "lang": "de",
        "header": "<p>Hi chipbennett, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "emiluzelac",
        "email": "longon@caramanon.com",
        "lang": "es",
        "header": "<p>Hi emiluzelac, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "lance",
        "email": "rancotanto@parabara.com",
        "lang": "en",
        "header": "<p>Hi lance, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "Test",
        "email": "test@test.com",
        "lang": "de",
        "header": "<p>Hi Test, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "themedemos",
        "email": "emilanga@pedrola.com",
        "lang": "fr",
        "header": "<p>Hi themedemos, we published this post on , enjoy!<\/p>"
      }
    ],
    "translatedUserPostProps": [
      {
        "name": "Abrigail Ataluncha",
        "email": "quezarapadon@quebrulacha.net",
        "lang": "fr",
        "header": "<p>Hi Abrigail Ataluncha, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "chipbennett",
        "email": "abracadabra@ganga.com",
        "lang": "de",
        "header": "<p>Hi chipbennett, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "emiluzelac",
        "email": "longon@caramanon.com",
        "lang": "es",
        "header": "<p>Hi emiluzelac, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "lance",
        "email": "rancotanto@parabara.com",
        "lang": "en",
        "header": "<p>Hi lance, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "Test",
        "email": "test@test.com",
        "lang": "de",
        "header": "<p>Hi Test, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "themedemos",
        "email": "emilanga@pedrola.com",
        "lang": "fr",
        "header": "<p>Hi themedemos, we published this post on , enjoy!<\/p>"
      }
    ],
    "emails": [
      {
        "name": "Abrigail Ataluncha",
        "email": "quezarapadon@quebrulacha.net",
        "lang": "fr",
        "header": "<p>Hi Abrigail Ataluncha, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "chipbennett",
        "email": "abracadabra@ganga.com",
        "lang": "de",
        "header": "<p>Hi chipbennett, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "emiluzelac",
        "email": "longon@caramanon.com",
        "lang": "es",
        "header": "<p>Hi emiluzelac, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "lance",
        "email": "rancotanto@parabara.com",
        "lang": "en",
        "header": "<p>Hi lance, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "Test",
        "email": "test@test.com",
        "lang": "de",
        "header": "<p>Hi Test, we published this post on , enjoy!<\/p>"
      },
      {
        "name": "themedemos",
        "email": "emilanga@pedrola.com",
        "lang": "fr",
        "header": "<p>Hi themedemos, we published this post on , enjoy!<\/p>"
      }
    ]
  }
}
```