### PR TITLE
Improve counting tags/catgories

### DIFF
--- a/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -83,20 +83,27 @@ abstract class AbstractCategoryTypeAPI extends TaxonomyTypeAPI implements Catego
     }
     public function getCategoryCount(array $query = [], array $options = []): int
     {
-        // There is no direct way to calculate the total
-        // (Documentation mentions to pass arg "count" => `true` to `get_categories`,
-        // but it doesn't work)
-        // So execute a normal `get_categories` retrieving all the IDs, and count them
-        $options['return-type'] = ReturnTypes::IDS;
         $query = $this->convertCategoriesQuery($query, $options);
+
+        // Indicate to return the count
+        $query['count'] = true;
+        $query['fields'] = 'count';
 
         // All results, no offset
         $query['number'] = 0;
         unset($query['offset']);
 
-        // Resolve and count
-        $categories = get_categories($query);
-        return count($categories);
+        // Execute query and return count
+        $count = \get_categories($query);
+        // For some reason, the count is returned as an array of 1 element!
+        if (is_array($count) && count($count) === 1) {
+            return (int) $count[0];
+        }
+        if (is_array($count)) {
+            // An error happened
+            return -1;
+        }
+        return (int)$count;
     }
     public function getCategories(array $query, array $options = []): array
     {

--- a/layers/Schema/packages/menus-wp/src/TypeAPIs/MenuTypeAPI.php
+++ b/layers/Schema/packages/menus-wp/src/TypeAPIs/MenuTypeAPI.php
@@ -98,8 +98,9 @@ class MenuTypeAPI implements MenuTypeAPIInterface
      */
     public function getMenuCount(array $query, array $options = []): int
     {
-        // Convert parameters
         $query = $this->convertMenusQuery($query, $options);
+
+        // Indicate to return the count
         $query['count'] = true;
         $query['fields'] = 'count';
 
@@ -107,9 +108,10 @@ class MenuTypeAPI implements MenuTypeAPIInterface
         $query['number'] = 0;
         unset($query['offset']);
 
-        // Execute query and count results
+        // Execute query and return count
         $count = \wp_get_nav_menus($query);
         if (!is_numeric($count)) {
+            // An error happened
             return -1;
         }
         return (int)$count;

--- a/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
+++ b/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
@@ -85,20 +85,27 @@ abstract class AbstractTagTypeAPI extends TaxonomyTypeAPI implements TagTypeAPII
     }
     public function getTagCount(array $query = [], array $options = []): int
     {
-        // There is no direct way to calculate the total
-        // (Documentation mentions to pass arg "count" => `true` to `get_tags`,
-        // but it doesn't work)
-        // So execute a normal `get_tags` retrieving all the IDs, and count them
-        $options['return-type'] = ReturnTypes::IDS;
         $query = $this->convertTagsQuery($query, $options);
+
+        // Indicate to return the count
+        $query['count'] = true;
+        $query['fields'] = 'count';
 
         // All results, no offset
         $query['number'] = 0;
         unset($query['offset']);
 
-        // Resolve and count
-        $tags = get_tags($query);
-        return count($tags);
+        // Execute query and return count
+        $count = \get_tags($query);
+        // For some reason, the count is returned as an array of 1 element!
+        if (is_array($count) && count($count) === 1) {
+            return (int) $count[0];
+        }
+        if (is_array($count)) {
+            // An error happened
+            return -1;
+        }
+        return (int)$count;
     }
     public function getTags(array $query, array $options = []): array
     {


### PR DESCRIPTION
Use `$query['fields'] = 'count';` for retrieving the number of tags, instead of counting the results in the response array.