### PR TITLE
Switch Monorepo builder to 9.4.28@original fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "rector/rector": "^0.11",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/var-dumper": "^5.1",
-        "symplify/monorepo-builder": "9.4.28",
+        "symplify/monorepo-builder": "^9.0",
         "szepeviktor/phpstan-wordpress": "^0.7"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "rector/rector": "^0.11",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/var-dumper": "^5.1",
-        "symplify/monorepo-builder": "dev-original",
+        "symplify/monorepo-builder": "9.4.28",
         "szepeviktor/phpstan-wordpress": "^0.7"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "rector/rector": "^0.11",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/var-dumper": "^5.1",
-        "symplify/monorepo-builder": "^9.0",
+        "symplify/monorepo-builder": "dev-original",
         "szepeviktor/phpstan-wordpress": "^0.7"
     },
     "autoload": {
@@ -513,6 +513,10 @@
         {
             "type": "composer",
             "url": "https://wpackagist.org"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/leoloso/monorepo-builder.git"
         }
     ],
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7fe2e7d48cf818f04141d404d4b3cff",
+    "content-hash": "94247150ae663a6213854dd9d82d7d7b",
     "packages": [
         {
             "name": "boxuk/wp-muplugin-loader",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9aebcbc526e955b9fbf407efedc99d7",
+    "content-hash": "d7fe2e7d48cf818f04141d404d4b3cff",
     "packages": [
         {
             "name": "boxuk/wp-muplugin-loader",
@@ -6241,23 +6241,53 @@
         },
         {
             "name": "symplify/autowire-array-parameter",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/autowire-array-parameter.git",
-                "reference": "f518ed926eb8b39ac9ff60242b894b42c08b3f9e"
+                "reference": "06b74f29623a1e5536303c766e70b8bea3edbce5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/f518ed926eb8b39ac9ff60242b894b42c08b3f9e",
-                "reference": "f518ed926eb8b39ac9ff60242b894b42c08b3f9e",
+                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/06b74f29623a1e5536303c766e70b8bea3edbce5",
+                "reference": "06b74f29623a1e5536303c766e70b8bea3edbce5",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
                 "symfony/dependency-injection": "^5.3",
-                "symplify/package-builder": "^9.4.1"
+                "symplify/package-builder": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/composer-json-manipulator": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-color-diff": "<9.4.28",
+                "symplify/console-package-builder": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/easy-testing": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/smart-file-system": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/symplify-kernel": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6279,7 +6309,7 @@
             ],
             "description": "Autowire array parameters for your Symfony applications",
             "support": {
-                "source": "https://github.com/symplify/autowire-array-parameter/tree/v9.4.1"
+                "source": "https://github.com/symplify/autowire-array-parameter/tree/9.4.28"
             },
             "funding": [
                 {
@@ -6291,20 +6321,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-29T17:57:00+00:00"
+            "time": "2021-08-11T15:38:33+00:00"
         },
         {
             "name": "symplify/composer-json-manipulator",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/composer-json-manipulator.git",
-                "reference": "b47c7b7482050f697afb5cec86d6580ec15ea8a6"
+                "reference": "2c5b23c5916a3cd51306f86cf0e592367788584a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/b47c7b7482050f697afb5cec86d6580ec15ea8a6",
-                "reference": "b47c7b7482050f697afb5cec86d6580ec15ea8a6",
+                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/2c5b23c5916a3cd51306f86cf0e592367788584a",
+                "reference": "2c5b23c5916a3cd51306f86cf0e592367788584a",
                 "shasum": ""
             },
             "require": {
@@ -6314,8 +6344,37 @@
                 "symfony/dependency-injection": "^5.3",
                 "symfony/filesystem": "^5.3",
                 "symfony/http-kernel": "^5.3",
-                "symplify/package-builder": "^9.4.1",
-                "symplify/smart-file-system": "^9.4.1"
+                "symplify/package-builder": "^9.4.28",
+                "symplify/smart-file-system": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/autowire-array-parameter": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-color-diff": "<9.4.28",
+                "symplify/console-package-builder": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/easy-testing": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/symplify-kernel": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6337,7 +6396,7 @@
             ],
             "description": "Package to load, merge and save composer.json file(s)",
             "support": {
-                "source": "https://github.com/symplify/composer-json-manipulator/tree/v9.4.1"
+                "source": "https://github.com/symplify/composer-json-manipulator/tree/9.4.28"
             },
             "funding": [
                 {
@@ -6349,20 +6408,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-29T17:57:02+00:00"
+            "time": "2021-08-11T15:38:31+00:00"
         },
         {
             "name": "symplify/console-color-diff",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/console-color-diff.git",
-                "reference": "1644f68d3e389c5336b08d844850945aadb36e23"
+                "reference": "95188c922092664ccd4e98b02e5526dbe93fef4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/console-color-diff/zipball/1644f68d3e389c5336b08d844850945aadb36e23",
-                "reference": "1644f68d3e389c5336b08d844850945aadb36e23",
+                "url": "https://api.github.com/repos/symplify/console-color-diff/zipball/95188c922092664ccd4e98b02e5526dbe93fef4b",
+                "reference": "95188c922092664ccd4e98b02e5526dbe93fef4b",
                 "shasum": ""
             },
             "require": {
@@ -6372,7 +6431,37 @@
                 "symfony/console": "^5.3",
                 "symfony/dependency-injection": "^5.3",
                 "symfony/http-kernel": "^5.3",
-                "symplify/package-builder": "^9.4.1"
+                "symplify/package-builder": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/autowire-array-parameter": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/composer-json-manipulator": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-package-builder": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/easy-testing": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/smart-file-system": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/symplify-kernel": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6394,7 +6483,7 @@
             ],
             "description": "Package to print diffs in console with colors",
             "support": {
-                "source": "https://github.com/symplify/console-color-diff/tree/v9.4.1"
+                "source": "https://github.com/symplify/console-color-diff/tree/9.4.28"
             },
             "funding": [
                 {
@@ -6406,32 +6495,62 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-29T17:57:04+00:00"
+            "time": "2021-08-11T15:38:35+00:00"
         },
         {
             "name": "symplify/console-package-builder",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/console-package-builder.git",
-                "reference": "833219e1d20474811b6622bb4457682d9e6ea184"
+                "reference": "fc26bb86cc4a5f390d0ff0c2e04a52bfeacd0e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/console-package-builder/zipball/833219e1d20474811b6622bb4457682d9e6ea184",
-                "reference": "833219e1d20474811b6622bb4457682d9e6ea184",
+                "url": "https://api.github.com/repos/symplify/console-package-builder/zipball/fc26bb86cc4a5f390d0ff0c2e04a52bfeacd0e53",
+                "reference": "fc26bb86cc4a5f390d0ff0c2e04a52bfeacd0e53",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "symfony/console": "^5.3",
                 "symfony/dependency-injection": "^5.3",
-                "symplify/symplify-kernel": "^9.4.1"
+                "symplify/symplify-kernel": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/autowire-array-parameter": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/composer-json-manipulator": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-color-diff": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/easy-testing": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/package-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/smart-file-system": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5",
                 "symfony/http-kernel": "^5.3",
-                "symplify/package-builder": "^9.4.1"
+                "symplify/package-builder": "^9.4.28"
             },
             "type": "library",
             "extra": {
@@ -6450,22 +6569,22 @@
             ],
             "description": "Package to speed up building command line applications",
             "support": {
-                "source": "https://github.com/symplify/console-package-builder/tree/v9.4.1"
+                "source": "https://github.com/symplify/console-package-builder/tree/9.4.28"
             },
-            "time": "2021-06-29T17:57:03+00:00"
+            "time": "2021-08-11T15:38:43+00:00"
         },
         {
             "name": "symplify/easy-testing",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-testing.git",
-                "reference": "cf7a950a63c0fb4a544c580dda4e36980903df0e"
+                "reference": "1fb3f9194ae8b2c1ae7a32026560d57099b5ca84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/cf7a950a63c0fb4a544c580dda4e36980903df0e",
-                "reference": "cf7a950a63c0fb4a544c580dda4e36980903df0e",
+                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/1fb3f9194ae8b2c1ae7a32026560d57099b5ca84",
+                "reference": "1fb3f9194ae8b2c1ae7a32026560d57099b5ca84",
                 "shasum": ""
             },
             "require": {
@@ -6475,10 +6594,37 @@
                 "symfony/dependency-injection": "^5.3",
                 "symfony/finder": "^5.3",
                 "symfony/http-kernel": "^5.3",
-                "symplify/console-package-builder": "^9.4.1",
-                "symplify/package-builder": "^9.4.1",
-                "symplify/smart-file-system": "^9.4.1",
-                "symplify/symplify-kernel": "^9.4.1"
+                "symplify/console-package-builder": "^9.4.28",
+                "symplify/package-builder": "^9.4.28",
+                "symplify/smart-file-system": "^9.4.28",
+                "symplify/symplify-kernel": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/autowire-array-parameter": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/composer-json-manipulator": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-color-diff": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6503,7 +6649,7 @@
             ],
             "description": "Testing made easy",
             "support": {
-                "source": "https://github.com/symplify/easy-testing/tree/v9.4.1"
+                "source": "https://github.com/symplify/easy-testing/tree/9.4.28"
             },
             "funding": [
                 {
@@ -6515,20 +6661,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-29T17:57:10+00:00"
+            "time": "2021-08-11T15:39:11+00:00"
         },
         {
             "name": "symplify/monorepo-builder",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symplify/monorepo-builder.git",
-                "reference": "7d718c5d22007018e7d80b897b078f03816de0b9"
+                "url": "https://github.com/leoloso/monorepo-builder.git",
+                "reference": "52533137bf8d88d4e476062c8bbe9cf3b2fb2fad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/monorepo-builder/zipball/7d718c5d22007018e7d80b897b078f03816de0b9",
-                "reference": "7d718c5d22007018e7d80b897b078f03816de0b9",
+                "url": "https://api.github.com/repos/leoloso/monorepo-builder/zipball/52533137bf8d88d4e476062c8bbe9cf3b2fb2fad",
+                "reference": "52533137bf8d88d4e476062c8bbe9cf3b2fb2fad",
                 "shasum": ""
             },
             "require": {
@@ -6539,11 +6685,37 @@
                 "symfony/dependency-injection": "^5.3",
                 "symfony/finder": "^5.3",
                 "symfony/process": "^5.3",
-                "symplify/composer-json-manipulator": "^9.4.1",
-                "symplify/console-color-diff": "^9.4.1",
-                "symplify/package-builder": "^9.4.1",
-                "symplify/smart-file-system": "^9.4.1",
-                "symplify/symplify-kernel": "^9.4.1"
+                "symplify/composer-json-manipulator": "^9.4.28",
+                "symplify/console-color-diff": "^9.4.28",
+                "symplify/package-builder": "^9.4.28",
+                "symplify/smart-file-system": "^9.4.28",
+                "symplify/symplify-kernel": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/autowire-array-parameter": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-package-builder": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/easy-testing": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6565,38 +6737,45 @@
                     ]
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Symplify\\MonorepoBuilder\\Tests\\": [
+                        "tests",
+                        "packages-tests"
+                    ]
+                }
+            },
             "license": [
                 "MIT"
             ],
             "description": "Not only Composer tools to build a Monorepo.",
             "support": {
-                "source": "https://github.com/symplify/monorepo-builder/tree/v9.4.1"
+                "source": "https://github.com/leoloso/monorepo-builder/tree/9.4.28"
             },
             "funding": [
                 {
-                    "url": "https://www.paypal.me/rectorphp",
-                    "type": "custom"
+                    "type": "github",
+                    "url": "https://github.com/tomasvotruba"
                 },
                 {
-                    "url": "https://github.com/tomasvotruba",
-                    "type": "github"
+                    "type": "custom",
+                    "url": "https://www.paypal.me/rectorphp"
                 }
             ],
-            "time": "2021-06-29T17:57:25+00:00"
+            "time": "2021-08-13T13:43:17+00:00"
         },
         {
             "name": "symplify/package-builder",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/package-builder.git",
-                "reference": "3472595aaad8de37f22cbc6c5a3aa7622ad2f5fa"
+                "reference": "d0e6d5a1bedb4947c1a62a099b192513047ee5bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/package-builder/zipball/3472595aaad8de37f22cbc6c5a3aa7622ad2f5fa",
-                "reference": "3472595aaad8de37f22cbc6c5a3aa7622ad2f5fa",
+                "url": "https://api.github.com/repos/symplify/package-builder/zipball/d0e6d5a1bedb4947c1a62a099b192513047ee5bd",
+                "reference": "d0e6d5a1bedb4947c1a62a099b192513047ee5bd",
                 "shasum": ""
             },
             "require": {
@@ -6608,8 +6787,37 @@
                 "symfony/dependency-injection": "^5.3",
                 "symfony/finder": "^5.3",
                 "symfony/http-kernel": "^5.3",
-                "symplify/easy-testing": "^9.4.1",
-                "symplify/symplify-kernel": "^9.4.1"
+                "symplify/easy-testing": "^9.4.28",
+                "symplify/symplify-kernel": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/autowire-array-parameter": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/composer-json-manipulator": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-color-diff": "<9.4.28",
+                "symplify/console-package-builder": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/smart-file-system": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6631,7 +6839,7 @@
             ],
             "description": "Dependency Injection, Console and Kernel toolkit for Symplify packages.",
             "support": {
-                "source": "https://github.com/symplify/package-builder/tree/v9.4.1"
+                "source": "https://github.com/symplify/package-builder/tree/9.4.28"
             },
             "funding": [
                 {
@@ -6643,20 +6851,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-29T17:57:25+00:00"
+            "time": "2021-08-11T15:39:13+00:00"
         },
         {
             "name": "symplify/smart-file-system",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/smart-file-system.git",
-                "reference": "9257a0fb850781adf3a1367f6b33eb66386d1aa5"
+                "reference": "766a783a8708d19d6ae6c756b219ae51b9631202"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/9257a0fb850781adf3a1367f6b33eb66386d1aa5",
-                "reference": "9257a0fb850781adf3a1367f6b33eb66386d1aa5",
+                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/766a783a8708d19d6ae6c756b219ae51b9631202",
+                "reference": "766a783a8708d19d6ae6c756b219ae51b9631202",
                 "shasum": ""
             },
             "require": {
@@ -6664,6 +6872,37 @@
                 "php": ">=8.0",
                 "symfony/filesystem": "^5.3",
                 "symfony/finder": "^5.3"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/autowire-array-parameter": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/composer-json-manipulator": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-color-diff": "<9.4.28",
+                "symplify/console-package-builder": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/easy-testing": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/package-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/symplify-kernel": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "nette/finder": "^2.5",
@@ -6686,7 +6925,7 @@
             ],
             "description": "Sanitized FileInfo with safe getRealPath() and other handy methods",
             "support": {
-                "source": "https://github.com/symplify/smart-file-system/tree/v9.4.1"
+                "source": "https://github.com/symplify/smart-file-system/tree/9.4.28"
             },
             "funding": [
                 {
@@ -6698,20 +6937,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-29T17:57:42+00:00"
+            "time": "2021-08-11T15:39:48+00:00"
         },
         {
             "name": "symplify/symplify-kernel",
-            "version": "v9.4.1",
+            "version": "9.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/symplify-kernel.git",
-                "reference": "57d99ff8e2138556ddbe79b9cd53dc793333f682"
+                "reference": "c9e2f0254949221e25ac864dd432ea058d3abc9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/57d99ff8e2138556ddbe79b9cd53dc793333f682",
-                "reference": "57d99ff8e2138556ddbe79b9cd53dc793333f682",
+                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/c9e2f0254949221e25ac864dd432ea058d3abc9c",
+                "reference": "c9e2f0254949221e25ac864dd432ea058d3abc9c",
                 "shasum": ""
             },
             "require": {
@@ -6719,10 +6958,37 @@
                 "symfony/console": "^5.3",
                 "symfony/dependency-injection": "^5.3",
                 "symfony/http-kernel": "^5.3",
-                "symplify/autowire-array-parameter": "^9.4.1",
-                "symplify/composer-json-manipulator": "^9.4.1",
-                "symplify/package-builder": "^9.4.1",
-                "symplify/smart-file-system": "^9.4.1"
+                "symplify/autowire-array-parameter": "^9.4.28",
+                "symplify/composer-json-manipulator": "^9.4.28",
+                "symplify/package-builder": "^9.4.28",
+                "symplify/smart-file-system": "^9.4.28"
+            },
+            "conflict": {
+                "symplify/amnesia": "<9.4.28",
+                "symplify/astral": "<9.4.28",
+                "symplify/coding-standard": "<9.4.28",
+                "symplify/config-transformer": "<9.4.28",
+                "symplify/console-color-diff": "<9.4.28",
+                "symplify/console-package-builder": "<9.4.28",
+                "symplify/easy-ci": "<9.4.28",
+                "symplify/easy-coding-standard": "<9.4.28",
+                "symplify/easy-hydrator": "<9.4.28",
+                "symplify/easy-testing": "<9.4.28",
+                "symplify/git-wrapper": "<9.4.28",
+                "symplify/markdown-diff": "<9.4.28",
+                "symplify/monorepo-builder": "<9.4.28",
+                "symplify/php-config-printer": "<9.4.28",
+                "symplify/phpstan-extensions": "<9.4.28",
+                "symplify/phpstan-rules": "<9.4.28",
+                "symplify/phpunit-upgrader": "<9.4.28",
+                "symplify/psr4-switcher": "<9.4.28",
+                "symplify/rule-doc-generator": "<9.4.28",
+                "symplify/rule-doc-generator-contracts": "<9.4.28",
+                "symplify/simple-php-doc-parser": "<9.4.28",
+                "symplify/skipper": "<9.4.28",
+                "symplify/symfony-php-config": "<9.4.28",
+                "symplify/symfony-static-dumper": "<9.4.28",
+                "symplify/vendor-patches": "<9.4.28"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6744,9 +7010,9 @@
             ],
             "description": "Internal Kernel for Symplify packages",
             "support": {
-                "source": "https://github.com/symplify/symplify-kernel/tree/v9.4.1"
+                "source": "https://github.com/symplify/symplify-kernel/tree/9.4.28"
             },
-            "time": "2021-06-29T17:57:51+00:00"
+            "time": "2021-08-11T15:40:00+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
@@ -14,12 +14,19 @@ class DataToAppendAndRemoveDataSource
         // Install also the monorepo-builder! So it can be used in CI
         return [
             'require-dev' => [
-                'symplify/monorepo-builder' => '^9.0',
+                // 'symplify/monorepo-builder' => '^9.0',
+                'symplify/monorepo-builder' => 'dev-original',
             ],
             'autoload' => [
                 'psr-4' => [
                     'PoP\\PoP\\' => 'src',
                 ],
+            ],
+            'repositories' => [
+                [
+                    'type' => 'vcs',
+                    'url' => 'https://github.com/leoloso/monorepo-builder.git',
+                ]
             ],
             // 'extra' => [
             //     'installer-paths' => [

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
@@ -14,8 +14,7 @@ class DataToAppendAndRemoveDataSource
         // Install also the monorepo-builder! So it can be used in CI
         return [
             'require-dev' => [
-                // 'symplify/monorepo-builder' => '^9.0',
-                'symplify/monorepo-builder' => '9.4.28',
+                'symplify/monorepo-builder' => '^9.0',
             ],
             'autoload' => [
                 'psr-4' => [

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
@@ -15,7 +15,7 @@ class DataToAppendAndRemoveDataSource
         return [
             'require-dev' => [
                 // 'symplify/monorepo-builder' => '^9.0',
-                'symplify/monorepo-builder' => 'dev-original',
+                'symplify/monorepo-builder' => '9.4.28',
             ],
             'autoload' => [
                 'psr-4' => [


### PR DESCRIPTION
Custom solution to access the Monorepo Builder in its original PHP 8.0 version, after its downgrade to PHP 7.1 broke the custom services in this repo.

See:

- https://github.com/symplify/symplify/issues/3468
- https://github.com/symplify/symplify/pull/3484

## Solution

I just split the original code of the Monorepo Builder into my own repo, and access this forked version on the project.

Steps:

- Forked monorepo `symplify/symplify` into [`leoloso/symplify`](https://github.com/leoloso/symplify)
- Created empty repo [`leoloso/monorepo-builder`](https://github.com/leoloso/monorepo-builder)
- Created a new branch called [`original`](https://github.com/leoloso/monorepo-builder/blob/original/) from the latest tag of the Monorepo Builder (9.4.28)
- Duplicated file `split_monorepo.yml` into [`split_monorepo_builder_original.yml`](https://github.com/leoloso/symplify/blob/original/.github/workflows/split_monorepo_builder_original.yaml), and edited so that:
  - It is triggered whenever pushing to branch `original`
  - It splits only the `monorepo-builder` package
- Pushed the file to the repo

After the last step, the original Monorepo Builder code in PHP 8.0 has been deployed to [`leoloso/monorepo-builder`](https://github.com/leoloso/monorepo-builder).

In this repo, I tagged the code from master with the original version, 9.4.28.

Finally, in `composer.json`, I [added this repository](https://github.com/leoloso/PoP/blob/559e031db25822bfb4db4641c8c71418e185f570/composer.json#L517-L520):

```json
{
    "type": "vcs",
    "url": "https://github.com/leoloso/monorepo-builder.git"
}
```

Voilà! Now the project is accessing the Monorepo Builder in its original PHP 8.0 version! 

## Updates

From now on, whenever the Monorepo Builder is tagged with a new version, I have to:

- Fetch the latest code from the `symplify/symplify` upstream
- Merge it into branch `original` in `leoloso/symplify`
- Push
- Go to `leoloso/monorepo-builder` and tag the new code