### PR TITLE
When setting flag `SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS`, no need to also set flag `SchemaTypeModifiers::IS_ARRAY`

### DIFF
--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -310,12 +310,16 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                 if ($schemaTypeModifiers & SchemaTypeModifiers::NON_NULLABLE) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] = true;
                 }
-                if ($schemaTypeModifiers & SchemaTypeModifiers::IS_ARRAY) {
+                // If setting the "array of arrays" flag, there's no need to set the "array" flag
+                $isArrayOfArrays = $schemaTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
+                if ($schemaTypeModifiers & SchemaTypeModifiers::IS_ARRAY
+                    || $isArrayOfArrays
+                ) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] = true;
                     if ($schemaTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY) {
                         $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] = true;
                     }
-                    if ($schemaTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) {
+                    if ($isArrayOfArrays) {
                         $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] = true;
                         if ($schemaTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS) {
                             $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] = true;

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FilterInputModuleProcessorTrait.php
@@ -46,12 +46,16 @@ trait FilterInputModuleProcessorTrait
             if ($description = $filterSchemaDefinitionResolver->getSchemaFilterInputDescription($module)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $description;
             }
-            if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsArrayType($module)) {
+            // If setting the "array of arrays" flag, there's no need to set the "array" flag
+            $isArrayOfArrays = $filterSchemaDefinitionResolver->getSchemaFilterInputIsArrayOfArraysType($module);
+            if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsArrayType($module)
+                || $isArrayOfArrays
+            ) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] = true;
                 if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsNonNullableItemsInArrayType($module)) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] = true;
                 }
-                if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsArrayOfArraysType($module)) {
+                if ($isArrayOfArrays) {
                     $schemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] = true;
                     if ($filterSchemaDefinitionResolver->getSchemaFilterInputIsNonNullableItemsInArrayOfArraysType($module)) {
                         $schemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] = true;

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -273,9 +273,11 @@ trait FieldOrDirectiveResolverTrait
                     SchemaDefinition::TYPE_OBJECT,
                     SchemaDefinition::TYPE_MIXED,
                 ]);
-                $enumTypeFieldOrDirectiveArgIsArray = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
-                $enumTypeFieldOrDirectiveArgNonNullArrayItems = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
+                // If setting the "array of arrays" flag, there's no need to set the "array" flag
                 $enumTypeFieldOrDirectiveArgIsArrayOfArrays = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
+                $enumTypeFieldOrDirectiveArgIsArray = ($enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false)
+                    || $enumTypeFieldOrDirectiveArgIsArrayOfArrays;
+                $enumTypeFieldOrDirectiveArgNonNullArrayItems = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
                 $enumTypeFieldOrDirectiveArgNonNullArrayOfArraysItems = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false;
                 // Each fieldArgumentEnumValue is an array with item "name" for sure, and maybe also "description", "deprecated" and "deprecationDescription"
                 $schemaFieldOrDirectiveArgumentEnumValues = $schemaFieldArgumentEnumValueDefinitions[$fieldOrDirectiveArgumentName];


### PR DESCRIPTION
When setting flag `SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS`, there's no need anymore to also set flag `SchemaTypeModifiers::IS_ARRAY`