### PR TITLE
Delete specific cache folders, and do it when ANY plugin is activated/deactivated

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 use Exception;
+use GraphQLAPI\GraphQLAPI\Facades\CacheConfigurationManagerFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\GraphQLAPI\PluginEnvironment;
 use GraphQLAPI\GraphQLAPI\PluginManagement\ExtensionManager;
 use GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractPlugin;
 use PoP\Engine\AppLoader;
 use PoP\Root\Environment as RootEnvironment;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Filesystem\Filesystem;
 
 abstract class AbstractMainPlugin extends AbstractPlugin
 {
@@ -85,6 +88,58 @@ abstract class AbstractMainPlugin extends AbstractPlugin
     }
 
     /**
+     * Remove the service container (and config) cache,
+     * and regenerate the timestamp
+     */
+    protected function invalidateCache(): void
+    {
+        $this->removeCachedFolders();
+
+        // Regenerate the timestamp
+        $userSettingsManager = UserSettingsManagerFacade::getInstance();
+        $userSettingsManager->storeTimestamp();
+    }
+
+    /**
+     * Remove the cached folders:
+     * 
+     * - Service Container
+     * - Config
+     * 
+     * Because the parent `cache` folder can be set by the user,
+     * we can't directly remove that one. (Otherwise, setting it
+     * to wp-content would completely remove this folder!)
+     */
+    protected function removeCachedFolders(): void
+    {
+        $fileSystem = new Filesystem();
+
+        // Service Container
+        [
+            $cacheContainerConfiguration,
+            $containerConfigurationCacheNamespace,
+            $containerConfigurationCacheDirectory
+        ] = $this->pluginConfiguration->getContainerCacheConfiguration();
+        if ($cacheContainerConfiguration) {
+            try {
+                $fileSystem->remove($containerConfigurationCacheDirectory);
+            } catch (IOExceptionInterface) {
+                // If the folder does not exist, do nothing
+            }
+        }
+
+        // Config
+        $cacheConfigurationManager = CacheConfigurationManagerFacade::getInstance();
+        if ($serviceContainerDir = $cacheConfigurationManager->getDirectory()) {
+            try {
+                $fileSystem->remove($serviceContainerDir);
+            } catch (IOExceptionInterface) {
+                // If the folder does not exist, do nothing
+            }
+        }
+    }
+
+    /**
      * Remove permalinks when deactivating the plugin
      *
      * @see https://developer.wordpress.org/plugins/plugin-basics/activation-deactivation-hooks/
@@ -121,6 +176,17 @@ abstract class AbstractMainPlugin extends AbstractPlugin
     public function setup(): void
     {
         parent::setup();
+
+        /**
+         * When activating/deactivating ANY plugin (either from GraphQL API
+         * or 3rd-parties), the cached service container and the config
+         * must be dumped, so that they can be regenerated.
+         * 
+         * This way, extensions depending on 3rd-party plugins
+         * can have their functionality automatically enabled/disabled.
+         */
+        \add_action('activate_plugin', [$this, 'invalidateCache']);
+        \add_action('deactivate_plugin', [$this, 'invalidateCache']);
 
         /**
          * PoP depends on hook "init" to set-up the endpoint rewrite,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -88,7 +88,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin
     }
 
     /**
-     * Remove the service container (and config) cache,
+     * Remove the cached folders (service container and config),
      * and regenerate the timestamp
      */
     protected function invalidateCache(): void
@@ -106,9 +106,9 @@ abstract class AbstractMainPlugin extends AbstractPlugin
      * - Service Container
      * - Config
      * 
-     * Because the parent `cache` folder can be set by the user,
-     * we can't directly remove that one. (Otherwise, setting it
-     * to wp-content would completely remove this folder!)
+     * Because the parent cache folder (defined under 'cache-dir')
+     * can be set by the user, we can't directly remove that one.
+     * Otherwise, setting it to "wp-content" would remove this folder!
      */
     protected function removeCachedFolders(): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -88,6 +88,20 @@ abstract class AbstractMainPlugin extends AbstractPlugin
     }
 
     /**
+     * When activating/deactivating ANY plugin (either from GraphQL API
+     * or 3rd-parties), the cached service container and the config
+     * must be dumped, so that they can be regenerated.
+     * 
+     * This way, extensions depending on 3rd-party plugins
+     * can have their functionality automatically enabled/disabled.
+     */
+    public function handleAnyPluginActivatedOrDeactivated(): void
+    {
+        $this->invalidateCache();
+    }
+    
+
+    /**
      * Remove the cached folders (service container and config),
      * and regenerate the timestamp
      */
@@ -185,8 +199,8 @@ abstract class AbstractMainPlugin extends AbstractPlugin
          * This way, extensions depending on 3rd-party plugins
          * can have their functionality automatically enabled/disabled.
          */
-        \add_action('activate_plugin', [$this, 'invalidateCache']);
-        \add_action('deactivate_plugin', [$this, 'invalidateCache']);
+        \add_action('activate_plugin', [$this, 'handleAnyPluginActivatedOrDeactivated']);
+        \add_action('deactivate_plugin', [$this, 'handleAnyPluginActivatedOrDeactivated']);
 
         /**
          * PoP depends on hook "init" to set-up the endpoint rewrite,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\PluginSkeleton;
 
 use GraphQLAPI\GraphQLAPI\Facades\Registries\CustomPostTypeRegistryFacade;
-use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
-use GraphQLAPI\GraphQLAPI\PluginManagement\MainPluginManager;
 use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\CustomPostTypeInterface;
 use PoP\Engine\AppLoader;
-use Symfony\Component\Filesystem\Filesystem;
 
 abstract class AbstractPlugin
 {
@@ -198,23 +195,6 @@ abstract class AbstractPlugin
     }
 
     /**
-     * Remove the service container (and config) cache,
-     * and regenerate the timestamp
-     */
-    protected function invalidateCache(): void
-    {
-        // The Service Container cache is generated always, so remove it always
-        // This folder may also contain the config cache (if enabled), remove it too
-        $mainPluginCacheDir = (string) MainPluginManager::getConfig('cache-dir');
-        $fileSystem = new Filesystem();
-        $fileSystem->remove([$mainPluginCacheDir]);
-
-        // Regenerate the timestamp
-        $userSettingsManager = UserSettingsManagerFacade::getInstance();
-        $userSettingsManager->storeTimestamp();
-    }
-
-    /**
      * Remove the CPTs from the DB
      */
     protected function unregisterPluginCustomPostTypes(): void
@@ -299,7 +279,12 @@ abstract class AbstractPlugin
 
         $this->unregisterPluginCustomPostTypes();
 
-        $this->invalidateCache();
+        /**
+         * No need to invalidate the cache here anymore,
+         * since AbstractMainPlugin already invalidates it
+         * for ANY deactivated plugin.
+         */
+        // $this->invalidateCache();
     }
 
     /**


### PR DESCRIPTION
This PR handles 2 issues:

- It removes the cache folder whenever ANY plugin is activated/deactivated.
- It removes the specific folders `cache/service-containers` and `cache/config-via-symfony-cache` instead of `cache`, since this folder can be overridden, and setting it to `wp-content` would remove this folder!

This PR is related to #795 and #741, and it makes #742 not needed anymore.