### PR TITLE
Switch `monorepo-split-github-action` back to v1.1

### DIFF
--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -197,7 +197,7 @@ jobs:
                 if: github.event_name == 'release'
 
             -   name: Publish to DIST repo
-                uses: symplify/monorepo-split-github-action@2.0
+                uses: symplify/monorepo-split-github-action@1.1
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -73,7 +73,7 @@ jobs:
                 # Uses an action in the root directory
             -   name: Split ${{ matrix.package.name }} (${{ matrix.package.path }})
                 if: "!startsWith(github.ref, 'refs/tags/')"
-                uses: symplify/monorepo-split-github-action@2.0
+                uses: symplify/monorepo-split-github-action@1.1
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -61,7 +61,7 @@ jobs:
                 # Uses an action in the root directory
             -   name: Monorepo Split of ${{ matrix.package.name }} (${{ matrix.package.path }})
                 if: "startsWith(github.ref, 'refs/tags/')"
-                uses: symplify/monorepo-split-github-action@2.0
+                uses: symplify/monorepo-split-github-action@1.1
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:


### PR DESCRIPTION
Because in v2.0 the CI run is always successful: https://github.com/symplify/monorepo-split-github-action/issues/19.

Once that bug is fixed, we can switch back to the newer version.