### PR TITLE
Monorepo Builder: Create an "env-var" command, and set empty env `CHECKOUT_SUBMODULES` in all GitHub Action workflows

### DIFF
--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -4,7 +4,9 @@ on:
         branches:
             - master
     pull_request: null
-
+env:
+    CHECKOUT_SUBMODULES: ""
+    
 jobs:
     provide_data:
         name: Provide list of package paths
@@ -13,7 +15,7 @@ jobs:
             -
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -39,7 +41,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
             -
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -36,6 +38,8 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -11,6 +11,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -35,6 +37,8 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
                 # see https://github.com/shivammathur/setup-php
             -   name: Set-up PHP

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -4,6 +4,8 @@ on:
         branches:
             - master
     pull_request: null
+env:
+    CHECKOUT_SUBMODULES: ""
 
 jobs:
     provide_data:
@@ -12,7 +14,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -38,7 +40,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
                 # see https://github.com/shivammathur/setup-php
             -   name: Set-up PHP

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -39,6 +39,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -67,6 +69,8 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   name: Create build folder
                 run: mkdir build

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -30,6 +30,7 @@ on:
     pull_request: null
 
 env:
+    CHECKOUT_SUBMODULES: ""
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-master"
 
@@ -40,7 +41,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -70,7 +71,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   name: Create build folder
                 run: mkdir build

--- a/.github/workflows/monorepo_validation.yml
+++ b/.github/workflows/monorepo_validation.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/monorepo_validation.yml
+++ b/.github/workflows/monorepo_validation.yml
@@ -4,6 +4,8 @@ on:
         branches:
             - master
     pull_request: null
+env:
+    CHECKOUT_SUBMODULES: ""
 
 jobs:
     main:
@@ -13,7 +15,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,6 +4,8 @@ on:
         branches:
             - master
     pull_request: null
+env:
+    CHECKOUT_SUBMODULES: ""
 
 jobs:
     main:
@@ -13,7 +15,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -10,6 +10,7 @@ on:
     pull_request: null
 
 env:
+    CHECKOUT_SUBMODULES: ""
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-master"
 
@@ -20,7 +21,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -49,7 +50,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
                 # see https://github.com/shivammathur/setup-php
             -   name: Set-up PHP

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -19,6 +19,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -46,6 +48,8 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
                 # see https://github.com/shivammathur/setup-php
             -   name: Set-up PHP

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -4,6 +4,8 @@ on:
     push:
         branches:
             - master
+env:
+    CHECKOUT_SUBMODULES: ""
 
 jobs:
     provide_packages_json:
@@ -15,7 +17,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             # required for matrix of packages set
             -   uses: shivammathur/setup-php@v2
@@ -66,7 +68,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
                 # Uses an action in the root directory
             -   name: Monorepo Split of ${{ matrix.package.name }} (${{ matrix.package.path }})

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -13,8 +13,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -
-                uses: actions/checkout@v2
+            -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             # required for matrix of packages set
             -   uses: shivammathur/setup-php@v2
@@ -63,12 +64,12 @@ jobs:
         name: Split Tests of ${{ matrix.package.name }} (${{ matrix.package.path }})
 
         steps:
-            -
-                uses: actions/checkout@v2
+            -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
-            -
                 # Uses an action in the root directory
-                name: Monorepo Split of ${{ matrix.package.name }} (${{ matrix.package.path }})
+            -   name: Monorepo Split of ${{ matrix.package.name }} (${{ matrix.package.path }})
                 uses: symplify/monorepo-split-github-action@1.1
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -5,6 +5,8 @@ on:
         # see https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/10?u=tomasvotruba
         tags:
             - '*'
+env:
+    CHECKOUT_SUBMODULES: ""
 
 jobs:
     provide_packages_json_tagged:
@@ -16,7 +18,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             # required for matrix of packages set
             -   uses: shivammathur/setup-php@v2
@@ -51,7 +53,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
                     # this is required for "WyriHaximus/github-action-get-previous-tag" workflow
                     # see https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
                     fetch-depth: 0

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -14,8 +14,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -
-                uses: actions/checkout@v2
+            -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             # required for matrix of packages set
             -   uses: shivammathur/setup-php@v2
@@ -48,21 +49,19 @@ jobs:
         name: Split with tag - ${{ matrix.package.name }} (${{ matrix.package.path }})
 
         steps:
