### PR TITLE
Monorepo Builder config: inject package path data via OOP 

### DIFF
--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PoP\PoP\Config\Symplify\MonorepoBuilder\PackageOrganizationConfig;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option as CustomOption;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
@@ -18,26 +19,11 @@ use Symplify\PackageBuilder\Neon\NeonPrinter;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
-    $packagePathOrganizations = [
-        'layers/Engine/packages' => 'getpop',
-        'layers/API/packages' => 'getpop',
-        'layers/Schema/packages' => 'PoPSchema',
-        'layers/GraphQLByPoP/packages' => 'GraphQLByPoP',
-        'layers/GraphQLAPIForWP/packages' => 'GraphQLAPI',
-        'layers/GraphQLAPIForWP/plugins' => 'GraphQLAPI',
-        'layers/SiteBuilder/packages' => 'getpop',
-        'layers/Wassup/packages' => 'PoPSites-Wassup',
-    ];
-    $parameters->set(CustomOption::PACKAGE_ORGANIZATIONS, $packagePathOrganizations);
-    $parameters->set(Option::PACKAGE_DIRECTORIES, array_map(
-        function (string $packagePath): string {
-            return __DIR__ . '/' . $packagePath;
-        },
-        array_keys($packagePathOrganizations)
-    ));
-    $parameters->set(Option::PACKAGE_DIRECTORIES_EXCLUDES, [
-        'graphql-api-for-wp/wordpress',
-    ]);
+    $packageOrganizationConfig = new PackageOrganizationConfig();
+
+    $parameters->set(CustomOption::PACKAGE_ORGANIZATIONS, $packageOrganizationConfig->getPackagePathOrganizations());
+    $parameters->set(Option::PACKAGE_DIRECTORIES, $packageOrganizationConfig->getPackageDirectories(__DIR__));
+    $parameters->set(Option::PACKAGE_DIRECTORIES_EXCLUDES, $packageOrganizationConfig->getPackageDirectoryExcludes());
 
     /**
      * Plugins to generate

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -20,10 +20,18 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
     $packageOrganizationConfig = new PackageOrganizationConfig();
-
-    $parameters->set(CustomOption::PACKAGE_ORGANIZATIONS, $packageOrganizationConfig->getPackagePathOrganizations());
-    $parameters->set(Option::PACKAGE_DIRECTORIES, $packageOrganizationConfig->getPackageDirectories(__DIR__));
-    $parameters->set(Option::PACKAGE_DIRECTORIES_EXCLUDES, $packageOrganizationConfig->getPackageDirectoryExcludes());
+    $parameters->set(
+        CustomOption::PACKAGE_ORGANIZATIONS,
+        $packageOrganizationConfig->getPackagePathOrganizations()
+    );
+    $parameters->set(
+        Option::PACKAGE_DIRECTORIES,
+        $packageOrganizationConfig->getPackageDirectories(__DIR__)
+    );
+    $parameters->set(
+        Option::PACKAGE_DIRECTORIES_EXCLUDES,
+        $packageOrganizationConfig->getPackageDirectoryExcludes()
+    );
 
     /**
      * Plugins to generate

--- a/src/Config/Symplify/MonorepoBuilder/PackageOrganizationConfig.php
+++ b/src/Config/Symplify/MonorepoBuilder/PackageOrganizationConfig.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Config\Symplify\MonorepoBuilder;
+
+class PackageOrganizationConfig
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getPackagePathOrganizations(): array
+    {
+        return [
+            'layers/Engine/packages' => 'getpop',
+            'layers/API/packages' => 'getpop',
+            'layers/Schema/packages' => 'PoPSchema',
+            'layers/GraphQLByPoP/packages' => 'GraphQLByPoP',
+            'layers/GraphQLAPIForWP/packages' => 'GraphQLAPI',
+            'layers/GraphQLAPIForWP/plugins' => 'GraphQLAPI',
+            'layers/SiteBuilder/packages' => 'getpop',
+            'layers/Wassup/packages' => 'PoPSites-Wassup',
+        ];
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getPackageDirectories(string $dir): array
+    {
+        return array_map(
+            fn (string $packagePath) => $dir . '/' . $packagePath,
+            array_keys($this->getPackagePathOrganizations())
+        );
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getPackageDirectoryExcludes(): array
+    {
+        return [
+            'graphql-api-for-wp/wordpress',
+        ];
+    }
+}


### PR DESCRIPTION
So it can be overridden in a multi-monorepo