### PR TITLE
Show error message on wrong email format

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -917,7 +917,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                     }
                 }
 
-                $castingErrorMessage = null;
+                /** @var Error[] */
+                $errorArgValues = [];
                 // Cast (or "coerce" in GraphQL terms) the value
                 if ($fieldOrDirectiveArgIsArrayOfArraysType) {
                     // If the value is an array of arrays, then cast each subelement to the item type
@@ -932,6 +933,13 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                         ),
                         $argValue
                     );
+                    $errorArgValues = GeneralUtils::arrayFlatten(array_filter(
+                        $argValue,
+                        fn (?array $arrayArgValueElem) => $arrayArgValueElem === null ? false : array_filter(
+                            $arrayArgValueElem,
+                            fn (mixed $arrayOfArraysArgValueElem) => GeneralUtils::isError($arrayOfArraysArgValueElem)
+                        )
+                    ));
                 } elseif ($fieldOrDirectiveArgIsArrayType) {
                     // If the value is an array, then cast each element to the item type
                     $argValue = array_map(
@@ -941,37 +949,31 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                         ),
                         $argValue
                     );
-                    $errorArgValue = array_filter(
+                    $errorArgValues = array_filter(
                         $argValue,
                         fn (mixed $arrayArgValueElem) => GeneralUtils::isError($arrayArgValueElem)
                     );
-                    if ($errorArgValue) {
-                        if (count($errorArgValue) === 1) {
-                            /** @var Error */
-                            $error = $errorArgValue[0];
-                            $castingErrorMessage = $error->getMessageOrCode();
-                        } else {
-                            $castingErrorMessage = implode(
-                                $this->translationAPI->__('; ', 'pop-component-model'),
-                                array_map(
-                                    fn (Error $errorArgValueElem) => $errorArgValueElem->getMessageOrCode(),
-                                    $errorArgValue
-                                )
-                            );
-                        }
-                    }
                 } else {
                     // Otherwise, simply cast the given value directly
                     $argValue = $argValue === null ? null : $this->typeCastingExecuter->cast($fieldOrDirectiveArgType, $argValue);
                     if (GeneralUtils::isError($argValue)) {
                         /** @var Error */
                         $error = $argValue;
-                        $castingErrorMessage = $error->getMessageOrCode();
+                        $errorArgValues[] = $error;
                     }
                 }
 
                 // If the response is an error, extract the error message and set value to null
-                if ($castingErrorMessage !== null) {
+                if ($errorArgValues) {
+                    $castingErrorMessage = count($errorArgValues) === 1 ?
+                        $errorArgValues[0]->getMessageOrCode()
+                        : implode(
+                            $this->translationAPI->__('; ', 'pop-component-model'),
+                            array_map(
+                                fn (Error $errorArgValueElem) => $errorArgValueElem->getMessageOrCode(),
+                                $errorArgValues
+                            )
+                        );                    
                     $failedCastingFieldOrDirectiveArgErrorMessages[$argName] = $castingErrorMessage;
                     $fieldOrDirectiveArgs[$argName] = null;
                     continue;

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -104,6 +104,19 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 ];
                 $valid = filter_var($value, $filters[$type]);
                 if ($valid === false) {
+                    $elements = [
+                        SchemaDefinition::TYPE_URL => $this->translationAPI->__('URL', 'component-model'),
+                        SchemaDefinition::TYPE_EMAIL => $this->translationAPI->__('email', 'component-model'),
+                        SchemaDefinition::TYPE_IP => $this->translationAPI->__('IP', 'component-model'),
+                    ];
+                    return new Error(
+                        sprintf('%s-cast', $elements[$type]),
+                        sprintf(
+                            $this->translationAPI->__('The format for the %s \'%s\' is not right', 'component-model'),
+                            $elements[$type],
+                            $value
+                        )
+                    );
                     return null;
                 }
                 return $value;
@@ -120,7 +133,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 if (!is_string($value)) {
                     return new Error(
                         'date-cast',
-                        $this->translationAPI->__('Date must be provided as a string')
+                        $this->translationAPI->__('Date must be provided as a string', 'component-model')
                     );
                 }
                 // Validate that the format is 'Y-m-d'
@@ -130,7 +143,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                     return new Error(
                         'date-cast',
                         sprintf(
-                            $this->translationAPI->__('Date format must be \'%s\''),
+                            $this->translationAPI->__('Date format must be \'%s\'', 'component-model'),
                             'Y-m-d'
                         )
                     );


### PR DESCRIPTION
For instance, when passed to field arg `emails` for field `unrestrictedUsers`:

```graphql
{
  unrestrictedUsers(emails:["saraza"]) {
    id
    name
    email
  }
}
```