### PR TITLE
Add WordPress-specific fields to `Media`

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -46,7 +46,17 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - `PostCategory.urlPath: String!`
   - `User.urlPath: String!`
 - Added field arguments to `Root.mediaItems` for filtering results
-- Added field `MediaItem.srcSet`
+- Added fields in `Media`:
+  - `srcSet`
+  - `url`
+  - `urlPath`
+  - `slug`
+  - `title`
+  - `caption`
+  - `altText`
+  - `description`
+  - `date`
+  - `mimeType`
 
 ### Added
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -147,7 +147,7 @@ For instance, if field `User.url` returns `"https://mysite.com/author/admin/"`, 
 
 ### Media
 
-Added field arguments to `Root.mediaItems` for filtering results, and the following fields to `Media`:
+Added field arguments to `Root.mediaItems: [Media]!` for filtering results, and the following fields to `Media`:
 
 - `srcSet`
 - `url`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -147,7 +147,18 @@ For instance, if field `User.url` returns `"https://mysite.com/author/admin/"`, 
 
 ### Media
 
-Added field arguments to `Root.mediaItems` for filtering results, and field `MediaItem.srcSet`.
+Added field arguments to `Root.mediaItems` for filtering results, and the following fields to `Media`:
+
+- `srcSet`
+- `url`
+- `urlPath`
+- `slug`
+- `title`
+- `caption`
+- `altText`
+- `description`
+- `date`
+- `mimeType`
 
 ```graphql
 {
@@ -161,6 +172,15 @@ Added field arguments to `Root.mediaItems` for filtering results, and field `Med
     src
     height
     width
