### PR TITLE
Add metadirectives to schema

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -492,7 +492,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
     /**
      * By default, a directive can be executed only one time for "Schema" and "System"
      * type directives (eg: <translate(en,es),translate(es,en)>),
-     * and many times for the other types, "Query" and "Scripting"
+     * and many times for the other types, "Query", "Scripting" and "Indexing"
      */
     public function isRepeatable(): bool
     {

--- a/layers/Engine/packages/component-model/src/Directives/DirectiveTypes.php
+++ b/layers/Engine/packages/component-model/src/Directives/DirectiveTypes.php
@@ -10,4 +10,5 @@ class DirectiveTypes
     const QUERY = 'query';
     const SYSTEM = 'system';
     const SCRIPTING = 'scripting';
+    const INDEXING = 'indexing';
 }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AdvancePointerInArrayDirectiveResolver.php
@@ -18,12 +18,9 @@ class AdvancePointerInArrayDirectiveResolver extends AbstractApplyNestedDirectiv
         return 'advancePointerInArray';
     }
 
-    /**
-     * This is a "Scripting" type directive
-     */
     public function getDirectiveType(): string
     {
-        return DirectiveTypes::SCRIPTING;
+        return DirectiveTypes::INDEXING;
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
@@ -21,12 +21,9 @@ class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayItems
         return 'forEach';
     }
 
-    /**
-     * This is a "Scripting" type directive
-     */
     public function getDirectiveType(): string
     {
-        return DirectiveTypes::SCRIPTING;
+        return DirectiveTypes::INDEXING;
     }
 
     public function getSchemaDirectiveDescription(TypeResolverInterface $typeResolver): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Enums/DirectiveTypeEnum.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Enums/DirectiveTypeEnum.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\Enums;
 
+use GraphQLByPoP\GraphQLQuery\ComponentConfiguration;
 use PoP\ComponentModel\Enums\AbstractEnum;
 use PoP\ComponentModel\Directives\DirectiveTypes;
 
@@ -22,9 +23,14 @@ class DirectiveTypeEnum extends AbstractEnum
     }
     public function getCoreValues(): ?array
     {
-        return [
-            DirectiveTypes::QUERY,
-            DirectiveTypes::SCHEMA,
-        ];
+        return array_merge(
+            [
+                DirectiveTypes::QUERY,
+                DirectiveTypes::SCHEMA,
+            ],
+            ComponentConfiguration::enableComposableDirectives() ? [
+                DirectiveTypes::INDEXING,
+            ] : [],
+        );
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/Extensions/FilterSystemDirectiveSchemaFieldResolver.php
@@ -67,10 +67,6 @@ class FilterSystemDirectiveSchemaFieldResolver extends SchemaFieldResolver
                             SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_ENUM,
                             SchemaDefinition::ARGNAME_IS_ARRAY => true,
                             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Include only directives of provided types', 'graphql-api'),
-                            // SchemaDefinition::ARGNAME_MANDATORY => true,
-                            // SchemaDefinition::ARGNAME_DEFAULT_VALUE => [
-                            //     DirectiveTypes::QUERY,
-                            // ],
                             SchemaDefinition::ARGNAME_ENUM_NAME => $directiveTypeEnum->getName(),
                             SchemaDefinition::ARGNAME_ENUM_VALUES => SchemaHelpers::convertToSchemaFieldArgEnumValueDefinitions(
                                 $directiveTypeEnum->getValues()

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Directive.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Directive.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\ObjectModels;
 
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\ComponentModel\Schema\SchemaDefinition;
+use GraphQLByPoP\GraphQLQuery\ComponentConfiguration;
 use GraphQLByPoP\GraphQLServer\ObjectModels\DirectiveLocations;
-use PoP\ComponentModel\Directives\DirectiveTypes;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasArgsSchemaDefinitionReferenceTrait;
+use PoP\ComponentModel\Directives\DirectiveTypes;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\State\ApplicationState;
 
 class Directive extends AbstractSchemaDefinitionReferenceObject
 {
@@ -35,11 +36,15 @@ class Directive extends AbstractSchemaDefinitionReferenceObject
         $directiveType = $this->schemaDefinition[SchemaDefinition::ARGNAME_DIRECTIVE_TYPE];
         $vars = ApplicationState::getVars();
         /**
-         * There are 2 cases for adding the "Query" type locations:
+         * There are 3 cases for adding the "Query" type locations:
          * 1. When the type is "Query"
          * 2. When the type is "Schema" and we are editing the query on the back-end (as to replace the lack of SDL)
+         * 3. When the type is "Indexing" and composable directives are enabled
          */
-        if ($directiveType == DirectiveTypes::QUERY || ($directiveType == DirectiveTypes::SCHEMA && isset($vars['edit-schema']) && $vars['edit-schema'])) {
+        if ($directiveType == DirectiveTypes::QUERY
+            || ($directiveType == DirectiveTypes::SCHEMA && isset($vars['edit-schema']) && $vars['edit-schema'])
+            || ($directiveType == DirectiveTypes::INDEXING && ComponentConfiguration::enableComposableDirectives())
+        ) {
             // Same DirectiveLocations as used by "@skip": https://graphql.github.io/graphql-spec/draft/#sec--skip
             $directives = array_merge(
                 $directives,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Directive.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Directive.php
@@ -41,7 +41,8 @@ class Directive extends AbstractSchemaDefinitionReferenceObject
          * 2. When the type is "Schema" and we are editing the query on the back-end (as to replace the lack of SDL)
          * 3. When the type is "Indexing" and composable directives are enabled
          */
-        if ($directiveType == DirectiveTypes::QUERY
+        if (
+            $directiveType == DirectiveTypes::QUERY
             || ($directiveType == DirectiveTypes::SCHEMA && isset($vars['edit-schema']) && $vars['edit-schema'])
             || ($directiveType == DirectiveTypes::INDEXING && ComponentConfiguration::enableComposableDirectives())
         ) {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -193,12 +193,14 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
                 }
             }
         }
-        // Remove all directives of types other than "Query" and "Schema"
-        // since GraphQL only supports these 2
+        // Remove all directives of types other than "Query", "Schema" and, maybe "Indexing"
         $supportedDirectiveTypes = [
             DirectiveTypes::SCHEMA,
             DirectiveTypes::QUERY,
         ];
+        if ($enableComposableDirectives) {
+            $supportedDirectiveTypes [] = DirectiveTypes::INDEXING;
+        }
         $directivesNamesToRemove = [];
         foreach (array_keys($this->fullSchemaDefinition[SchemaDefinition::ARGNAME_GLOBAL_DIRECTIVES]) as $directiveName) {
             if (!in_array($this->fullSchemaDefinition[SchemaDefinition::ARGNAME_GLOBAL_DIRECTIVES][$directiveName][SchemaDefinition::ARGNAME_DIRECTIVE_TYPE], $supportedDirectiveTypes)) {


### PR DESCRIPTION
Have `@forEach` and `@advancePointerInArray` not show an error in the GraphiQL client.

For that, a new directive type `"Indexing"` was introduced, in addition to `"Scripting"`, and this type is included in the schema if "composable directives" is enabled.