### PR TITLE
Use `REDEFINED_FIELD_ARGS_SYMBOLS` to define replacement for `()` for field args

### DIFF
--- a/layers/Engine/packages/query-parsing/src/QueryParser.php
+++ b/layers/Engine/packages/query-parsing/src/QueryParser.php
@@ -54,7 +54,6 @@ class QueryParser implements QueryParserInterface
          * 
          * @see https://github.com/leoloso/PoP/pull/734#issuecomment-871074708
          */
-        // if (!$this->hasOnlyChars($skipFromChars) || !$this->hasOnlyChars($skipUntilChars)) {
         if ($longStrings = array_filter(
             array_unique(array_merge($skipFromChars, $skipUntilChars)),
             fn ($string) => mb_strlen($string) > 1
@@ -200,16 +199,5 @@ class QueryParser implements QueryParserInterface
             $stack = array_reverse(array_map('strrev', $stack));
         }
         return $stack;
-    }
-
-
-    /**
-     * Indicate if the array only has strings of length 1
-     *
-     * @param string[] $strings
-     */
-    protected function hasOnlyChars(array $strings): bool
-    {
-        return empty(array_filter($strings, fn ($string) => strlen($string) > 1));
     }
 }

--- a/layers/Engine/packages/query-parsing/src/QueryParser.php
+++ b/layers/Engine/packages/query-parsing/src/QueryParser.php
@@ -56,7 +56,7 @@ class QueryParser implements QueryParserInterface
          */
         if ($longStrings = array_filter(
             array_unique(array_merge($skipFromChars, $skipUntilChars)),
-            fn ($string) => mb_strlen($string) > 1
+            fn ($string) => strlen($string) > 1
         )) {
             throw new Exception(
                 sprintf(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -107,20 +107,28 @@ class PluginConfiguration
      */
     public static function initialize(): void
     {
-        self::redefineQuerySyntax();
+        self::maybeRedefineQuerySyntax();
         self::mapEnvVariablesToWPConfigConstants();
         self::defineEnvironmentConstantsFromSettings();
         self::defineEnvironmentConstantsFromCallbacks();
     }
 
     /**
-     * Make it difficult to have the string be considered a field (eg: title()),
-     * by changing the field args `()` symbols into something difficult.
+     * Allow to change the query syntax for field/directive arguments,
+     * to avoid the issue of passing an ending with `()` being considered a field
+     * and executed.
+     * 
+     * Because there is no suitable replacement, allow the user to input
+     * it via environment constants.
+     * 
+     * @see https://github.com/leoloso/PoP/pull/734
      */
-    protected static function redefineQuerySyntax(): void
+    protected static function maybeRedefineQuerySyntax(): void
     {
-        QuerySyntax::$SYMBOL_FIELDARGS_OPENING = '≤';
-        QuerySyntax::$SYMBOL_FIELDARGS_CLOSING = '≥';
+        if ($redefinedFieldArgsSymbols = PluginEnvironment::getRedefinedFieldArgsSymbols()) {
+            QuerySyntax::$SYMBOL_FIELDARGS_OPENING = $redefinedFieldArgsSymbols[0];
+            QuerySyntax::$SYMBOL_FIELDARGS_CLOSING = $redefinedFieldArgsSymbols[1];
+        }
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
@@ -10,6 +10,7 @@ class PluginEnvironment
 {
     public const DISABLE_CACHING = 'DISABLE_CACHING';
     public const CACHE_DIR = 'CACHE_DIR';
+    public const REDEFINED_FIELD_ARGS_SYMBOLS = 'REDEFINED_FIELD_ARGS_SYMBOLS';
 
     /**
      * If the information is provided by either environment variable
@@ -45,5 +46,30 @@ class PluginEnvironment
         }
         
         return dirname(__FILE__, 2) . \DIRECTORY_SEPARATOR . 'cache';
+    }
+
+    /**
+     * Make it difficult to have the string be considered a field (eg: title()),
+     * by changing the field args `()` symbols into something different.
+     * 
+     * Must pass a string of exactly two characters:
+     * 
+     *   1st: QuerySyntax::$SYMBOL_FIELDARGS_OPENING (eg: `{`)
+     *   2nd: QuerySyntax::$SYMBOL_FIELDARGS_CLOSING (eg: `}`)
+     * 
+     * Eg: REDEFINED_FIELD_ARGS_SYMBOLS={}
+     */
+    public static function getRedefinedFieldArgsSymbols(): ?array
+    {
+        $chars = null;
+        if (getenv(self::REDEFINED_FIELD_ARGS_SYMBOLS) !== false) {
+            $chars = getenv(self::REDEFINED_FIELD_ARGS_SYMBOLS);
+        } elseif (PluginConfigurationHelpers::isWPConfigConstantDefined(self::REDEFINED_FIELD_ARGS_SYMBOLS)) {
+            $chars = PluginConfigurationHelpers::getWPConfigConstantValue(self::REDEFINED_FIELD_ARGS_SYMBOLS);
+        }
+        if ($chars !== null && strlen($chars) === 2) {
+            return [$chars[0], $chars[1]];
+        }
+        return null;
     }
 }


### PR DESCRIPTION
After implementing #734, introspection stopped working. The (truncated) response has errors:

```json
{
  "errors": [
    {
      "message": "Arguments 'fields≤includeDeprecated:1≥<include≤if:or≤values:[0:isType≤type:\"__Type\"≥,1:implements≤interface:\"__Type\"≥]≥≥>' must start with symbol '≤' and end with symbol '≥'. Query section '__schema.types.fields≤includeDeprecated:1≥<include≤if:or≤values:[0:isType≤type:\"__Type\"≥,1:implements≤interface:\"__Type\"≥]≥≥>.name' has been ignored"
    },
    {
      "message": "Arguments 'fields≤includeDeprecated:1≥<include≤if:or≤values:[0:isType≤type:\"__Type\"≥,1:implements≤interface:\"__Type\"≥]≥≥>' must start with symbol '≤' and end with symbol '≥'. Query section '__schema.types.fields≤includeDeprecated:1≥<include≤if:or≤values:[0:isType≤type:\"__Type\"≥,1:implements≤interface:\"__Type\"≥]≥≥>.description' has been ignored"
    },
    {
      "message": "Arguments 'fields≤includeDeprecated:1≥<include≤if:or≤values:[0:isType≤type:\"__Type\"≥,1:implements≤interface:\"__Type\"≥]≥≥>' must start with symbol '≤' and end with symbol '≥'. Query section '__schema.types.fields≤includeDeprecated:1≥<include≤if:or≤values:[0:isType≤type:\"__Type\"≥,1:implements≤interface:\"__Type\"≥]≥≥>.args.name<include≤if:or≤values:[0:isType≤type:\"__InputValue\"≥,1:implements≤interface:\"__InputValue\"≥]≥≥>' has been ignored"
    }
  ],
  "data": {
    "__schema": {
      "queryType": {
        "name": "QueryRoot"
      },
      "mutationType": {
        "name": "MutationRoot"
      },
      "subscriptionType": null,
      "types": [
        [],
        [],
        []
      ]
    }
  }
}
```

The issue is `mb_strlen` inside `splitElements`: it doesn't work. Using characters of more than one byte, `≤≥`, cannot be supported.

So we're back to square 1.

As a partial solution to still address the issue, this PR adds the environment constant `REDEFINED_FIELD_ARGS_SYMBOLS`, to be defined by the user with the 2 replacement symbols. Eg:

```dotenv
REDEFINED_FIELD_ARGS_SYMBOLS={}
```

In this case, `{}` will be used for field/directive args.

By default, the expected syntax with `()` is used. If any user has issues with them (eg: `posts(searchfor:"hola()")`), will be advised to set the environment constant.

It's not a perfect solution, but well, it will hopefully work.