### PR TITLE
Fix PHP notice: "is_singular was called incorrectly"

### DIFF
--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractClient.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractClient.php
@@ -20,11 +20,25 @@ abstract class AbstractClient extends AbstractEndpointHandler
     public function initialize(): void
     {
         /**
-         * Subject to the endpoint having been defined
+         * Subject to the endpoint having been defined.
+         * 
+         * Execute on "init" to make sure that the CPT has been defined,
+         * with priority 0 to execute before `initialize` on parent.
+         * 
+         * Otherwise, if running `is_singular(...)` on service initialization,
+         * it will throw an error:
+         *   
+         *   Notice: is_singular was called <strong>incorrectly</strong>.
+         *   Conditional query tags do not work before the query is run.
+         *   Before then, they always return false.
+         * 
+         * @see https://github.com/leoloso/PoP/issues/710
          */
-        if (!$this->isClientDisabled()) {
-            parent::initialize();
-        }
+        \add_action('init', function (): void {
+            if (!$this->isClientDisabled()) {
+                parent::initialize();
+            }
+        }, 0);
     }
 
     /**


### PR DESCRIPTION
Fixes #710.

Call `isClientDisabled` (from where some class calls `is_singular`) on the `"init"` hook, as to wait for the query to be initialized.