### PR TITLE
Add `SetCurrentMutualConflictsReleaseWorker` to the monorepo builder `release` command

### DIFF
--- a/src/Config/Symplify/MonorepoBuilder/DataSources/ReleaseWorkersDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/ReleaseWorkersDataSource.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
 
-use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushNextDevReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetCurrentMutualConflictsReleaseWorker;
@@ -25,7 +24,6 @@ class ReleaseWorkersDataSource
             UpdateReplaceReleaseWorker::class,
             SetCurrentMutualConflictsReleaseWorker::class,
             SetCurrentMutualDependenciesReleaseWorker::class,
-            AddTagToChangelogReleaseWorker::class,
             TagVersionReleaseWorker::class,
             PushTagReleaseWorker::class,
             SetNextMutualDependenciesReleaseWorker::class,

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/ReleaseWorkersDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/ReleaseWorkersDataSource.php
@@ -7,6 +7,7 @@ namespace PoP\PoP\Config\Symplify\MonorepoBuilder\DataSources;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushNextDevReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetCurrentMutualConflictsReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetCurrentMutualDependenciesReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetNextMutualDependenciesReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
@@ -22,6 +23,7 @@ class ReleaseWorkersDataSource
     {
         return [
             UpdateReplaceReleaseWorker::class,
+            SetCurrentMutualConflictsReleaseWorker::class,
             SetCurrentMutualDependenciesReleaseWorker::class,
             AddTagToChangelogReleaseWorker::class,
             TagVersionReleaseWorker::class,


### PR DESCRIPTION
And also removed the unneeded `AddTagToChangelogReleaseWorker`