### PR TITLE
Register `echoStr` on runtime. For that, initialize schema on `Boot` event, instead of `BeforeBoot`

### DIFF
--- a/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionService.php
+++ b/layers/Engine/packages/component-model/src/AttachableExtensions/AttachExtensionService.php
@@ -20,7 +20,7 @@ class AttachExtensionService implements AttachExtensionServiceInterface
     }
     public function attachExtensions(string $event): void
     {
-        foreach ($this->classGroups[$event] as $group => $extensions) {
+        foreach (($this->classGroups[$event] ?? []) as $group => $extensions) {
             // Only attach the enabled thervices
             $extensions = array_filter(
                 $extensions,

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -54,6 +54,8 @@ class Component extends AbstractComponent
 
     public static function beforeBoot(): void
     {
+        parent::beforeBoot();
+
         // Initialize the Component Configuration
         ComponentConfiguration::init();
 
@@ -61,8 +63,18 @@ class Component extends AbstractComponent
         $attachExtensionService->attachExtensions(ApplicationEvents::BEFORE_BOOT);
     }
 
+    public static function boot(): void
+    {
+        parent::boot();
+
+        $attachExtensionService = AttachExtensionServiceFacade::getInstance();
+        $attachExtensionService->attachExtensions(ApplicationEvents::BOOT);
+    }
+
     public static function afterBoot(): void
     {
+        parent::afterBoot();
+
         $attachExtensionService = AttachExtensionServiceFacade::getInstance();
         $attachExtensionService->attachExtensions(ApplicationEvents::AFTER_BOOT);
     }

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/BeforeBootAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/BeforeBootAttachExtensionCompilerPass.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Container\CompilerPasses;
 
-use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
 use PoP\Root\Component\ApplicationEvents;
-use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
-use PoP\ComponentModel\FieldResolvers\FieldResolverInterface;
-use PoP\ComponentModel\TypeResolverPickers\TypeResolverPickerInterface;
 
 class BeforeBootAttachExtensionCompilerPass extends AbstractAttachExtensionCompilerPass
 {
@@ -22,10 +18,7 @@ class BeforeBootAttachExtensionCompilerPass extends AbstractAttachExtensionCompi
      */
     protected function getAttachableClassGroups(): array
     {
-        return [
-            FieldResolverInterface::class => AttachableExtensionGroups::FIELDRESOLVERS,
-            DirectiveResolverInterface::class => AttachableExtensionGroups::DIRECTIVERESOLVERS,
-            TypeResolverPickerInterface::class => AttachableExtensionGroups::TYPERESOLVERPICKERS,
-        ];
+        // Nothing to initialize
+        return [];
     }
 }

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/BootAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/BootAttachExtensionCompilerPass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Container\CompilerPasses;
+
+use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
+use PoP\Root\Component\ApplicationEvents;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\FieldResolvers\FieldResolverInterface;
+use PoP\ComponentModel\TypeResolverPickers\TypeResolverPickerInterface;
+
+class BootAttachExtensionCompilerPass extends AbstractAttachExtensionCompilerPass
+{
+    protected function getAttachExtensionEvent(): string
+    {
+        return ApplicationEvents::BOOT;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    protected function getAttachableClassGroups(): array
+    {
+        return [
+            FieldResolverInterface::class => AttachableExtensionGroups::FIELDRESOLVERS,
+            DirectiveResolverInterface::class => AttachableExtensionGroups::DIRECTIVERESOLVERS,
+            TypeResolverPickerInterface::class => AttachableExtensionGroups::TYPERESOLVERPICKERS,
+        ];
+    }
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -60,7 +60,7 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
     /**
      * Setting options
      */
-    public const OPTION_ENABLE_ADMIN_SCHEMA = 'enable-admin-schema';
+    public const OPTION_ENABLE = 'enable';
     public const OPTION_LIST_DEFAULT_LIMIT = 'list-default-limit';
     public const OPTION_LIST_MAX_LIMIT = 'list-max-limit';
     public const OPTION_ADD_TYPE_TO_CUSTOMPOST_UNION_TYPE = 'add-type-to-custompost-union-type';
@@ -470,7 +470,7 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
     {
         $defaultValues = [
             self::SCHEMA_ADMIN_SCHEMA => [
-                self::OPTION_ENABLE_ADMIN_SCHEMA => false,
+                self::OPTION_ENABLE => false,
             ],
             self::SCHEMA_CUSTOMPOSTS => [
                 self::OPTION_LIST_DEFAULT_LIMIT => 10,
@@ -546,7 +546,7 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
         $maxLimitMessagePlaceholder = \__('Maximum number of results from querying %s. Use <code>%s</code> for unlimited', 'graphql-api');
         // Do the if one by one, so that the SELECT do not get evaluated unless needed
         if ($module == self::SCHEMA_ADMIN_SCHEMA) {
-            $option = self::OPTION_ENABLE_ADMIN_SCHEMA;
+            $option = self::OPTION_ENABLE;
             $moduleSettings[] = [
                 Properties::INPUT => $option,
                 Properties::NAME => $this->getSettingOptionName(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -778,7 +778,6 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
             ])
         ) {
             $entriesTitle = \__('Settings entries', 'graphql-api');
-            $metaKeyDesc = \__('List of all the meta keys, to either allow or deny access to, when querying field <code>meta</code> on %s.', 'graphql-api');
             $headsUpDesc = sprintf(
                 \__('<strong>Heads up:</strong> Entries surrounded with <code>/</code> are evaluated as regex (regular expressions).', 'graphql-api'),
                 'option',

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -329,7 +329,7 @@ class PluginConfiguration extends AbstractMainPluginConfiguration
                 'class' => ComponentModelComponentConfiguration::class,
                 'envVariable' => ComponentModelEnvironment::ENABLE_ADMIN_SCHEMA,
                 'module' => SchemaTypeModuleResolver::SCHEMA_ADMIN_SCHEMA,
-                'option' => SchemaTypeModuleResolver::OPTION_ENABLE_ADMIN_SCHEMA,
+                'option' => SchemaTypeModuleResolver::OPTION_ENABLE,
             ],
         ];
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/config/ConditionalOnContext/EmbeddableFields/schema-services.yaml
+++ b/layers/GraphQLByPoP/packages/graphql-server/config/ConditionalOnContext/EmbeddableFields/schema-services.yaml
@@ -1,7 +1,0 @@
-services:
-    _defaults:
-        public: true
-        autowire: true
-
-    GraphQLByPoP\GraphQLServer\ConditionalOnContext\EmbeddableFields\SchemaServices\:
-        resource: '../../../src/ConditionalOnContext/EmbeddableFields/SchemaServices/*'

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Component.php
@@ -10,7 +10,6 @@ use GraphQLByPoP\GraphQLServer\Configuration\MutationSchemes;
 use GraphQLByPoP\GraphQLServer\Configuration\Request;
 use GraphQLByPoP\GraphQLServer\Environment;
 use PoP\AccessControl\ComponentConfiguration as AccessControlComponentConfiguration;
-use PoP\API\ComponentConfiguration as APIComponentConfiguration;
 use PoP\Engine\Component as EngineComponent;
 use PoP\Engine\Environment as EngineEnvironment;
 use PoP\Root\Component\AbstractComponent;
@@ -92,10 +91,7 @@ class Component extends AbstractComponent
             self::initServices(dirname(__DIR__), '/Overrides');
             self::initSchemaServices(dirname(__DIR__), $skipSchema);
 
-            // Boot conditional on having embeddable fields
-            if (APIComponentConfiguration::enableEmbeddableFields()) {
-                self::initSchemaServices(dirname(__DIR__), $skipSchema, '/ConditionalOnContext/EmbeddableFields');
-            }
+            // Boot conditionals
             if (
                 class_exists(CacheControlComponent::class)
                 && class_exists(AccessControlComponent::class)

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EchoOperatorGlobalFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/EchoOperatorGlobalFieldResolver.php
@@ -2,17 +2,29 @@
 
 declare(strict_types=1);
 
-namespace GraphQLByPoP\GraphQLServer\ConditionalOnContext\EmbeddableFields\SchemaServices\FieldResolvers;
+namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\Engine\FieldResolvers\OperatorGlobalFieldResolver;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\API\ComponentConfiguration as APIComponentConfiguration;
 
 /**
- * When Embeddable Fields is enabled, register the `echo` field
+ * When Embeddable Fields is enabled, register the `echoStr` field
  */
 class EchoOperatorGlobalFieldResolver extends OperatorGlobalFieldResolver
 {
+    /**
+     * Only use it when "embeddable fields" is enabled.
+     * 
+     * Check on runtime (not via container) since this option can be
+     * assigned to the Schema Configuration in the GraphQL API plugin.
+     */
+    public function isServiceEnabled(): bool
+    {
+        return APIComponentConfiguration::enableEmbeddableFields();
+    }
+
     /**
      * By making it not global, it gets registered on each single type.
      * Otherwise, it is not exposed in the schema


### PR DESCRIPTION
`ENABLE_EMBEDDABLE_FIELDS` must be set before the schema is generated (which happens when calling `$attachExtensionService->attachExtensions(...)` for entities `FieldResolverInterface` and others), as to add or not field `echoStr` on runtime, enabling it or not via the Schema Configuration.

Because the SchemaConfigurationExecuters are executed on the `boot` event, then the schema entities must also be initialized on the `boot` event. Then, the SchemaConfigurationExecuters are able to modify the configuration via hooks.

Also made code more DRY.