### PR TITLE
Revert overriding field args symbols

### DIFF
--- a/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
+++ b/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
@@ -56,7 +56,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
         $executeQueryBatchInStrictOrder = ComponentConfiguration::executeQueryBatchInStrictOrder();
         $operationMaxLevels = 0;
         $maxDepth = 0;
-        $dotNotations = $this->queryParser->splitElements($operationDotNotation, FieldQueryQuerySyntax::SYMBOL_OPERATIONS_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+        $dotNotations = $this->queryParser->splitElements($operationDotNotation, FieldQueryQuerySyntax::SYMBOL_OPERATIONS_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
         foreach ($dotNotations as $dotNotation) {
             // Support a query combining relational and properties:
             // ?field=posts.id|title|author.id|name|posts.id|title|author.name
@@ -66,7 +66,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
 
             // Replace all fragment placeholders with the actual fragments
             $replacedDotNotation = [];
-            foreach ($this->queryParser->splitElements($dotNotation, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING) as $commafields) {
+            foreach ($this->queryParser->splitElements($dotNotation, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING) as $commafields) {
                 if ($replacedCommaFields = $this->replaceFragments($commafields, $fragments)) {
                     $replacedDotNotation[] = $replacedCommaFields;
                 }
@@ -82,7 +82,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                 $operationMaxLevels = 0;
 
                 // Split the ElemCount by ",". Use `splitElements` instead of `explode` so that the "," can also be inside the fieldArgs
-                $commafieldSet = $this->queryParser->splitElements($dotNotation, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                $commafieldSet = $this->queryParser->splitElements($dotNotation, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                 foreach ($commafieldSet as $commafields) {
                     // Initialize the pointer
                     $requestedPointer = &$requestedFields;
@@ -97,7 +97,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                     // The fields are split by "."
                     // Watch out: we need to ignore all instances of "(" and ")" which may happen inside the fieldArg values!
                     // Eg: /api/?query=posts(searchfor:this => ( and this => ) are part of the search too).id|title
-                    $dotfields = $this->queryParser->splitElements($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                    $dotfields = $this->queryParser->splitElements($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
 
                     if ($executeQueryBatchInStrictOrder) {
                         // Count the depth of each query when doing batching
@@ -108,7 +108,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                         // If surrounded by "[]", the first element references a bookmark from a previous iteration. If so, retrieve it
                         $firstPathLevel = $dotfields[0];
                         // Remove the fieldDirective, if it has one
-                        if ($fieldDirectiveSplit = $this->queryParser->splitElements($firstPathLevel, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING, FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING)) {
+                        if ($fieldDirectiveSplit = $this->queryParser->splitElements($firstPathLevel, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING)) {
                             $firstPathLevel = $fieldDirectiveSplit[0];
                         }
                         if (
@@ -177,7 +177,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                     // The last level can contain several fields, separated by "|"
                     $pipefields = $dotfields[count($dotfields) - 1];
                     // Use `splitElements` instead of `explode` so that the "|" can also be inside the fieldArgs (eg: order:title|asc)
-                    foreach ($this->queryParser->splitElements($pipefields, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING) as $pipefield) {
+                    foreach ($this->queryParser->splitElements($pipefields, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING) as $pipefield) {
                         $errorMessageOrSymbolPositions = $this->validateProperty(
                             $pipefield
                         );
@@ -308,8 +308,8 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
         $regex = sprintf(
             '/%s(\s*)([a-zA-Z_][0-9a-zA-Z_]*(%s.*%s)?)(\s*)%s/',
             APIQuerySyntax::SYMBOL_EMBEDDABLE_FIELD_PREFIX,
-            FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING,
-            FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+            FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING,
+            FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING,
             APIQuerySyntax::SYMBOL_EMBEDDABLE_FIELD_SUFFIX
         );
         foreach ($fieldOrDirectiveArgValues as $fieldOrDirectiveArgValue) {
@@ -360,7 +360,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                     /**
                      * If the field has no fieldArgs, then add "()" at the end, to make it resolvable
                      */
-                    if (!str_ends_with($fieldNames[$i], FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING)) {
+                    if (!str_ends_with($fieldNames[$i], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING)) {
                         $fieldNames[$i] = $this->fieldQueryInterpreter->composeField(
                             $fieldNames[$i],
                             $this->fieldQueryInterpreter->getFieldArgsAsString([], true)
@@ -423,7 +423,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
     {
         $errorMessage = $this->translationAPI->__('Fragment \'%s\' (which resolves to \'%s\'), cannot contain %s, so it has been ignored', 'api');
         foreach ($fragments as $fragmentName => $fragment) {
-            $fragmentDotNotations = $this->queryParser->splitElements($fragment, FieldQueryQuerySyntax::SYMBOL_OPERATIONS_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+            $fragmentDotNotations = $this->queryParser->splitElements($fragment, FieldQueryQuerySyntax::SYMBOL_OPERATIONS_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
             if (count($fragmentDotNotations) >= 2) {
                 $this->feedbackMessageStore->addQueryError(sprintf(
                     $errorMessage,
@@ -434,7 +434,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                 unset($fragments[$fragmentName]);
                 continue;
             }
-            $fragmentCommaFields = $this->queryParser->splitElements($fragment, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+            $fragmentCommaFields = $this->queryParser->splitElements($fragment, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
             if (count($fragmentCommaFields) >= 2) {
                 $this->feedbackMessageStore->addQueryError(sprintf(
                     $errorMessage,
@@ -519,20 +519,20 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
         // ?field=posts.id|title,posts.author.id|name,posts.author.posts.id|title,posts.author.posts.author.name
         // Strategy: continuously search for "." appearing after "|", recreate their full path, and add them as new query sections (separated by ",")
         $expandedDotNotations = [];
-        foreach ($this->queryParser->splitElements($dotNotation, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING) as $commafields) {
-            $dotPos = QueryUtils::findFirstSymbolPosition($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+        foreach ($this->queryParser->splitElements($dotNotation, FieldQueryQuerySyntax::SYMBOL_QUERYFIELDS_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_BOOKMARK_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING) as $commafields) {
+            $dotPos = QueryUtils::findFirstSymbolPosition($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
             if ($dotPos !== false) {
                 while ($dotPos !== false) {
                     // Position of the first "|". Everything before there is path + first property
                     // We must make sure the "|" is not inside "()", otherwise this would fail:
                     // /api/graphql/?query=posts(order:title|asc).id|title
-                    $pipeElements = $this->queryParser->splitElements($commafields, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                    $pipeElements = $this->queryParser->splitElements($commafields, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                     if (count($pipeElements) >= 2) {
                         $pipePos = strlen($pipeElements[0]);
                         // Make sure the dot is not inside "()". Otherwise this will not work:
                         // /api/graphql/?query=posts(order:title|asc).id|date(format:Y.m.d)
                         $pipeRest = substr($commafields, 0, $pipePos);
-                        $dotElements = $this->queryParser->splitElements($pipeRest, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                        $dotElements = $this->queryParser->splitElements($pipeRest, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                         // Watch out case in which there is no previous sectionPath. Eg: query=id|comments.id
                         if ($lastDotPos = strlen($pipeRest) - strlen($dotElements[count($dotElements) - 1])) {
                             // The path to the properties
@@ -544,8 +544,8 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                             $sectionRest = $commafields;
                         }
                         // If there is another "." after a "|", then it keeps going down the relational path to load other elements
-                        $sectionRestPipePos = QueryUtils::findFirstSymbolPosition($sectionRest, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
-                        $sectionRestDotPos = QueryUtils::findFirstSymbolPosition($sectionRest, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                        $sectionRestPipePos = QueryUtils::findFirstSymbolPosition($sectionRest, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                        $sectionRestDotPos = QueryUtils::findFirstSymbolPosition($sectionRest, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                         if ($sectionRestPipePos !== false && $sectionRestDotPos !== false && $sectionRestDotPos > $sectionRestPipePos) {
                             // Extract the last property, from which further relational ElemCount are loaded, and create a new query section for it
                             // This is the subtring from the last ocurrence of "|" before the "." up to the "."
@@ -556,8 +556,8 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                                     $sectionRestDotPos
                                 ),
                                 FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR,
-                                [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING],
-                                [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING],
+                                [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING],
+                                [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING],
                                 FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING,
                                 FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING
                             );
@@ -576,7 +576,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                             $expandedDotNotations[] = $sectionPath . $sectionRest;
                             $commafields = $sectionPath . $querySectionRest;
                             // Keep iterating
-                            $dotPos = QueryUtils::findFirstSymbolPosition($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                            $dotPos = QueryUtils::findFirstSymbolPosition($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                         } else {
                             // The element has no further relationships
                             $expandedDotNotations[] = $commafields;
@@ -705,7 +705,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
         // But only if the component doesn't already have a directive! Otherwise, the directive at the definition level takes priority
         // Same with adding "?" for Skip output if null
         if ($fragmentDirectives || $alias || $skipOutputIfNull) {
-            $fragmentPipeFields = $this->queryParser->splitElements($fragment, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+            $fragmentPipeFields = $this->queryParser->splitElements($fragment, FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
             $fragment = implode(FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, array_filter(array_map(function ($fragmentField) use ($fragmentDirectives, $alias, $skipOutputIfNull, $fragmentPipeFields) {
                 // Calculate if to add the alias
                 $addAliasToFragmentField = false;
@@ -784,7 +784,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
         // The fields are split by "."
         // Watch out: we need to ignore all instances of "(" and ")" which may happen inside the fieldArg values!
         // Eg: /api/?query=posts(searchfor:this => ( and this => ) are part of the search too).id|title
-        $dotfields = $this->queryParser->splitElements($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+        $dotfields = $this->queryParser->splitElements($commafields, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
 
         // Replace all fragment placeholders with the actual fragments
         // Do this at the beginning, because the fragment may contain new leaves, which need be at the last level of the $dotfields array. So this array must be recalculated after replacing the fragments in
@@ -792,7 +792,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
         // Right now only for the properties. For the path will be done immediately after
         $lastLevel = count($dotfields) - 1;
         // Replace fragments for the properties, adding them to temporary variable $lastLevelProperties
-        $pipefields = $this->queryParser->splitElements($dotfields[$lastLevel], FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+        $pipefields = $this->queryParser->splitElements($dotfields[$lastLevel], FieldQueryQuerySyntax::SYMBOL_FIELDPROPERTIES_SEPARATOR, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
         $lastPropertyNumber = count($pipefields) - 1;
         $lastLevelProperties = [];
         for ($propertyNumber = 0; $propertyNumber <= $lastPropertyNumber; $propertyNumber++) {
@@ -828,7 +828,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
                     // Remove whole query section
                     return null;
                 }
-                $fragmentDotfields = $this->queryParser->splitElements($resolvedFragment, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                $fragmentDotfields = $this->queryParser->splitElements($resolvedFragment, FieldQueryQuerySyntax::SYMBOL_RELATIONALFIELDS_NEXTLEVEL, [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING], [FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING, FieldQueryQuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING], FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, FieldQueryQuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                 array_splice($dotfields, $pathLevel, 1, $fragmentDotfields);
             }
         }
@@ -869,8 +869,8 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
             return sprintf(
                 $this->translationAPI->__('Arguments \'%s\' must start with symbol \'%s\' and end with symbol \'%s\'. %s', 'api'),
                 $property,
-                FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_OPENING,
-                FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                FieldQueryQuerySyntax::SYMBOL_FIELDARGS_OPENING,
+                FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                 $errorMessageEnd
             );
         }
@@ -945,11 +945,11 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
         $aliasSymbolPos = QueryHelpers::findFieldAliasSymbolPosition($property);
         $skipOutputIfNullSymbolPos = QueryHelpers::findSkipOutputIfNullSymbolPosition($property);
         if ($fieldArgsClosingSymbolPos !== false) {
-            $nextCharPos = $fieldArgsClosingSymbolPos + strlen(FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING);
+            $nextCharPos = $fieldArgsClosingSymbolPos + strlen(FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING);
             if (
                 !(
                 // It's in the last position
-                ($fieldArgsClosingSymbolPos == strlen($property) - strlen(FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING)) ||
+                ($fieldArgsClosingSymbolPos == strlen($property) - strlen(FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING)) ||
                 // Next comes "["
                 ($bookmarkOpeningSymbolPos !== false && $bookmarkOpeningSymbolPos == $nextCharPos) ||
                 // Next comes "@"
@@ -962,7 +962,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
             ) {
                 return sprintf(
                     $this->translationAPI->__('After \'%s\', property \'%s\' must either end or be followed by \'%s\', \'%s\', \'%s\' or \'%s\'. %s', 'api'),
-                    FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                    FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                     $property,
                     FieldQueryQuerySyntax::SYMBOL_BOOKMARK_OPENING,
                     FieldQueryQuerySyntax::SYMBOL_FIELDALIAS_PREFIX,
@@ -975,7 +975,7 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
 
         // After the "]", it must be either the end, "?" or "<"
         if ($bookmarkClosingSymbolPos !== false) {
-            $nextCharPos = $bookmarkClosingSymbolPos + strlen(FieldQueryQuerySyntax::$SYMBOL_FIELDARGS_CLOSING);
+            $nextCharPos = $bookmarkClosingSymbolPos + strlen(FieldQueryQuerySyntax::SYMBOL_FIELDARGS_CLOSING);
             if (
                 !(
                 // It's in the last position

--- a/layers/API/packages/api/src/Schema/FieldQueryInterpreter.php
+++ b/layers/API/packages/api/src/Schema/FieldQueryInterpreter.php
@@ -62,15 +62,15 @@ class FieldQueryInterpreter extends \PoP\ComponentModel\Schema\FieldQueryInterpr
     {
         $fieldOrDirectiveArgValues = [];
         // Remove the opening and closing brackets
-        $fieldOrDirectiveArgsStr = substr($fieldOrDirectiveArgsStr, strlen(QuerySyntax::$SYMBOL_FIELDARGS_OPENING), strlen($fieldOrDirectiveArgsStr) - strlen(QuerySyntax::$SYMBOL_FIELDARGS_OPENING) - strlen(QuerySyntax::$SYMBOL_FIELDARGS_CLOSING));
+        $fieldOrDirectiveArgsStr = substr($fieldOrDirectiveArgsStr, strlen(QuerySyntax::SYMBOL_FIELDARGS_OPENING), strlen($fieldOrDirectiveArgsStr) - strlen(QuerySyntax::SYMBOL_FIELDARGS_OPENING) - strlen(QuerySyntax::SYMBOL_FIELDARGS_CLOSING));
         // Remove the white spaces before and after
         if ($fieldOrDirectiveArgsStr = trim($fieldOrDirectiveArgsStr)) {
             // Iterate all the elements, and extract them into the array
-            if ($fieldArgElems = $this->queryParser->splitElements($fieldOrDirectiveArgsStr, QuerySyntax::SYMBOL_FIELDARGS_ARGSEPARATOR, [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING)) {
+            if ($fieldArgElems = $this->queryParser->splitElements($fieldOrDirectiveArgsStr, QuerySyntax::SYMBOL_FIELDARGS_ARGSEPARATOR, [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING)) {
                 for ($i = 0; $i < count($fieldArgElems); $i++) {
                     $fieldArg = $fieldArgElems[$i];
                     // If there is no separator, then the element is the value
-                    $separatorPos = QueryUtils::findFirstSymbolPosition($fieldArg, QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR, [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                    $separatorPos = QueryUtils::findFirstSymbolPosition($fieldArg, QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR, [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                     if ($separatorPos === false) {
                         $fieldArgValue = $fieldArg;
                     } else {

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -126,15 +126,15 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         // Extract the args from the string into an array
         if ($fieldArgsStr = $this->getFieldArgs($field)) {
             // Remove the opening and closing brackets
-            $fieldArgsStr = substr($fieldArgsStr, strlen(QuerySyntax::$SYMBOL_FIELDARGS_OPENING), strlen($fieldArgsStr) - strlen(QuerySyntax::$SYMBOL_FIELDARGS_OPENING) - strlen(QuerySyntax::$SYMBOL_FIELDARGS_CLOSING));
+            $fieldArgsStr = substr($fieldArgsStr, strlen(QuerySyntax::SYMBOL_FIELDARGS_OPENING), strlen($fieldArgsStr) - strlen(QuerySyntax::SYMBOL_FIELDARGS_OPENING) - strlen(QuerySyntax::SYMBOL_FIELDARGS_CLOSING));
             // Remove the white spaces before and after
             if ($fieldArgsStr = trim($fieldArgsStr)) {
                 // Iterate all the elements, and extract them into the array
-                if ($fieldArgElems = $this->queryParser->splitElements($fieldArgsStr, QuerySyntax::SYMBOL_FIELDARGS_ARGSEPARATOR, [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING)) {
+                if ($fieldArgElems = $this->queryParser->splitElements($fieldArgsStr, QuerySyntax::SYMBOL_FIELDARGS_ARGSEPARATOR, [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING)) {
                     for ($i = 0; $i < count($fieldArgElems); $i++) {
                         $fieldArg = $fieldArgElems[$i];
                         // If there is no separator, then skip this arg, since it is not static (without the schema, we can't know which fieldArgName it is)
-                        $separatorPos = QueryUtils::findFirstSymbolPosition($fieldArg, QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR, [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                        $separatorPos = QueryUtils::findFirstSymbolPosition($fieldArg, QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR, [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                         if ($separatorPos === false) {
                             continue;
                         }
@@ -244,7 +244,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             // Either one of 2 formats are accepted:
             // 1. The key:value pair
             // 2. Only the value, and extract the key from the schema definition (if enabled for that fieldOrDirective)
-            $separatorPos = QueryUtils::findFirstSymbolPosition($fieldOrDirectiveArg, QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR, [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+            $separatorPos = QueryUtils::findFirstSymbolPosition($fieldOrDirectiveArg, QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR, [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
             if ($separatorPos === false) {
                 $fieldOrDirectiveArgValue = $fieldOrDirectiveArg;
                 if (!$orderedFieldOrDirectiveArgNamesEnabled || !isset($orderedFieldOrDirectiveArgNames[$i])) {
@@ -1345,7 +1345,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                 return [];
             }
             // Elements are split by ","
-            $fieldArgValueElems = $this->queryParser->splitElements($arrayValue, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_SEPARATOR, [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+            $fieldArgValueElems = $this->queryParser->splitElements($arrayValue, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_SEPARATOR, [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
             // Watch out! If calling with value "[true,false]" it gets transformed to "[1,]" when passing the composed field around (it's converted back to string),
             // This must be transformed to array(true, false), however the last empty space is ignored by `splitElements`
             // So we handle these 2 cases (empty spaces at beginning and end of string) in an exceptional way
@@ -1363,7 +1363,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             // These 2 can be combined, and the corresponding array will mix elements: [value1,key2=value2]
             $fieldArgValue = [];
             foreach ($fieldArgValueElems as $fieldArgValueElem) {
-                $fieldArgValueElemComponents = $this->queryParser->splitElements($fieldArgValueElem, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_KEYVALUEDELIMITER, [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
+                $fieldArgValueElemComponents = $this->queryParser->splitElements($fieldArgValueElem, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_KEYVALUEDELIMITER, [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING], [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING], QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING, QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING);
                 if (count($fieldArgValueElemComponents) === 1) {
                     // Remove the string quotes if it has them
                     $fieldArgValue[] = $this->maybeConvertFieldArgumentValue($fieldArgValueElemComponents[0]);
@@ -1479,7 +1479,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             ) = QueryHelpers::listFieldArgsSymbolPositions($fieldArgValue);
 
             // If there is no "(" or ")", or if the ")" is not at the end, of if the "(" is at the beginning, then it's simply a string
-            if ($fieldArgsClosingSymbolPos !== (strlen($fieldArgValue) - strlen(QuerySyntax::$SYMBOL_FIELDARGS_CLOSING)) || $fieldArgsOpeningSymbolPos === false || $fieldArgsOpeningSymbolPos === 0) {
+            if ($fieldArgsClosingSymbolPos !== (strlen($fieldArgValue) - strlen(QuerySyntax::SYMBOL_FIELDARGS_CLOSING)) || $fieldArgsOpeningSymbolPos === false || $fieldArgsOpeningSymbolPos === 0) {
                 return [];
             }
             // // If there is only one of them, it's a query error, so discard the query bit
@@ -1488,8 +1488,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             //         sprintf(
             //             $this->translationAPI->__('Arguments in field \'%s\' must start with symbol \'%s\' and end with symbol \'%s\', so they have been ignored', 'pop-component-model'),
             //             $fieldArgValue,
-            //             QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
-            //             QuerySyntax::$SYMBOL_FIELDARGS_CLOSING
+            //             QuerySyntax::SYMBOL_FIELDARGS_OPENING,
+            //             QuerySyntax::SYMBOL_FIELDARGS_CLOSING
             //         ),
             //     ];
             // }
@@ -1508,7 +1508,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             //         sprintf(
             //             $this->translationAPI->__('Field \'%s\' has arguments, but because the closing argument symbol \'%s\' is not at the end, it has been ignored', 'pop-component-model'),
             //             $fieldArgValue,
-            //             QuerySyntax::$SYMBOL_FIELDARGS_CLOSING
+            //             QuerySyntax::SYMBOL_FIELDARGS_CLOSING
             //         ),
             //     ];
             // }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -413,8 +413,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             $counterSeparatorPos = QueryUtils::findLastSymbolPosition(
                 $enqueuedFieldDirective,
                 FieldSymbols::REPEATED_DIRECTIVE_COUNTER_SEPARATOR,
-                [QuerySyntax::$SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING],
-                [QuerySyntax::$SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING],
+                [QuerySyntax::SYMBOL_FIELDARGS_OPENING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING],
+                [QuerySyntax::SYMBOL_FIELDARGS_CLOSING, QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING],
                 QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING,
                 QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING
             );

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -169,8 +169,8 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                     'field-query'
                 ),
                 $field,
-                QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
-                QuerySyntax::$SYMBOL_FIELDARGS_CLOSING
+                QuerySyntax::SYMBOL_FIELDARGS_OPENING,
+                QuerySyntax::SYMBOL_FIELDARGS_CLOSING
             ));
             return null;
         }
@@ -179,7 +179,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
         return substr(
             $field,
             (int)$fieldArgsOpeningSymbolPos,
-            $fieldArgsClosingSymbolPos + strlen(QuerySyntax::$SYMBOL_FIELDARGS_CLOSING) - $fieldArgsOpeningSymbolPos
+            $fieldArgsClosingSymbolPos + strlen(QuerySyntax::SYMBOL_FIELDARGS_CLOSING) - $fieldArgsOpeningSymbolPos
         );
     }
 
@@ -254,12 +254,12 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
             && is_string($fieldArgValue)
             && substr(
                 $fieldArgValue,
-                -1 * strlen(QuerySyntax::$SYMBOL_FIELDARGS_CLOSING)
-            ) == QuerySyntax::$SYMBOL_FIELDARGS_CLOSING
+                -1 * strlen(QuerySyntax::SYMBOL_FIELDARGS_CLOSING)
+            ) == QuerySyntax::SYMBOL_FIELDARGS_CLOSING
             // Please notice: if position is 0 (i.e. for a string "(something)") then it's not a field,
             // since the fieldName is missing
             // Then it's ok asking for strpos: either `false` or `0` must both fail
-            && strpos($fieldArgValue, QuerySyntax::$SYMBOL_FIELDARGS_OPENING);
+            && strpos($fieldArgValue, QuerySyntax::SYMBOL_FIELDARGS_OPENING);
     }
 
     public function isFieldArgumentValueAnExpression(mixed $fieldArgValue): bool
@@ -514,12 +514,12 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                 $fieldDirectives,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_SEPARATOR,
                 [
-                    QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                    QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                     QuerySyntax::SYMBOL_BOOKMARK_OPENING,
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
                 ],
                 [
-                    QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                    QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                     QuerySyntax::SYMBOL_BOOKMARK_CLOSING,
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING
                 ],
@@ -731,8 +731,8 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
         if (!$fieldArgs) {
             if ($addFieldArgSymbolsIfEmpty) {
                 return
-                    QuerySyntax::$SYMBOL_FIELDARGS_OPENING .
-                    QuerySyntax::$SYMBOL_FIELDARGS_CLOSING;
+                    QuerySyntax::SYMBOL_FIELDARGS_OPENING .
+                    QuerySyntax::SYMBOL_FIELDARGS_CLOSING;
             }
             return '';
         }
@@ -753,9 +753,9 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
             $elems[] = $fieldArgKey . QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR . $fieldArgValue;
         }
         return
-            QuerySyntax::$SYMBOL_FIELDARGS_OPENING .
+            QuerySyntax::SYMBOL_FIELDARGS_OPENING .
             implode(QuerySyntax::SYMBOL_FIELDARGS_ARGSEPARATOR, $elems) .
-            QuerySyntax::$SYMBOL_FIELDARGS_CLOSING;
+            QuerySyntax::SYMBOL_FIELDARGS_CLOSING;
     }
 
     /**

--- a/layers/Engine/packages/field-query/src/QueryHelpers.php
+++ b/layers/Engine/packages/field-query/src/QueryHelpers.php
@@ -16,7 +16,7 @@ class QueryHelpers
         return [
             QueryUtils::findFirstSymbolPosition(
                 $field,
-                QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                 [
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
                 ],
@@ -26,7 +26,7 @@ class QueryHelpers
             ),
             QueryUtils::findLastSymbolPosition(
                 $field,
-                QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                 [
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
                 ],
@@ -47,11 +47,11 @@ class QueryHelpers
                 $field,
                 QuerySyntax::SYMBOL_BOOKMARK_OPENING,
                 [
-                    QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                    QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
                 ],
                 [
-                    QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                    QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING
                 ]
             ),
@@ -59,11 +59,11 @@ class QueryHelpers
                 $field,
                 QuerySyntax::SYMBOL_BOOKMARK_CLOSING,
                 [
-                    QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                    QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
                 ],
                 [
-                    QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                    QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                     QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING
                 ]
             ),
@@ -76,11 +76,11 @@ class QueryHelpers
             $field,
             QuerySyntax::SYMBOL_FIELDALIAS_PREFIX,
             [
-                QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
             ],
             [
-                QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING
             ]
         );
@@ -92,12 +92,12 @@ class QueryHelpers
             $field,
             QuerySyntax::SYMBOL_SKIPOUTPUTIFNULL,
             [
-                QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                 QuerySyntax::SYMBOL_BOOKMARK_OPENING,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
             ],
             [
-                QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                 QuerySyntax::SYMBOL_BOOKMARK_CLOSING,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING
             ]
@@ -113,21 +113,21 @@ class QueryHelpers
             QueryUtils::findFirstSymbolPosition(
                 $field,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING,
-                QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
-                QuerySyntax::$SYMBOL_FIELDARGS_CLOSING
+                QuerySyntax::SYMBOL_FIELDARGS_OPENING,
+                QuerySyntax::SYMBOL_FIELDARGS_CLOSING
             ),
             QueryUtils::findLastSymbolPosition(
                 $field,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING,
-                QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
-                QuerySyntax::$SYMBOL_FIELDARGS_CLOSING
+                QuerySyntax::SYMBOL_FIELDARGS_OPENING,
+                QuerySyntax::SYMBOL_FIELDARGS_CLOSING
             ),
         ];
     }
 
     public static function getEmptyFieldArgs(): string
     {
-        return QuerySyntax::$SYMBOL_FIELDARGS_OPENING . QuerySyntax::$SYMBOL_FIELDARGS_CLOSING;
+        return QuerySyntax::SYMBOL_FIELDARGS_OPENING . QuerySyntax::SYMBOL_FIELDARGS_CLOSING;
     }
 
     /**
@@ -139,11 +139,11 @@ class QueryHelpers
             // Remove the opening and closing brackets
             $fieldArgsAsString = substr(
                 $fieldArgsAsString,
-                strlen(QuerySyntax::$SYMBOL_FIELDARGS_OPENING),
+                strlen(QuerySyntax::SYMBOL_FIELDARGS_OPENING),
                 (
                     strlen($fieldArgsAsString)
-                    - strlen(QuerySyntax::$SYMBOL_FIELDARGS_OPENING)
-                    - strlen(QuerySyntax::$SYMBOL_FIELDARGS_CLOSING)
+                    - strlen(QuerySyntax::SYMBOL_FIELDARGS_OPENING)
+                    - strlen(QuerySyntax::SYMBOL_FIELDARGS_CLOSING)
                 )
             );
             // Remove the white spaces before and after
@@ -155,11 +155,11 @@ class QueryHelpers
                     $fieldArgsAsString,
                     QuerySyntax::SYMBOL_FIELDARGS_ARGSEPARATOR,
                     [
-                        QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                        QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                         QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING
                     ],
                     [
-                        QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                        QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                         QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEARRAY_CLOSING
                     ],
                     QuerySyntax::SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING,
@@ -190,12 +190,12 @@ class QueryHelpers
             $fieldDirectives,
             QuerySyntax::SYMBOL_FIELDDIRECTIVE_SEPARATOR,
             [
-                QuerySyntax::$SYMBOL_FIELDARGS_OPENING,
+                QuerySyntax::SYMBOL_FIELDARGS_OPENING,
                 QuerySyntax::SYMBOL_BOOKMARK_OPENING,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_OPENING
             ],
             [
-                QuerySyntax::$SYMBOL_FIELDARGS_CLOSING,
+                QuerySyntax::SYMBOL_FIELDARGS_CLOSING,
                 QuerySyntax::SYMBOL_BOOKMARK_CLOSING,
                 QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING
             ],

--- a/layers/Engine/packages/field-query/src/QuerySyntax.php
+++ b/layers/Engine/packages/field-query/src/QuerySyntax.php
@@ -10,10 +10,8 @@ class QuerySyntax
     const SYMBOL_QUERYFIELDS_SEPARATOR = ',';
     const SYMBOL_FIELDPROPERTIES_SEPARATOR = '|';
     const SYMBOL_RELATIONALFIELDS_NEXTLEVEL = '.';
-    // Make these vars instead of consts, so they can be overriden
-    // by the GraphQL API for WordPress
-    public static string $SYMBOL_FIELDARGS_OPENING = '(';
-    public static string $SYMBOL_FIELDARGS_CLOSING = ')';
+    const SYMBOL_FIELDARGS_OPENING = '(';
+    const SYMBOL_FIELDARGS_CLOSING = ')';
     const SYMBOL_FIELDALIAS_PREFIX = '@';
     const SYMBOL_BOOKMARK_OPENING = '[';
     const SYMBOL_BOOKMARK_CLOSING = ']';

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -107,28 +107,9 @@ class PluginConfiguration
      */
     public static function initialize(): void
     {
-        self::maybeRedefineQuerySyntax();
         self::mapEnvVariablesToWPConfigConstants();
         self::defineEnvironmentConstantsFromSettings();
         self::defineEnvironmentConstantsFromCallbacks();
-    }
-
-    /**
-     * Allow to change the query syntax for field/directive arguments,
-     * to avoid the issue of passing an ending with `()` being considered a field
-     * and executed.
-     * 
-     * Because there is no suitable replacement, allow the user to input
-     * it via environment constants.
-     * 
-     * @see https://github.com/leoloso/PoP/pull/734
-     */
-    protected static function maybeRedefineQuerySyntax(): void
-    {
-        if ($redefinedFieldArgsSymbols = PluginEnvironment::getRedefinedFieldArgsSymbols()) {
-            QuerySyntax::$SYMBOL_FIELDARGS_OPENING = $redefinedFieldArgsSymbols[0];
-            QuerySyntax::$SYMBOL_FIELDARGS_CLOSING = $redefinedFieldArgsSymbols[1];
-        }
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginEnvironment.php
@@ -47,29 +47,4 @@ class PluginEnvironment
         
         return dirname(__FILE__, 2) . \DIRECTORY_SEPARATOR . 'cache';
     }
-
-    /**
-     * Make it difficult to have the string be considered a field (eg: title()),
-     * by changing the field args `()` symbols into something different.
-     * 
-     * Must pass a string of exactly two characters:
-     * 
-     *   1st: QuerySyntax::$SYMBOL_FIELDARGS_OPENING (eg: `{`)
-     *   2nd: QuerySyntax::$SYMBOL_FIELDARGS_CLOSING (eg: `}`)
-     * 
-     * Eg: REDEFINED_FIELD_ARGS_SYMBOLS={}
-     */
-    public static function getRedefinedFieldArgsSymbols(): ?array
-    {
-        $chars = null;
-        if (getenv(self::REDEFINED_FIELD_ARGS_SYMBOLS) !== false) {
-            $chars = getenv(self::REDEFINED_FIELD_ARGS_SYMBOLS);
-        } elseif (PluginConfigurationHelpers::isWPConfigConstantDefined(self::REDEFINED_FIELD_ARGS_SYMBOLS)) {
-            $chars = PluginConfigurationHelpers::getWPConfigConstantValue(self::REDEFINED_FIELD_ARGS_SYMBOLS);
-        }
-        if ($chars !== null && strlen($chars) === 2) {
-            return [$chars[0], $chars[1]];
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
Since implementing the better solution #744 to problem #743, the solution to override the syntax for field/directive args (#734) has been reverted.