### PR TITLE
Catch exceptions from field and directive resolvers, and return as GraphQL errors

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -711,6 +711,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                     [],
                     $idsDataFields,
                     $pipelineIDsDataFields,
+                    $dbItems,
                     $schemaErrors,
                     $schemaWarnings
                 );
@@ -750,6 +751,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         array $failedFields,
         array &$idsDataFields,
         array &$succeedingPipelineIDsDataFields,
+        array &$dbItems,
         array &$schemaErrors,
         array &$schemaWarnings
     ): void {
@@ -778,7 +780,14 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         // If the failure must be processed as an error, we must also remove the fields from the directive pipeline
         $removeFieldIfDirectiveFailed = ComponentConfiguration::removeFieldIfDirectiveFailed();
         if ($removeFieldIfDirectiveFailed) {
-            $this->removeIDsDataFields($idsDataFieldsToRemove, $succeedingPipelineIDsDataFields);
+            $this->removeIDsDataFields(
+                $idsDataFieldsToRemove,
+                $succeedingPipelineIDsDataFields
+            );
+            $this->maybeSetFailingFieldResponseAsNull(
+                $idsDataFieldsToRemove,
+                $dbItems
+            );
         }
 
         // Show the failureMessage either as error or as warning

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -779,6 +779,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         }
         // If the failure must be processed as an error, we must also remove the fields from the directive pipeline
         $removeFieldIfDirectiveFailed = ComponentConfiguration::removeFieldIfDirectiveFailed();
