### PR TITLE
Purge service container cache

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -243,7 +243,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin
                 \flush_rewrite_rules();
 
                 // Regenerate the timestamp, to generate the service container
-                $this->regenerateTimestamp();
+                $this->regenerateServiceContainer();
             },
             PluginLifecyclePriorities::HANDLE_NEW_ACTIVATIONS
         );

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 use GraphQLAPI\GraphQLAPI\Facades\Registries\CustomPostTypeRegistryFacade;
-use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\CustomPostTypeInterface;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
+use GraphQLAPI\GraphQLAPI\PluginManagement\MainPluginManager;
+use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\CustomPostTypeInterface;
 use PoP\Engine\AppLoader;
+use Symfony\Component\Filesystem\Filesystem;
 
 abstract class AbstractPlugin
 {
@@ -196,10 +198,16 @@ abstract class AbstractPlugin
     }
 
     /**
-     * Regenerate the timestamp
+     * Remove the cache, and regenerate the timestamp
      */
-    protected function regenerateTimestamp(): void
+    protected function regenerateServiceContainer(): void
     {
+        // Remove the cache
+        $mainPluginCacheDir = (string) MainPluginManager::getConfig('cache-dir');
+        $fileSystem = new Filesystem();
+        $fileSystem->remove([$mainPluginCacheDir]);
+
+        // Regenerate the timestamp
         $userSettingsManager = UserSettingsManagerFacade::getInstance();
         $userSettingsManager->storeTimestamp();
     }
@@ -289,7 +297,7 @@ abstract class AbstractPlugin
 
         $this->unregisterPluginCustomPostTypes();
 
-        $this->regenerateTimestamp();
+        $this->regenerateServiceContainer();
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -198,7 +198,8 @@ abstract class AbstractPlugin
     }
 
     /**
-     * Remove the cache, and regenerate the timestamp
+     * Remove the service container cache (and also the config),
+     * and regenerate the timestamp
      */
     protected function regenerateServiceContainer(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
@@ -36,7 +36,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      * 
      * By providing `time()`, the cached service container is always
      * a one-time-use before accessing the wp-admin and
-     * having a new timestamp generated via `regenerateTimestamp`.
+     * having a new timestamp generated via `regenerateServiceContainer`.
      */
     public function getTimestamp(): int
     {


### PR DESCRIPTION
Whenever regenerating the timestamp, also purge the stale `cache` folder.