### PR TITLE
Enable passing `null` in field args

### DIFF
--- a/layers/Engine/packages/component-model/src/FormInputs/FormInput.php
+++ b/layers/Engine/packages/component-model/src/FormInputs/FormInput.php
@@ -34,7 +34,7 @@ class FormInput
     protected function getValueFromSource(array $source): mixed
     {
         // If not set, it will be NULL
-        $value =  $source[$this->getName()] ?? null;
+        $value = $source[$this->getName()] ?? null;
 
         // If it is multiple and the URL contains an empty value (eg: &searchfor[]=&), it will interpret it as array(''),
         // but instead it must be an empty array
@@ -42,8 +42,8 @@ class FormInput
 
         //     $value = array();
         // }
-        if ($this->isMultiple() && !is_null($value)) {
-            $value = array_filter($value);
+        if ($value !== null && $this->isMultiple()) {
+            return array_filter($value);
         }
 
         return $value;
@@ -64,15 +64,29 @@ class FormInput
             return $this->selected;
         }
 
-        // If no source is passed, then use the request
-        $source = $source ?? $_REQUEST;
-
-        $selected = $this->getValueFromSource($source);
-        if (!is_null($selected)) {
-            return $selected;
+        if (!$this->isInputSetInSource($source)) {
+            return $this->getDefaultValue();
         }
 
-        return $this->getDefaultValue();
+        return $this->getValueFromSource($this->getSource($source));
+    }
+
+    /**
+     * If no source is passed, then use the request
+     */
+    protected function getSource(?array $source = null): array
+    {
+        return $source ?? $_REQUEST;
+    }
+
+    /**
+     * It checks if the key with the input's name has been set.
+     * Setting `key=null` counts as `true`
+     */
+    public function isInputSetInSource(?array $source = null): bool
+    {
+        $source = $this->getSource($source);
+        return array_key_exists($this->getName(), $source);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsFilterInputModuleProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/DataloadQueryArgsFilterInputModuleProcessorInterface.php
@@ -7,6 +7,7 @@ namespace PoP\ComponentModel\ModuleProcessors;
 interface DataloadQueryArgsFilterInputModuleProcessorInterface
 {
     public function getValue(array $module, ?array $source = null): mixed;
+    public function isInputSetInSource(array $module, ?array $source = null): mixed;
     public function getFilterInput(array $module): ?array;
     public function getFilterInputSchemaDefinitionItems(array $module): array;
     public function getFilterInputSchemaDefinitionResolver(array $module): ?DataloadQueryArgsSchemaFilterInputModuleProcessorInterface;

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FilterDataModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FilterDataModuleProcessorTrait.php
@@ -53,7 +53,7 @@ trait FilterDataModuleProcessorTrait
                 function (array $module) use ($moduleProcessorManager, $source) {
                     /** @var DataloadQueryArgsFilterInputModuleProcessorInterface */
                     $dataloadQueryArgsFilterInputModuleProcessor = $moduleProcessorManager->getProcessor($module);
-                    return !is_null($dataloadQueryArgsFilterInputModuleProcessor->getValue($module, $source));
+                    return $dataloadQueryArgsFilterInputModuleProcessor->isInputSetInSource($module, $source);
                 }
             );
         }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FormInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FormInputModuleProcessorTrait.php
@@ -10,6 +10,8 @@ use PoP\ComponentModel\FormInputs\FormMultipleInput;
 
 trait FormInputModuleProcessorTrait
 {
+    private ?FormInput $formInput = null;
+
     // This function CANNOT have $props, since multiple can change the value of the input (eg: from Select to MultiSelect => from '' to array())
     // Yet we do not always go through initModelProps to initialize it, then changing the multiple in the form through $props, and trying to retrieve the value in an actionexecuter will fail
     public function isMultiple(array $module): bool
@@ -34,9 +36,12 @@ trait FormInputModuleProcessorTrait
 
     final public function getInput(array $module): FormInput
     {
-        $options = $this->getInputOptions($module);
-        $input_class = $this->getInputClass($module);
-        return new $input_class($options);
+        if ($this->formInput === null) {
+            $options = $this->getInputOptions($module);
+            $input_class = $this->getInputClass($module);
+            $this->formInput = new $input_class($options);
+        }
+        return $this->formInput;
     }
 
     // This function CANNOT have $props, since we do not always go through initModelProps to set the name of the input
@@ -50,6 +55,11 @@ trait FormInputModuleProcessorTrait
     public function getValue(array $module, ?array $source = null): mixed
     {
         return $this->getInput($module)->getValue($source);
+    }
+
+    public function isInputSetInSource(array $module, ?array $source = null): mixed
+    {
+        return $this->getInput($module)->isInputSetInSource($source);
     }
 
     public function getInputDefaultValue(array $module, array &$props): mixed

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/FormInputModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/FormInputModuleProcessorTrait.php
@@ -10,7 +10,10 @@ use PoP\ComponentModel\FormInputs\FormMultipleInput;
 
 trait FormInputModuleProcessorTrait
 {
-    private ?FormInput $formInput = null;
+    /**
+     * @var array<string,FormInput>
+     */
+    private array $formInputs = [];
 
     // This function CANNOT have $props, since multiple can change the value of the input (eg: from Select to MultiSelect => from '' to array())
     // Yet we do not always go through initModelProps to initialize it, then changing the multiple in the form through $props, and trying to retrieve the value in an actionexecuter will fail
@@ -36,12 +39,13 @@ trait FormInputModuleProcessorTrait
 
     final public function getInput(array $module): FormInput
     {
-        if ($this->formInput === null) {
+        $inputName = $this->getName($module);
+        if (!isset($this->formInputs[$inputName])) {
             $options = $this->getInputOptions($module);
             $input_class = $this->getInputClass($module);
-            $this->formInput = new $input_class($options);
+            $this->formInputs[$inputName] = new $input_class($options);
         }
-        return $this->formInput;
+        return $this->formInputs[$inputName];
     }
 
     // This function CANNOT have $props, since we do not always go through initModelProps to set the name of the input

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -418,23 +418,19 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         return $fieldArgumentNameDefaultValues;
     }
 
-    protected function filterFieldOrDirectiveArgs(
-        array $fieldOrDirectiveArgs,
-        bool $allowNullValues = false
-    ): array {
-        // If there was an error, the value will be NULL. In this case, remove it
+    protected function filterFieldOrDirectiveArgs(array $fieldOrDirectiveArgs): array {
+        // Remove all errors, allow null values
         return array_filter(
             $fieldOrDirectiveArgs,
-            function ($elem) use ($allowNullValues): bool {
+            function ($elem): bool {
                 // If the input is `[[String]]`, must then validate if any subitem is Error
                 if (is_array($elem)) {
                     // Filter elements in the array. If any is missing, filter the array out
-                    $filteredElem = $this->filterFieldOrDirectiveArgs($elem, true);
+                    $filteredElem = $this->filterFieldOrDirectiveArgs($elem);
                     return count($elem) === count($filteredElem);
                 }
-                // Remove only NULL values and Errors. Keep '', 0, false and []
-                return !GeneralUtils::isError($elem)
-                    && ($elem !== null || $allowNullValues);
+                // Remove only Errors. Keep NULL, '', 0, false and []
+                return !GeneralUtils::isError($elem);
             }
         );
     }
@@ -1446,12 +1442,10 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         }
         if (is_array($fieldArgValue)) {
             // Resolve each element the same way
-            // `null` values in the array are permitted
             return $this->filterFieldOrDirectiveArgs(
                 array_map(function ($arrayValueElem) use ($variables) {
                     return $this->maybeConvertFieldArgumentValue($arrayValueElem, $variables);
-                }, $fieldArgValue),
-                true
+                }, $fieldArgValue)
             );
         }
 

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1221,7 +1221,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             $castedFieldArgs,
             fn (mixed $fieldArgValue) =>
                 (!is_array($fieldArgValue) && GeneralUtils::isError($fieldArgValue))
-                || (is_array($fieldArgValue) && $this->getFailedCastingFieldArgs($fieldArgValue))
+                || (is_array($fieldArgValue) && !empty($this->getFailedCastingFieldArgs($fieldArgValue)))
         );
     }
 

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -418,7 +418,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         return $fieldArgumentNameDefaultValues;
     }
 
