### PR TITLE
Fix CodeSniffer

### DIFF
--- a/layers/API/packages/api-clients/phpcs.xml.dist
+++ b/layers/API/packages/api-clients/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/API/packages/api-endpoints-for-wp/phpcs.xml.dist
+++ b/layers/API/packages/api-endpoints-for-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/API/packages/api-endpoints/phpcs.xml.dist
+++ b/layers/API/packages/api-endpoints/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/API/packages/api-graphql/phpcs.xml.dist
+++ b/layers/API/packages/api-graphql/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/API/packages/api-mirrorquery/phpcs.xml.dist
+++ b/layers/API/packages/api-mirrorquery/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/API/packages/api-rest/phpcs.xml.dist
+++ b/layers/API/packages/api-rest/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/API/packages/api/phpcs.xml.dist
+++ b/layers/API/packages/api/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/access-control/phpcs.xml.dist
+++ b/layers/Engine/packages/access-control/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/cache-control/phpcs.xml.dist
+++ b/layers/Engine/packages/cache-control/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/component-model/phpcs.xml.dist
+++ b/layers/Engine/packages/component-model/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -71,10 +71,10 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
 
     /**
      * The directiveResolvers are NOT instantiated through the service container!
-     * 
+     *
      * Instead, the directive will be instantiated in AbstractTypeResolver:
      *   new $directiveClass($fieldDirective)
-     * 
+     *
      * Whenever having depended-upon services, these can be obtained like this (or via a Facade):
      *   $instanceManager->getInstance(...)
      *

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -95,7 +95,7 @@ class Engine implements EngineInterface
     protected ?array $entryModule = null;
 
     /**
-     * `mixed` could be string[] for "direct", or array<string,string[]> for "conditional" 
+     * `mixed` could be string[] for "direct", or array<string,string[]> for "conditional"
      * @var array<string,array<string|int,array<string,mixed>>>>
      */
     protected array $typeResolverClass_ids_data_fields = [];

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -242,7 +242,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
             $fieldArgs,
         );
     }
-    
+
     /**
      * Custom validations. Function to override
      */

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
@@ -20,7 +20,7 @@ trait QueryDataModuleProcessorTrait
      * @var array<string, array<string[]>>
      */
     protected array $activeDataloadQueryArgsFilteringModules = [];
