### PR TITLE
Use `time()` as base timestamp, instead of `0`, to avoid bug from cached stale service container

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
@@ -18,11 +18,29 @@ class UserSettingsManager implements UserSettingsManagerInterface
 
     /**
      * Timestamp of latest executed write to DB, concerning plugin activation,
-     * module enabled/disabled, user settings updated
+     * module enabled/disabled, user settings updated.
+     * 
+     * If there is not timestamp yet, then we just installed the plugin.
+     * 
+     * In that case, we must return a random `time()` timestamp and not
+     * a fixed value such as `0`, because the service container
+     * will be generated on each interaction with WordPress,
+     * including WP-CLI.
+     * 
+     * Using `0` as the default value, when installing the plugin
+     * and an extension via WP-CLI (before accessing wp-admin)
+     * it will throw errors, because after installing the main plugin
+     * the container cache is generated and cached with timestamp `0`,
+     * and it would be loaded again when installing the extension,
+     * however the cache does not contain the services from the extension.
+     * 
+     * By providing `time()`, the cached service container is always
+     * a one-time-use before accessing the wp-admin and
+     * having a new timestamp generated via `regenerateTimestamp`.
      */
     public function getTimestamp(): int
     {
-        return (int) \get_option(Options::TIMESTAMP, 0);
+        return (int) \get_option(Options::TIMESTAMP, time());
     }
     /**
      * Store the current time to indicate the latest executed write to DB,


### PR DESCRIPTION
If there is not `graphql-api-timestamp` entry yet in `wp_option`, then we just installed the GraphQL API plugin.

In that case, we must return a random `time()` timestamp and not a fixed value such as `"0"` in `UserSettingsManager.getTimestamp()`, because the service container will be generated on each interaction with WordPress, including WP-CLI.

Using `"0"` as the default value, when installing the plugin and an extension via WP-CLI (before accessing wp-admin) it will throw errors, because after installing the main plugin the container cache is generated and cached with timestamp `"0"`, and it would be loaded again when installing the extension, however the cache does not contain the services from the extension.

By providing `time()`, the cached service container is always a one-time-use before accessing the wp-admin and having a new timestamp generated via `regenerateTimestamp`. 