### PR TITLE
Fix issue in `CacheDirectiveResolver`: "max age must be of type int"

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -61,6 +61,11 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * @var array[]
      */
     protected array $nestedDirectivePipelineData = [];
+
+    /**
+     * @var array<string, array>
+     */
+    protected array $schemaDefinitionForDirectiveCache = [];
     
     /**
      * The directiveResolvers are NOT instantiated through the service container!
@@ -861,56 +866,61 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
     public function getSchemaDefinitionForDirective(TypeResolverInterface $typeResolver): array
     {
-        $directiveName = $this->getDirectiveName();
-        $schemaDefinition = [
-            SchemaDefinition::ARGNAME_NAME => $directiveName,
-            SchemaDefinition::ARGNAME_DIRECTIVE_TYPE => $this->getDirectiveType(),
-            SchemaDefinition::ARGNAME_DIRECTIVE_PIPELINE_POSITION => $this->getPipelinePosition(),
-            SchemaDefinition::ARGNAME_DIRECTIVE_IS_REPEATABLE => $this->isRepeatable(),
-            SchemaDefinition::ARGNAME_DIRECTIVE_NEEDS_DATA_TO_EXECUTE => $this->needsIDsDataFieldsToExecute(),
-        ];
-        if ($limitedToFields = $this->getFieldNamesToApplyTo()) {
-            $schemaDefinition[SchemaDefinition::ARGNAME_DIRECTIVE_LIMITED_TO_FIELDS] = $limitedToFields;
-        }
-        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
-            if ($description = $schemaDefinitionResolver->getSchemaDirectiveDescription($typeResolver)) {
-                $schemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $description;
+        // First check if the value was cached
+        $key = $typeResolver->getNamespacedTypeName();
+        if (!isset($this->schemaDefinitionForDirectiveCache[$key])) {
+            $directiveName = $this->getDirectiveName();
+            $schemaDefinition = [
+                SchemaDefinition::ARGNAME_NAME => $directiveName,
+                SchemaDefinition::ARGNAME_DIRECTIVE_TYPE => $this->getDirectiveType(),
+                SchemaDefinition::ARGNAME_DIRECTIVE_PIPELINE_POSITION => $this->getPipelinePosition(),
+                SchemaDefinition::ARGNAME_DIRECTIVE_IS_REPEATABLE => $this->isRepeatable(),
+                SchemaDefinition::ARGNAME_DIRECTIVE_NEEDS_DATA_TO_EXECUTE => $this->needsIDsDataFieldsToExecute(),
+            ];
+            if ($limitedToFields = $this->getFieldNamesToApplyTo()) {
+                $schemaDefinition[SchemaDefinition::ARGNAME_DIRECTIVE_LIMITED_TO_FIELDS] = $limitedToFields;
             }
-            if ($expressions = $schemaDefinitionResolver->getSchemaDirectiveExpressions($typeResolver)) {
-                $schemaDefinition[SchemaDefinition::ARGNAME_DIRECTIVE_EXPRESSIONS] = $expressions;
-            }
-            if ($deprecationDescription = $schemaDefinitionResolver->getSchemaDirectiveDeprecationDescription($typeResolver)) {
-                $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATED] = true;
-                $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATIONDESCRIPTION] = $deprecationDescription;
-            }
-            if ($args = $schemaDefinitionResolver->getFilteredSchemaDirectiveArgs($typeResolver)) {
-                // Add the args under their name.
-                // Watch out: the name is mandatory!
-                // If it hasn't been set, then skip the entry
-                $nameArgs = [];
-                foreach ($args as $arg) {
-                    if (!isset($arg[SchemaDefinition::ARGNAME_NAME])) {
-                        continue;
-                    }
-                    $nameArgs[$arg[SchemaDefinition::ARGNAME_NAME]] = $arg;
+            if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
+                if ($description = $schemaDefinitionResolver->getSchemaDirectiveDescription($typeResolver)) {
+                    $schemaDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $description;
                 }
-                $schemaDefinition[SchemaDefinition::ARGNAME_ARGS] = $nameArgs;
+                if ($expressions = $schemaDefinitionResolver->getSchemaDirectiveExpressions($typeResolver)) {
+                    $schemaDefinition[SchemaDefinition::ARGNAME_DIRECTIVE_EXPRESSIONS] = $expressions;
+                }
+                if ($deprecationDescription = $schemaDefinitionResolver->getSchemaDirectiveDeprecationDescription($typeResolver)) {
+                    $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATED] = true;
+                    $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATIONDESCRIPTION] = $deprecationDescription;
+                }
+                if ($args = $schemaDefinitionResolver->getFilteredSchemaDirectiveArgs($typeResolver)) {
+                    // Add the args under their name.
+                    // Watch out: the name is mandatory!
+                    // If it hasn't been set, then skip the entry
+                    $nameArgs = [];
+                    foreach ($args as $arg) {
+                        if (!isset($arg[SchemaDefinition::ARGNAME_NAME])) {
+                            continue;
+                        }
+                        $nameArgs[$arg[SchemaDefinition::ARGNAME_NAME]] = $arg;
+                    }
+                    $schemaDefinition[SchemaDefinition::ARGNAME_ARGS] = $nameArgs;
+                }
             }
-        }
-        /**
-         * Please notice: the version always comes from the directiveResolver, and not from the schemaDefinitionResolver
-         * That is because it is the implementer the one who knows what version it is, and not the one defining the interface
-         * If the interface changes, the implementer will need to change, so the version will be upgraded
-         * But it could also be that the contract doesn't change, but the implementation changes
-         * it's really not their responsibility
-         */
-        if (Environment::enableSemanticVersionConstraints()) {
-            if ($version = $this->getSchemaDirectiveVersion($typeResolver)) {
-                $schemaDefinition[SchemaDefinition::ARGNAME_VERSION] = $version;
+            /**
+             * Please notice: the version always comes from the directiveResolver, and not from the schemaDefinitionResolver
+             * That is because it is the implementer the one who knows what version it is, and not the one defining the interface
+             * If the interface changes, the implementer will need to change, so the version will be upgraded
+             * But it could also be that the contract doesn't change, but the implementation changes
+             * it's really not their responsibility
+             */
+            if (Environment::enableSemanticVersionConstraints()) {
+                if ($version = $this->getSchemaDirectiveVersion($typeResolver)) {
+                    $schemaDefinition[SchemaDefinition::ARGNAME_VERSION] = $version;
+                }
             }
+            $this->addSchemaDefinitionForDirective($schemaDefinition);
+            $this->schemaDefinitionForDirectiveCache[$key] = $schemaDefinition;
         }
-        $this->addSchemaDefinitionForDirective($schemaDefinition);
-        return $schemaDefinition;
+        return $this->schemaDefinitionForDirectiveCache[$key];
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -522,13 +522,10 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         return [];
     }
 
