### PR TITLE
Rename `QueryExecution` to `Endpoint`

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/endpoint-options/src/index.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/endpoint-options/src/index.js
@@ -56,7 +56,7 @@ registerBlockType( 'graphql-api/endpoint-options', {
 	attributes: {
 		/**
 		 * Same attribute name as defined in
-		 * GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock::ATTRIBUTE_NAME_IS_ENABLED
+		 * GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock::ATTRIBUTE_NAME_IS_ENABLED
 		 */
 		isEnabled: {
 			type: 'boolean',

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/persisted-query-options/src/index.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/persisted-query-options/src/index.js
@@ -56,7 +56,7 @@ registerBlockType( 'graphql-api/persisted-query-options', {
 	attributes: {
 		/**
 		 * Same attribute name as defined in
-		 * GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock::ATTRIBUTE_NAME_IS_ENABLED
+		 * GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock::ATTRIBUTE_NAME_IS_ENABLED
 		 */
 		isEnabled: {
 			type: 'boolean',

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-configuration/src/index.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-configuration/src/index.js
@@ -57,7 +57,7 @@ registerBlockType( 'graphql-api/schema-configuration', {
 	attributes: {
 		/**
 		 * Same attribute name as defined in
-		 * GraphQLAPI\GraphQLAPI\Services\Blocks\SchemaConfigurationBlock::ATTRIBUTE_NAME_SCHEMA_CONFIGURATION
+		 * GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointSchemaConfigurationBlock::ATTRIBUTE_NAME_SCHEMA_CONFIGURATION
 		 */
 		schemaConfiguration: {
 			type: 'integer',

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-configuration/src/schema-configuration-meta-values.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-configuration/src/schema-configuration-meta-values.js
@@ -1,13 +1,13 @@
 /**
- * Same value as in GraphQLAPI\GraphQLAPI\Services\Blocks\SchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_DEFAULT
+ * Same value as in GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointSchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_DEFAULT
  */
 const ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_DEFAULT = 0;
 /**
- * Same value as in GraphQLAPI\GraphQLAPI\Services\Blocks\SchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_NONE
+ * Same value as in GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointSchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_NONE
  */
 const ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_NONE = -1;
 /**
- * Same value as in GraphQLAPI\GraphQLAPI\Services\Blocks\SchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_INHERIT
+ * Same value as in GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointSchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_INHERIT
  */
 const ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_INHERIT = -2;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
@@ -913,7 +913,7 @@ msgstr ""
 msgid "Cache Control for GraphQL"
 msgstr ""
 
-#: src/Services/BlockCategories/EndpointBlockCategory.php:38
+#: src/Services/BlockCategories/CustomEndpointBlockCategory.php:38
 #: src/Services/CustomPostTypes/GraphQLCustomEndpointCustomPostType.php:67
 msgid "GraphQL endpoint"
 msgstr ""

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
@@ -126,7 +126,7 @@ msgstr ""
 
 #: src/ComponentConfiguration.php:89
 #: src/Services/Blocks/AccessControlBlock.php:99
-#: src/Services/Blocks/SchemaConfigurationBlock.php:81
+#: src/Services/Blocks/EndpointSchemaConfigurationBlock.php:81
 msgid "Default"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgid "Default max-age value (in seconds) for the Cache-Control header, for all 
 msgstr ""
 
 #: src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php:98
-#: src/Services/Blocks/SchemaConfigurationBlock.php:117
+#: src/Services/Blocks/EndpointSchemaConfigurationBlock.php:117
 #: src/Services/CustomPostTypes/GraphQLSchemaConfigurationCustomPostType.php:52
 #: src/Services/ModuleTypeResolvers/ModuleTypeResolver.php:57
 msgid "Schema Configuration"
@@ -451,7 +451,7 @@ msgid "Enable to communicate the existence of some field from the schema to cert
 msgstr ""
 
 #: src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php:169
-#: src/Services/Blocks/SchemaConfigurationBlock.php:83
+#: src/Services/Blocks/EndpointSchemaConfigurationBlock.php:83
 msgid "None"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgstr ""
 msgid "(Nothing here: All Schema Configuration options are disabled)"
 msgstr ""
 
-#: src/Services/Blocks/SchemaConfigurationBlock.php:85
+#: src/Services/Blocks/EndpointSchemaConfigurationBlock.php:85
 msgid "Inherit from parent"
 msgstr ""
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
@@ -923,7 +923,7 @@ msgstr ""
 msgid "GraphQL persisted query"
 msgstr ""
 
-#: src/Services/BlockCategories/QueryExecutionBlockCategory.php:43
+#: src/Services/BlockCategories/EndpointBlockCategory.php:43
 msgid "Query execution (endpoint/persisted query)"
 msgstr ""
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/languages/graphql-api.pot
@@ -966,12 +966,12 @@ msgstr ""
 msgid "❌ No"
 msgstr ""
 
-#: src/Services/Blocks/AbstractQueryExecutionOptionsBlock.php:36
+#: src/Services/Blocks/AbstractEndpointOptionsBlock.php:36
 #: src/Services/Blocks/SchemaConfigOptionsBlock.php:119
 msgid "Options"
 msgstr ""
 
-#: src/Services/Blocks/AbstractQueryExecutionOptionsBlock.php:49
+#: src/Services/Blocks/AbstractEndpointOptionsBlock.php:49
 msgid "Enabled:"
 msgstr ""
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/CustomEndpointBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/CustomEndpointBlockCategory.php
@@ -8,7 +8,7 @@ use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\GraphQLCustomEndpointCustomPo
 
 class CustomEndpointBlockCategory extends AbstractBlockCategory
 {
-    public const ENDPOINT_BLOCK_CATEGORY = 'graphql-api-endpoint';
+    public const CUSTOM_ENDPOINT_BLOCK_CATEGORY = 'graphql-api-endpoint';
 
     /**
      * Custom Post Type for which to enable the block category
@@ -29,7 +29,7 @@ class CustomEndpointBlockCategory extends AbstractBlockCategory
      */
     protected function getBlockCategorySlug(): string
     {
-        return self::ENDPOINT_BLOCK_CATEGORY;
+        return self::CUSTOM_ENDPOINT_BLOCK_CATEGORY;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/CustomEndpointBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/CustomEndpointBlockCategory.php
@@ -6,7 +6,7 @@ namespace GraphQLAPI\GraphQLAPI\Services\BlockCategories;
 
 use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\GraphQLCustomEndpointCustomPostType;
 
-class EndpointBlockCategory extends AbstractBlockCategory
+class CustomEndpointBlockCategory extends AbstractBlockCategory
 {
     public const ENDPOINT_BLOCK_CATEGORY = 'graphql-api-endpoint';
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/EndpointBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/EndpointBlockCategory.php
@@ -10,7 +10,7 @@ use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\GraphQLCustomEndpointCustomPo
 /**
  * It comprises the endpoint and the persisted query CPTs
  */
-class QueryExecutionBlockCategory extends AbstractBlockCategory
+class EndpointBlockCategory extends AbstractBlockCategory
 {
     public const QUERY_EXECUTION_BLOCK_CATEGORY = 'graphql-api-query-exec';
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/EndpointBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/EndpointBlockCategory.php
@@ -12,7 +12,7 @@ use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\GraphQLCustomEndpointCustomPo
  */
 class EndpointBlockCategory extends AbstractBlockCategory
 {
-    public const QUERY_EXECUTION_BLOCK_CATEGORY = 'graphql-api-query-exec';
+    public const ENDPOINT_BLOCK_CATEGORY = 'graphql-api-query-exec';
 
     /**
      * Custom Post Type for which to enable the block category
@@ -36,7 +36,7 @@ class EndpointBlockCategory extends AbstractBlockCategory
      */
     protected function getBlockCategorySlug(): string
     {
-        return self::QUERY_EXECUTION_BLOCK_CATEGORY;
+        return self::ENDPOINT_BLOCK_CATEGORY;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/QueryExecutionBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/QueryExecutionBlockCategory.php
@@ -24,10 +24,10 @@ class QueryExecutionBlockCategory extends AbstractBlockCategory
         /** @var GraphQLPersistedQueryEndpointCustomPostType */
         $persistedQueryEndpointCustomPostTypeService = $this->instanceManager->getInstance(GraphQLPersistedQueryEndpointCustomPostType::class);
         /** @var GraphQLCustomEndpointCustomPostType */
-        $endpointCustomPostTypeService = $this->instanceManager->getInstance(GraphQLCustomEndpointCustomPostType::class);
+        $customEndpointCustomPostTypeService = $this->instanceManager->getInstance(GraphQLCustomEndpointCustomPostType::class);
         return [
             $persistedQueryEndpointCustomPostTypeService->getCustomPostType(),
-            $endpointCustomPostTypeService->getCustomPostType(),
+            $customEndpointCustomPostTypeService->getCustomPostType(),
         ];
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractEndpointOptionsBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractEndpointOptionsBlock.php
@@ -7,7 +7,7 @@ namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 /**
  * Query Execution (endpoint and persisted query) Options block
  */
-abstract class AbstractQueryExecutionOptionsBlock extends AbstractBlock
+abstract class AbstractEndpointOptionsBlock extends AbstractBlock
 {
     use OptionsBlockTrait;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractEndpointOptionsBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/AbstractEndpointOptionsBlock.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 
 /**
- * Query Execution (endpoint and persisted query) Options block
+ * Endpoint (custom endpoint and persisted query) Options block
  */
 abstract class AbstractEndpointOptionsBlock extends AbstractBlock
 {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointGraphiQLBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointGraphiQLBlock.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 
 use GraphQLAPI\GraphQLAPI\Services\Blocks\MainPluginBlockTrait;
-use GraphQLAPI\GraphQLAPI\Services\BlockCategories\EndpointBlockCategory;
+use GraphQLAPI\GraphQLAPI\Services\BlockCategories\CustomEndpointBlockCategory;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\ClientFunctionalityModuleResolver;
 
@@ -32,7 +32,7 @@ class EndpointGraphiQLBlock extends AbstractQueryExecutionOptionsBlock implement
 
     protected function getBlockCategoryClass(): ?string
     {
-        return EndpointBlockCategory::class;
+        return CustomEndpointBlockCategory::class;
     }
 
     protected function isDynamicBlock(): bool

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointGraphiQLBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointGraphiQLBlock.php
@@ -6,10 +6,10 @@ namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 
 use GraphQLAPI\GraphQLAPI\Services\Blocks\MainPluginBlockTrait;
 use GraphQLAPI\GraphQLAPI\Services\BlockCategories\CustomEndpointBlockCategory;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\ClientFunctionalityModuleResolver;
 
-class EndpointGraphiQLBlock extends AbstractQueryExecutionOptionsBlock implements EndpointEditorBlockServiceTagInterface
+class EndpointGraphiQLBlock extends AbstractEndpointOptionsBlock implements EndpointEditorBlockServiceTagInterface
 {
     use MainPluginBlockTrait;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointOptionsBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointOptionsBlock.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 
 use GraphQLAPI\GraphQLAPI\Services\Blocks\MainPluginBlockTrait;
-use GraphQLAPI\GraphQLAPI\Services\BlockCategories\EndpointBlockCategory;
+use GraphQLAPI\GraphQLAPI\Services\BlockCategories\CustomEndpointBlockCategory;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
 
 /**
@@ -27,6 +27,6 @@ class EndpointOptionsBlock extends AbstractQueryExecutionOptionsBlock implements
 
     protected function getBlockCategoryClass(): ?string
     {
-        return EndpointBlockCategory::class;
+        return CustomEndpointBlockCategory::class;
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointOptionsBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointOptionsBlock.php
@@ -6,12 +6,12 @@ namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 
 use GraphQLAPI\GraphQLAPI\Services\Blocks\MainPluginBlockTrait;
 use GraphQLAPI\GraphQLAPI\Services\BlockCategories\CustomEndpointBlockCategory;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock;
 
 /**
  * Endpoint Options block
  */
-class EndpointOptionsBlock extends AbstractQueryExecutionOptionsBlock implements EndpointEditorBlockServiceTagInterface
+class EndpointOptionsBlock extends AbstractEndpointOptionsBlock implements EndpointEditorBlockServiceTagInterface
 {
     use MainPluginBlockTrait;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointSchemaConfigurationBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointSchemaConfigurationBlock.php
@@ -12,7 +12,7 @@ use GraphQLAPI\GraphQLAPI\Services\BlockCategories\QueryExecutionBlockCategory;
 /**
  * SchemaConfiguration block
  */
-class SchemaConfigurationBlock extends AbstractBlock implements PersistedQueryEndpointEditorBlockServiceTagInterface, EndpointEditorBlockServiceTagInterface
+class EndpointSchemaConfigurationBlock extends AbstractBlock implements PersistedQueryEndpointEditorBlockServiceTagInterface, EndpointEditorBlockServiceTagInterface
 {
     use MainPluginBlockTrait;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointSchemaConfigurationBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointSchemaConfigurationBlock.php
@@ -7,7 +7,7 @@ namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 use GraphQLAPI\GraphQLAPI\Services\Helpers\CPTUtils;
 use GraphQLAPI\GraphQLAPI\Services\Helpers\BlockRenderingHelpers;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\EndpointFunctionalityModuleResolver;
-use GraphQLAPI\GraphQLAPI\Services\BlockCategories\QueryExecutionBlockCategory;
+use GraphQLAPI\GraphQLAPI\Services\BlockCategories\EndpointBlockCategory;
 
 /**
  * SchemaConfiguration block
@@ -36,7 +36,7 @@ class EndpointSchemaConfigurationBlock extends AbstractBlock implements Persiste
 
     protected function getBlockCategoryClass(): ?string
     {
-        return QueryExecutionBlockCategory::class;
+        return EndpointBlockCategory::class;
     }
 
     protected function isDynamicBlock(): bool

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointVoyagerBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/EndpointVoyagerBlock.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 
 use GraphQLAPI\GraphQLAPI\Services\Blocks\MainPluginBlockTrait;
-use GraphQLAPI\GraphQLAPI\Services\BlockCategories\EndpointBlockCategory;
+use GraphQLAPI\GraphQLAPI\Services\BlockCategories\CustomEndpointBlockCategory;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\ClientFunctionalityModuleResolver;
 
 class EndpointVoyagerBlock extends AbstractBlock implements EndpointEditorBlockServiceTagInterface
@@ -32,7 +32,7 @@ class EndpointVoyagerBlock extends AbstractBlock implements EndpointEditorBlockS
 
     protected function getBlockCategoryClass(): ?string
     {
-        return EndpointBlockCategory::class;
+        return CustomEndpointBlockCategory::class;
     }
 
     protected function isDynamicBlock(): bool

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryEndpointOptionsBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryEndpointOptionsBlock.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace GraphQLAPI\GraphQLAPI\Services\Blocks;
 
 use GraphQLAPI\GraphQLAPI\Services\Blocks\MainPluginBlockTrait;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock;
 use GraphQLAPI\GraphQLAPI\Services\BlockCategories\PersistedQueryEndpointBlockCategory;
 
 /**
  * Persisted Query Options block
  */
-class PersistedQueryEndpointOptionsBlock extends AbstractQueryExecutionOptionsBlock implements PersistedQueryEndpointEditorBlockServiceTagInterface
+class PersistedQueryEndpointOptionsBlock extends AbstractEndpointOptionsBlock implements PersistedQueryEndpointEditorBlockServiceTagInterface
 {
     use MainPluginBlockTrait;
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLEndpointCustomPostType.php
@@ -239,7 +239,7 @@ abstract class AbstractGraphQLEndpointCustomPostType extends AbstractCustomPostT
         return $nature;
     }
 
-    abstract protected function getQueryExecutionOptionsBlock(): AbstractEndpointOptionsBlock;
+    abstract protected function getEndpointOptionsBlock(): AbstractEndpointOptionsBlock;
 
     /**
      * Read the options block and check the value of attribute "isEnabled"
@@ -278,7 +278,7 @@ abstract class AbstractGraphQLEndpointCustomPostType extends AbstractCustomPostT
         $blockHelpers = $this->instanceManager->getInstance(BlockHelpers::class);
         return $blockHelpers->getSingleBlockOfTypeFromCustomPost(
             $postOrID,
-            $this->getQueryExecutionOptionsBlock()
+            $this->getEndpointOptionsBlock()
         );
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLEndpointCustomPostType.php
@@ -16,7 +16,7 @@ use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointSchemaConfigurationBlock;
 use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\AbstractCustomPostType;
 use GraphQLAPI\GraphQLAPI\Services\EndpointResolvers\EndpointResolverTrait;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\SchemaConfigurationFunctionalityModuleResolver;
 
 abstract class AbstractGraphQLEndpointCustomPostType extends AbstractCustomPostType
@@ -239,7 +239,7 @@ abstract class AbstractGraphQLEndpointCustomPostType extends AbstractCustomPostT
         return $nature;
     }
 
-    abstract protected function getQueryExecutionOptionsBlock(): AbstractQueryExecutionOptionsBlock;
+    abstract protected function getQueryExecutionOptionsBlock(): AbstractEndpointOptionsBlock;
 
     /**
      * Read the options block and check the value of attribute "isEnabled"
@@ -264,7 +264,7 @@ abstract class AbstractGraphQLEndpointCustomPostType extends AbstractCustomPostT
         // `true` is the default option in Gutenberg, so it's not saved to the DB!
         return $this->isOptionsBlockValueOn(
             $postOrID,
-            AbstractQueryExecutionOptionsBlock::ATTRIBUTE_NAME_IS_ENABLED,
+            AbstractEndpointOptionsBlock::ATTRIBUTE_NAME_IS_ENABLED,
             true
         );
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractGraphQLEndpointCustomPostType.php
@@ -13,7 +13,7 @@ use GraphQLAPI\GraphQLAPI\Services\Helpers\BlockHelpers;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\SchemaConfigurationBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointSchemaConfigurationBlock;
 use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\AbstractCustomPostType;
 use GraphQLAPI\GraphQLAPI\Services\EndpointResolvers\EndpointResolverTrait;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
@@ -331,9 +331,9 @@ abstract class AbstractGraphQLEndpointCustomPostType extends AbstractCustomPostT
     {
         if ($this->moduleRegistry->isModuleEnabled(SchemaConfigurationFunctionalityModuleResolver::SCHEMA_CONFIGURATION)) {
             /**
-             * @var SchemaConfigurationBlock
+             * @var EndpointSchemaConfigurationBlock
              */
-            $schemaConfigurationBlock = $this->instanceManager->getInstance(SchemaConfigurationBlock::class);
+            $schemaConfigurationBlock = $this->instanceManager->getInstance(EndpointSchemaConfigurationBlock::class);
             $template[] = [$schemaConfigurationBlock->getBlockFullName()];
         }
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLCustomEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLCustomEndpointCustomPostType.php
@@ -12,7 +12,7 @@ use GraphQLAPI\GraphQLAPI\Registries\BlockRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\EndpointBlockRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointGraphiQLBlock;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointOptionsBlock;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointVoyagerBlock;
@@ -180,7 +180,7 @@ class GraphQLCustomEndpointCustomPostType extends AbstractGraphQLEndpointCustomP
         return QueryExecutionHelpers::extractRequestedGraphQLQueryPayload();
     }
 
-    protected function getQueryExecutionOptionsBlock(): AbstractQueryExecutionOptionsBlock
+    protected function getQueryExecutionOptionsBlock(): AbstractEndpointOptionsBlock
     {
         /**
          * @var EndpointOptionsBlock

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLCustomEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLCustomEndpointCustomPostType.php
@@ -180,7 +180,7 @@ class GraphQLCustomEndpointCustomPostType extends AbstractGraphQLEndpointCustomP
         return QueryExecutionHelpers::extractRequestedGraphQLQueryPayload();
     }
 
-    protected function getQueryExecutionOptionsBlock(): AbstractEndpointOptionsBlock
+    protected function getEndpointOptionsBlock(): AbstractEndpointOptionsBlock
     {
         /**
          * @var EndpointOptionsBlock

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryEndpointCustomPostType.php
@@ -248,7 +248,7 @@ class GraphQLPersistedQueryEndpointCustomPostType extends AbstractGraphQLEndpoin
         return $this->graphQLQueryPostTypeHelpers->getGraphQLQueryPostAttributes($graphQLQueryPost, true);
     }
 
-    protected function getQueryExecutionOptionsBlock(): AbstractEndpointOptionsBlock
+    protected function getEndpointOptionsBlock(): AbstractEndpointOptionsBlock
     {
         /**
          * @var PersistedQueryEndpointOptionsBlock

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryEndpointCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/GraphQLPersistedQueryEndpointCustomPostType.php
@@ -10,7 +10,7 @@ use GraphQLAPI\GraphQLAPI\Registries\BlockRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\PersistedQueryEndpointBlockRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractQueryExecutionOptionsBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\AbstractEndpointOptionsBlock;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\PersistedQueryEndpointGraphiQLBlock;
 use GraphQLAPI\GraphQLAPI\Services\Blocks\PersistedQueryEndpointOptionsBlock;
 use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\AbstractGraphQLEndpointCustomPostType;
@@ -248,7 +248,7 @@ class GraphQLPersistedQueryEndpointCustomPostType extends AbstractGraphQLEndpoin
         return $this->graphQLQueryPostTypeHelpers->getGraphQLQueryPostAttributes($graphQLQueryPost, true);
     }
 
-    protected function getQueryExecutionOptionsBlock(): AbstractQueryExecutionOptionsBlock
+    protected function getQueryExecutionOptionsBlock(): AbstractEndpointOptionsBlock
     {
         /**
          * @var PersistedQueryEndpointOptionsBlock

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractEndpointSchemaConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractEndpointSchemaConfigurator.php
@@ -14,7 +14,7 @@ use GraphQLAPI\GraphQLAPI\Services\Helpers\BlockHelpers;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use WP_Post;
 
-abstract class AbstractQueryExecutionSchemaConfigurator implements SchemaConfiguratorInterface
+abstract class AbstractEndpointSchemaConfigurator implements SchemaConfiguratorInterface
 {
     public function __construct(
         protected InstanceManagerInterface $instanceManager,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractQueryExecutionSchemaConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/AbstractQueryExecutionSchemaConfigurator.php
@@ -9,7 +9,7 @@ use GraphQLAPI\GraphQLAPI\ModuleResolvers\EndpointFunctionalityModuleResolver;
 use GraphQLAPI\GraphQLAPI\ModuleResolvers\SchemaConfigurationFunctionalityModuleResolver;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\SchemaConfigurationExecuterRegistryInterface;
-use GraphQLAPI\GraphQLAPI\Services\Blocks\SchemaConfigurationBlock;
+use GraphQLAPI\GraphQLAPI\Services\Blocks\EndpointSchemaConfigurationBlock;
 use GraphQLAPI\GraphQLAPI\Services\Helpers\BlockHelpers;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use WP_Post;
@@ -72,9 +72,9 @@ abstract class AbstractQueryExecutionSchemaConfigurator implements SchemaConfigu
         /** @var BlockHelpers */
         $blockHelpers = $this->instanceManager->getInstance(BlockHelpers::class);
         /**
-         * @var SchemaConfigurationBlock
+         * @var EndpointSchemaConfigurationBlock
          */
-        $block = $this->instanceManager->getInstance(SchemaConfigurationBlock::class);
+        $block = $this->instanceManager->getInstance(EndpointSchemaConfigurationBlock::class);
         $schemaConfigurationBlockDataItem = $blockHelpers->getSingleBlockOfTypeFromCustomPost(
             $customPostID,
             $block
@@ -86,13 +86,13 @@ abstract class AbstractQueryExecutionSchemaConfigurator implements SchemaConfigu
             return $this->getUserSettingSchemaConfigurationID();
         }
 
-        $schemaConfiguration = $schemaConfigurationBlockDataItem['attrs'][SchemaConfigurationBlock::ATTRIBUTE_NAME_SCHEMA_CONFIGURATION] ?? null;
+        $schemaConfiguration = $schemaConfigurationBlockDataItem['attrs'][EndpointSchemaConfigurationBlock::ATTRIBUTE_NAME_SCHEMA_CONFIGURATION] ?? null;
         // Check if $schemaConfiguration is one of the meta options (default, none, inherit)
-        if ($schemaConfiguration == SchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_NONE) {
+        if ($schemaConfiguration == EndpointSchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_NONE) {
             return null;
-        } elseif ($schemaConfiguration == SchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_DEFAULT) {
+        } elseif ($schemaConfiguration == EndpointSchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_DEFAULT) {
             return $this->getUserSettingSchemaConfigurationID();
-        } elseif ($schemaConfiguration == SchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_INHERIT) {
+        } elseif ($schemaConfiguration == EndpointSchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_INHERIT) {
             // If disabled by module, then return nothing
             if (!$this->moduleRegistry->isModuleEnabled(EndpointFunctionalityModuleResolver::API_HIERARCHY)) {
                 return null;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/EndpointSchemaConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/EndpointSchemaConfigurator.php
@@ -7,10 +7,10 @@ namespace GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators;
 use GraphQLAPI\GraphQLAPI\Registries\EndpointSchemaConfigurationExecuterRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\SchemaConfigurationExecuterRegistryInterface;
-use GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators\AbstractQueryExecutionSchemaConfigurator;
+use GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators\AbstractEndpointSchemaConfigurator;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 
-class EndpointSchemaConfigurator extends AbstractQueryExecutionSchemaConfigurator
+class EndpointSchemaConfigurator extends AbstractEndpointSchemaConfigurator
 {
     public function __construct(
         InstanceManagerInterface $instanceManager,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/PersistedQueryEndpointSchemaConfigurator.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/SchemaConfigurators/PersistedQueryEndpointSchemaConfigurator.php
@@ -7,10 +7,10 @@ namespace GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators;
 use GraphQLAPI\GraphQLAPI\Registries\ModuleRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\PersistedQueryEndpointSchemaConfigurationExecuterRegistryInterface;
 use GraphQLAPI\GraphQLAPI\Registries\SchemaConfigurationExecuterRegistryInterface;
-use GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators\AbstractQueryExecutionSchemaConfigurator;
+use GraphQLAPI\GraphQLAPI\Services\SchemaConfigurators\AbstractEndpointSchemaConfigurator;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 
-class PersistedQueryEndpointSchemaConfigurator extends AbstractQueryExecutionSchemaConfigurator
+class PersistedQueryEndpointSchemaConfigurator extends AbstractEndpointSchemaConfigurator
 {
     public function __construct(
         InstanceManagerInterface $instanceManager,


### PR DESCRIPTION
Replacements done (in order):

- `SchemaConfigurationBlock` => `EndpointSchemaConfigurationBlock`
- `EndpointBlockCategory` => `CustomEndpointBlockCategory`
- `ENDPOINT_BLOCK_CATEGORY` => `CUSTOM_ENDPOINT_BLOCK_CATEGORY`
- `QueryExecutionBlockCategory` => `EndpointBlockCategory`
- `QUERY_EXECUTION_BLOCK_CATEGORY` => `ENDPOINT_BLOCK_CATEGORY`
- `AbstractQueryExecutionOptionsBlock` => `AbstractEndpointOptionsBlock`
- `getQueryExecutionOptionsBlock` => `getEndpointOptionsBlock`
- `AbstractQueryExecutionSchemaConfigurator` => `AbstractEndpointSchemaConfigurator`