### PR TITLE
Execute supporting lists of lists of types: `[[String]]`, `[[Int!]]`, etc

### DIFF
--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorCodes.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorCodes.php
@@ -8,9 +8,11 @@ class ErrorCodes
 {
     // public const NO_DIRECTIVE = 'no-directive';
     public const NON_NULLABLE_FIELD = 'non-nullable-field';
-    public const MUST_BE_ARRAY_FIELD = 'must-be-array-field';
     public const MUST_NOT_BE_ARRAY_FIELD = 'must-not-be-array-field';
+    public const MUST_BE_ARRAY_FIELD = 'must-be-array-field';
     public const ARRAY_MUST_NOT_HAVE_EMPTY_ITEMS_FIELD = 'array-must-not-have-empty-field';
+    public const MUST_BE_ARRAY_OF_ARRAYS_FIELD = 'must-be-array-of-arrays-field';
+    public const ARRAY_OF_ARRAYS_MUST_NOT_HAVE_EMPTY_ITEMS_FIELD = 'array-of-arrays-must-not-have-empty-field';
     public const NO_FIELD = 'no-field';
     public const VALIDATION_FAILED = 'validation-failed';
     public const NO_FIELD_RESOLVER_UNIT_PROCESSES_FIELD = 'no-fieldresolverunit-processes-field';

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -119,6 +119,19 @@ class ErrorProvider implements ErrorProviderInterface
         );
     }
 
+    public function getMustNotBeArrayOfArraysFieldError(string $fieldName, mixed $value): Error
+    {
+        return $this->getError(
+            $fieldName,
+            ErrorCodes::MUST_BE_ARRAY_OF_ARRAYS_FIELD,
+            sprintf(
+                $this->translationAPI->__('Array value in field \'%s\' must not contain arrays, but returned \'%s\'', 'pop-component-model'),
+                $fieldName,
+                (string) $value
+            )
+        );
+    }
+
     public function getMustBeArrayOfArraysFieldError(string $fieldName, mixed $value): Error
     {
         return $this->getError(

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -127,7 +127,7 @@ class ErrorProvider implements ErrorProviderInterface
             sprintf(
                 $this->translationAPI->__('Array value in field \'%s\' must not contain arrays, but returned \'%s\'', 'pop-component-model'),
                 $fieldName,
-                (string) $value
+                json_encode($value)
             )
         );
     }
@@ -140,7 +140,7 @@ class ErrorProvider implements ErrorProviderInterface
             sprintf(
                 $this->translationAPI->__('Field \'%s\' must return an array of arrays, but returned \'%s\'', 'pop-component-model'),
                 $fieldName,
-                (string) $value
+                json_encode($value)
             )
         );
     }

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -73,22 +73,6 @@ class ErrorProvider implements ErrorProviderInterface
     }
 
     /**
-     * Return an error to indicate that an array field is returning a non-array value
-     */
-    public function getMustBeArrayFieldError(string $fieldName, mixed $value): Error
-    {
-        return $this->getError(
-            $fieldName,
-            ErrorCodes::MUST_BE_ARRAY_FIELD,
-            sprintf(
-                $this->translationAPI->__('Field \'%s\' must return an array, but returned \'%s\'', 'pop-component-model'),
-                $fieldName,
-                (string) $value
-            )
-        );
-    }
-
-    /**
      * Return an error to indicate that a non-array field is returning an array value
      */
     public function getMustNotBeArrayFieldError(string $fieldName, array $value): Error
@@ -105,6 +89,22 @@ class ErrorProvider implements ErrorProviderInterface
     }
 
     /**
+     * Return an error to indicate that an array field is returning a non-array value
+     */
+    public function getMustBeArrayFieldError(string $fieldName, mixed $value): Error
+    {
+        return $this->getError(
+            $fieldName,
+            ErrorCodes::MUST_BE_ARRAY_FIELD,
+            sprintf(
+                $this->translationAPI->__('Field \'%s\' must return an array, but returned \'%s\'', 'pop-component-model'),
+                $fieldName,
+                (string) $value
+            )
+        );
+    }
+
+    /**
      * Return an error to indicate that an array field is returning an array with null items
      */
     public function getArrayMustNotHaveNullItemsFieldError(string $fieldName, array $value): Error