-    public function getFilteredSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
-    {
-        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
-            $schemaDirectiveArgs = $schemaDefinitionResolver->getSchemaDirectiveArgs($typeResolver);
-        } else {
-            $schemaDirectiveArgs = [];
-        }
+    protected function getFilteredSchemaDirectiveArgs(
+        TypeResolverInterface $typeResolver,
+        array $schemaDirectiveArgs
+    ): array {
         $this->maybeAddVersionConstraintSchemaFieldOrDirectiveArg(
             $schemaDirectiveArgs,
             !empty($this->getSchemaDirectiveVersion($typeResolver))
@@ -891,7 +888,8 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                     $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATED] = true;
                     $schemaDefinition[SchemaDefinition::ARGNAME_DEPRECATIONDESCRIPTION] = $deprecationDescription;
                 }
-                if ($args = $schemaDefinitionResolver->getFilteredSchemaDirectiveArgs($typeResolver)) {
+                if ($args = $schemaDefinitionResolver->getSchemaDirectiveArgs($typeResolver)) {
+                    $args = $this->getFilteredSchemaDirectiveArgs($typeResolver, $args);
                     // Add the args under their name.
                     // Watch out: the name is mandatory!
                     // If it hasn't been set, then skip the entry

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractSchemaDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractSchemaDirectiveResolver.php
@@ -32,15 +32,6 @@ abstract class AbstractSchemaDirectiveResolver extends AbstractDirectiveResolver
     {
         return [];
     }
-    public function getFilteredSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
-    {
-        $schemaDirectiveArgs = $this->getSchemaDirectiveArgs($typeResolver);
-        $this->maybeAddVersionConstraintSchemaFieldOrDirectiveArg(
-            $schemaDirectiveArgs,
-            !empty($this->getSchemaDirectiveVersion($typeResolver))
-        );
-        return $schemaDirectiveArgs;
-    }
     public function enableOrderedSchemaDirectiveArgs(TypeResolverInterface $typeResolver): bool
     {
         return true;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
@@ -76,17 +76,6 @@ trait AliasSchemaDirectiveResolverTrait
     /**
      * Proxy pattern: execute same function on the aliased DirectiveResolver
      */
-    public function getFilteredSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array
-    {
-        $aliasedDirectiveResolver = $this->getAliasedDirectiveResolverInstance();
-        return $aliasedDirectiveResolver->getFilteredSchemaDirectiveArgs(
-            $typeResolver
-        );
-    }
-
-    /**
-     * Proxy pattern: execute same function on the aliased DirectiveResolver
-     */
     public function getSchemaDirectiveExpressions(TypeResolverInterface $typeResolver): array
     {
         $aliasedDirectiveResolver = $this->getAliasedDirectiveResolverInstance();

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
@@ -23,10 +23,6 @@ interface SchemaDirectiveResolverInterface
      */
     public function getSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array;
     /**
-     * Filtered Schema Directive Arguments
-     */
-    public function getFilteredSchemaDirectiveArgs(TypeResolverInterface $typeResolver): array;
-    /**
      * Expressions set by the directive
      */
     public function getSchemaDirectiveExpressions(TypeResolverInterface $typeResolver): array;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -62,19 +62,6 @@ abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverI
         return null;
     }
 
-    /**
-     * The fieldResolver will determine if it has a version or not, however the signature
-     * of the fields comes from the interface. Only if there's a version will fieldArg "versionConstraint"
-     * be added to the field. Hence, the interface must always say it has a version.
-     * This will make fieldArg "versionConstraint" be always added to fields implementing an interface,
-     * even if they do not have a version. However, the other way around, to say `false`,
-     * would not allow any field implementing an interface to be versioned. So this way is better.
-     */
-    protected function hasSchemaFieldVersion(string $fieldName): bool
-    {
-        return true;
-    }
-
     // public function getSchemaInterfaceVersion(string $fieldName): ?string
     // {
     //     return null;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -11,7 +11,6 @@ interface FieldInterfaceSchemaDefinitionResolverInterface
     public function getSchemaFieldTypeModifiers(string $fieldName): ?int;
     public function getSchemaFieldDescription(string $fieldName): ?string;
     public function getSchemaFieldArgs(string $fieldName): array;
-    public function getFilteredSchemaFieldArgs(string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(string $fieldName, array $fieldArgs = []): ?string;
     public function addSchemaDefinitionForField(array &$schemaDefinition, string $fieldName): void;
 }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -54,26 +54,6 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         return [];
     }
 
-    abstract protected function hasSchemaFieldVersion(string $fieldName): bool;
-
-    public function getFilteredSchemaFieldArgs(string $fieldName): array
-    {
-        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
-            $schemaFieldArgs = $schemaDefinitionResolver->getSchemaFieldArgs($fieldName);
-        } else {
-            $schemaFieldArgs = [];
-        }
-
-        /**
-         * Add the "versionConstraint" param. Add it at the end, so it doesn't affect the order of params for "orderedSchemaFieldArgs"
-         */
-        $this->maybeAddVersionConstraintSchemaFieldOrDirectiveArg(
-            $schemaFieldArgs,
-            $this->hasSchemaFieldVersion($fieldName)
-        );
-        return $schemaFieldArgs;
-    }
-
     public function getSchemaFieldDeprecationDescription(string $fieldName, array $fieldArgs = []): ?string
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -41,21 +41,6 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
         return [];
     }
 