+        $setFailingFieldResponseAsNull = ComponentConfiguration::setFailingFieldResponseAsNull();
         if ($removeFieldIfDirectiveFailed) {
             $this->removeIDsDataFields(
                 $idsDataFieldsToRemove,
@@ -792,7 +793,14 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
         // Show the failureMessage either as error or as warning
         $directiveName = $this->getDirectiveName();
-        if ($removeFieldIfDirectiveFailed) {
+        if ($setFailingFieldResponseAsNull) {
+            foreach ($failedFields as $failedField) {
+                $schemaErrors[] = [
+                    Tokens::PATH => [$failedField, $this->directive],
+                    Tokens::MESSAGE => $failureMessage,
+                ];
+            }
+        } elseif ($removeFieldIfDirectiveFailed) {
             if (count($failedFields) == 1) {
                 $message = $this->translationAPI->__('%s. Field \'%s\' has been removed from the directive pipeline', 'component-model');
             } else {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -809,7 +809,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                 ];
             }
         } else {
-            if (count($failedFields) == 1) {
+            if (count($failedFields) === 1) {
                 $message = $this->translationAPI->__('%s. Execution of directive \'%s\' has been ignored on field \'%s\'', 'component-model');
             } else {
                 $message = $this->translationAPI->__('%s. Execution of directive \'%s\' has been ignored on fields \'%s\'', 'component-model');

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -779,13 +779,15 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         }
         // If the failure must be processed as an error, we must also remove the fields from the directive pipeline
         $removeFieldIfDirectiveFailed = ComponentConfiguration::removeFieldIfDirectiveFailed();
-        $setFailingFieldResponseAsNull = ComponentConfiguration::setFailingFieldResponseAsNull();
         if ($removeFieldIfDirectiveFailed) {
             $this->removeIDsDataFields(
                 $idsDataFieldsToRemove,
                 $succeedingPipelineIDsDataFields
             );
-            $this->maybeSetFailingFieldResponseAsNull(
+        }
+        $setFailingFieldResponseAsNull = ComponentConfiguration::setFailingFieldResponseAsNull();
+        if ($setFailingFieldResponseAsNull) {
+            $this->setIDsDataFieldsAsNull(
                 $idsDataFieldsToRemove,
                 $dbItems
             );

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
@@ -85,18 +85,14 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
                     $failedDataFields
                 );
             }
-            $this->removeIDsDataFields($idsDataFieldsToRemove, $succeedingPipelineIDsDataFields);
-
-            // For GraphQL, set the response for the failing field as null
-            if (ComponentConfiguration::setFailingFieldResponseAsNull()) {
-                foreach (array_keys($idsDataFieldsToRemove) as $id) {
-                    $fieldsToRemoveForID = $idsDataFieldsToRemove[(string)$id]['direct'];
-                    foreach ($fieldsToRemoveForID as $field) {
-                        $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
-                        $dbItems[(string)$id][$fieldOutputKey] = null;
-                    }
-                }
-            }
+            $this->removeIDsDataFields(
+                $idsDataFieldsToRemove,
+                $succeedingPipelineIDsDataFields
+            );
+            $this->maybeSetFailingFieldResponseAsNull(
+                $idsDataFieldsToRemove,
+                $dbItems
+            );
         }
         // Since adding the Validate directive also when processing the conditional fields, there is no need to validate them now
         // They will be validated when it's their turn to be processed

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
@@ -89,10 +89,12 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
                 $idsDataFieldsToRemove,
                 $succeedingPipelineIDsDataFields
             );
-            $this->maybeSetFailingFieldResponseAsNull(
-                $idsDataFieldsToRemove,
-                $dbItems
-            );
+            if (ComponentConfiguration::setFailingFieldResponseAsNull()) {
+                $this->setIDsDataFieldsAsNull(
+                    $idsDataFieldsToRemove,
+                    $dbItems
+                );
+            }
         }
         // Since adding the Validate directive also when processing the conditional fields, there is no need to validate them now
         // They will be validated when it's their turn to be processed

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/RemoveIDsDataFieldsDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/RemoveIDsDataFieldsDirectiveResolverTrait.php
@@ -33,17 +33,15 @@ trait RemoveIDsDataFieldsDirectiveResolverTrait
     /**
      * For GraphQL, set the response for the failing field as null
      */
-    protected function maybeSetFailingFieldResponseAsNull(
-        array &$idsDataFieldsToRemove,
+    protected function setIDsDataFieldsAsNull(
+        array &$idsDataFieldsToSetAsNull,
         array &$dbItems
     ): void {
-        if (ComponentConfiguration::setFailingFieldResponseAsNull()) {
-            foreach (array_keys($idsDataFieldsToRemove) as $id) {
-                $fieldsToRemoveForID = $idsDataFieldsToRemove[(string)$id]['direct'];
-                foreach ($fieldsToRemoveForID as $field) {
-                    $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
-                    $dbItems[(string)$id][$fieldOutputKey] = null;
-                }
+        foreach (array_keys($idsDataFieldsToSetAsNull) as $id) {
+            $fieldsToSetAsNullForID = $idsDataFieldsToSetAsNull[(string)$id]['direct'];
+            foreach ($fieldsToSetAsNullForID as $field) {
+                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $dbItems[(string)$id][$fieldOutputKey] = null;
             }
         }
     }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/RemoveIDsDataFieldsDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/RemoveIDsDataFieldsDirectiveResolverTrait.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\DirectiveResolvers;
 
+use PoP\ComponentModel\ComponentConfiguration;
+
 trait RemoveIDsDataFieldsDirectiveResolverTrait
 {
-    protected function removeIDsDataFields(array &$idsDataFieldsToRemove, array &$succeedingPipelineIDsDataFields)
-    {
+    protected function removeIDsDataFields(
+        array &$idsDataFieldsToRemove,
+        array &$succeedingPipelineIDsDataFields
+    ): void {
         // For each combination of ID and field, remove them from the upcoming pipeline stages
         foreach ($idsDataFieldsToRemove as $id => $dataFields) {
             foreach ($succeedingPipelineIDsDataFields as &$pipelineStageIDsDataFields) {
@@ -21,6 +25,24 @@ trait RemoveIDsDataFieldsDirectiveResolverTrait
                 );
                 foreach ($dataFields['direct'] as $removeField) {
                     unset($pipelineStageIDsDataFields[(string)$id]['conditional'][$removeField]);
+                }
+            }
+        }
+    }
+
+    /**
+     * For GraphQL, set the response for the failing field as null
+     */
+    protected function maybeSetFailingFieldResponseAsNull(
+        array &$idsDataFieldsToRemove,
+        array &$dbItems
+    ): void {
+        if (ComponentConfiguration::setFailingFieldResponseAsNull()) {
+            foreach (array_keys($idsDataFieldsToRemove) as $id) {
+                $fieldsToRemoveForID = $idsDataFieldsToRemove[(string)$id]['direct'];
+                foreach ($fieldsToRemoveForID as $field) {
+                    $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                    $dbItems[(string)$id][$fieldOutputKey] = null;
                 }
             }
         }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -238,6 +238,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         // $fieldOrDirectiveOutputKey = $this->getFieldOutputKey($fieldOrDirective);
         $fieldOrDirectiveArgs = [];
         $treatUndefinedFieldOrDirectiveArgsAsErrors = ComponentConfiguration::treatUndefinedFieldOrDirectiveArgsAsErrors();
+        $setFailingFieldResponseAsNull = ComponentConfiguration::setFailingFieldResponseAsNull();
         for ($i = 0; $i < count($fieldOrDirectiveArgElems); $i++) {
             $fieldOrDirectiveArg = $fieldOrDirectiveArgElems[$i];
             // Either one of 2 formats are accepted:
@@ -259,7 +260,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                     if ($treatUndefinedFieldOrDirectiveArgsAsErrors) {
                         $schemaErrors[] = [
                             Tokens::PATH => [$fieldOrDirective],
-                            Tokens::MESSAGE => $resolverType === ResolverTypes::FIELD ?
+                            Tokens::MESSAGE => ($resolverType === ResolverTypes::FIELD || $setFailingFieldResponseAsNull) ?
                                 $errorMessage
                                 : sprintf(
                                     $this->translationAPI->__('%s. The directive has been ignored', 'pop-component-model'),
@@ -307,7 +308,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                     if ($treatUndefinedFieldOrDirectiveArgsAsErrors) {
                         $schemaErrors[] = [
                             Tokens::PATH => [$fieldOrDirective],
-                            Tokens::MESSAGE => $resolverType === ResolverTypes::FIELD ?
+                            Tokens::MESSAGE => ($resolverType === ResolverTypes::FIELD || $setFailingFieldResponseAsNull) ?
                                 $errorMessage
                                 : sprintf(
                                     $this->translationAPI->__('%s. The directive has been ignored', 'pop-component-model'),

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1439,8 +1439,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                         return $this->errorProvider->getValidationFailedError($fieldName, $fieldArgs, $validationErrorDescriptions);
                     }
                     
-                    // Resolve the value. If the resolver threw an Error or Exception,
-                    // catch it and transform it to a GraphQL error
+                    // Resolve the value. If the resolver throws an Exception,
+                    // catch it and return the equivalent GraphQL error
                     try {
                         $value = $fieldResolver->resolveValue($this, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
                     } catch (Exception $e) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1439,7 +1439,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                         return $this->errorProvider->getValidationFailedError($fieldName, $fieldArgs, $validationErrorDescriptions);
                     }
                     
-                    // Resolve the value. If the resolver throws an Exception,
+                    // Resolve the value. If the field resolver throws an Exception,
                     // catch it and return the equivalent GraphQL error
                     try {
                         $value = $fieldResolver->resolveValue($this, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers;
 
+use Exception;
 use League\Pipeline\PipelineBuilder;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
 use PoP\ComponentModel\ComponentConfiguration;
@@ -1438,8 +1439,20 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                         return $this->errorProvider->getValidationFailedError($fieldName, $fieldArgs, $validationErrorDescriptions);
                     }
                     
-                    // Resolve the value
-                    $value = $fieldResolver->resolveValue($this, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
+                    // Resolve the value. If the resolver threw an Error or Exception,
+                    // catch it and transform it to a GraphQL error
+                    try {
+                        $value = $fieldResolver->resolveValue($this, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
+                    } catch (Exception $e) {
+                        return new Error(
+                            'exception',
+                            sprintf(
+                                $this->translationAPI->__('Resolving field \'%s\' produced an exception, with message: \'%s\'', 'component-model'),
+                                $field,
+                                $e->getMessage()
+                            )
+                        );
+                    }
 
                     /**
                      * Validate that the value is what was defined in the schema, or throw a corresponding error.

--- a/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
@@ -113,7 +113,10 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
                 }
 
                 // Remove the $idsDataFields for them
-                $this->removeIDsDataFields($idsDataFieldsToRemove, $pipelineIDsDataFieldsToRemove);
+                $this->removeIDsDataFields(
+                    $idsDataFieldsToRemove,
+                    $pipelineIDsDataFieldsToRemove
+                );
             }
 
             // Log the cached items

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
@@ -51,6 +51,9 @@ trait FilterIDsSatisfyingConditionDirectiveResolverTrait
             },
             ARRAY_FILTER_USE_KEY
         );
-        $this->removeIDsDataFields($idsDataFieldsToRemove, $succeedingPipelineIDsDataFields);
+        $this->removeIDsDataFields(
+            $idsDataFieldsToRemove,
+            $succeedingPipelineIDsDataFields
+        );
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ConditionalOnContext/RemoveIfNull/SchemaServices/DirectiveResolvers/RemoveIfNullDirectiveResolver.php
@@ -225,7 +225,10 @@ class RemoveIfNullDirectiveResolver extends AbstractGlobalDirectiveResolver
          * (check function `needsIDsDataFieldsToExecute` must be `false` for them)
          */
         if ($idsDataFieldsToRemove) {
-            $this->removeIDsDataFields($idsDataFieldsToRemove, $succeedingPipelineIDsDataFields);
+            $this->removeIDsDataFields(
+                $idsDataFieldsToRemove,
+                $succeedingPipelineIDsDataFields
+            );
         }
     }
 


### PR DESCRIPTION
If any field or directive resolver thrown an `Exception`, then catch it and add a corresponding `schemaError`, to show in GraphQL's `errors` response.