### PR TITLE
Switch from `lkwdwrd/wp-muplugin-loader` to `boxuk/wp-muplugin-loader`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "guzzlehttp/guzzle": "~6.3",
         "jrfnl/php-cast-to-type": "^2.0",
         "league/pipeline": "^1.0",
-        "lkwdwrd/wp-muplugin-loader": "dev-support-php-8",
+        "boxuk/wp-muplugin-loader": "dev-support-php-8",
         "michelf/php-markdown": "^1.9",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "guzzlehttp/guzzle": "~6.3",
         "jrfnl/php-cast-to-type": "^2.0",
         "league/pipeline": "^1.0",
-        "lkwdwrd/wp-muplugin-loader": "dev-feature-composer-v2",
+        "lkwdwrd/wp-muplugin-loader": "dev-support-php-8",
         "michelf/php-markdown": "^1.9",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,79 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cf8081af36ae000a3ae341adb462780",
+    "content-hash": "639c0b96fb257f70314c7a3554f554b4",
     "packages": [
+        {
+            "name": "boxuk/wp-muplugin-loader",
+            "version": "dev-support-php-8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/leoloso/wp-muplugin-loader.git",
+                "reference": "7ec8553abe07bb30b46303f386db065fff88290a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/leoloso/wp-muplugin-loader/zipball/7ec8553abe07bb30b46303f386db065fff88290a",
+                "reference": "7ec8553abe07bb30b46303f386db065fff88290a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "10up/wp_mock": "^0.4",
+                "codeclimate/php-test-reporter": "^0.4.4",
+                "composer/composer": "^1.10 || ^2.0",
+                "mockery/mockery": "~1.3.3",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "LkWdwrd\\Composer\\MULoaderPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "LkWdwrd\\Composer\\": "src/lkwdwrd/Composer"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "LkWdwrd\\Composer\\Tests\\": "tests/phpunit/Composer"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "vendor/bin/phpunit --colors"
+                ],
+                "export-coverage": [
+                    "vendor/bin/test-reporter"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Box UK",
+                    "email": "developers@boxuk.com"
+                },
+                {
+                    "name": "Luke Woodward",
+                    "email": "woodward.lucas@gmail.com"
+                }
+            ],
+            "description": "A drop-in MU Plugin loader for WordPress",
+            "keywords": [
+                "loader",
+                "muplugin",
+                "wordpress"
+            ],
+            "support": {
+                "source": "https://github.com/leoloso/wp-muplugin-loader/tree/support-php-8"
+            },
+            "time": "2021-07-05T08:04:35+00:00"
+        },
         {
             "name": "brain/cortex",
             "version": "1.0.0-alpha.7",
@@ -606,65 +677,6 @@
                 "source": "https://github.com/thephpleague/pipeline/tree/master"
             },
             "time": "2018-06-05T21:06:51+00:00"
-        },
-        {
-            "name": "lkwdwrd/wp-muplugin-loader",
-            "version": "dev-feature-composer-v2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/leoloso/wp-muplugin-loader.git",
-                "reference": "ab5817acdfb8da0f37a628d3f1577c98880b5bfe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/leoloso/wp-muplugin-loader/zipball/ab5817acdfb8da0f37a628d3f1577c98880b5bfe",
-                "reference": "ab5817acdfb8da0f37a628d3f1577c98880b5bfe",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0"
-            },
-            "require-dev": {
-                "10up/wp_mock": "dev-dev",
-                "codeclimate/php-test-reporter": "^0.4.4",
-                "phpunit/phpunit": "^7.1.4"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "LkWdwrd\\Composer\\MULoaderPlugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "LkWdwrd\\Composer\\": "src/lkwdwrd/Composer"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit --colors"
-                ],
-                "export-coverage": [
-                    "test-reporter"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Luke Woodward",
-                    "email": "woodward.lucas@gmail.com"
-                }
-            ],
-            "description": "A drop-in MU Plugin loader for WordPress",
-            "keywords": [
-                "loader",
-                "muplugin",
-                "wordpress"
-            ],
-            "support": {
-                "source": "https://github.com/leoloso/wp-muplugin-loader/tree/feature-composer-v2"
-            },
-            "time": "2020-11-04T12:05:26+00:00"
         },
         {
             "name": "michelf/php-markdown",
@@ -6922,7 +6934,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "lkwdwrd/wp-muplugin-loader": 20
+        "boxuk/wp-muplugin-loader": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/layers/Engine/packages/engine-wp-bootloader/composer.json
+++ b/layers/Engine/packages/engine-wp-bootloader/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.0",
         "composer/installers": "~1.0",
         "getpop/routing-wp": "^0.8",
-        "lkwdwrd/wp-muplugin-loader": "dev-support-php-8"
+        "boxuk/wp-muplugin-loader": "dev-support-php-8"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0"

--- a/layers/Engine/packages/engine-wp-bootloader/composer.json
+++ b/layers/Engine/packages/engine-wp-bootloader/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.0",
         "composer/installers": "~1.0",
         "getpop/routing-wp": "^0.8",
-        "lkwdwrd/wp-muplugin-loader": "dev-feature-composer-v2"
+        "lkwdwrd/wp-muplugin-loader": "dev-support-php-8"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0"

--- a/src/Config/Rector/Downgrade/Configurators/GraphQLAPIContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/GraphQLAPIContainerConfigurationService.php
@@ -48,7 +48,7 @@ class GraphQLAPIContainerConfigurationService extends AbstractPluginDowngradeCon
     
                 // Skip since they are not needed and they fail
                 $this->pluginDir . '/vendor/composer/*',
-                $this->pluginDir . '/vendor/lkwdwrd/wp-muplugin-loader/*',
+                $this->pluginDir . '/vendor/boxuk/wp-muplugin-loader/*',
     
                 // These are skipped in the .sh since it's faster
                 // // All the "migrate" folders

--- a/src/Config/Rector/Downgrade/Configurators/MonorepoContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/MonorepoContainerConfigurationService.php
@@ -22,7 +22,7 @@ class MonorepoContainerConfigurationService extends AbstractDowngradeContainerCo
 
                 // Skip since they are not needed and they fail
                 $this->rootDirectory . '/vendor/composer/*',
-                $this->rootDirectory . '/vendor/lkwdwrd/wp-muplugin-loader/*',
+                $this->rootDirectory . '/vendor/boxuk/wp-muplugin-loader/*',
 
                 // Ignore errors from classes we don't have in our environment,
                 // or that come from referencing a class present in DEV, not PROD


### PR DESCRIPTION
Fixes #773

Because `boxuk/wp-muplugin-loader` does not support PHP 8, this PR points to branch `support-php-8` implemented in fork `leoloso/wp-muplugin-loader`