-    
+
     protected function getImmutableDataloadQueryArgs(array $module, array &$props): array
     {
         return array();

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -94,7 +94,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
      * It is needed to find out which fieldResolver will process a field,
      * where we can't depend on the schema since this one needs to know
      * who the fieldResolver is, creating an infitine loop.
-     * 
+     *
      * Directive arguments have the same syntax as field arguments,
      * so simply re-utilize the corresponding function for field arguments.
      */

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractUnionTypeResolver.php
@@ -196,7 +196,7 @@ abstract class AbstractUnionTypeResolver extends AbstractTypeResolver implements
     /**
      * In order to enable elements from different types (such as posts and users) to have same ID,
      * add the type to the ID.
-     * 
+     *
      * @return string|int|null the ID of the passed object, or `null` if there is no resolver to handle it
      */
     public function getID(object $resultItem): string | int | null

--- a/layers/Engine/packages/component-model/src/TypeResolvers/TypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/TypeResolverInterface.php
@@ -13,7 +13,7 @@ interface TypeResolverInterface
     /**
      * All objects MUST have an ID. `null` is supported for the UnionTypeResolver,
      * when it cannot find a resolver to handle the object.
-     * 
+     *
      * @return string|int|null the ID of the passed object, or `null` if there is no resolver to handle it (for the UnionTypeResolver)
      */
     public function getID(object $resultItem): string | int | null;

--- a/layers/Engine/packages/configurable-schema-feedback/phpcs.xml.dist
+++ b/layers/Engine/packages/configurable-schema-feedback/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/definitions/phpcs.xml.dist
+++ b/layers/Engine/packages/definitions/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/engine-wp-bootloader/phpcs.xml.dist
+++ b/layers/Engine/packages/engine-wp-bootloader/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/engine-wp/phpcs.xml.dist
+++ b/layers/Engine/packages/engine-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/engine/phpcs.xml.dist
+++ b/layers/Engine/packages/engine/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/field-query/phpcs.xml.dist
+++ b/layers/Engine/packages/field-query/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/filestore/phpcs.xml.dist
+++ b/layers/Engine/packages/filestore/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/function-fields/phpcs.xml.dist
+++ b/layers/Engine/packages/function-fields/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/guzzle-helpers/phpcs.xml.dist
+++ b/layers/Engine/packages/guzzle-helpers/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/hooks-wp/phpcs.xml.dist
+++ b/layers/Engine/packages/hooks-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/hooks/phpcs.xml.dist
+++ b/layers/Engine/packages/hooks/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/loosecontracts/phpcs.xml.dist
+++ b/layers/Engine/packages/loosecontracts/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/mandatory-directives-by-configuration/phpcs.xml.dist
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/modulerouting/phpcs.xml.dist
+++ b/layers/Engine/packages/modulerouting/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/query-parsing/phpcs.xml.dist
+++ b/layers/Engine/packages/query-parsing/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/root/phpcs.xml.dist
+++ b/layers/Engine/packages/root/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/routing-wp/phpcs.xml.dist
+++ b/layers/Engine/packages/routing-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/routing/phpcs.xml.dist
+++ b/layers/Engine/packages/routing/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/translation-wp/phpcs.xml.dist
+++ b/layers/Engine/packages/translation-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Engine/packages/translation/phpcs.xml.dist
+++ b/layers/Engine/packages/translation/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLAPIForWP/packages/external-dependency-wrappers/phpcs.xml.dist
+++ b/layers/GraphQLAPIForWP/packages/external-dependency-wrappers/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLAPIForWP/packages/markdown-convertor/phpcs.xml.dist
+++ b/layers/GraphQLAPIForWP/packages/markdown-convertor/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLAPIForWP/plugins/extension-demo/phpcs.xml.dist
+++ b/layers/GraphQLAPIForWP/plugins/extension-demo/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpcs.xml.dist
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -481,7 +481,7 @@ class PluginConfiguration extends AbstractMainPluginConfiguration
         $moduleRegistry = SystemModuleRegistryFacade::getInstance();
         $isDev = RootEnvironment::isApplicationEnvironmentDev();
         $mainPluginURL = (string) MainPluginManager::getConfig('url');
-        
+
         $componentClassConfiguration = [];
         $componentClassConfiguration[\PoP\ComponentModel\Component::class] = [
             /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginConfigurationHelper.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginConfigurationHelper.php
@@ -100,7 +100,7 @@ class PluginConfigurationHelper
         // Make sure the path does not have "/" on either end
         return trim($value, '/');
     }
-    
+
     /**
      * Determine if the environment variable was defined
      * as a constant in wp-config.php

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtensionConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractExtensionConfiguration.php
@@ -8,5 +8,6 @@ namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
  * Base class to set the configuration in all the PoP components for the Extension.
  */
 abstract class AbstractExtensionConfiguration extends AbstractPluginConfiguration
-{    
+{
+
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPluginConfiguration.php
@@ -92,10 +92,10 @@ abstract class AbstractPluginConfiguration
     protected function defineEnvironmentConstantsFromSettings(): void
     {
         $moduleRegistry = SystemModuleRegistryFacade::getInstance();
-        
+
         // All the environment variables to override
         $mappings = $this->getEnvironmentConstantsFromSettingsMapping();
-        
+
         // For each environment variable, see if its value has been saved in the settings
         $userSettingsManager = UserSettingsManagerFacade::getInstance();
         foreach ($mappings as $mapping) {
@@ -241,7 +241,7 @@ abstract class AbstractPluginConfiguration
         if ($endpointHelpers->isRequestingAdminFixedSchemaGraphQLEndpoint()) {
             return [];
         }
-        
+
         // Component classes are skipped if the module is disabled
         $moduleRegistry = SystemModuleRegistryFacade::getInstance();
         $skipSchemaModuleComponentClasses = array_filter(

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/phpcs.xml.dist
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/phpcs.xml.dist
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLByPoP/packages/graphql-parser/phpcs.xml.dist
+++ b/layers/GraphQLByPoP/packages/graphql-parser/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLByPoP/packages/graphql-query/phpcs.xml.dist
+++ b/layers/GraphQLByPoP/packages/graphql-query/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLByPoP/packages/graphql-request/phpcs.xml.dist
+++ b/layers/GraphQLByPoP/packages/graphql-request/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/GraphQLByPoP/packages/graphql-server/phpcs.xml.dist
+++ b/layers/GraphQLByPoP/packages/graphql-server/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/everythingelse-wp/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/everythingelse-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/everythingelse/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/everythingelse/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/highlights-wp/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/highlights-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/highlights/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/highlights/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/notifications-wp/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/notifications-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/notifications/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/notifications/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/stances-wp/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/stances-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Schema/packages/stances/phpcs.xml.dist
+++ b/layers/Legacy/Schema/packages/stances/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/phpcs.xml.dist
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Legacy/Wassup/packages/wassup/phpcs.xml.dist
+++ b/layers/Legacy/Wassup/packages/wassup/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/basic-directives/phpcs.xml.dist
+++ b/layers/Schema/packages/basic-directives/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/block-metadata-for-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/block-metadata-for-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/categories-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/categories-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/categories/phpcs.xml.dist
+++ b/layers/Schema/packages/categories/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/comment-mutations-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/comment-mutations-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/comment-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/comment-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/commentmeta-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/commentmeta-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/commentmeta/phpcs.xml.dist
+++ b/layers/Schema/packages/commentmeta/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/comments-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/comments-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/comments/phpcs.xml.dist
+++ b/layers/Schema/packages/comments/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompost-categories-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/custompost-categories-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompost-category-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/custompost-category-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompost-mutations-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/custompost-mutations-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompost-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/custompost-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompost-tag-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/custompost-tag-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompost-tags-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/custompost-tags-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompostmedia-mutations-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/custompostmedia-mutations-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompostmedia-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/custompostmedia-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompostmedia-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/custompostmedia-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompostmedia/phpcs.xml.dist
+++ b/layers/Schema/packages/custompostmedia/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompostmeta-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/custompostmeta-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/custompostmeta/phpcs.xml.dist
+++ b/layers/Schema/packages/custompostmeta/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/customposts-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/customposts-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/customposts/phpcs.xml.dist
+++ b/layers/Schema/packages/customposts/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/customposts/src/ModuleProcessors/CustomPostFilterInnerModuleProcessor.php
+++ b/layers/Schema/packages/customposts/src/ModuleProcessors/CustomPostFilterInnerModuleProcessor.php
@@ -52,17 +52,17 @@ class CustomPostFilterInnerModuleProcessor extends AbstractModuleProcessor
                     [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_IDS],
                     [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],
                 ],
-            self::MODULE_FILTERINNER_UNIONCUSTOMPOSTCOUNT,
-            self::MODULE_FILTERINNER_ADMINUNIONCUSTOMPOSTCOUNT,
-            self::MODULE_FILTERINNER_CUSTOMPOSTLISTCOUNT,
-            self::MODULE_FILTERINNER_ADMINCUSTOMPOSTLISTCOUNT => 
+                self::MODULE_FILTERINNER_UNIONCUSTOMPOSTCOUNT,
+                self::MODULE_FILTERINNER_ADMINUNIONCUSTOMPOSTCOUNT,
+                self::MODULE_FILTERINNER_CUSTOMPOSTLISTCOUNT,
+                self::MODULE_FILTERINNER_ADMINCUSTOMPOSTLISTCOUNT =>
                 [
                     [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH],
                     [CommonFilterMultipleInputModuleProcessor::class, CommonFilterMultipleInputModuleProcessor::MODULE_FILTERINPUT_DATES],
                     [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_IDS],
                     [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],
                 ],
-            default => []
+                default => []
         };
         // Fields "customPosts" and "customPostCount" also have the "postTypes" filter
         if (

--- a/layers/Schema/packages/generic-customposts/phpcs.xml.dist
+++ b/layers/Schema/packages/generic-customposts/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/media-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/media-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/media/phpcs.xml.dist
+++ b/layers/Schema/packages/media/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/menus-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/menus-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/menus/phpcs.xml.dist
+++ b/layers/Schema/packages/menus/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/meta/phpcs.xml.dist
+++ b/layers/Schema/packages/meta/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/metaquery-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/metaquery-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/metaquery/phpcs.xml.dist
+++ b/layers/Schema/packages/metaquery/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/pages-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/pages-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/pages/phpcs.xml.dist
+++ b/layers/Schema/packages/pages/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-categories-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/post-categories-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-categories/phpcs.xml.dist
+++ b/layers/Schema/packages/post-categories/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-category-mutations-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/post-category-mutations-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-category-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/post-category-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/post-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-tag-mutations-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/post-tag-mutations-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-tag-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/post-tag-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-tags-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/post-tags-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/post-tags/phpcs.xml.dist
+++ b/layers/Schema/packages/post-tags/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/posts-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/posts-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/posts/phpcs.xml.dist
+++ b/layers/Schema/packages/posts/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/queriedobject-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/queriedobject-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/queriedobject/phpcs.xml.dist
+++ b/layers/Schema/packages/queriedobject/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/schema-commons/phpcs.xml.dist
+++ b/layers/Schema/packages/schema-commons/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/settings-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/settings-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/settings/phpcs.xml.dist
+++ b/layers/Schema/packages/settings/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/tags-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/tags-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/tags/phpcs.xml.dist
+++ b/layers/Schema/packages/tags/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/taxonomies-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/taxonomies-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/taxonomies/phpcs.xml.dist
+++ b/layers/Schema/packages/taxonomies/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/taxonomymeta-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/taxonomymeta-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/taxonomymeta/phpcs.xml.dist
+++ b/layers/Schema/packages/taxonomymeta/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/taxonomyquery-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/taxonomyquery-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/taxonomyquery/phpcs.xml.dist
+++ b/layers/Schema/packages/taxonomyquery/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-roles-access-control/phpcs.xml.dist
+++ b/layers/Schema/packages/user-roles-access-control/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-roles-acl/phpcs.xml.dist
+++ b/layers/Schema/packages/user-roles-acl/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-roles-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/user-roles-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-roles/phpcs.xml.dist
+++ b/layers/Schema/packages/user-roles/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-state-access-control/phpcs.xml.dist
+++ b/layers/Schema/packages/user-state-access-control/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-state-mutations-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/user-state-mutations-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-state-mutations/phpcs.xml.dist
+++ b/layers/Schema/packages/user-state-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-state-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/user-state-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/user-state/phpcs.xml.dist
+++ b/layers/Schema/packages/user-state/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/usermeta-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/usermeta-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/usermeta/phpcs.xml.dist
+++ b/layers/Schema/packages/usermeta/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/users-wp/phpcs.xml.dist
+++ b/layers/Schema/packages/users-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -246,6 +246,7 @@ class UserTypeAPI implements UserTypeAPIInterface
      * @param bool   $wild   Whether to allow wildcard searches. Default is false for Network Admin, true for single site.
      *                       Single site allows leading and trailing wildcards, Network Admin only trailing.
      * @return string
+     * phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
      */
     protected function get_search_sql($string, $cols, $wild = false)
     {

--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -230,45 +230,46 @@ class UserTypeAPI implements UserTypeAPIInterface
         }
     }
 
-	/**
+    /**
      * Function copied from WordPress source, because it is protected!
-     * 
+     *
      * @source wp-includes/class-wp-user-query.php
-     * 
-	 * Used internally to generate an SQL string for searching across multiple columns
-	 *
-	 * @since 3.1.0
-	 *
-	 * @global wpdb $wpdb WordPress database abstraction object.
-	 *
-	 * @param string $string
-	 * @param array  $cols
-	 * @param bool   $wild   Whether to allow wildcard searches. Default is false for Network Admin, true for single site.
-	 *                       Single site allows leading and trailing wildcards, Network Admin only trailing.
-	 * @return string
-	 */
-	protected function get_search_sql( $string, $cols, $wild = false ) {
-		global $wpdb;
+     *
+     * Used internally to generate an SQL string for searching across multiple columns
+     *
+     * @since 3.1.0
+     *
+     * @global wpdb $wpdb WordPress database abstraction object.
+     *
+     * @param string $string
+     * @param array  $cols
+     * @param bool   $wild   Whether to allow wildcard searches. Default is false for Network Admin, true for single site.
+     *                       Single site allows leading and trailing wildcards, Network Admin only trailing.
+     * @return string
+     */
+    protected function get_search_sql($string, $cols, $wild = false)
+    {
+        global $wpdb;
 
-		$searches      = array();
+        $searches      = array();
         // Avoid PHPStan errors:
         //   Result of || is always false
-		// $leading_wild  = ( 'leading' === $wild || 'both' === $wild ) ? '%' : '';
-		// $trailing_wild = ( 'trailing' === $wild || 'both' === $wild ) ? '%' : '';
-		$leading_wild  = '';
-		$trailing_wild = '';
-		$like          = $leading_wild . $wpdb->esc_like( $string ) . $trailing_wild;
+        // $leading_wild  = ( 'leading' === $wild || 'both' === $wild ) ? '%' : '';
+        // $trailing_wild = ( 'trailing' === $wild || 'both' === $wild ) ? '%' : '';
+        $leading_wild  = '';
+        $trailing_wild = '';
+        $like          = $leading_wild . $wpdb->esc_like($string) . $trailing_wild;
 
-		foreach ( $cols as $col ) {
-			if ( 'ID' === $col ) {
-				$searches[] = $wpdb->prepare( "$col = %s", $string );
-			} else {
-				$searches[] = $wpdb->prepare( "$col LIKE %s", $like );
-			}
-		}
+        foreach ($cols as $col) {
+            if ('ID' === $col) {
+                $searches[] = $wpdb->prepare("$col = %s", $string);
+            } else {
+                $searches[] = $wpdb->prepare("$col LIKE %s", $like);
+            }
+        }
 
-		return ' AND (' . implode( ' OR ', $searches ) . ')';
-	}
+        return ' AND (' . implode(' OR ', $searches) . ')';
+    }
 
     protected function getUserProperty(string $property, string | int | object $userObjectOrID): ?string
     {

--- a/layers/Schema/packages/users/phpcs.xml.dist
+++ b/layers/Schema/packages/users/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/application-wp/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/application-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/application/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/application/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/component-model-configuration/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/component-model-configuration/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/definitionpersistence/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/definitionpersistence/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/definitions-base36/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/definitions-base36/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/definitions-emoji/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/definitions-emoji/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/multisite/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/multisite/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/resourceloader/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/resourceloader/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/resources/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/resources/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/site-builder-api/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/site-builder-api/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/site-wp/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/site-wp/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/site/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/site/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/spa/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/spa/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/SiteBuilder/packages/static-site-generator/phpcs.xml.dist
+++ b/layers/SiteBuilder/packages/static-site-generator/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/comment-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/comment-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/contactus-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/contactus-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/contactuser-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/contactuser-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/custompost-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/custompost-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/custompostlink-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/custompostlink-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/flag-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/flag-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/form-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/form-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/gravityforms-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/gravityforms-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/highlight-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/highlight-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/newsletter-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/newsletter-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/notification-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/notification-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/post-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/post-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/postlink-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/postlink-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/share-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/share-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/socialnetwork-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/socialnetwork-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/stance-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/stance-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/system-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/system-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/user-state-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/user-state-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/layers/Wassup/packages/volunteer-mutations/phpcs.xml.dist
+++ b/layers/Wassup/packages/volunteer-mutations/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,7 +4,6 @@
     <arg value="p" />
 
     <config name="ignore_warnings_on_exit" value="1" />
-    <config name="ignore_errors_on_exit" value="1" />
 
     <!-- Don't show a warning on the line length -->
     <rule ref="Generic.Files.LineLength.MaxExceeded">

--- a/src/Config/Rector/Downgrade/Configurators/AbstractContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/AbstractContainerConfigurationService.php
@@ -13,6 +13,6 @@ abstract class AbstractContainerConfigurationService
         protected string $rootDirectory,
     ) {
     }
-    
+
     abstract public function configureContainer(): void;
 }

--- a/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
@@ -28,14 +28,14 @@ abstract class AbstractDowngradeContainerConfigurationService extends AbstractCo
          * Replace the current `DowngradeParameterTypeWideningRector` (because it takes too long)
          * with a "legacy" version (from up to v0.10.9), which is fast
          * but does not replace code within traits.
-         * 
+         *
          * To make up, the hack below manually fixes the code within traits.
-         * 
+         *
          * @see https://github.com/leoloso/PoP/issues/715
          */
         // $this->containerConfigurator->import(DowngradeSetList::PHP_72);
         $this->containerConfigurator->import(CustomDowngradeSetList::PHP_72);
-        
+
         /**
          * Hack to fix bug.
          *
@@ -66,7 +66,7 @@ abstract class AbstractDowngradeContainerConfigurationService extends AbstractCo
             ]]);
 
         $parameters = $this->containerConfigurator->parameters();
-        
+
         // is your PHP version different from the one your refactor to? [default: your PHP version]
         $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_71);
 
@@ -88,7 +88,8 @@ abstract class AbstractDowngradeContainerConfigurationService extends AbstractCo
     /**
      * @return string[]
      */
-    protected function getBootstrapFiles(): array {
+    protected function getBootstrapFiles(): array
+    {
         return [
             $this->rootDirectory . '/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php',
         ];
@@ -97,7 +98,8 @@ abstract class AbstractDowngradeContainerConfigurationService extends AbstractCo
     /**
      * @return string[]
      */
-    protected function getSkip(): array {
+    protected function getSkip(): array
+    {
         return [
             // Skip tests
             '*/tests/*',

--- a/src/Config/Rector/Downgrade/Configurators/ChainedRules/AbstractArrowFnMixedTypeChainedRuleContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/ChainedRules/AbstractArrowFnMixedTypeChainedRuleContainerConfigurationService.php
@@ -10,10 +10,10 @@ use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeMixedTypeDeclarationRecto
  * Hack to fix bug.
  *
  * `fn(mixed $foo)` requires 2 steps to be downgraded:
- * 
+ *
  *   1. function(mixed $foo)
  *   2. function($foo)
- * 
+ *
  * Because of chained rules not taking place, manually execute the 2nd rule
  */
 abstract class AbstractArrowFnMixedTypeChainedRuleContainerConfigurationService extends AbstractChainedRuleContainerConfigurationService

--- a/src/Config/Rector/Downgrade/Configurators/ChainedRules/AbstractArrowFnUnionTypeChainedRuleContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/ChainedRules/AbstractArrowFnUnionTypeChainedRuleContainerConfigurationService.php
@@ -10,10 +10,10 @@ use Rector\DowngradePhp80\Rector\FunctionLike\DowngradeUnionTypeDeclarationRecto
  * Hack to fix bug.
  *
  * `fn(int | string $foo)` requires 2 steps to be downgraded:
- * 
+ *
  *   1. function(int | string $foo)
  *   2. function($foo)
- * 
+ *
  * Because of chained rules not taking place, manually execute the 2nd rule
  */
 abstract class AbstractArrowFnUnionTypeChainedRuleContainerConfigurationService extends AbstractChainedRuleContainerConfigurationService

--- a/src/Config/Rector/Downgrade/Configurators/ChainedRules/AbstractChainedRuleContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/ChainedRules/AbstractChainedRuleContainerConfigurationService.php
@@ -30,8 +30,8 @@ abstract class AbstractChainedRuleContainerConfigurationService extends Abstract
 
         $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_71);
         $parameters->set(Option::AUTO_IMPORT_NAMES, false);
-        $parameters->set(Option::IMPORT_SHORT_CLASSES, false); 
-        
+        $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+
         $parameters->set(Option::PATHS, $this->getPaths());
     }
 

--- a/src/Config/Rector/Downgrade/Configurators/ChainedRules/GraphQLAPIArrowFnMixedTypeChainedRuleContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/ChainedRules/GraphQLAPIArrowFnMixedTypeChainedRuleContainerConfigurationService.php
@@ -9,7 +9,7 @@ use PoP\PoP\Config\Rector\Downgrade\Configurators\GraphQLAPIContainerConfigurati
 class GraphQLAPIArrowFnMixedTypeChainedRuleContainerConfigurationService extends AbstractPluginArrowFnMixedTypeChainedRuleContainerConfigurationService
 {
     use GraphQLAPIContainerConfigurationServiceTrait;
-    
+
     protected function getPaths(): array
     {
         return [

--- a/src/Config/Rector/Downgrade/Configurators/ChainedRules/GraphQLAPIArrowFnUnionTypeChainedRuleContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/ChainedRules/GraphQLAPIArrowFnUnionTypeChainedRuleContainerConfigurationService.php
@@ -9,7 +9,7 @@ use PoP\PoP\Config\Rector\Downgrade\Configurators\GraphQLAPIContainerConfigurati
 class GraphQLAPIArrowFnUnionTypeChainedRuleContainerConfigurationService extends AbstractPluginArrowFnUnionTypeChainedRuleContainerConfigurationService
 {
     use GraphQLAPIContainerConfigurationServiceTrait;
-    
+
     protected function getPaths(): array
     {
         return [

--- a/src/Config/Rector/Downgrade/Configurators/ChainedRules/GraphQLAPICacheItemChainedRuleContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/ChainedRules/GraphQLAPICacheItemChainedRuleContainerConfigurationService.php
@@ -9,7 +9,7 @@ use PoP\PoP\Config\Rector\Downgrade\Configurators\GraphQLAPIContainerConfigurati
 class GraphQLAPICacheItemChainedRuleContainerConfigurationService extends AbstractPluginCacheItemChainedRuleContainerConfigurationService
 {
     use GraphQLAPIContainerConfigurationServiceTrait;
-    
+
     protected function getPaths(): array
     {
         return [

--- a/src/Config/Rector/Downgrade/Configurators/GraphQLAPIContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/GraphQLAPIContainerConfigurationService.php
@@ -7,7 +7,7 @@ namespace PoP\PoP\Config\Rector\Downgrade\Configurators;
 class GraphQLAPIContainerConfigurationService extends AbstractPluginDowngradeContainerConfigurationService
 {
     use GraphQLAPIContainerConfigurationServiceTrait;
-    
+
     public function configureContainer(): void
     {
         parent::configureContainer();
@@ -42,14 +42,14 @@ class GraphQLAPIContainerConfigurationService extends AbstractPluginDowngradeCon
                 //   "vendor/pop-schema/pages/src/ConditionalOnComponent/RESTAPI/RouteModuleProcessors/EntryRouteModuleProcessor.php" file, due to:
                 //   "Analyze error: "Class PoP\RESTAPI\RouteModuleProcessors\AbstractRESTEntryRouteModuleProcessor not found."
                 '*/ConditionalOnComponent/RESTAPI/*',
-    
+
                 // Even when downgrading all packages, skip Symfony's polyfills
                 $this->pluginDir . '/vendor/symfony/polyfill-*',
-    
+
                 // Skip since they are not needed and they fail
                 $this->pluginDir . '/vendor/composer/*',
                 $this->pluginDir . '/vendor/boxuk/wp-muplugin-loader/*',
-    
+
                 // These are skipped in the .sh since it's faster
                 // // All the "migrate" folders
                 // $this->pluginDir . '/vendor/getpop/migrate-*/*',
@@ -59,7 +59,7 @@ class GraphQLAPIContainerConfigurationService extends AbstractPluginDowngradeCon
                 // $this->pluginDir . '/vendor/getpop/*/tests/*',
                 // $this->pluginDir . '/vendor/pop-schema/*/tests/*',
                 // $this->pluginDir . '/vendor/graphql-by-pop/*/tests/*',
-    
+
                 // Ignore errors from classes we don't have in our environment,
                 // or that come from referencing a class present in DEV, not PROD
                 $this->pluginDir . '/vendor/symfony/cache/Adapter/MemcachedAdapter.php',

--- a/src/Config/Symplify/MonorepoBuilder/Configurators/ContainerConfigurationService.php
+++ b/src/Config/Symplify/MonorepoBuilder/Configurators/ContainerConfigurationService.php
@@ -24,7 +24,7 @@ class ContainerConfigurationService
         protected string $rootDirectory,
     ) {
     }
-    
+
     public function configureContainer(): void
     {
         $parameters = $this->containerConfigurator->parameters();
@@ -129,32 +129,32 @@ class ContainerConfigurationService
     {
         return new PackageOrganizationDataSource($this->rootDirectory);
     }
-    
+
     protected function getPluginDataSource(): ?PluginDataSource
     {
         return new PluginDataSource($this->rootDirectory);
     }
-    
+
     protected function getDowngradeRectorDataSource(): ?DowngradeRectorDataSource
     {
         return new DowngradeRectorDataSource($this->rootDirectory);
     }
-    
+
     protected function getEnvironmentVariablesDataSource(): ?EnvironmentVariablesDataSource
     {
         return new EnvironmentVariablesDataSource();
     }
-    
+
     protected function getPHPStanDataSource(): ?PHPStanDataSource
     {
         return new PHPStanDataSource();
     }
-    
+
     protected function getDataToAppendAndRemoveDataSource(): ?DataToAppendAndRemoveDataSource
     {
         return new DataToAppendAndRemoveDataSource();
     }
-    
+
     protected function getReleaseWorkersDataSource(): ?ReleaseWorkersDataSource
     {
         return new ReleaseWorkersDataSource();

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
@@ -18,7 +18,7 @@ class DataToAppendAndRemoveDataSource
             ],
             'autoload' => [
                 'psr-4' => [
-                    'PoP\\PoP\\'=> 'src',
+                    'PoP\\PoP\\' => 'src',
                 ],
             ],
             // 'extra' => [

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/DowngradeRectorDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/DowngradeRectorDataSource.php
@@ -7,7 +7,7 @@ namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
 class DowngradeRectorDataSource
 {
     public function __construct(protected string $rootDir)
-    {        
+    {
     }
 
     /**

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PackageOrganizationDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PackageOrganizationDataSource.php
@@ -7,7 +7,7 @@ namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
 class PackageOrganizationDataSource
 {
     public function __construct(protected string $rootDir)
-    {        
+    {
     }
 
     /**

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -7,7 +7,7 @@ namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
 class PluginDataSource
 {
     public function __construct(protected string $rootDir)
-    {        
+    {
     }
 
     /**

--- a/src/Extensions/Rector/DowngradePhp72/Rector/ClassMethod/LegacyDowngradeParameterTypeWideningRector.php
+++ b/src/Extensions/Rector/DowngradePhp72/Rector/ClassMethod/LegacyDowngradeParameterTypeWideningRector.php
@@ -74,8 +74,9 @@ class C implements A
     public function test(array $input){}
 }
 CODE_SAMPLE
-            ),
-            ]);
+                ),
+            ]
+        );
     }
 
     /**
@@ -243,7 +244,7 @@ CODE_SAMPLE
         if ($classReflection->isTrait()) {
             return;
         }
-        
+
         $classMethod = $classLike->getMethod($classMethodName);
         if ($classMethod === null) {
             return;

--- a/src/Extensions/Rector/Set/ValueObject/CustomDowngradeSetList.php
+++ b/src/Extensions/Rector/Set/ValueObject/CustomDowngradeSetList.php
@@ -10,7 +10,7 @@ use Rector\Set\Contract\SetListInterface;
  * Replace the current `DowngradeParameterTypeWideningRector` (because it takes too long)
  * with a "legacy" version (from up to v0.10.9), which is fast
  * but does not replace code within traits.
- * 
+ *
  * @see https://github.com/leoloso/PoP/issues/715
  */
 final class CustomDowngradeSetList implements SetListInterface

--- a/src/Extensions/Rector/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationInTraitRector.php
+++ b/src/Extensions/Rector/TypeDeclaration/Rector/ClassMethod/AddParamTypeDeclarationInTraitRector.php
@@ -68,7 +68,7 @@ trait SomeTrait
     }
 }
 CODE_SAMPLE
-,
+                ,
                 <<<'CODE_SAMPLE'
 trait SomeTrait
 {
@@ -77,7 +77,7 @@ trait SomeTrait
     }
 }
 CODE_SAMPLE
-            ,
+                ,
                 $configuration
             ),
         ]);

--- a/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Command/SourcePackagesCommand.php
@@ -65,7 +65,7 @@ final class SourcePackagesCommand extends AbstractSymplifyCommand
     {
         $asJSON = (bool) $input->getOption(Option::JSON);
         $psr4Only = (bool) $input->getOption(Option::PSR4_ONLY);
-        
+
         // If --skip-unmigrated, fetch the list of failing unmigrated packages
         $skipUnmigrated = (bool) $input->getOption(Option::SKIP_UNMIGRATED);
         $packagesToSkip = $skipUnmigrated ? $this->unmigratedFailingPackages : [];

--- a/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
+++ b/src/Extensions/Symplify/MonorepoBuilder/Json/SourcePackagesProvider.php
@@ -50,7 +50,7 @@ final class SourcePackagesProvider
             $packages,
             $packagesToSkip
         ));
-        
+
         // If provided, filter the packages to the ones containing
         // the list of files. Useful to launch GitHub runners to split modified packages only
         if ($fileListFilter !== []) {


### PR DESCRIPTION
It was not throwing errors on GitHub Actions, because `phpcs.xml.dist` had this configuration:

```xml
<config name="ignore_errors_on_exit" value="1" />
```

Removed now, and fixed all issues.