### PR TITLE
Monorepo Builder config: allow to override config, per command

### DIFF
--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -24,7 +24,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=package_code_paths::$(vendor/bin/monorepo-builder source-packages --psr4-only --subfolder=src --subfolder=tests)"
+                    echo "::set-output name=package_code_paths::$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests)"
 
         outputs:
             package_code_paths: ${{ steps.output_data.outputs.package_code_paths }}

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -23,7 +23,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=package_srcs::$(vendor/bin/monorepo-builder source-packages --psr4-only --subfolder=src)"
+                    echo "::set-output name=package_srcs::$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src)"
 
         outputs:
             package_srcs: ${{ steps.output_data.outputs.package_srcs }}

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -95,8 +95,8 @@ jobs:
             # https://github.com/symplify/symplify/issues/2773
             -   name: Localize package paths
                 run: |
-                    vendor/bin/monorepo-builder custom-bump-interdependency "dev-master"
-                    vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.pluginConfig.path }}/composer.json --ansi
+                    vendor/bin/monorepo-builder custom-bump-interdependency --config=config/monorepo-builder/custom-bump-interdependency.php "dev-master"
+                    vendor/bin/monorepo-builder localize-composer-paths --config=config/monorepo-builder/localize-composer-paths.php ${{ matrix.pluginConfig.path }}/composer.json --ansi
 
             -   name: Install plugin dependencies, avoiding v2 platform check
                 run: |

--- a/.github/workflows/monorepo_validation.yml
+++ b/.github/workflows/monorepo_validation.yml
@@ -25,5 +25,5 @@ jobs:
                 uses: "ramsey/composer-install@v1"
 
             -   name: Run validation
-                run: vendor/bin/monorepo-builder validate --ansi
+                run: vendor/bin/monorepo-builder validate --config=config/monorepo-builder/validate.php --ansi
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -25,7 +25,7 @@ jobs:
                 uses: "ramsey/composer-install@v1"
 
             -   name: Regenerate Monorepo PHPStan config
-                run: vendor/bin/monorepo-builder merge-phpstan --skip-unmigrated --ansi
+                run: vendor/bin/monorepo-builder merge-phpstan --config=config/monorepo-builder/merge-phpstan.php --skip-unmigrated --ansi
 
             -   name: Run PHPStan
                 run: vendor/bin/phpstan analyse --ansi

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -31,7 +31,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json --scoped-only)"
+                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json --config=config/monorepo-builder/plugin-config-entries-json.php --scoped-only)"
         outputs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 
@@ -63,8 +63,8 @@ jobs:
             # https://github.com/symplify/symplify/issues/2773
             -   name: Localize package paths
                 run: |
-                    vendor/bin/monorepo-builder custom-bump-interdependency "dev-master"
-                    vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.pluginConfig.path }}/composer.json --ansi
+                    vendor/bin/monorepo-builder custom-bump-interdependency --config=config/monorepo-builder/custom-bump-interdependency.php "dev-master"
+                    vendor/bin/monorepo-builder localize-composer-paths --config=config/monorepo-builder/localize-composer-paths.php ${{ matrix.pluginConfig.path }}/composer.json --ansi
 
             -   name: Install release dependencies for PROD
                 run: composer install --no-dev --no-progress --no-interaction --ansi

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -45,7 +45,7 @@ jobs:
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
                     filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / --filter=/g')"
-                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json --config=config/monorepo-builder/package-entries-json.php $(echo $filter_arg))"
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -55,7 +55,7 @@ jobs:
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
                     filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / \-\-filter=/g')"
-                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json $(echo $filter_arg))"
+                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json --config=config/monorepo-builder/package-entries-json.php $(echo $filter_arg))"
 
         outputs:
             matrix: ${{ steps.output_data.outputs.matrix }}
@@ -82,7 +82,7 @@ jobs:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   uses: "ramsey/composer-install@v1"
 
-            -   run: vendor/bin/monorepo-builder localize-composer-paths ${{ matrix.package.path }}/composer.json --ansi
+            -   run: vendor/bin/monorepo-builder localize-composer-paths --config=config/monorepo-builder/localize-composer-paths.php ${{ matrix.package.path }}/composer.json --ansi
 
             -   run: composer update --no-progress --ansi --working-dir ${{ matrix.package.path }}
 

