### PR TITLE
[Downgrade] Reinstate `mixed` type and union types in anonymous functions

### DIFF
--- a/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnMixedType.php
+++ b/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnMixedType.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+require_once __DIR__ . '/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php';
+
+/**
+ * Hack to fix bug.
+ *
+ * fn(mixed $foo) requires 2 steps to be downgraded:
+ * 
+ * 1. function(mixed $foo)
+ * 2. function($foo)
+ * 
+ * Because of chained rules not taking place, manually execute the 2nd rule
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // Shared configuration
+    doCommonContainerConfiguration($containerConfigurator);
+
+    $monorepoDir = dirname(__DIR__, 2);
+    $pluginDir = $monorepoDir . '/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp';
+
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        $pluginDir . '/vendor/getpop/component-model/src/Schema/FieldQueryInterpreter.php',
+        $pluginDir . '/vendor/getpop/api/src/Schema/FieldQueryConvertor.php',
+    ]);
+};

--- a/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnMixedType.php
+++ b/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnMixedType.php
@@ -10,10 +10,10 @@ require_once __DIR__ . '/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php
 /**
  * Hack to fix bug.
  *
- * fn(mixed $foo) requires 2 steps to be downgraded:
+ * `fn(mixed $foo)` requires 2 steps to be downgraded:
  * 
- * 1. function(mixed $foo)
- * 2. function($foo)
+ *   1. function(mixed $foo)
+ *   2. function($foo)
  * 
  * Because of chained rules not taking place, manually execute the 2nd rule
  */

--- a/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnUnionType.php
+++ b/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnUnionType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+require_once __DIR__ . '/rector-downgrade-code-shared-hacks-ArrowFnUnionType.php';
+
+/**
+ * Hack to fix bug.
+ *
+ * `fn(int | string $foo)` requires 2 steps to be downgraded:
+ * 
+ *   1. function(int | string $foo)
+ *   2. function($foo)
+ * 
+ * Because of chained rules not taking place, manually execute the 2nd rule
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // Shared configuration
+    doCommonContainerConfiguration($containerConfigurator);
+
+    $monorepoDir = dirname(__DIR__, 2);
+    $pluginDir = $monorepoDir . '/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp';
+
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        $pluginDir . '/vendor/getpop/component-model/src/TypeResolvers/AbstractTypeResolver.php',
+        $pluginDir . '/vendor/getpop/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php',
+        $pluginDir . '/vendor/pop-schema/menus/src/TypeDataLoaders/MenuItemTypeDataLoader.php',
+        $pluginDir . '/vendor/pop-schema/menus/src/TypeDataLoaders/MenuTypeDataLoader.php',
+    ]);
+};

--- a/ci/downgrades/rector-downgrade-code-hacks-ArrowFnMixedType.php
+++ b/ci/downgrades/rector-downgrade-code-hacks-ArrowFnMixedType.php
@@ -10,10 +10,10 @@ require_once __DIR__ . '/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php
 /**
  * Hack to fix bug.
  *
- * fn(mixed $foo) requires 2 steps to be downgraded:
+ * `fn(mixed $foo)` requires 2 steps to be downgraded:
  * 
- * 1. function(mixed $foo)
- * 2. function($foo)
+ *   1. function(mixed $foo)
+ *   2. function($foo)
  * 
  * Because of chained rules not taking place, manually execute the 2nd rule
  */

--- a/ci/downgrades/rector-downgrade-code-hacks-ArrowFnMixedType.php
+++ b/ci/downgrades/rector-downgrade-code-hacks-ArrowFnMixedType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+require_once __DIR__ . '/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php';
+
+/**
+ * Hack to fix bug.
+ *
+ * fn(mixed $foo) requires 2 steps to be downgraded:
+ * 
+ * 1. function(mixed $foo)
+ * 2. function($foo)
+ * 
+ * Because of chained rules not taking place, manually execute the 2nd rule
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // Shared configuration
+    doCommonContainerConfiguration($containerConfigurator);
+
+    $monorepoDir = dirname(__DIR__, 2);
+
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        $monorepoDir . '/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php',
+        $monorepoDir . '/layers/API/packages/api/src/Schema/FieldQueryConvertor.php',
+    ]);
+};

--- a/ci/downgrades/rector-downgrade-code-hacks-ArrowFnUnionType.php
+++ b/ci/downgrades/rector-downgrade-code-hacks-ArrowFnUnionType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+require_once __DIR__ . '/rector-downgrade-code-shared-hacks-ArrowFnUnionType.php';
+
+/**
+ * Hack to fix bug.
+ *
+ * `fn(int | string $foo)` requires 2 steps to be downgraded:
+ * 
+ *   1. function(int | string $foo)
+ *   2. function($foo)
+ * 
+ * Because of chained rules not taking place, manually execute the 2nd rule
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // Shared configuration
+    doCommonContainerConfiguration($containerConfigurator);
+
+    $monorepoDir = dirname(__DIR__, 2);
+
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        $monorepoDir . '/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php',
+        $monorepoDir . '/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php',
+        $monorepoDir . '/layers/Schema/packages/menus/src/TypeDataLoaders/MenuItemTypeDataLoader.php',
+        $monorepoDir . '/layers/Schema/packages/menus/src/TypeDataLoaders/MenuTypeDataLoader.php',
+    ]);
+};

--- a/ci/downgrades/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php
+++ b/ci/downgrades/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+/**
+ * Hack to fix bug.
+ *
+ * fn(mixed $foo) requires 2 steps to be downgraded:
+ * 
+ * 1. function(mixed $foo)
+ * 2. function($foo)
+ * 
+ * Because of chained rules not taking place, manually execute the 2nd rule
+ */
+function doCommonContainerConfiguration(ContainerConfigurator $containerConfigurator): void
+{
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeMixedTypeDeclarationRector::class);
+
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_71);
+    $parameters->set(Option::AUTO_IMPORT_NAMES, false);
+    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+};