-            -
-                uses: actions/checkout@v2
-                # this is required for "WyriHaximus/github-action-get-previous-tag" workflow
-                # see https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
+            -   uses: actions/checkout@v2
                 with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    # this is required for "WyriHaximus/github-action-get-previous-tag" workflow
+                    # see https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
                     fetch-depth: 0
 
             # see https://github.com/WyriHaximus/github-action-get-previous-tag
-            -
-                id: previous_tag
+            -   id: previous_tag
                 uses: "WyriHaximus/github-action-get-previous-tag@master"
 
-            -
                 # Uses an action in the root directory
-                name: Monorepo Split of ${{ matrix.package.name }} (${{ matrix.package.path }})
+            -   name: Monorepo Split of ${{ matrix.package.name }} (${{ matrix.package.path }})
                 uses: symplify/monorepo-split-github-action@1.1
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -16,6 +16,7 @@ on:
     pull_request: null
 
 env:
+    CHECKOUT_SUBMODULES: ""
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-master"
 
@@ -27,7 +28,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -76,7 +77,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/split_unit_tests.yaml.disabled
+++ b/.github/workflows/split_unit_tests.yaml.disabled
@@ -26,6 +26,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   uses: shivammathur/setup-php@v2
                 with:
@@ -73,6 +75,8 @@ jobs:
 
         steps:
             -   uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v2
+                with:
+                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,6 +4,8 @@ on:
         branches:
             - master
     pull_request: null
+env:
+    CHECKOUT_SUBMODULES: ""
 
 jobs:
     main:
@@ -13,7 +15,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@v2
                 with:
-                    submodules: "$(vendor/bin/monorepo-builder env-var checkout-submodules)"
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
             -   name: Set-up PHP
                 uses: shivammathur/setup-php@v2

--- a/src/Config/Symplify/MonorepoBuilder/Configurators/ContainerConfigurationService.php
+++ b/src/Config/Symplify/MonorepoBuilder/Configurators/ContainerConfigurationService.php
@@ -6,6 +6,7 @@ namespace PoP\PoP\Config\Symplify\MonorepoBuilder\Configurators;
 
 use PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources\DataToAppendAndRemoveDataSource;
 use PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources\DowngradeRectorDataSource;
+use PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources\EnvironmentVariablesDataSource;
 use PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources\PackageOrganizationDataSource;
 use PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources\PluginDataSource;
 use PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources\ReleaseWorkersDataSource;
@@ -70,6 +71,16 @@ class ContainerConfigurationService
         }
 
         /**
+         * Environment variables
+         */
+        if ($environmentVariablesConfig = $this->getEnvironmentVariablesDataSource()) {
+            $parameters->set(
+                CustomOption::ENVIRONMENT_VARIABLES,
+                $environmentVariablesConfig->getEnvironmentVariables()
+            );
+        }
+
+        /**
          * Temporary hack! PHPStan is currently failing for these packages,
          * because they have not been fully converted to PSR-4 (WIP),
          * and converting them will take some time. Hence, for the time being,
@@ -124,6 +135,11 @@ class ContainerConfigurationService
     protected function getDowngradeRectorDataSource(): ?DowngradeRectorDataSource
     {
         return new DowngradeRectorDataSource($this->rootDirectory);
+    }
+    
+    protected function getEnvironmentVariablesDataSource(): ?EnvironmentVariablesDataSource
+    {
+        return new EnvironmentVariablesDataSource();
     }
     
     protected function getUnmigratedFailingPackagesDataSource(): ?UnmigratedFailingPackagesDataSource

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/EnvironmentVariablesDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/EnvironmentVariablesDataSource.php
@@ -7,18 +7,10 @@ namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
 class EnvironmentVariablesDataSource
 {
     /**
-     * @var string
-     */
-    public const CHECKOUT_SUBMODULES = 'checkout-submodules';
-
-    /**
      * @return array<string,string>
      */
     public function getEnvironmentVariables(): array
     {
-        return [
-            // [multi-monorepo] Env var overriden by downstream monorepo
-            self::CHECKOUT_SUBMODULES => '',
-        ];
+        return [];
     }
 }

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/EnvironmentVariablesDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/EnvironmentVariablesDataSource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
+
+class EnvironmentVariablesDataSource
+{
+    /**
+     * @return array<string,string>
+     */
+    public function getEnvironmentVariables(): array
+    {
+        return [];
+    }
+}

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/EnvironmentVariablesDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/EnvironmentVariablesDataSource.php
@@ -7,10 +7,18 @@ namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
 class EnvironmentVariablesDataSource
 {
     /**
+     * @var string
+     */
+    public const CHECKOUT_SUBMODULES = 'checkout-submodules';
+
+    /**
      * @return array<string,string>
      */
     public function getEnvironmentVariables(): array
     {
-        return [];
+        return [
+            // [multi-monorepo] Env var overriden by downstream monorepo
+            self::CHECKOUT_SUBMODULES => '',
+        ];
     }
 }

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/AdditionalDowngradeRectorConfigsCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/AdditionalDowngradeRectorConfigsCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
 