-    abstract protected function hasSchemaFieldVersion(string $fieldName): bool;
-
-    public function getFilteredSchemaFieldArgs(string $fieldName): array
-    {
-        $schemaFieldArgs = $this->getSchemaFieldArgs($fieldName);
-        /**
-         * Add the "versionConstraint" param. Add it at the end, so it doesn't affect the order of params for "orderedSchemaFieldArgs"
-         */
-        $this->maybeAddVersionConstraintSchemaFieldOrDirectiveArg(
-            $schemaFieldArgs,
-            $this->hasSchemaFieldVersion($fieldName)
-        );
-        return $schemaFieldArgs;
-    }
-
     public function getSchemaFieldDeprecationDescription(string $fieldName, array $fieldArgs = []): ?string
     {
         return null;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -242,19 +242,6 @@ trait AliasSchemaFieldResolverTrait
      * Proxy pattern: execute same function on the aliased FieldResolver,
      * for the aliased $fieldName
      */
-    public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
-    {
-        $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
-        return $aliasedFieldResolver->getFilteredSchemaFieldArgs(
-            $typeResolver,
-            $this->getAliasedFieldName($fieldName)
-        );
-    }
-
-    /**
-     * Proxy pattern: execute same function on the aliased FieldResolver,
-     * for the aliased $fieldName
-     */
     public function getSchemaFieldDeprecationDescription(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?string
     {
         $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -14,7 +14,6 @@ interface FieldSchemaDefinitionResolverInterface
     public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int;
     public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string;
     public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;
-    public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?string;
     public function addSchemaDefinitionForField(array &$schemaDefinition, TypeResolverInterface $typeResolver, string $fieldName): void;
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -54,26 +54,6 @@ trait FieldSchemaDefinitionResolverTrait
         return [];
     }
 
-    abstract protected function hasSchemaFieldVersion(TypeResolverInterface $typeResolver, string $fieldName): bool;
-
-    public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
-    {
-        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {
-            $schemaFieldArgs = $schemaDefinitionResolver->getSchemaFieldArgs($typeResolver, $fieldName);
-        } else {
-            $schemaFieldArgs = [];
-        }
-
-        /**
-         * Add the "versionConstraint" param. Add it at the end, so it doesn't affect the order of params for "orderedSchemaFieldArgs"
-         */
-        $this->maybeAddVersionConstraintSchemaFieldOrDirectiveArg(
-            $schemaFieldArgs,
-            $this->hasSchemaFieldVersion($typeResolver, $fieldName)
-        );
-        return $schemaFieldArgs;
-    }
-
     public function getSchemaFieldDeprecationDescription(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?string
     {
         if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($typeResolver)) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -45,21 +45,6 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return [];
     }
 
-    abstract protected function hasSchemaFieldVersion(TypeResolverInterface $typeResolver, string $fieldName): bool;
-
-    public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
-    {
-        $schemaFieldArgs = $this->getSchemaFieldArgs($typeResolver, $fieldName);
-        /**
-         * Add the "versionConstraint" param. Add it at the end, so it doesn't affect the order of params for "orderedSchemaFieldArgs"
-         */
-        $this->maybeAddVersionConstraintSchemaFieldOrDirectiveArg(
-            $schemaFieldArgs,
-            $this->hasSchemaFieldVersion($typeResolver, $fieldName)
-        );
-        return $schemaFieldArgs;
-    }
-
     public function getSchemaFieldDeprecationDescription(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?string
     {
         return null;

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -59,11 +59,6 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->getSchemaFieldArgs($fieldName);
     }
 
-    public function getFilteredSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
-    {
-        return $this->fieldInterfaceResolver->getFilteredSchemaFieldArgs($fieldName);
-    }
-
     public function getSchemaFieldDeprecationDescription(TypeResolverInterface $typeResolver, string $fieldName, array $fieldArgs = []): ?string
     {
         return $this->fieldInterfaceResolver->getSchemaFieldDeprecationDescription($fieldName, $fieldArgs);

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1000,10 +1000,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     protected function getDirectiveSchemaDefinitionArgs(DirectiveResolverInterface $directiveResolver, TypeResolverInterface $typeResolver): array
     {
         if (!isset($this->directiveSchemaDefinitionArgsCache[get_class($directiveResolver)][get_class($typeResolver)])) {
-            $directiveSchemaDefinitionArgs = [];
-            if ($directiveSchemaDefinitionResolver = $directiveResolver->getSchemaDefinitionResolver($typeResolver)) {
-                $directiveSchemaDefinitionArgs = $directiveSchemaDefinitionResolver->getFilteredSchemaDirectiveArgs($typeResolver);
-            }
+            $directiveSchemaDefinition = $directiveResolver->getSchemaDefinitionForDirective($typeResolver);
+            $directiveSchemaDefinitionArgs = $directiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? [];
             $this->directiveSchemaDefinitionArgsCache[get_class($directiveResolver)][get_class($typeResolver)] = $directiveSchemaDefinitionArgs;
         }
         return $this->directiveSchemaDefinitionArgsCache[get_class($directiveResolver)][get_class($typeResolver)];

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -92,7 +92,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 }
                 return $value;
             case SchemaDefinition::TYPE_STRING:
-                return (string)$value;
+                return (string) $value;
             case SchemaDefinition::TYPE_URL:
             case SchemaDefinition::TYPE_EMAIL:
             case SchemaDefinition::TYPE_IP:
@@ -137,16 +137,16 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 }
                 return $value;
             case SchemaDefinition::TYPE_INT:
-                return CastToType::_int($value);
+                return (int) CastToType::_int($value);
             case SchemaDefinition::TYPE_FLOAT:
-                return CastToType::_float($value);
+                return (float) CastToType::_float($value);
             case SchemaDefinition::TYPE_BOOL:
                 // Watch out! In Library CastToType, an empty string is not false, but it's NULL
                 // But for us it must be false, since calling query ?query=and([true,false]) gets transformed to the $field string "[1,]"
                 if ($value == '') {
                     return false;
                 }
-                return CastToType::_bool($value);
+                return (bool) CastToType::_bool($value);
             case SchemaDefinition::TYPE_TIME:
                 $converted = strtotime($value);
                 if ($converted === false) {


### PR DESCRIPTION
This issue was that the directive args were not organized under their own name, and so getting their type failed and `MIXED` was always used.

The solution was to not call `getFilteredSchemaDirectiveArgs` but to get the args from `getSchemaDefinitionForDirective`, were they are ordered.

As an optimization, have `getFilteredSchemaDirectiveArgs` be a protected function, so it can't be called from outside, and now it's only called from within `getSchemaDefinitionForDirective`.

Implemented for fields too.