### PR TITLE
Remove escaping fieldArgs symbols for embeddable fields

### DIFF
--- a/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
+++ b/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
@@ -304,15 +304,12 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
          * Use a single `sprintf` for all matches.
          * Eg: "title is {{title}} and authorID is {{authorID}}" is replaced
          * as "sprintf(title is %s and authorID is %s, [title(), authorID()])"
-         *
-         * We know that SYMBOL_FIELDARGS_OPENING is "(" and SYMBOL_FIELDARGS_CLOSING is ")",
-         * so we escape them in the regex using "\\"
          */
         $regex = sprintf(
             '/%s(\s*)([a-zA-Z_][0-9a-zA-Z_]*(%s.*%s)?)(\s*)%s/',
             APIQuerySyntax::SYMBOL_EMBEDDABLE_FIELD_PREFIX,
-            '\\' . FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING,
-            '\\' . FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING,
+            FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING,
+            FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING,
             APIQuerySyntax::SYMBOL_EMBEDDABLE_FIELD_SUFFIX
         );
         foreach ($fieldOrDirectiveArgValues as $fieldOrDirectiveArgValue) {


### PR DESCRIPTION
Embeddable fields are converted to composable fields:

```graphql
query MyQuery {
  echoStr(value:"{{ hello(value:songa) }}")
}
```

...becomes:

```
echoStr(value:hello(value:songa) ())
```

The regex was escaping the `()`:

```php
$regex = sprintf(
  '/%s(\s*)([a-zA-Z_][0-9a-zA-Z_]*(%s.*%s)?)(\s*)%s/',
  APIQuerySyntax::SYMBOL_EMBEDDABLE_FIELD_PREFIX,
  // Here it is escaped
  '\\' . FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING,
  // Here it is escaped
  '\\' . FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING,
  APIQuerySyntax::SYMBOL_EMBEDDABLE_FIELD_SUFFIX
);
```

But it stopped working!

To fix it, this PR removes the escape `\\` chars.

Regex test: https://rubular.com/r/zMlvHOheb45dae