### PR TITLE
Install the SaFly Curl Patch plugin in the Lando webservers

### DIFF
--- a/webservers/graphql-api-for-wp/setup/install-safly-curl-patch.sh
+++ b/webservers/graphql-api-for-wp/setup/install-safly-curl-patch.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+#Fix for https://github.com/lando/lando/issues/2913
+cd /tmp
+curl -O https://downloads.wordpress.org/plugin/safly-curl-patch.1.0.0.zip
+unzip safly-curl-patch.1.0.0.zip
+mv safly-curl-patch /app/wordpress/wp-content/plugins/
+wp plugin activate safly-curl-patch --path=/app/wordpress

--- a/webservers/graphql-api-for-wp/setup/install-safly-curl-patch.sh
+++ b/webservers/graphql-api-for-wp/setup/install-safly-curl-patch.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 #Fix for https://github.com/lando/lando/issues/2913
+echo "Downloading and installing SaFly Curl Patch"
 cd /tmp
 curl -O https://downloads.wordpress.org/plugin/safly-curl-patch.1.0.0.zip
 unzip safly-curl-patch.1.0.0.zip

--- a/webservers/graphql-api-for-wp/setup/setup.sh
+++ b/webservers/graphql-api-for-wp/setup/setup.sh
@@ -8,5 +8,6 @@ echo "Installing WordPress..."
 /bin/sh /app/setup/install.sh
 /bin/sh /app/setup/configure.sh
 /bin/sh /app/setup/fix-install.sh
+/bin/sh /app/setup/install-safly-curl-patch.sh
 /bin/sh /app/setup/activate-plugins.sh
 /bin/sh /app/setup/import-data.sh

--- a/webservers/graphql-by-pop/setup/install-safly-curl-patch.sh
+++ b/webservers/graphql-by-pop/setup/install-safly-curl-patch.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+#Fix for https://github.com/lando/lando/issues/2913
+cd /tmp
+curl -O https://downloads.wordpress.org/plugin/safly-curl-patch.1.0.0.zip
+unzip safly-curl-patch.1.0.0.zip
+mv safly-curl-patch /app/wordpress/wp-content/plugins/
+wp plugin activate safly-curl-patch --path=/app/wordpress

--- a/webservers/graphql-by-pop/setup/install-safly-curl-patch.sh
+++ b/webservers/graphql-by-pop/setup/install-safly-curl-patch.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 #Fix for https://github.com/lando/lando/issues/2913
+echo "Downloading and installing SaFly Curl Patch"
 cd /tmp
 curl -O https://downloads.wordpress.org/plugin/safly-curl-patch.1.0.0.zip
 unzip safly-curl-patch.1.0.0.zip

--- a/webservers/graphql-by-pop/setup/setup.sh
+++ b/webservers/graphql-by-pop/setup/setup.sh
@@ -8,4 +8,5 @@ echo "Installing WordPress..."
 /bin/sh /app/setup/install.sh
 /bin/sh /app/setup/configure.sh
 /bin/sh /app/setup/load-custom-code.sh
+/bin/sh /app/setup/install-safly-curl-patch.sh
 /bin/sh /app/setup/activate-plugins.sh


### PR DESCRIPTION
WordPress plugin: https://wordpress.org/plugins/safly-curl-patch

It fixes issue: https://github.com/lando/lando/issues/2913

The problem is somehow related to IPv6 and Docker, where (at least in my dev environment) the WordPress site can't connect to downloads.wordpress.org. The problem is described here: https://wordpress.org/support/topic/error-wordpress-could-not-establish-a-secure-connection-to-wordpress-org/, and the plugin solves the issue.