@@ -114,6 +114,31 @@ class ErrorProvider implements ErrorProviderInterface
             ErrorCodes::ARRAY_MUST_NOT_HAVE_EMPTY_ITEMS_FIELD,
             sprintf(
                 $this->translationAPI->__('Field \'%s\' must not return an array with null items', 'pop-component-model'),
+                $fieldName
+            )
+        );
+    }
+
+    public function getMustBeArrayOfArraysFieldError(string $fieldName, mixed $value): Error
+    {
+        return $this->getError(
+            $fieldName,
+            ErrorCodes::MUST_BE_ARRAY_OF_ARRAYS_FIELD,
+            sprintf(
+                $this->translationAPI->__('Field \'%s\' must return an array of arrays, but returned \'%s\'', 'pop-component-model'),
+                $fieldName,
+                (string) $value
+            )
+        );
+    }
+
+    public function getArrayOfArraysMustNotHaveNullItemsFieldError(string $fieldName, array $value): Error
+    {
+        return $this->getError(
+            $fieldName,
+            ErrorCodes::ARRAY_OF_ARRAYS_MUST_NOT_HAVE_EMPTY_ITEMS_FIELD,
+            sprintf(
+                $this->translationAPI->__('Field \'%s\' must not return an array of arrays with null items', 'pop-component-model'),
                 $fieldName
             )
         );

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
@@ -38,6 +38,7 @@ interface ErrorProviderInterface
     public function getMustBeArrayFieldError(string $fieldName, mixed $value): Error;
     public function getArrayMustNotHaveNullItemsFieldError(string $fieldName, array $value): Error;
     public function getMustBeArrayOfArraysFieldError(string $fieldName, mixed $value): Error;
+    public function getMustNotBeArrayOfArraysFieldError(string $fieldName, mixed $value): Error;
     public function getArrayOfArraysMustNotHaveNullItemsFieldError(string $fieldName, array $value): Error;
     /**
      * Return an error to indicate that no fieldResolver processes this field,

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
@@ -34,9 +34,11 @@ interface ErrorProviderInterface
      * @return Error
      */
     public function getNonNullableFieldError(string $fieldName): Error;
-    public function getMustBeArrayFieldError(string $fieldName, mixed $value): Error;
     public function getMustNotBeArrayFieldError(string $fieldName, array $value): Error;
+    public function getMustBeArrayFieldError(string $fieldName, mixed $value): Error;
     public function getArrayMustNotHaveNullItemsFieldError(string $fieldName, array $value): Error;
+    public function getMustBeArrayOfArraysFieldError(string $fieldName, mixed $value): Error;
+    public function getArrayOfArraysMustNotHaveNullItemsFieldError(string $fieldName, array $value): Error;
     /**
      * Return an error to indicate that no fieldResolver processes this field,
      * which is different than returning a null value.

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -315,6 +315,12 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                     if ($schemaTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY) {
                         $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] = true;
                     }
+                    if ($schemaTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) {
+                        $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] = true;
+                        if ($schemaTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS) {
+                            $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] = true;
+                        }
+                    }
                 }
                 if ($description = $schemaDefinitionResolver->getSchemaFieldDescription($typeResolver, $fieldName)) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $description;

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsSchemaFilterInputModuleProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsSchemaFilterInputModuleProcessorInterface.php
@@ -11,6 +11,8 @@ interface DataloadQueryArgsSchemaFilterInputModuleProcessorInterface
     public function getSchemaFilterInputDeprecationDescription(array $module): ?string;
     public function getSchemaFilterInputIsArrayType(array $module): bool;
     public function getSchemaFilterInputIsNonNullableItemsInArrayType(array $module): bool;
+    public function getSchemaFilterInputIsArrayOfArraysType(array $module): bool;
+    public function getSchemaFilterInputIsNonNullableItemsInArrayOfArraysType(array $module): bool;
     public function getSchemaFilterInputMandatory(array $module): bool;
     public function addSchemaDefinitionForFilter(array &$schemaDefinition, array $module): void;
 }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
@@ -51,6 +51,12 @@ trait FilterInputModuleProcessorTrait
                 if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsNonNullableItemsInArrayType($module)) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] = true;
                 }
+                if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsArrayOfArraysType($module)) {
+                    $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] = true;
+                    if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsNonNullableItemsInArrayOfArraysType($module)) {
+                        $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] = true;
+                    }
+                }
             }
             if ($filterSchemaDefinitionResolver->getSchemaFilterInputMandatory($module)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] = true;

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/SchemaFilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/SchemaFilterInputModuleProcessorTrait.php
@@ -33,6 +33,14 @@ trait SchemaFilterInputModuleProcessorTrait
     {
         return false;
     }
+    public function getSchemaFilterInputIsArrayOfArraysType(array $module): bool
+    {
+        return false;
+    }
+    public function getSchemaFilterInputIsNonNullableItemsInArrayOfArraysType(array $module): bool
+    {
+        return false;
+    }
     public function getSchemaFilterInputMandatory(array $module): bool
     {
         return false;

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -161,6 +161,20 @@ trait FieldOrDirectiveResolverTrait
                         $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
                         $fieldOrDirectiveName
                     );
+                } elseif (!$fieldOrDirectiveArgIsArrayOfArrays
+                    && is_array($fieldOrDirectiveArgumentValue)
+                    // Check if any element is not an array
+                    && array_filter(
+                        $fieldOrDirectiveArgumentValue,
+                        fn ($arrayItem) => is_array($arrayItem)
+                    )
+                ) {
+                    $errors[] = sprintf(
+                        $translationAPI->__('The array for argument \'%1$s\' in %2$s \'%3$s\' must not contain arrays', 'component-model'),
+                        $fieldOrDirectiveArgumentName,
+                        $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
+                        $fieldOrDirectiveName
+                    );
                 } elseif ($fieldOrDirectiveArgIsArrayOfArrays
                     && is_array($fieldOrDirectiveArgumentValue)
                     // Check if any element is not an array
@@ -298,6 +312,21 @@ trait FieldOrDirectiveResolverTrait
                     ) {
                         $errors[] = sprintf(
                             $translationAPI->__('The array for argument \'%1$s\' in %2$s \'%3$s\' cannot have `null` values', 'component-model'),
+                            $fieldOrDirectiveArgumentName,
+                            $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
+                            $fieldOrDirectiveName
+                        );
+                        continue;
+                    }
+                    if (!$enumTypeFieldOrDirectiveArgIsArrayOfArrays
+                        && is_array($fieldOrDirectiveArgumentValue)
+                        && array_filter(
+                            $fieldOrDirectiveArgumentValue,
+                            fn ($arrayItem) => is_array($arrayItem)
+                        )
+                    ) {
+                        $errors[] = sprintf(
+                            $translationAPI->__('The array for argument \'%1$s\' in %2$s \'%3$s\' must not contain arrays', 'component-model'),
                             $fieldOrDirectiveArgumentName,
                             $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
                             $fieldOrDirectiveName

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Resolvers;
 
-use PoP\ComponentModel\Schema\SchemaHelpers;
+use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\Translation\Facades\TranslationAPIFacade;
+use PoP\ComponentModel\Schema\SchemaHelpers;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Translation\Facades\TranslationAPIFacade;
 
 trait FieldOrDirectiveResolverTrait
 {
@@ -127,27 +128,65 @@ trait FieldOrDirectiveResolverTrait
                 }
                 $fieldOrDirectiveArgIsArray = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
                 $fieldOrDirectiveArgNonNullArrayItems = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
-                if ($fieldOrDirectiveArgIsArray && !is_array($fieldOrDirectiveArgumentValue)) {
+                $fieldOrDirectiveArgIsArrayOfArrays = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
+                $fieldOrDirectiveArgNonNullArrayOfArraysItems = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false;
+                if ($fieldOrDirectiveArgIsArray
+                    && !is_array($fieldOrDirectiveArgumentValue)
+                ) {
                     $errors[] = sprintf(
                         $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must be an array', 'component-model'),
                         $fieldOrDirectiveArgumentName,
                         $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
                         $fieldOrDirectiveName
                     );
-                } elseif (!$fieldOrDirectiveArgIsArray && is_array($fieldOrDirectiveArgumentValue)) {
+                } elseif (!$fieldOrDirectiveArgIsArray
+                    && is_array($fieldOrDirectiveArgumentValue)
+                ) {
                     $errors[] = sprintf(
                         $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must not be an array', 'component-model'),
                         $fieldOrDirectiveArgumentName,
                         $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
                         $fieldOrDirectiveName
                     );
-                } elseif ($fieldOrDirectiveArgIsArray
-                    && $fieldOrDirectiveArgNonNullArrayItems
+                } elseif ($fieldOrDirectiveArgNonNullArrayItems
                     && is_array($fieldOrDirectiveArgumentValue)
-                    && array_filter($fieldOrDirectiveArgumentValue, fn ($arrayItem) => $arrayItem === null)
+                    && array_filter(
+                        $fieldOrDirectiveArgumentValue,
+                        fn ($arrayItem) => $arrayItem === null
+                    )
                 ) {
                     $errors[] = sprintf(
                         $translationAPI->__('The array for argument \'%1$s\' in %2$s \'%3$s\' cannot have `null` values', 'component-model'),
+                        $fieldOrDirectiveArgumentName,
+                        $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
+                        $fieldOrDirectiveName
+                    );
+                } elseif ($fieldOrDirectiveArgIsArrayOfArrays
+                    && is_array($fieldOrDirectiveArgumentValue)
+                    // Check if any element is not an array
+                    && array_filter(
+                        $fieldOrDirectiveArgumentValue,
+                        fn ($arrayItem) => !is_array($arrayItem)
+                    )
+                ) {
+                    $errors[] = sprintf(
+                        $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must be an array of arrays', 'component-model'),
+                        $fieldOrDirectiveArgumentName,
+                        $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
+                        $fieldOrDirectiveName
+                    );
+                } elseif ($fieldOrDirectiveArgNonNullArrayOfArraysItems
+                    && is_array($fieldOrDirectiveArgumentValue)
+                    && array_filter(
+                        $fieldOrDirectiveArgumentValue,
+                        fn ($arrayItem) => array_filter(
+                            $arrayItem,
+                            fn ($arrayItemItem) => $arrayItemItem === null
+                        )
+                    )
+                ) {
+                    $errors[] = sprintf(
+                        $translationAPI->__('The array of arrays for argument \'%1$s\' in %2$s \'%3$s\' cannot have `null` values', 'component-model'),
                         $fieldOrDirectiveArgumentName,
                         $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
                         $fieldOrDirectiveName
@@ -183,8 +222,12 @@ trait FieldOrDirectiveResolverTrait
         }
         return $this->enumValueArgumentValidationCache[$key];
     }
-    protected function doValidateEnumFieldOrDirectiveArguments(array $enumTypeFieldOrDirectiveArgsSchemaDefinition, string $fieldOrDirectiveName, array $fieldOrDirectiveArgs, string $type): ?array
-    {
+    protected function doValidateEnumFieldOrDirectiveArguments(
+        array $enumTypeFieldOrDirectiveArgsSchemaDefinition,
+        string $fieldOrDirectiveName,
+        array $fieldOrDirectiveArgs,
+        string $type
+    ): ?array {
         $translationAPI = TranslationAPIFacade::getInstance();
         $errors = $deprecations = [];
         $fieldOrDirectiveArgumentNames = SchemaHelpers::getSchemaFieldArgNames($enumTypeFieldOrDirectiveArgsSchemaDefinition);
@@ -218,10 +261,25 @@ trait FieldOrDirectiveResolverTrait
                 ]);
                 $enumTypeFieldOrDirectiveArgIsArray = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
                 $enumTypeFieldOrDirectiveArgNonNullArrayItems = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
+                $enumTypeFieldOrDirectiveArgIsArrayOfArrays = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
+                $enumTypeFieldOrDirectiveArgNonNullArrayOfArraysItems = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false;
                 // Each fieldArgumentEnumValue is an array with item "name" for sure, and maybe also "description", "deprecated" and "deprecationDescription"
                 $schemaFieldOrDirectiveArgumentEnumValues = $schemaFieldArgumentEnumValueDefinitions[$fieldOrDirectiveArgumentName];
-                if ($enumTypeFieldOrDirectiveArgIsArray) {
-                    if (!$enumTypeFieldOrDirectiveArgMayBeArray && !is_array($fieldOrDirectiveArgumentValue)) {
+                if (!$enumTypeFieldOrDirectiveArgMayBeArray) {
+                    if (!$enumTypeFieldOrDirectiveArgIsArray
+                        && is_array($fieldOrDirectiveArgumentValue)
+                    ) {
+                        $errors[] = sprintf(
+                            $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must not be an array', 'component-model'),
+                            $fieldOrDirectiveArgumentName,
+                            $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
+                            $fieldOrDirectiveName
+                        );
+                        continue;
+                    }
+                    if ($enumTypeFieldOrDirectiveArgIsArray
+                        && !is_array($fieldOrDirectiveArgumentValue)
+                    ) {
                         $errors[] = sprintf(
                             $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must be an array', 'component-model'),
                             $fieldOrDirectiveArgumentName,
@@ -229,11 +287,14 @@ trait FieldOrDirectiveResolverTrait
                             $fieldOrDirectiveName
                         );
                         continue;
-                    } elseif (
-                        !$enumTypeFieldOrDirectiveArgMayBeArray
-                        && $enumTypeFieldOrDirectiveArgNonNullArrayItems
+                    }
+                    if ($enumTypeFieldOrDirectiveArgIsArray
                         && is_array($fieldOrDirectiveArgumentValue)
-                        && array_filter($fieldOrDirectiveArgumentValue, fn ($arrayItem) => $arrayItem === null)
+                        && $enumTypeFieldOrDirectiveArgNonNullArrayItems
+                        && array_filter(
+                            $fieldOrDirectiveArgumentValue,
+                            fn ($arrayItem) => $arrayItem === null
+                        )
                     ) {
                         $errors[] = sprintf(
                             $translationAPI->__('The array for argument \'%1$s\' in %2$s \'%3$s\' cannot have `null` values', 'component-model'),
@@ -243,35 +304,62 @@ trait FieldOrDirectiveResolverTrait
                         );
                         continue;
                     }
-                    $this->doValidateEnumFieldOrDirectiveArgumentsItem(
-                        $errors,
-                        $deprecations,
-                        $schemaFieldOrDirectiveArgumentEnumValues,
-                        $fieldOrDirectiveArgumentValue,
-                        $fieldOrDirectiveArgumentName,
-                        $fieldOrDirectiveName,
-                        $type,
-                    );
-                } else {
-                    if (!$enumTypeFieldOrDirectiveArgMayBeArray && is_array($fieldOrDirectiveArgumentValue)) {
+                    if ($enumTypeFieldOrDirectiveArgIsArrayOfArrays
+                        && is_array($fieldOrDirectiveArgumentValue)
+                        && array_filter(
+                            $fieldOrDirectiveArgumentValue,
+                            fn ($arrayItem) => !is_array($arrayItem)
+                        )
+                    ) {
                         $errors[] = sprintf(
-                            $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must not be an array', 'component-model'),
+                            $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must be an array of arrays', 'component-model'),
                             $fieldOrDirectiveArgumentName,
                             $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
                             $fieldOrDirectiveName
                         );
                         continue;
                     }
-                    $this->doValidateEnumFieldOrDirectiveArgumentsItem(
-                        $errors,
-                        $deprecations,
-                        $schemaFieldOrDirectiveArgumentEnumValues,
-                        [$fieldOrDirectiveArgumentValue],
-                        $fieldOrDirectiveArgumentName,
-                        $fieldOrDirectiveName,
-                        $type,
-                    );
+                    if ($enumTypeFieldOrDirectiveArgIsArrayOfArrays
+                        && is_array($fieldOrDirectiveArgumentValue)
+                        && $enumTypeFieldOrDirectiveArgNonNullArrayOfArraysItems
+                        && array_filter(
+                            $fieldOrDirectiveArgumentValue,
+                            fn ($arrayItem) => array_filter(
+                                $arrayItem,
+                                fn ($arrayItemItem) => $arrayItemItem === null
+                            )
+                        )
+                    ) {
+                        $errors[] = sprintf(
+                            $translationAPI->__('The array of arrays for argument \'%1$s\' in %2$s \'%3$s\' cannot have `null` values', 'component-model'),
+                            $fieldOrDirectiveArgumentName,
+                            $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
+                            $fieldOrDirectiveName
+                        );
+                        continue;
+                    }
                 }
+                // Pass all the enum values to be validated, as a list.
+                // Possibilities:
+                //   1. Single item => [item]
+                //   2. Array => Array
+                //   3. Array of arrays => flatten into array
+                if ($enumTypeFieldOrDirectiveArgIsArrayOfArrays) {
+                    $fieldOrDirectiveArgumentValueEnums = array_unique(GeneralUtils::arrayFlatten($fieldOrDirectiveArgumentValue));
+                } elseif ($enumTypeFieldOrDirectiveArgIsArray) {
+                    $fieldOrDirectiveArgumentValueEnums = $fieldOrDirectiveArgumentValue;
+                } else {
+                    $fieldOrDirectiveArgumentValueEnums = [$fieldOrDirectiveArgumentValue];
+                }
+                $this->doValidateEnumFieldOrDirectiveArgumentsItem(
+                    $errors,
+                    $deprecations,
+                    $schemaFieldOrDirectiveArgumentEnumValues,
+                    $fieldOrDirectiveArgumentValueEnums,
+                    $fieldOrDirectiveArgumentName,
+                    $fieldOrDirectiveName,
+                    $type,
+                );
             }
         }
         // if ($errors) {

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -130,20 +130,20 @@ trait FieldOrDirectiveResolverTrait
                 $fieldOrDirectiveArgNonNullArrayItems = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
                 $fieldOrDirectiveArgIsArrayOfArrays = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
                 $fieldOrDirectiveArgNonNullArrayOfArraysItems = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false;
-                if ($fieldOrDirectiveArgIsArray
-                    && !is_array($fieldOrDirectiveArgumentValue)
-                ) {
-                    $errors[] = sprintf(
-                        $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must be an array', 'component-model'),
-                        $fieldOrDirectiveArgumentName,
-                        $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
-                        $fieldOrDirectiveName
-                    );
-                } elseif (!$fieldOrDirectiveArgIsArray
+                if (!$fieldOrDirectiveArgIsArray
                     && is_array($fieldOrDirectiveArgumentValue)
                 ) {
                     $errors[] = sprintf(
                         $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must not be an array', 'component-model'),
+                        $fieldOrDirectiveArgumentName,
+                        $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
+                        $fieldOrDirectiveName
+                    );
+                } elseif ($fieldOrDirectiveArgIsArray
+                    && !is_array($fieldOrDirectiveArgumentValue)
+                ) {
+                    $errors[] = sprintf(
+                        $translationAPI->__('The value for argument \'%1$s\' in %2$s \'%3$s\' must be an array', 'component-model'),
                         $fieldOrDirectiveArgumentName,
                         $type == ResolverTypes::FIELD ? $translationAPI->__('field', 'component-model') : $translationAPI->__('directive', 'component-model'),
                         $fieldOrDirectiveName

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -854,7 +854,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                         $errorMessage = sprintf(
                             $this->translationAPI->__('Argument \'%s\' expects an array of arrays, but value \'%s\' was provided', 'pop-component-model'),
                             $argName,
-                            $argValue
+                            json_encode($argValue)
                         );
                     } elseif ($fieldOrDirectiveArgIsNonNullArrayOfArraysItemsType
                         && is_array($argValue)
@@ -1097,8 +1097,14 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             foreach (array_keys($failedCastingDirectiveArgs) as $failedCastingDirectiveArgName) {
                 // If it is Error, also show the error message
                 $directiveArgIsArrayType = $directiveArgNameSchemaDefinition[$failedCastingDirectiveArgName][SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
+                $directiveArgIsArrayOfArraysType = $directiveArgNameSchemaDefinition[$failedCastingDirectiveArgName][SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
                 $composedDirectiveArgType = $directiveArgNameTypes[$failedCastingDirectiveArgName];
-                if ($directiveArgIsArrayType) {
+                if ($directiveArgIsArrayOfArraysType) {
+                    $composedDirectiveArgType = sprintf(
+                        $this->translationAPI->__('array of arrays of %s', 'pop-component-model'),
+                        $composedDirectiveArgType
+                    );
+                } elseif ($directiveArgIsArrayType) {
                     $composedDirectiveArgType = sprintf(
                         $this->translationAPI->__('array of %s', 'pop-component-model'),
                         $composedDirectiveArgType
@@ -1187,8 +1193,14 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             foreach (array_keys($failedCastingFieldArgs) as $failedCastingFieldArgName) {
                 // If it is Error, also show the error message
                 $fieldArgIsArrayType = $fieldArgNameSchemaDefinition[$failedCastingFieldArgName][SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
+                $fieldArgIsArrayOfArraysType = $fieldArgNameSchemaDefinition[$failedCastingFieldArgName][SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
                 $composedFieldArgType = $fieldArgNameTypes[$failedCastingFieldArgName];
-                if ($fieldArgIsArrayType) {
+                if ($fieldArgIsArrayOfArraysType) {
+                    $composedFieldArgType = sprintf(
+                        $this->translationAPI->__('array of arrays of %s', 'pop-component-model'),
+                        $composedFieldArgType
+                    );
+                } elseif ($fieldArgIsArrayType) {
                     $composedFieldArgType = sprintf(
                         $this->translationAPI->__('array of %s', 'pop-component-model'),
                         $composedFieldArgType

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -14,6 +14,8 @@ class SchemaDefinition
     const ARGNAME_NON_NULLABLE = 'nonNullable';
     const ARGNAME_IS_ARRAY = 'isArray';
     const ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY = 'isNonNullableItemsInArray';
+    const ARGNAME_IS_ARRAY_OF_ARRAYS = 'isArrayOfArrays';
+    const ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS = 'isNonNullableItemsInArrayOfArrays';
     const ARGNAME_REFERENCED_TYPE = 'referencedType';
     const ARGNAME_DESCRIPTION = 'description';
     const ARGNAME_VERSION = 'version';

--- a/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaTypeModifiers.php
@@ -14,4 +14,6 @@ class SchemaTypeModifiers
     public const NON_NULLABLE = 1;
     public const IS_ARRAY = 2;
     public const IS_NON_NULLABLE_ITEMS_IN_ARRAY = 4;
+    public const IS_ARRAY_OF_ARRAYS = 8;
+    public const IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS = 16;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1481,15 +1481,48 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                         ]);
                         if (!$fieldMayBeArrayType) {
                             $fieldIsArrayType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
-                            if (is_array($value) && !$fieldIsArrayType) {
+                            if (!$fieldIsArrayType
+                                && is_array($value)
+                            ) {
                                 return $this->errorProvider->getMustNotBeArrayFieldError($fieldName, $value);
                             }
-                            if (!is_array($value) && $fieldIsArrayType) {
+                            if ($fieldIsArrayType
+                                && !is_array($value)
+                            ) {
                                 return $this->errorProvider->getMustBeArrayFieldError($fieldName, $value);
                             }
                             $fieldIsNonNullArrayItemsType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
-                            if ($fieldIsNonNullArrayItemsType && is_array($value) && array_filter($value, fn ($arrayItem) => $arrayItem === null)) {
+                            if ($fieldIsNonNullArrayItemsType
+                                && is_array($value)
+                                && array_filter(
+                                    $value,
+                                    fn ($arrayItem) => $arrayItem === null
+                                )
+                            ) {
                                 return $this->errorProvider->getArrayMustNotHaveNullItemsFieldError($fieldName, $value);
+                            }
+                            $fieldIsArrayOfArraysType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
+                            if ($fieldIsArrayOfArraysType
+                                && is_array($value)
+                                && array_filter(
+                                    $value,
+                                    fn ($arrayItem) => !is_array($arrayItem)
+                                )
+                            ) {
+                                return $this->errorProvider->getMustBeArrayOfArraysFieldError($fieldName, $value);
+                            }
+                            $fieldIsNonNullArrayOfArraysItemsType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false;
+                            if ($fieldIsNonNullArrayOfArraysItemsType
+                                && is_array($value)
+                                && array_filter(
+                                    $value,
+                                    fn ($arrayItem) => array_filter(
+                                        $arrayItem,
+                                        fn ($arrayItemItem) => $arrayItemItem === null
+                                    )
+                                )
+                            ) {
+                                return $this->errorProvider->getArrayOfArraysMustNotHaveNullItemsFieldError($fieldName, $value);
                             }
                         }
                     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1502,6 +1502,15 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                                 return $this->errorProvider->getArrayMustNotHaveNullItemsFieldError($fieldName, $value);
                             }
                             $fieldIsArrayOfArraysType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
+                            if (!$fieldIsArrayOfArraysType
+                                && is_array($value)
+                                && array_filter(
+                                    $value,
+                                    fn ($arrayItem) => is_array($arrayItem)
+                                )
+                            ) {
+                                return $this->errorProvider->getMustNotBeArrayOfArraysFieldError($fieldName, $value);
+                            }
                             if ($fieldIsArrayOfArraysType
                                 && is_array($value)
                                 && array_filter(

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -365,9 +365,11 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
         $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
         $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
             $type,
+            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] ?? null,
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false,
-            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] ?? null
+            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false,
+            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false,
         );
         $this->introduceSDLNotationToFieldOrDirectiveArgs($fieldSchemaDefinitionPath);
     }
@@ -382,9 +384,11 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
                 $type = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? $this->schemaDefinitionService->getDefaultType();
                 $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
                     $type,
+                    $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null,
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false,
-                    $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null
+                    $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false,
+                    $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false,
                 );
                 // If it is an input object, it may have its own args to also convert
                 if ($type == SchemaDefinition::TYPE_INPUT_OBJECT) {
@@ -392,9 +396,11 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
                         $inputFieldType = $inputFieldArgDefinition[SchemaDefinition::ARGNAME_TYPE];
                         $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_ARGS][$inputFieldArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
                             $inputFieldType,
+                            $inputFieldArgDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null,
                             $inputFieldArgDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
                             $inputFieldArgDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false,
-                            $inputFieldArgDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null
+                            $inputFieldArgDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false,
+                            $inputFieldArgDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false,
                         );
                     }
                 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/SchemaHelpers.php
@@ -19,13 +19,26 @@ class SchemaHelpers
      * - field response: isNonNullable
      * - field argument: isMandatory (its provided value can still be null)
      */
-    public static function getTypeToOutputInSchema(string $type, ?bool $isArray = false, ?bool $isNonNullArrayItems = false, ?bool $isNonNullableOrMandatory = false): string
-    {
+    public static function getTypeToOutputInSchema(
+        string $type,
+        ?bool $isNonNullableOrMandatory = false,
+        ?bool $isArray = false,
+        ?bool $isNonNullArrayItems = false,
+        ?bool $isArrayOfArrays = false,
+        ?bool $isNonNullArrayOfArraysItems = false,
+    ): string {
         // Convert the type name to standards by GraphQL
         $convertedType = self::convertTypeNameToGraphQLStandard($type);
 
         // Wrap the type with the array brackets
         if ($isArray) {
+            if ($isArrayOfArrays) {
+                $convertedType = sprintf(
+                    '[%s%s]',
+                    $convertedType,
+                    $isNonNullArrayOfArraysItems ? '!' : ''
+                );
+            }
             $convertedType = sprintf(
                 '[%s%s]',
                 $convertedType,


### PR DESCRIPTION
As defined in the GraphQL spec: https://spec.graphql.org/draft/#sec-List

At this stage, only 2 levels are supported: `[[String]]`.

3 levels or more, such as `[[[Int]]]`, are not yet supported.