### PR TITLE
If persisted query has no parent, do not show API hierarchy section in `?view=source`

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryEndpointAPIHierarchyBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryEndpointAPIHierarchyBlock.php
@@ -70,7 +70,20 @@ class PersistedQueryEndpointAPIHierarchyBlock extends AbstractBlock implements P
         // Append "-front" because this style must be used only on the client, not on the admin
         $className = $this->getBlockClassName() . '-front';
 
-        // If there are no attributes, it's because the post has no parent
+        /**
+         * If there are no attributes, it's because the post has no parent.
+         * Then show a message, that the API hierarchy is disabled.
+         * 
+         * This works at the beginning only. If the user has set a parent,
+         * and then removes it, this section will then show, even though it's not valid.
+         * 
+         * The issue is that we don't receive the postID here, so we can't check
+         * if the post has a parent or not! Alternatively, if we can update the state
+         * of the block when `queryPostParent` changes in persisted-query-api-hierarchy.js,
+         * then this data could be stored in the block and obtained as an attribute.
+         * 
+         * @todo Fix issue
+         */
         if (!$attributes) {
             $blockContentPlaceholder = '<p><em>%s</em></p>';
             $blockContent = sprintf(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryEndpointAPIHierarchyBlock.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Blocks/PersistedQueryEndpointAPIHierarchyBlock.php
@@ -70,12 +70,21 @@ class PersistedQueryEndpointAPIHierarchyBlock extends AbstractBlock implements P
         // Append "-front" because this style must be used only on the client, not on the admin
         $className = $this->getBlockClassName() . '-front';
 
-        $blockContentPlaceholder = '<p><strong>%s</strong></p><p>%s</p>';
-        $blockContent = sprintf(
-            $blockContentPlaceholder,
-            \__('Inherit query from ancestor(s):', 'graphql-api'),
-            $this->getBooleanLabel($attributes[self::ATTRIBUTE_NAME_INHERIT_QUERY] ?? false)
-        );
+        // If there are no attributes, it's because the post has no parent
+        if (!$attributes) {
+            $blockContentPlaceholder = '<p><em>%s</em></p>';
+            $blockContent = sprintf(
+                $blockContentPlaceholder,
+                \__('This section is not enabled, since the persisted query has no ancestor.', 'graphql-api')
+            );
+        } else {
+            $blockContentPlaceholder = '<p><strong>%s</strong></p><p>%s</p>';
+            $blockContent = sprintf(
+                $blockContentPlaceholder,
+                \__('Inherit query from ancestor(s):', 'graphql-api'),
+                $this->getBooleanLabel($attributes[self::ATTRIBUTE_NAME_INHERIT_QUERY] ?? false)
+            );
+        }
 
         $blockContentPlaceholder = <<<EOT
             <div class="%s">


### PR DESCRIPTION
This PR doesn't completely fix the issue, it only makes it less serious.

If there are no attributes, it prints a message saying that API hierarchy is disabled. This behavior is right, but it works at the beginning only.

The problem still happens when the user has set a parent, and then removes it. Then, the API hierarchy section will then show, even though it's not valid.

The issue is that `render_callback` does not pass the postID, so we can't check if the post has a parent or not!

Alternatively, if we can update the state of the block when `queryPostParent` changes in `persisted-query-api-hierarchy.js`, then this data could be stored in the block and obtained as an attribute.
