### PR TITLE
Fix: do not filter out empty arrays

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -412,16 +412,16 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         // If there was an error, the value will be NULL. In this case, remove it
         return array_filter(
             $fieldOrDirectiveArgs,
-            function ($elem) use ($allowNullValues) {
+            function ($elem) use ($allowNullValues): bool {
                 // If the input is `[[String]]`, must then validate if any subitem is Error
                 if (is_array($elem)) {
-                    return $this->filterFieldOrDirectiveArgs($elem, true);
+                    // Filter elements in the array. If any is missing, filter the array out
+                    $filteredElem = $this->filterFieldOrDirectiveArgs($elem, true);
+                    return count($elem) === count($filteredElem);
                 }
-                // Remove only NULL values and Errors. Keep '', 0 and false
+                // Remove only NULL values and Errors. Keep '', 0, false and []
                 return !GeneralUtils::isError($elem)
-                    && ($elem !== null
-                        || ($elem === null && $allowNullValues)
-                    );
+                    && ($elem !== null || $allowNullValues);
             }
         );
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -158,7 +158,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                     $dbWarning = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
-                            $this->translationAPI->__('Warning validating function \'%s\' on object with ID \'%s\' and field under property \'%s\')', 'component-model'),
+                            $this->translationAPI->__('Nested warnings validating function \'%s\' on object with ID \'%s\' and field under property \'%s\')', 'component-model'),
                             $function,
                             $id,
                             $fieldOutputKey
@@ -172,14 +172,23 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                     $dbWarnings[(string)$id][] = $dbWarning;
                 }
                 if ($schemaDBErrors) {
+                    if ($fieldOutputKey != $field) {
+                        $errorMessage = sprintf(
+                            $this->translationAPI->__('Applying function on field \'%s\' (under property \'%s\') on object with ID \'%s\' can\'t be executed due to nested errors', 'component-model'),
+                            $field,
+                            $fieldOutputKey,
+                            $id
+                        );
+                    } else {
+                        $errorMessage = sprintf(
+                            $this->translationAPI->__('Applying function on field \'%s\' on object with ID \'%s\' can\'t be executed due to nested errors', 'component-model'),
+                            $fieldOutputKey,
+                            $id
+                        );
+                    }
                     $dbError = [
                         Tokens::PATH => [$this->directive],
-                        Tokens::MESSAGE => sprintf(
-                            $this->translationAPI->__('Error validating function \'%s\' on object with ID \'%s\' and field under property \'%s\')', 'component-model'),
-                            $function,
-                            $id,
-                            $fieldOutputKey
-                        )
+                        Tokens::MESSAGE => $errorMessage
                     ];
                     foreach ($schemaDBErrors as $schemaDBError) {
                         array_unshift($schemaDBError[Tokens::PATH], $this->directive);
@@ -187,26 +196,6 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                         $dbError[Tokens::EXTENSIONS][Tokens::NESTED][] = $schemaDBError;
                     }
                     $dbErrors[(string)$id][] = $dbError;
-                    // if ($fieldOutputKey != $field) {
-                    //     $dbErrors[(string)$id][] = [
-                    //         Tokens::PATH => [$this->directive],
-                    //         Tokens::MESSAGE => sprintf(
-                    //             $this->translationAPI->__('Applying function on field \'%s\' (under property \'%s\') on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
-                    //             $field,
-                    //             $fieldOutputKey,
-                    //             $id
-                    //         ),
-                    //     ];
-                    // } else {
-                    //     $dbErrors[(string)$id][] = [
-                    //         Tokens::PATH => [$this->directive],
-                    //         Tokens::MESSAGE => sprintf(
-                    //             $this->translationAPI->__('Applying function on field \'%s\' on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
-                    //             $fieldOutputKey,
-                    //             $id
-                    //         ),
-                    //     ];
-                    // }
                     continue;
                 }
 

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -155,52 +155,58 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
 
                 // Place the errors not under schema but under DB, since they may change on a resultItem by resultItem basis
                 if ($schemaDBWarnings) {
-                    foreach ($schemaDBWarnings as $warningMessage) {
-                        $dbWarnings[(string)$id][] = [
-                            Tokens::PATH => [$this->directive],
-                            Tokens::MESSAGE => sprintf(
-                                $this->translationAPI->__('Warning validating function \'%s\' on object with ID \'%s\' and field under property \'%s\': %s)', 'component-model'),
-                                $function,
-                                $id,
-                                $fieldOutputKey,
-                                $warningMessage
-                            ),
-                        ];
+                    $dbWarning = [
+                        Tokens::PATH => [$this->directive],
+                        Tokens::MESSAGE => sprintf(
+                            $this->translationAPI->__('Warning validating function \'%s\' on object with ID \'%s\' and field under property \'%s\')', 'component-model'),
+                            $function,
+                            $id,
+                            $fieldOutputKey
+                        )
+                    ];
+                    foreach ($schemaDBWarnings as $schemaDBWarning) {
+                        array_unshift($schemaDBWarning[Tokens::PATH], $this->directive);
+                        $this->prependPathOnNestedErrors($schemaDBWarning);
+                        $dbWarning[Tokens::EXTENSIONS][Tokens::NESTED][] = $schemaDBWarning;
                     }
+                    $dbWarnings[(string)$id][] = $dbWarning;
                 }
                 if ($schemaDBErrors) {
-                    foreach ($schemaDBErrors as $errorMessage) {
-                        $dbErrors[(string)$id][] = [
-                            Tokens::PATH => [$this->directive],
-                            Tokens::MESSAGE => sprintf(
-                                $this->translationAPI->__('Error validating function \'%s\' on object with ID \'%s\' and field under property \'%s\': %s)', 'component-model'),
-                                $function,
-                                $id,
-                                $fieldOutputKey,
-                                $errorMessage
-                            ),
-                        ];
+                    $dbError = [
+                        Tokens::PATH => [$this->directive],
+                        Tokens::MESSAGE => sprintf(
+                            $this->translationAPI->__('Error validating function \'%s\' on object with ID \'%s\' and field under property \'%s\')', 'component-model'),
+                            $function,
+                            $id,
+                            $fieldOutputKey
+                        )
+                    ];
+                    foreach ($schemaDBErrors as $schemaDBError) {
+                        array_unshift($schemaDBError[Tokens::PATH], $this->directive);
+                        $this->prependPathOnNestedErrors($schemaDBError);
+                        $dbError[Tokens::EXTENSIONS][Tokens::NESTED][] = $schemaDBError;
                     }
-                    if ($fieldOutputKey != $field) {
-                        $dbErrors[(string)$id][] = [
-                            Tokens::PATH => [$this->directive],
-                            Tokens::MESSAGE => sprintf(
-                                $this->translationAPI->__('Applying function on field \'%s\' (under property \'%s\') on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
-                                $field,
-                                $fieldOutputKey,
-                                $id
-                            ),
-                        ];
-                    } else {
-                        $dbErrors[(string)$id][] = [
-                            Tokens::PATH => [$this->directive],
-                            Tokens::MESSAGE => sprintf(
-                                $this->translationAPI->__('Applying function on field \'%s\' on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
-                                $fieldOutputKey,
-                                $id
-                            ),
-                        ];
-                    }
+                    $dbErrors[(string)$id][] = $dbError;
+                    // if ($fieldOutputKey != $field) {
+                    //     $dbErrors[(string)$id][] = [
+                    //         Tokens::PATH => [$this->directive],
+                    //         Tokens::MESSAGE => sprintf(
+                    //             $this->translationAPI->__('Applying function on field \'%s\' (under property \'%s\') on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
+                    //             $field,
+                    //             $fieldOutputKey,
+                    //             $id
+                    //         ),
+                    //     ];
+                    // } else {
+                    //     $dbErrors[(string)$id][] = [
+                    //         Tokens::PATH => [$this->directive],
+                    //         Tokens::MESSAGE => sprintf(
+                    //             $this->translationAPI->__('Applying function on field \'%s\' on object with ID \'%s\' can\'t be executed due to previous errors', 'component-model'),
+                    //             $fieldOutputKey,
+                    //             $id
+                    //         ),
+                    //     ];
+                    // }
                     continue;
                 }
 


### PR DESCRIPTION
Passing input `{array: []`}` returned `{}`. This PR fixes it.

In addition, it fixes nested warnings/errors from `@applyFunction`