+    slug
+    url
+    urlPath
+    title
+    caption
+    altText
+    description
+    date
+    mimeType
   }
 }
 ```

--- a/layers/WPSchema/packages/media/composer.json
+++ b/layers/WPSchema/packages/media/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "pop-schema/media-wp": "^0.9"
+        "pop-schema/media-wp": "^0.9",
+        "pop-schema/queriedobject-wp": "^0.9"
     },
     "require-dev": {
         "johnpbloch/wordpress": ">=5.5",

--- a/layers/WPSchema/packages/media/src/Component.php
+++ b/layers/WPSchema/packages/media/src/Component.php
@@ -20,6 +20,7 @@ class Component extends AbstractComponent
     {
         return [
             \PoPSchema\MediaWP\Component::class,
+            \PoPSchema\QueriedObjectWP\Component::class,
         ];
     }
 

--- a/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -64,6 +64,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'urlPath',
             'slug',
             'title',
+            'caption',
             'date',
         ];
     }
@@ -75,6 +76,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'urlPath' => SchemaDefinition::TYPE_STRING,
             'slug' => SchemaDefinition::TYPE_STRING,
             'title' => SchemaDefinition::TYPE_STRING,
+            'caption' => SchemaDefinition::TYPE_STRING,
             'date' => SchemaDefinition::TYPE_DATE,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
@@ -101,6 +103,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'urlPath' => $this->translationAPI->__('Media element URL path', 'pop-media'),
             'slug' => $this->translationAPI->__('Media element slug', 'pop-media'),
             'title' => $this->translationAPI->__('Media element title', 'pop-media'),
+            'caption' => $this->translationAPI->__('Media element caption', 'pop-media'),
             'date' => $this->translationAPI->__('Media element\'s published date', 'pop-media'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
@@ -159,6 +162,8 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
                 return $mediaItem->post_name;
             case 'title':
                 return $mediaItem->post_title;
+            case 'caption':
+                return $mediaItem->post_excerpt;
             case 'date':
                 return $this->dateFormatter->format(
                     $fieldArgs['format'],

--- a/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\Media\FieldResolvers;
+
+use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
+use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
+use PoP\ComponentModel\Instances\InstanceManagerInterface;
+use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\Engine\CMS\CMSServiceInterface;
+use PoP\Engine\Formatters\DateFormatterInterface;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\LooseContracts\NameResolverInterface;
+use PoP\Translation\TranslationAPIInterface;
+use PoPSchema\Media\TypeResolvers\MediaTypeResolver;
+use PoPSchema\QueriedObject\FieldInterfaceResolvers\QueryableFieldInterfaceResolver;
+use PoPSchema\QueriedObject\Helpers\QueriedObjectHelperServiceInterface;
+use WP_Post;
+
+class MediaFieldResolver extends AbstractDBDataFieldResolver
+{
+    public function __construct(
+        TranslationAPIInterface $translationAPI,
+        HooksAPIInterface $hooksAPI,
+        InstanceManagerInterface $instanceManager,
+        FieldQueryInterpreterInterface $fieldQueryInterpreter,
+        NameResolverInterface $nameResolver,
+        CMSServiceInterface $cmsService,
+        SemverHelperServiceInterface $semverHelperService,
+        protected QueriedObjectHelperServiceInterface $queriedObjectHelperService,
+        protected DateFormatterInterface $dateFormatter
+    ) {
+        parent::__construct(
+            $translationAPI,
+            $hooksAPI,
+            $instanceManager,
+            $fieldQueryInterpreter,
+            $nameResolver,
+            $cmsService,
+            $semverHelperService,
+        );
+    }
+    
+    public function getClassesToAttachTo(): array
+    {
+        return array(MediaTypeResolver::class);
+    }
+
+    public function getImplementedFieldInterfaceResolverClasses(): array
+    {
+        return [
+            QueryableFieldInterfaceResolver::class,
+        ];
+    }
+
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'url',
+            'urlPath',
+            'slug',
+            'title',
+            'date',
+        ];
+    }
+
+    public function getSchemaFieldType(TypeResolverInterface $typeResolver, string $fieldName): string
+    {
+        $types = [
+            'url' => SchemaDefinition::TYPE_URL,
+            'urlPath' => SchemaDefinition::TYPE_STRING,
+            'slug' => SchemaDefinition::TYPE_STRING,
+            'title' => SchemaDefinition::TYPE_STRING,
+            'date' => SchemaDefinition::TYPE_DATE,
+        ];
+        return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
+    }
+
+    public function getSchemaFieldTypeModifiers(TypeResolverInterface $typeResolver, string $fieldName): ?int
+    {
+        $nonNullableFieldNames = [
+            'url',
+            'urlPath',
+            'slug',
+            'date',
+        ];
+        if (in_array($fieldName, $nonNullableFieldNames)) {
+            return SchemaTypeModifiers::NON_NULLABLE;
+        }
+        return parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName);
+    }
+
+    public function getSchemaFieldDescription(TypeResolverInterface $typeResolver, string $fieldName): ?string
+    {
+        $descriptions = [
+            'url' => $this->translationAPI->__('Media element URL', 'pop-media'),
+            'urlPath' => $this->translationAPI->__('Media element URL path', 'pop-media'),
+            'slug' => $this->translationAPI->__('Media element slug', 'pop-media'),
+            'title' => $this->translationAPI->__('Media element title', 'pop-media'),
+            'date' => $this->translationAPI->__('Media element\'s published date', 'pop-media'),
+        ];
+        return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
+    }
+
+    public function getSchemaFieldArgs(TypeResolverInterface $typeResolver, string $fieldName): array
+    {
+        $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
+        switch ($fieldName) {
+            case 'date':
+                return array_merge(
+                    $schemaFieldArgs,
+                    [
+                        [
+                            SchemaDefinition::ARGNAME_NAME => 'format',
+                            SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
+                            SchemaDefinition::ARGNAME_DESCRIPTION => sprintf(
+                                $this->translationAPI->__('Date format, as defined in %s', 'media'),
+                                'https://www.php.net/manual/en/function.date.php'
+                            ),
+                            SchemaDefinition::ARGNAME_DEFAULT_VALUE => $this->cmsService->getOption($this->nameResolver->getName('popcms:option:dateFormat')),
+                        ],
+                    ]
+                );
+        }
+
+        return $schemaFieldArgs;
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
+     * @param array<string, mixed>|null $variables
+     * @param array<string, mixed>|null $expressions
+     * @param array<string, mixed> $options
+     */
+    public function resolveValue(
+        TypeResolverInterface $typeResolver,
+        object $resultItem,
+        string $fieldName,
+        array $fieldArgs = [],
+        ?array $variables = null,
+        ?array $expressions = null,
+        array $options = []
+    ): mixed {
+        /** @var WP_Post */
+        $mediaItem = $resultItem;
+        switch ($fieldName) {
+            case 'url':
+            case 'urlPath':
+                $url = \get_permalink($mediaItem->ID);
+                if ($fieldName === 'url') {
+                    return $url;
+                }
+                return $this->queriedObjectHelperService->getURLPath($url);
+            case 'slug':
+                return $mediaItem->post_name;
+            case 'title':
+                return $mediaItem->post_title;
+            case 'date':
+                return $this->dateFormatter->format(
+                    $fieldArgs['format'],
+                    $mediaItem->post_date
+                );
+        }
+
+        return parent::resolveValue($typeResolver, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
+    }
+}

--- a/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -66,6 +66,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'title',
             'caption',
             'altText',
+            'description',
             'date',
         ];
     }
@@ -79,6 +80,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'title' => SchemaDefinition::TYPE_STRING,
             'caption' => SchemaDefinition::TYPE_STRING,
             'altText' => SchemaDefinition::TYPE_STRING,
+            'description' => SchemaDefinition::TYPE_STRING,
             'date' => SchemaDefinition::TYPE_DATE,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
@@ -107,6 +109,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'title' => $this->translationAPI->__('Media element title', 'pop-media'),
             'caption' => $this->translationAPI->__('Media element caption', 'pop-media'),
             'altText' => $this->translationAPI->__('Media element alt text', 'pop-media'),
+            'description' => $this->translationAPI->__('Media element description', 'pop-media'),
             'date' => $this->translationAPI->__('Media element\'s published date', 'pop-media'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
@@ -169,6 +172,8 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
                 return $mediaItem->post_excerpt;
             case 'altText':
                 return get_post_meta($mediaItem->ID, '_wp_attachment_image_alt', true);
+            case 'description':
+                return $mediaItem->post_content;
             case 'date':
                 return $this->dateFormatter->format(
                     $fieldArgs['format'],

--- a/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -65,6 +65,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'slug',
             'title',
             'caption',
+            'altText',
             'date',
         ];
     }
@@ -77,6 +78,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'slug' => SchemaDefinition::TYPE_STRING,
             'title' => SchemaDefinition::TYPE_STRING,
             'caption' => SchemaDefinition::TYPE_STRING,
+            'altText' => SchemaDefinition::TYPE_STRING,
             'date' => SchemaDefinition::TYPE_DATE,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
@@ -104,6 +106,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'slug' => $this->translationAPI->__('Media element slug', 'pop-media'),
             'title' => $this->translationAPI->__('Media element title', 'pop-media'),
             'caption' => $this->translationAPI->__('Media element caption', 'pop-media'),
+            'altText' => $this->translationAPI->__('Media element alt text', 'pop-media'),
             'date' => $this->translationAPI->__('Media element\'s published date', 'pop-media'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
@@ -164,6 +167,8 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
                 return $mediaItem->post_title;
             case 'caption':
                 return $mediaItem->post_excerpt;
+            case 'altText':
+                return get_post_meta($mediaItem->ID, '_wp_attachment_image_alt', true);
             case 'date':
                 return $this->dateFormatter->format(
                     $fieldArgs['format'],

--- a/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -68,6 +68,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'altText',
             'description',
             'date',
+            'mimeType',
         ];
     }
 
@@ -82,6 +83,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'altText' => SchemaDefinition::TYPE_STRING,
             'description' => SchemaDefinition::TYPE_STRING,
             'date' => SchemaDefinition::TYPE_DATE,
+            'mimeType' => SchemaDefinition::TYPE_STRING,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -111,6 +113,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             'altText' => $this->translationAPI->__('Media element alt text', 'pop-media'),
             'description' => $this->translationAPI->__('Media element description', 'pop-media'),
             'date' => $this->translationAPI->__('Media element\'s published date', 'pop-media'),
+            'mimeType' => $this->translationAPI->__('Media element\'s mime type', 'pop-media'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -179,6 +182,8 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
                     $fieldArgs['format'],
                     $mediaItem->post_date
                 );
+            case 'mimeType':
+                return $mediaItem->post_mime_type;
         }
 
         return parent::resolveValue($typeResolver, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/MediaFieldResolver.php
@@ -44,7 +44,7 @@ class MediaFieldResolver extends AbstractDBDataFieldResolver
             $semverHelperService,
         );
     }
-    
+
     public function getClassesToAttachTo(): array
     {
         return array(MediaTypeResolver::class);


### PR DESCRIPTION
Added the following fields to `Media`:

- `url`
- `urlPath`
- `slug`
- `title`
- `caption`
- `altText`
- `description`
- `date`
- `mimeType`