--- a/composer.json
+++ b/composer.json
@@ -532,10 +532,10 @@
     ],
     "scripts": {
         "test": "phpunit",
-        "check-style": "phpcs -n src $(monorepo-builder source-packages --psr4-only --subfolder=src --subfolder=tests)",
-        "fix-style": "phpcbf -n src $(monorepo-builder source-packages --psr4-only --subfolder=src --subfolder=tests)",
+        "check-style": "phpcs -n src $(monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests)",
+        "fix-style": "phpcbf -n src $(monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests)",
         "analyse": "phpstan analyse --ansi",
-        "preview-src-downgrade": "rector process $(monorepo-builder source-packages --psr4-only --subfolder=src) --config=ci/downgrades/rector-downgrade-code.php --ansi --dry-run || true",
+        "preview-src-downgrade": "rector process $(monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src) --config=ci/downgrades/rector-downgrade-code.php --ansi --dry-run || true",
         "preview-vendor-downgrade": "ci/downgrades/downgrade_code.sh ci/downgrades/rector-downgrade-code.php --dry-run || true",
         "preview-code-downgrade": [
             "@preview-src-downgrade",
@@ -552,11 +552,11 @@
         "enable-caching": "composer enable-caching -d webservers/graphql-api-for-wp",
         "disable-caching": "composer disable-caching -d webservers/graphql-api-for-wp",
         "purge-cache": "composer purge-cache -d webservers/graphql-api-for-wp",
-        "merge-monorepo": "monorepo-builder merge --ansi",
-        "propagate-monorepo": "monorepo-builder propagate --ansi",
-        "validate-monorepo": "monorepo-builder validate --ansi",
-        "release": "monorepo-builder release patch --ansi",
-        "merge-phpstan": "monorepo-builder merge-phpstan --skip-unmigrated --ansi",
+        "merge-monorepo": "monorepo-builder merge --config=config/monorepo-builder/merge.php --ansi",
+        "propagate-monorepo": "monorepo-builder propagate --config=config/monorepo-builder/propagate.php --ansi",
+        "validate-monorepo": "monorepo-builder validate --config=config/monorepo-builder/validate.php --ansi",
+        "release": "monorepo-builder release --config=config/monorepo-builder/release.php patch --ansi",
+        "merge-phpstan": "monorepo-builder merge-phpstan --config=config/monorepo-builder/merge-phpstan.php --skip-unmigrated --ansi",
         "improve-code-quality": "rector process --config=ci/rector-code-quality.php --ansi"
     },
     "scripts-descriptions": {

--- a/src/Config/Symplify/MonorepoBuilder/Configurators/ContainerConfigurationService.php
+++ b/src/Config/Symplify/MonorepoBuilder/Configurators/ContainerConfigurationService.php
@@ -158,7 +158,7 @@ class ContainerConfigurationService
     {
         $services
             ->set(NeonPrinter::class) // Required to inject into PHPStanNeonContentProvider
-            ->load('PoP\\PoP\\', 'src/*');
+            ->load('PoP\\PoP\\', $this->rootDirectory . '/src/*');
     }
 
     protected function setReleaseWorkerServices(ServicesConfigurator $services): void

--- a/webservers/graphql-api-for-wp/composer.json
+++ b/webservers/graphql-api-for-wp/composer.json
@@ -55,12 +55,12 @@
         ],
         "symlink-vendor-for-graphql-api-for-wp-plugin": [
             "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json', '../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.local.json');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.local.json",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package --config=config/monorepo-builder/symlink-local-package.php layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.local.json",
             "COMPOSER=composer.local.json composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/graphql-api-for-wp"
         ],
         "symlink-vendor-for-graphql-api-extension-demo": [
             "php -r \"copy('../../layers/GraphQLAPIForWP/plugins/extension-demo/composer.json', '../../layers/GraphQLAPIForWP/plugins/extension-demo/composer.local.json');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package layers/GraphQLAPIForWP/plugins/extension-demo/composer.local.json",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package --config=config/monorepo-builder/symlink-local-package.php layers/GraphQLAPIForWP/plugins/extension-demo/composer.local.json",
             "COMPOSER=composer.local.json composer update --no-dev --working-dir=../../layers/GraphQLAPIForWP/plugins/extension-demo"
         ],
         "log-server-errors": "lando logs -t -f | grep \"php:error\"",

--- a/webservers/graphql-by-pop/composer.json
+++ b/webservers/graphql-by-pop/composer.json
@@ -126,7 +126,7 @@
         ],
         "symlink-vendor": [
             "php -r \"copy('composer.json', 'composer.local.json');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package webservers/graphql-by-pop/composer.local.json",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package --config=config/monorepo-builder/symlink-local-package.php webservers/graphql-by-pop/composer.local.json",
             "COMPOSER=composer.local.json composer update --no-dev"
         ],
         "log-server-errors": "lando logs -t -f | grep \"php:error\"",

--- a/webservers/wassup/composer.json
+++ b/webservers/wassup/composer.json
@@ -67,7 +67,7 @@
         ],
         "symlink-vendor": [
             "php -r \"copy('composer.json', 'composer.local.json');\"",
-            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package webservers/wassup/composer.local.json",
+            "cd ../../ && vendor/bin/monorepo-builder symlink-local-package --config=config/monorepo-builder/symlink-local-package.php webservers/wassup/composer.local.json",
             "COMPOSER=composer.local.json composer update --no-dev"
         ],
         "log-server-errors": "lando logs -t -f | grep \"php:error\"",


### PR DESCRIPTION
In a multi-monorepo, the monorepo downstream will need to execute some command with either:

- Upstream + downstream packages (eg: `localize-composer-paths`)
- Only downstream packages (eg: `source-packages`, called when splitting the monorepo)

Luckily, the Monorepo Builder accepts param `--config` with a custom config file and, if it doesn't exist, it will load the default `monorepo-builder.php` ([source](https://github.com/symplify/symplify/blob/90714eec76fb7de8aa0088748d006a40ae75a21c/packages/monorepo-builder/bin/monorepo-builder.php#L45-L60)).

Then, every single command can be invoked using `--config=config/monorepo-builder/command-name.php`. If that command needs be overridden downstream, it can be done. Otherwise, if the file doesn't exist (as it's the case by default in the upstream monorepo), then nothing happens, and the default config is loaded.

This PR adds the `--config` param to all `monorepo-builder` calls.

For instance, from now on we will execute:

```bash
monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests
```

Instead of:

```bash
monorepo-builder source-packages --psr4-only --subfolder=src --subfolder=tests
```

And like that, for all `monorepo-builder` commands in the repo (in all `composer.json` files, and all GitHub Action workflows)