--- a/ci/downgrades/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php
+++ b/ci/downgrades/rector-downgrade-code-shared-hacks-ArrowFnMixedType.php
@@ -10,10 +10,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 /**
  * Hack to fix bug.
  *
- * fn(mixed $foo) requires 2 steps to be downgraded:
+ * `fn(mixed $foo)` requires 2 steps to be downgraded:
  * 
- * 1. function(mixed $foo)
- * 2. function($foo)
+ *   1. function(mixed $foo)
+ *   2. function($foo)
  * 
  * Because of chained rules not taking place, manually execute the 2nd rule
  */

--- a/ci/downgrades/rector-downgrade-code-shared-hacks-ArrowFnUnionType.php
+++ b/ci/downgrades/rector-downgrade-code-shared-hacks-ArrowFnUnionType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeUnionTypeDeclarationRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+/**
+ * Hack to fix bug.
+ *
+ * `fn(int | string $foo)` requires 2 steps to be downgraded:
+ * 
+ *   1. function(int | string $foo)
+ *   2. function($foo)
+ * 
+ * Because of chained rules not taking place, manually execute the 2nd rule
+ */
+function doCommonContainerConfiguration(ContainerConfigurator $containerConfigurator): void
+{
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+
+    $services = $containerConfigurator->services();
+    $services->set(DowngradeUnionTypeDeclarationRector::class);
+
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_71);
+    $parameters->set(Option::AUTO_IMPORT_NAMES, false);
+    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+};

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1087,11 +1087,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     protected function castAndValidateFieldArguments(TypeResolverInterface $typeResolver, array $castedFieldArgs, array &$failedCastingFieldArgErrorMessages, string $field, array $fieldArgs, array &$schemaErrors, array &$schemaWarnings): array
     {
         // If any casting can't be done, show an error
-        if (
-            $failedCastingFieldArgs = array_filter($castedFieldArgs, function (mixed $fieldArgValue) {
-                return is_null($fieldArgValue);
-            })
-        ) {
+        if ($failedCastingFieldArgs = array_filter($castedFieldArgs, fn (mixed $fieldArgValue) => is_null($fieldArgValue))) {
             // $fieldOutputKey = $this->getFieldOutputKey($field);
             $fieldName = $this->getFieldName($field);
             $fieldArgNameTypes = $this->getFieldArgumentNameTypes($typeResolver, $field);

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1088,10 +1088,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     {
         // If any casting can't be done, show an error
         if (
-            // Temporarily commented out until Rector can downgrade `mixed` in anonymous functions
-            // @see https://github.com/leoloso/PoP/issues/626
-            // $failedCastingFieldArgs = array_filter($castedFieldArgs, function (mixed $fieldArgValue) {
-            $failedCastingFieldArgs = array_filter($castedFieldArgs, function ($fieldArgValue) {
+            $failedCastingFieldArgs = array_filter($castedFieldArgs, function (mixed $fieldArgValue) {
                 return is_null($fieldArgValue);
             })
         ) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -172,17 +172,10 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         // Add the type before the ID
         $dbObjectIDs = is_array($dbObjectIDOrIDs) ? $dbObjectIDOrIDs : [$dbObjectIDOrIDs];
         $qualifiedDBObjectIDs = array_map(
-            /**
-             * Commented temporarily until Rector can downgrade union types on anonymous functions
-             * @see https://github.com/rectorphp/rector/issues/5989
-             */
-            // function (int | string $id) {
-            function ($id) {
-                return UnionTypeHelpers::getDBObjectComposedTypeAndID(
-                    $this,
-                    $id
-                );
-            },
+            fn (int | string $id) => UnionTypeHelpers::getDBObjectComposedTypeAndID(
+                $this,
+                $id
+            ),
             $dbObjectIDs
         );
         return is_array($dbObjectIDOrIDs) ? $qualifiedDBObjectIDs : $qualifiedDBObjectIDs[0];
@@ -734,14 +727,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             }
             $ids_data_fields = array_filter(
                 $ids_data_fields,
-                /**
-                 * Commented temporarily until Rector can downgrade union types on anonymous functions
-                 * @see https://github.com/rectorphp/rector/issues/5989
-                 */
-                // function (int | string $id) use ($unresolvedResultItemIDs) {
-                function ($id) use ($unresolvedResultItemIDs) {
-                    return !in_array($id, $unresolvedResultItemIDs);
-                },
+                fn (int | string $id) => !in_array($id, $unresolvedResultItemIDs),
                 ARRAY_FILTER_USE_KEY
             );
         }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
@@ -41,14 +41,7 @@ trait FilterIDsSatisfyingConditionDirectiveResolverTrait
         // Calculate the $idsDataFields that must be removed from all the upcoming stages of the pipeline
         $idsDataFieldsToRemove = array_filter(
             $idsDataFields,
-            /**
-             * Commented temporarily until Rector can downgrade union types on anonymous functions
-             * @see https://github.com/rectorphp/rector/issues/5989
-             */
-            // function (int | string $id) use ($idsToRemove) {
-            function ($id) use ($idsToRemove) {
-                return in_array($id, $idsToRemove);
-            },
+            fn (int | string $id) => in_array($id, $idsToRemove),
             ARRAY_FILTER_USE_KEY
         );
         $this->removeIDsDataFields(

--- a/layers/Schema/packages/menus/src/TypeDataLoaders/MenuItemTypeDataLoader.php
+++ b/layers/Schema/packages/menus/src/TypeDataLoaders/MenuItemTypeDataLoader.php
@@ -13,12 +13,7 @@ class MenuItemTypeDataLoader extends AbstractTypeDataLoader
     {
         $menuItemTypeAPI = MenuItemTypeAPIFacade::getInstance();
         return array_map(
-            /**
-             * Commented temporarily until Rector can downgrade union types on anonymous functions
-             * @see https://github.com/rectorphp/rector/issues/5989
-             */
-            // fn (string | int $id) => $menuItemTypeAPI->getMenuItem($id),
-            fn ($id) => $menuItemTypeAPI->getMenuItem($id),
+            fn (string | int $id) => $menuItemTypeAPI->getMenuItem($id),
             $ids
         );
     }

--- a/layers/Schema/packages/menus/src/TypeDataLoaders/MenuTypeDataLoader.php
+++ b/layers/Schema/packages/menus/src/TypeDataLoaders/MenuTypeDataLoader.php
@@ -14,12 +14,7 @@ class MenuTypeDataLoader extends AbstractTypeDataLoader
         $menuTypeAPI = MenuTypeAPIFacade::getInstance();
         // If the menu doesn't exist, remove the `null` entry
         return array_filter(array_map(
-            /**
-             * Commented temporarily until Rector can downgrade union types on anonymous functions
-             * @see https://github.com/rectorphp/rector/issues/5989
-             */
-            // fn (string | int $id) => $menuTypeAPI->getMenu($id),
-            fn ($id) => $menuTypeAPI->getMenu($id),
+            fn (string | int $id) => $menuTypeAPI->getMenu($id),
             $ids
         ));
     }

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -54,6 +54,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'additional_rector_configs' => [
                 __DIR__ . '/ci/downgrades/rector-downgrade-code-graphql-api-hacks-CacheItem.php',
                 __DIR__ . '/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnMixedType.php',
+                __DIR__ . '/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnUnionType.php',
             ],
             'rector_downgrade_config' => __DIR__ . '/ci/downgrades/rector-downgrade-code-graphql-api.php',
             'scoping' => [
@@ -82,6 +83,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(CustomOption::ADDITIONAL_DOWNGRADE_RECTOR_CONFIGS, [
         __DIR__ . '/ci/downgrades/rector-downgrade-code-hacks-CacheItem.php',
         __DIR__ . '/ci/downgrades/rector-downgrade-code-hacks-ArrowFnMixedType.php',
+        __DIR__ . '/ci/downgrades/rector-downgrade-code-hacks-ArrowFnUnionType.php',
     ]);
 
     $parameters = $containerConfigurator->parameters();

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -53,6 +53,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'dist_repo_name' => 'graphql-api-for-wp-dist',
             'additional_rector_configs' => [
                 __DIR__ . '/ci/downgrades/rector-downgrade-code-graphql-api-hacks-CacheItem.php',
+                __DIR__ . '/ci/downgrades/rector-downgrade-code-graphql-api-hacks-ArrowFnMixedType.php',
             ],
             'rector_downgrade_config' => __DIR__ . '/ci/downgrades/rector-downgrade-code-graphql-api.php',
             'scoping' => [
@@ -80,6 +81,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
      */
     $parameters->set(CustomOption::ADDITIONAL_DOWNGRADE_RECTOR_CONFIGS, [
         __DIR__ . '/ci/downgrades/rector-downgrade-code-hacks-CacheItem.php',
+        __DIR__ . '/ci/downgrades/rector-downgrade-code-hacks-ArrowFnMixedType.php',
     ]);
 
     $parameters = $containerConfigurator->parameters();


### PR DESCRIPTION
Fixes #626.

To transform `fn (int | string $foo)` (and same with `mixed`), there will be a chained rule:

1. `function (int | string $foo)`
2. `function ($foo)`

Chained rules are not processed by Rector (https://github.com/rectorphp/rector/issues/5962), then this PR also adds hacks to manually run the 2nd rule on the corresponding files.