-use Nette\Utils\Json;
 use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/EnvVarCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/EnvVarCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\PoP\Extensions\Symplify\MonorepoBuilder\Command;
+
+use PoP\PoP\Extensions\Symplify\MonorepoBuilder\ValueObject\Option;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
+use Symplify\PackageBuilder\Console\ShellCode;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+
+final class EnvVarCommand extends AbstractSymplifyCommand
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $environmentVariables = [];
+
+    public function __construct(
+        ParameterProvider $parameterProvider
+    ) {
+        parent::__construct();
+        $this->environmentVariables = $parameterProvider->provideArrayParameter(Option::ENVIRONMENT_VARIABLES);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Get the value for an environment variable set via the Monorepo Builder config');
+        $this->addArgument(
+            Option::ENVIRONMENT_VARIABLE_NAME,
+            InputArgument::REQUIRED,
+            'The name of the environment variable'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string */
+        $environmentVariable = $input->getArgument(Option::ENVIRONMENT_VARIABLE_NAME);
+
+        // If not set, return an empty string
+        $environmentVariableValue = $this->environmentVariables[$environmentVariable] ?? '';
+
+        $this->symfonyStyle->writeln($environmentVariableValue);
+
+        return ShellCode::SUCCESS;
+    }
+}

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
@@ -25,6 +25,10 @@ final class Option
     /**
      * @var string
      */
+    public const ENVIRONMENT_VARIABLE_NAME = 'environment-variable-name';
+    /**
+     * @var string
+     */
     public const JSON = 'json';
     /**
      * @var string

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
@@ -9,19 +9,19 @@ final class Option
     /**
      * @var string
      */
-    public const PACKAGE_ORGANIZATIONS = 'package_organizations';
+    public const PACKAGE_ORGANIZATIONS = 'package-organizations';
     /**
      * @var string
      */
-    public const PLUGIN_CONFIG_ENTRIES = 'plugin_config_entries';
+    public const PLUGIN_CONFIG_ENTRIES = 'plugin-config-entries';
     /**
      * @var string
      */
-    public const ADDITIONAL_DOWNGRADE_RECTOR_CONFIGS = 'additional_downgrade_rector_configs';
+    public const ADDITIONAL_DOWNGRADE_RECTOR_CONFIGS = 'additional-downgrade-rector-configs';
     /**
      * @var string
      */
-    public const ENVIRONMENT_VARIABLES = 'environment_variables';
+    public const ENVIRONMENT_VARIABLES = 'environment-variables';
     /**
      * @var string
      */
@@ -37,7 +37,7 @@ final class Option
     /**
      * @var string
      */
-    public const UNMIGRATED_FAILING_PACKAGES = 'unmigrated_failing_packages';
+    public const UNMIGRATED_FAILING_PACKAGES = 'unmigrated-failing-packages';
     /**
      * @var string
      */

--- a/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/ValueObject/Option.php
@@ -21,6 +21,10 @@ final class Option
     /**
      * @var string
      */
+    public const ENVIRONMENT_VARIABLES = 'environment_variables';
+    /**
+     * @var string
+     */
     public const JSON = 'json';
     /**
      * @var string


### PR DESCRIPTION
Have a generic `monorepo-builder env-var [env-var-name]` command to inject any value into GitHub Actions (which doesn't naturally support environment variables).

It will be used to fetch the `submodules` property for `actions/checkout` in GitHub Actions in a multi-monorepo.

Initialize this env var as empty, and already use it in all GitHub Action workflows.

This env var will be set as `"recursive"` by the downstream monorepo.