-    protected function filterFieldOrDirectiveArgs(array $fieldOrDirectiveArgs): array {
+    protected function filterFieldOrDirectiveArgs(array $fieldOrDirectiveArgs): array
+    {
         // Remove all errors, allow null values
         return array_filter(
             $fieldOrDirectiveArgs,
@@ -1216,7 +1217,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     /**
      * Any element that is Error, or any array that contains an error
      */
-    protected function getFailedCastingFieldArgs(array $castedFieldArgs): array {
+    protected function getFailedCastingFieldArgs(array $castedFieldArgs): array
+    {
         return array_filter(
             $castedFieldArgs,
             fn (mixed $fieldArgValue) =>

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -957,9 +957,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
                     // Otherwise, simply cast the given value directly
                     $argValue = $argValue === null ? null : $this->typeCastingExecuter->cast($fieldOrDirectiveArgType, $argValue);
                     if (GeneralUtils::isError($argValue)) {
-                        /** @var Error */
-                        $error = $argValue;
-                        $errorArgValues[] = $error;
+                        /** @var Error $argValue */
+                        $errorArgValues[] = $argValue;
                     }
                 }
 

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1214,22 +1214,14 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     }
 
     /**
-     * Any element that is null or error,
-     * or any array that contains an error
+     * Any element that is Error, or any array that contains an error
      */
-    protected function getFailedCastingFieldArgs(
-        array $castedFieldArgs,
-        bool $isNullValueFailing
-    ): array {
+    protected function getFailedCastingFieldArgs(array $castedFieldArgs): array {
         return array_filter(
             $castedFieldArgs,
             fn (mixed $fieldArgValue) =>
-                GeneralUtils::isError($fieldArgValue)
-                || ($isNullValueFailing && $fieldArgValue === null)
-                || (is_array($fieldArgValue) && $this->getFailedCastingFieldArgs(
-                    $fieldArgValue,
-                    false
-                ))
+                (!is_array($fieldArgValue) && GeneralUtils::isError($fieldArgValue))
+                || (is_array($fieldArgValue) && $this->getFailedCastingFieldArgs($fieldArgValue))
         );
     }
 
@@ -1243,12 +1235,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         array &$schemaWarnings
     ): array {
         // If any casting can't be done, show an error
-        if (
-            $failedCastingFieldArgs = $this->getFailedCastingFieldArgs(
-                $castedFieldArgs,
-                true
-            )
-        ) {
+        if ($failedCastingFieldArgs = $this->getFailedCastingFieldArgs($castedFieldArgs)) {
             // $fieldOutputKey = $this->getFieldOutputKey($field);
             $fieldName = $this->getFieldName($field);
             $fieldArgNameTypes = $this->getFieldArgumentNameTypes($typeResolver, $field);

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -24,6 +24,13 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
      */
     public function cast(string $type, mixed $value): mixed
     {
+        if ($value === null) {                
+            return new Error(
+                'null-cast',
+                $this->translationAPI->__('Cannot cast null', 'component-model')
+            );
+        }
+
         // Fail if passing an array for unsupporting types
         if (is_array($value) && in_array($type, [
             SchemaDefinition::TYPE_ANY_SCALAR,

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -16,7 +16,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
     }
 
     /**
-     * Cast the value to the indicated type, or return null or Error (with a message) if it fails.
+     * Cast the value to the indicated type, or return Error (with a message) if it fails.
      *
      * An array is not a type. For instance, in `[String]`, the type is `String`,
      * and the array is a modifier.
@@ -88,7 +88,10 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 // Type ID in GraphQL spec: only String or Int allowed.
                 // @see https://spec.graphql.org/draft/#sec-ID.Input-Coercion
                 if (is_float($value) || is_bool($value)) {
-                    return null;
+                    return new Error(
+                        'id-cast',
+                        $this->translationAPI->__('Type ID in GraphQL spec: only String or Int allowed', 'component-model')
+                    );
                 }
                 return $value;
             case SchemaDefinition::TYPE_STRING:
@@ -125,7 +128,13 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
             case SchemaDefinition::TYPE_OBJECT:
             case SchemaDefinition::TYPE_INPUT_OBJECT:
                 if (!(is_object($value) || is_array($value))) {
-                    return null;
+                    return new Error(
+                        'object-cast',
+                        sprintf(
+                            $this->translationAPI->__('An object cannot be casted from \'%s\'', 'component-model'),
+                            $value
+                        )
+                    );
                 }
                 return $value;
             case SchemaDefinition::TYPE_DATE:
@@ -162,7 +171,13 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
             case SchemaDefinition::TYPE_TIME:
                 $converted = strtotime($value);
                 if ($converted === false) {
-                    return null;
+                    return new Error(
+                        'time-cast',
+                        sprintf(
+                            $this->translationAPI->__('Cannot cast time from \'%s\'', 'component-model'),
+                            $value
+                        )
+                    );
                 }
                 return $converted;
         }

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -25,30 +25,28 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
     public function cast(string $type, mixed $value): mixed
     {
         // Fail if passing an array for unsupporting types
-        switch ($type) {
-            case SchemaDefinition::TYPE_ANY_SCALAR:
-            case SchemaDefinition::TYPE_ID:
-            case SchemaDefinition::TYPE_ARRAY_KEY:
-            case SchemaDefinition::TYPE_STRING:
-            case SchemaDefinition::TYPE_URL:
-            case SchemaDefinition::TYPE_EMAIL:
-            case SchemaDefinition::TYPE_IP:
-            case SchemaDefinition::TYPE_ENUM:
-            case SchemaDefinition::TYPE_DATE:
-            case SchemaDefinition::TYPE_INT:
-            case SchemaDefinition::TYPE_FLOAT:
-            case SchemaDefinition::TYPE_BOOL:
-            case SchemaDefinition::TYPE_TIME:
-                if (is_array($value)) {
-                    return new Error(
-                        'array-cast',
-                        sprintf(
-                            $this->translationAPI->__('An array cannot be casted to type \'%s\'', 'component-model'),
-                            $type
-                        )
-                    );
-                }
-                break;
+        if (is_array($value) && in_array($type, [
+            SchemaDefinition::TYPE_ANY_SCALAR,
+            SchemaDefinition::TYPE_ID,
+            SchemaDefinition::TYPE_ARRAY_KEY,
+            SchemaDefinition::TYPE_STRING,
+            SchemaDefinition::TYPE_URL,
+            SchemaDefinition::TYPE_EMAIL,
+            SchemaDefinition::TYPE_IP,
+            SchemaDefinition::TYPE_ENUM,
+            SchemaDefinition::TYPE_DATE,
+            SchemaDefinition::TYPE_INT,
+            SchemaDefinition::TYPE_FLOAT,
+            SchemaDefinition::TYPE_BOOL,
+            SchemaDefinition::TYPE_TIME,
+        ])) {                
+            return new Error(
+                'array-cast',
+                sprintf(
+                    $this->translationAPI->__('An array cannot be casted to type \'%s\'', 'component-model'),
+                    $type
+                )
+            );
         }
 
         // Fail if passing an object for unsupporting types

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -32,7 +32,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
         }
 
         // Fail if passing an array for unsupporting types
-        if (is_array($value) && in_array($type, [
+        if ((is_array($value) || is_object($value)) && in_array($type, [
             SchemaDefinition::TYPE_ANY_SCALAR,
             SchemaDefinition::TYPE_ID,
             SchemaDefinition::TYPE_ARRAY_KEY,
@@ -47,40 +47,15 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
             SchemaDefinition::TYPE_BOOL,
             SchemaDefinition::TYPE_TIME,
         ])) {                
+            $entity = is_array($value) ? 'array' : 'object';
             return new Error(
-                'array-cast',
+                sprintf('%s-cast', $entity),
                 sprintf(
-                    $this->translationAPI->__('An array cannot be casted to type \'%s\'', 'component-model'),
+                    $this->translationAPI->__('An %s cannot be casted to type \'%s\'', 'component-model'),
+                    $entity,
                     $type
                 )
             );
-        }
-
-        // Fail if passing an object for unsupporting types
-        switch ($type) {
-            case SchemaDefinition::TYPE_ANY_SCALAR:
-            case SchemaDefinition::TYPE_ID:
-            case SchemaDefinition::TYPE_ARRAY_KEY:
-            case SchemaDefinition::TYPE_STRING:
-            case SchemaDefinition::TYPE_URL:
-            case SchemaDefinition::TYPE_EMAIL:
-            case SchemaDefinition::TYPE_IP:
-            case SchemaDefinition::TYPE_ENUM:
-            case SchemaDefinition::TYPE_DATE:
-            case SchemaDefinition::TYPE_INT:
-            case SchemaDefinition::TYPE_FLOAT:
-            case SchemaDefinition::TYPE_BOOL:
-            case SchemaDefinition::TYPE_TIME:
-                if (is_object($value)) {
-                    return new Error(
-                        'object-cast',
-                        sprintf(
-                            $this->translationAPI->__('An object cannot be casted to type \'%s\'', 'component-model'),
-                            $type
-                        )
-                    );
-                }
-                break;
         }
 
         switch ($type) {

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -24,7 +24,7 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
      */
     public function cast(string $type, mixed $value): mixed
     {
-        if ($value === null) {                
+        if ($value === null) {
             return new Error(
                 'null-cast',
                 $this->translationAPI->__('Cannot cast null', 'component-model')
@@ -32,7 +32,8 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
         }
 
         // Fail if passing an array for unsupporting types
-        if ((is_array($value) || is_object($value)) && in_array($type, [
+        if (
+            (is_array($value) || is_object($value)) && in_array($type, [
             SchemaDefinition::TYPE_ANY_SCALAR,
             SchemaDefinition::TYPE_ID,
             SchemaDefinition::TYPE_ARRAY_KEY,
@@ -46,7 +47,8 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
             SchemaDefinition::TYPE_FLOAT,
             SchemaDefinition::TYPE_BOOL,
             SchemaDefinition::TYPE_TIME,
-        ])) {                
+            ])
+        ) {
             $entity = is_array($value) ? 'array' : 'object';
             return new Error(
                 sprintf('%s-cast', $entity),

--- a/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
+++ b/layers/Engine/packages/component-model/src/Schema/TypeCastingExecuter.php
@@ -161,6 +161,9 @@ class TypeCastingExecuter implements TypeCastingExecuterInterface
                 }
                 return $converted;
         }
-        return $value;
+        return new Error(
+            'unidentified-type-cast',
+            $this->translationAPI->__('The type of the value cannot be identified, and so cannot be casted', 'component-model')
+        );
     }
 }

--- a/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -295,10 +295,14 @@ abstract class AbstractCategoryTypeAPI extends TaxonomyTypeAPI implements Catego
     /**
      * @return array<string|int>|null
      */
-    public function getCategoryChildIDs(string | int | object $catObjectOrID): array
+    public function getCategoryChildIDs(string | int | object $catObjectOrID): ?array
     {
         $categoryID = is_object($catObjectOrID) ? $this->getCategoryID($catObjectOrID) : $catObjectOrID;
-        return \get_term_children($catObjectOrID, $this->getCategoryTaxonomyName());
+        $childrenIDs = \get_term_children($categoryID, $this->getCategoryTaxonomyName());
+        if ($childrenIDs instanceof WP_Error) {
+            return null;
+        }
+        return $childrenIDs;
     }
 
     public function getCategoryDescription(string | int | object $catObjectOrID): string

--- a/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -166,8 +166,7 @@ abstract class AbstractCategoryTypeAPI extends TaxonomyTypeAPI implements Catego
             $query['slug'] = $query['slugs'];
             unset($query['slugs']);
         }
-        // Watch out: "parent-id" can also be null
-        if (array_key_exists('parent-id', $query)) {
+        if (isset($query['parent-id'])) {
             $query['parent'] = $query['parent-id'];
             unset($query['parent-id']);
         }

--- a/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -166,6 +166,7 @@ abstract class AbstractCategoryTypeAPI extends TaxonomyTypeAPI implements Catego
             $query['slug'] = $query['slugs'];
             unset($query['slugs']);
         }
+        // Watch out: "parent-id" can also be null!
         if (isset($query['parent-id'])) {
             $query['parent'] = $query['parent-id'];
             unset($query['parent-id']);

--- a/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -166,8 +166,8 @@ abstract class AbstractCategoryTypeAPI extends TaxonomyTypeAPI implements Catego
             $query['slug'] = $query['slugs'];
             unset($query['slugs']);
         }
-        // Watch out: "parent-id" can also be null!
-        if (isset($query['parent-id'])) {
+        // Watch out: "parent-id" can also be null
+        if (array_key_exists('parent-id', $query)) {
             $query['parent'] = $query['parent-id'];
             unset($query['parent-id']);
         }

--- a/layers/Schema/packages/categories/src/ModuleProcessors/CategoryFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/categories/src/ModuleProcessors/CategoryFilterInputContainerModuleProcessor.php
@@ -49,10 +49,12 @@ class CategoryFilterInputContainerModuleProcessor extends AbstractFilterInputCon
             ],
             default => [],
         };
-        if (in_array($module[1], [
+        if (
+            in_array($module[1], [
             self::MODULE_FILTERINPUTCONTAINER_CATEGORIES,
             self::MODULE_FILTERINPUTCONTAINER_CATEGORYCOUNT,
-        ])) {
+            ])
+        ) {
             $filterInputModules[] = [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_PARENT_ID];
         }
         return $filterInputModules;


### PR DESCRIPTION
This query now works:

```graphql
{
  postCategories(parentID: null) {
    id
    name
  }
}
```