### PR TITLE
Bootloader: Wait until all plugins are loaded to initialize

### DIFF
--- a/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
+++ b/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
@@ -13,6 +13,13 @@ if (!class_exists(AppLoader::class)) {
     return;
 }
 
-// Initialize PoP Engine through the Bootloader
-AppLoader::bootSystem();
-AppLoader::bootApplication();
+/**
+ * Initialize PoP Engine through the Bootloader.
+ * 
+ * Wait until all plugins are loaded, so that Components can decide to be resolved
+ * or not based on their required plugins being active.
+ */
+\add_action('plugins_loaded', function(): void {
+    AppLoader::bootSystem();
+    AppLoader::bootApplication();
+});


### PR DESCRIPTION
Wait until all plugins are loaded, to initialize PoP Engine through the Bootloader.

This way, Components can decide to be resolved or not based on their required plugins being active.