### PR TITLE
Added `getUniqueFieldOutputKey`: Don't override value when the fieldOutputKey is repeated

### DIFF
--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -139,7 +139,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
             foreach ($idsDataFields as $id => $dataFields) {
                 foreach ($dataFields['direct'] as $relationalField) {
                     // The data is stored under the field's output key
-                    $relationalFieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($relationalField);
+                    $relationalFieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $relationalField);
                     // Validate that the current object has `relationalField` property set
                     // Since we are fetching from a relational object (placed one level below in the iteration stack), the value could've been set only in a previous iteration
                     // Then it must be in $previousDBItems (it can't be in $dbItems unless set by chance, because the same IDs were involved for a possibly different query)

--- a/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/DuplicatePropertyDirectiveResolver.php
@@ -78,7 +78,7 @@ class DuplicatePropertyDirectiveResolver extends AbstractGlobalDirectiveResolver
         $copyTo = $this->directiveArgsForSchema['to'];
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                 if (!array_key_exists($fieldOutputKey, $dbItems[(string)$id])) {
                     $dbWarnings[(string)$id][] = [
                         Tokens::PATH => [$this->directive],

--- a/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/RenamePropertyDirectiveResolver.php
@@ -77,7 +77,7 @@ class RenamePropertyDirectiveResolver extends DuplicatePropertyDirectiveResolver
         );
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                 unset($dbItems[(string)$id][$fieldOutputKey]);
             }
         }

--- a/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/TransformArrayItemsDirectiveResolver.php
@@ -94,7 +94,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
         // By making the property "propertyName:key", the "key" can be extracted and passed under expression `%key%` to the function
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
 
                 // Validate that the property exists
                 $isValueInDBItems = array_key_exists($fieldOutputKey, $dbItems[(string)$id] ?? []);
@@ -178,7 +178,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
                         $fieldSkipOutputIfNull,
                         $fieldDirectives
                     );
-                    $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($arrayItemProperty);
+                    $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $arrayItemProperty);
                     // Place into the current object
                     $dbItems[(string)$id][$arrayItemPropertyOutputKey] = $value;
                     // Place it into list of fields to process
@@ -191,7 +191,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
         // 3. Composer the array from the results for each array item
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                 $isValueInDBItems = array_key_exists($fieldOutputKey, $dbItems[(string)$id] ?? []);
                 $value = $isValueInDBItems ?
                     $dbItems[(string)$id][$fieldOutputKey] :
@@ -226,7 +226,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
                         $fieldDirectives
                     );
                     // Place the result of executing the function on the array item
-                    $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($arrayItemProperty);
+                    $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $arrayItemProperty);
                     $arrayItemValue = $dbItems[(string)$id][$arrayItemPropertyOutputKey];
                     // Remove this temporary property from $dbItems
                     unset($dbItems[(string)$id][$arrayItemPropertyOutputKey]);
@@ -290,7 +290,7 @@ class TransformArrayItemsDirectiveResolver extends ApplyFunctionDirectiveResolve
         // First let the parent add $value, then also add $key, which can be deduced from the fieldOutputKey
         parent::addExpressionsForResultItem($typeResolver, $id, $field, $resultIDItems, $dbItems, $previousDBItems, $variables, $messages, $dbErrors, $dbWarnings, $dbDeprecations, $schemaErrors, $schemaWarnings, $schemaDeprecations);
 
-        $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+        $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
         $arrayItemPropertyElems = $this->extractElementsFromArrayItemProperty($arrayItemPropertyOutputKey);
         $key = $arrayItemPropertyElems[1];
         $this->addExpressionForResultItem($id, 'key', $key, $messages);

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -750,6 +750,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                     $e->getMessage()
                 );
                 $this->processFailure(
+                    $typeResolver,
                     $failureMessage,
                     [],
                     $idsDataFields,
@@ -790,6 +791,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * or show an error and remove the fields from the directive pipeline for further execution
      */
     protected function processFailure(
+        TypeResolverInterface $typeResolver,
         string $failureMessage,
         array $failedFields,
         array &$idsDataFields,

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -831,6 +831,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
         $setFailingFieldResponseAsNull = ComponentConfiguration::setFailingFieldResponseAsNull();
         if ($setFailingFieldResponseAsNull) {
             $this->setIDsDataFieldsAsNull(
+                $typeResolver,
                 $idsDataFieldsToRemove,
                 $dbItems
             );

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
@@ -91,6 +91,7 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
             );
             if (ComponentConfiguration::setFailingFieldResponseAsNull()) {
                 $this->setIDsDataFieldsAsNull(
+                    $typeResolver,
                     $idsDataFieldsToRemove,
                     $dbItems
                 );

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/RemoveIDsDataFieldsDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/RemoveIDsDataFieldsDirectiveResolverTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\DirectiveResolvers;
 
 use PoP\ComponentModel\ComponentConfiguration;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 trait RemoveIDsDataFieldsDirectiveResolverTrait
 {
@@ -34,13 +35,14 @@ trait RemoveIDsDataFieldsDirectiveResolverTrait
      * For GraphQL, set the response for the failing field as null
      */
     protected function setIDsDataFieldsAsNull(
+        TypeResolverInterface $typeResolver,
         array &$idsDataFieldsToSetAsNull,
         array &$dbItems
     ): void {
         foreach (array_keys($idsDataFieldsToSetAsNull) as $id) {
             $fieldsToSetAsNullForID = $idsDataFieldsToSetAsNull[(string)$id]['direct'];
             foreach ($fieldsToSetAsNullForID as $field) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                 $dbItems[(string)$id][$fieldOutputKey] = null;
             }
         }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -94,7 +94,7 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
             foreach (array_filter($idsDataFields[$id]['conditional']) as $conditionDataField => $conditionalDataFields) {
                 // Check if the condition field has value `true`
                 // All 'conditional' fields must have their own key as 'direct', then simply look for this element on $dbItems
-                $conditionFieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($conditionDataField);
+                $conditionFieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $conditionDataField);
                 if (isset($dbItems[$id]) && array_key_exists($conditionFieldOutputKey, $dbItems[$id])) {
                     $conditionSatisfied = (bool)$dbItems[$id][$conditionFieldOutputKey];
                 } else {
@@ -217,12 +217,12 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
 
             // For GraphQL, set the response for the failing field as null
             if (ComponentConfiguration::setFailingFieldResponseAsNull()) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                 $dbItems[(string)$id][$fieldOutputKey] = null;
             }
         } else {
             // If there is an alias, store the results under this. Otherwise, on the fieldName+fieldArgs
-            $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+            $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
             $dbItems[(string)$id][$fieldOutputKey] = $value;
         }
     }

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -1630,7 +1630,7 @@ class Engine implements EngineInterface
                 $subcomponent_typeResolver_class = $this->dataloadHelperService->getTypeResolverClassFromSubcomponentDataField($targetTypeResolver, $subcomponent_data_field);
             }
             if ($subcomponent_typeResolver_class) {
-                $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getFieldOutputKey($subcomponent_data_field);
+                $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $subcomponent_data_field);
                 // The array_merge_recursive when there are at least 2 levels will make the data_fields to be duplicated, so remove duplicates now
                 $subcomponent_data_fields = array_unique($subcomponent_data_properties['data-fields'] ?? []);
                 $subcomponent_conditional_data_fields = $subcomponent_data_properties['conditional-data-fields'] ?? [];

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
@@ -515,7 +515,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                 if ($subcomponent_typeResolver_class = $this->dataloadHelperService->getTypeResolverClassFromSubcomponentDataField($typeResolver, $subcomponent_data_field)) {
                     $subcomponent_typeResolver = $this->instanceManager->getInstance($subcomponent_typeResolver_class);
                     // If there is an alias, store the results under this. Otherwise, on the fieldName+fieldArgs
-                    $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getFieldOutputKey($subcomponent_data_field);
+                    $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($subcomponent_typeResolver, $subcomponent_data_field);
                     $ret[$subcomponent_data_field_outputkey] = $subcomponent_typeResolver->getTypeOutputName();
                 }
             }
@@ -525,7 +525,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
                     if ($subcomponentTypeResolverClass = $this->dataloadHelperService->getTypeResolverClassFromSubcomponentDataField($typeResolver, $conditionalDataField)) {
                         $subcomponent_typeResolver = $this->instanceManager->getInstance($subcomponentTypeResolverClass);
                         // If there is an alias, store the results under this. Otherwise, on the fieldName+fieldArgs
-                        $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getFieldOutputKey($conditionalDataField);
+                        $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($subcomponent_typeResolver, $conditionalDataField);
                         $ret[$subcomponent_data_field_outputkey] = $subcomponent_typeResolver->getTypeOutputName();
                     }
                 }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -89,7 +89,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         parent::__construct($translationAPI, $feedbackMessageStore, $queryParser);
     }
 
-    public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string
+    final public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string
     {
         return $this->getUniqueFieldOutputKeyByTypeName(
             $typeResolver->getTypeOutputName(),

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -96,12 +96,33 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             $field
         );
     }
+    
     /**
-     * @todo IMPLEMENT!
+     * Obtain a unique fieldOutputKey for the field, for the type.
+     * This is to avoid overriding a previous value with the same alias,
+     * but placed on a different iteration:
+     * 
+     *   ```graphql
+     *   {
+     *     posts {
+     *       title
+     *       self {
+     *         title: excerpt
+     *       }
+     *     }
+     *   ```
+     * 
+     * In this query, the field "excerpt" has alias "title", and would override
+     * the title value from the previous iteration.
+     * 
+     * By keeping a registry of fields to fieldOutputNames, we can always provide
+     * a unique name, and avoid overriding the value.
      */
     public function getUniqueFieldOutputKeyByTypeOutputName(string $typeOutputName, string $field): string
     {
-        return $this->getFieldOutputKey($field);
+        $fieldOutputKey = $this->getFieldOutputKey($field);
+
+        return $fieldOutputKey;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\ComponentModel\ErrorHandling\ErrorDataTokens;
 use PoP\ComponentModel\Feedback\Tokens;
+use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Resolvers\ResolverTypes;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
@@ -93,7 +94,8 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         TranslationAPIInterface $translationAPI,
         UpstreamFeedbackMessageStoreInterface $feedbackMessageStore,
         protected TypeCastingExecuterInterface $typeCastingExecuter,
-        QueryParserInterface $queryParser
+        protected InstanceManagerInterface $instanceManager,
+        QueryParserInterface $queryParser,
     ) {
         parent::__construct($translationAPI, $feedbackMessageStore, $queryParser);
     }
@@ -102,6 +104,18 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     {
         return $this->getUniqueFieldOutputKeyByTypeOutputName(
             $typeResolver->getTypeOutputName(),
+            $field
+        );
+    }
+
+    final public function getUniqueFieldOutputKeyByTypeResolverClass(string $typeResolverClass, string $field): string
+    {
+        /**
+         * @var TypeResolverInterface
+         */
+        $typeResolver = $this->instanceManager->getInstance($typeResolverClass);
+        return $this->getUniqueFieldOutputKey(
+            $typeResolver,
             $field
         );
     }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -89,6 +89,21 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         parent::__construct($translationAPI, $feedbackMessageStore, $queryParser);
     }
 
+    public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string
+    {
+        return $this->getUniqueFieldOutputKeyFromDBKey(
+            $typeResolver->getTypeOutputName(),
+            $field
+        );
+    }
+    /**
+     * @todo IMPLEMENT!
+     */
+    public function getUniqueFieldOutputKeyFromDBKey(string $dbKey, string $field): string
+    {
+        return $this->getFieldOutputKey($field);
+    }
+
     /**
      * Extract field args without using the schema.
      * It is needed to find out which fieldResolver will process a field,

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -119,12 +119,12 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
             $field
         );
     }
-    
+
     /**
      * Obtain a unique fieldOutputKey for the field, for the type.
      * This is to avoid overriding a previous value with the same alias,
      * but placed on a different iteration:
-     * 
+     *
      *   ```graphql
      *   {
      *     posts {
@@ -134,10 +134,10 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
      *       }
      *     }
      *   ```
-     * 
+     *
      * In this query, the field "excerpt" has alias "title", and would override
      * the title value from the previous iteration.
-     * 
+     *
      * By keeping a registry of fields to fieldOutputNames, we can always provide
      * a unique name, and avoid overriding the value.
      */

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -91,7 +91,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
 
     final public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string
     {
-        return $this->getUniqueFieldOutputKeyByTypeName(
+        return $this->getUniqueFieldOutputKeyByTypeOutputName(
             $typeResolver->getTypeOutputName(),
             $field
         );
@@ -99,7 +99,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     /**
      * @todo IMPLEMENT!
      */
-    public function getUniqueFieldOutputKeyByTypeName(string $typeOutputName, string $field): string
+    public function getUniqueFieldOutputKeyByTypeOutputName(string $typeOutputName, string $field): string
     {
         return $this->getFieldOutputKey($field);
     }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -258,7 +258,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
         if ($orderedFieldOrDirectiveArgNamesEnabled) {
             $orderedFieldOrDirectiveArgNames = array_keys($fieldOrDirectiveArgumentNameTypes);
         }
-        // $fieldOrDirectiveOutputKey = $this->getFieldOutputKey($fieldOrDirective);
         $fieldOrDirectiveArgs = [];
         $treatUndefinedFieldOrDirectiveArgsAsErrors = ComponentConfiguration::treatUndefinedFieldOrDirectiveArgsAsErrors();
         $setFailingFieldResponseAsNull = ComponentConfiguration::setFailingFieldResponseAsNull();
@@ -1253,7 +1252,6 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     ): array {
         // If any casting can't be done, show an error
         if ($failedCastingFieldArgs = $this->getFailedCastingFieldArgs($castedFieldArgs)) {
-            // $fieldOutputKey = $this->getFieldOutputKey($field);
             $fieldName = $this->getFieldName($field);
             $fieldArgNameTypes = $this->getFieldArgumentNameTypes($typeResolver, $field);
             $fieldArgNameSchemaDefinition = $this->getFieldSchemaDefinitionArgs($typeResolver, $field);

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -91,7 +91,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
 
     public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string
     {
-        return $this->getUniqueFieldOutputKeyFromDBKey(
+        return $this->getUniqueFieldOutputKeyByTypeName(
             $typeResolver->getTypeOutputName(),
             $field
         );
@@ -99,7 +99,7 @@ class FieldQueryInterpreter extends \PoP\FieldQuery\FieldQueryInterpreter implem
     /**
      * @todo IMPLEMENT!
      */
-    public function getUniqueFieldOutputKeyFromDBKey(string $dbKey, string $field): string
+    public function getUniqueFieldOutputKeyByTypeName(string $typeOutputName, string $field): string
     {
         return $this->getFieldOutputKey($field);
     }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -10,6 +10,18 @@ use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 interface FieldQueryInterpreterInterface extends \PoP\FieldQuery\FieldQueryInterpreterInterface
 {
     /**
+     * If two different fields for the same type have the same fieldOutputKey, then
+     * add a counter to the second one, so each of them is unique.
+     * That is to avoid overriding the previous value, as when doing:
+     * 
+     *   ?query=posts.title|self.excerpt@title
+     * 
+     * In this case, the value of the excerpt would override the value of the title,
+     * since they both have fieldOutputKey "title"
+     */
+    public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string;
+    public function getUniqueFieldOutputKeyFromDBKey(string $dbKey, string $field): string;
+    /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop
      */
     public function extractStaticFieldArguments(string $field, ?array $variables = null): array;

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -20,6 +20,7 @@ interface FieldQueryInterpreterInterface extends \PoP\FieldQuery\FieldQueryInter
      * since they both have fieldOutputKey "title"
      */
     public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string;
+    public function getUniqueFieldOutputKeyByTypeResolverClass(string $typeResolverClass, string $field): string;
     public function getUniqueFieldOutputKeyByTypeOutputName(string $dbKey, string $field): string;
     /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -20,7 +20,7 @@ interface FieldQueryInterpreterInterface extends \PoP\FieldQuery\FieldQueryInter
      * since they both have fieldOutputKey "title"
      */
     public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string;
-    public function getUniqueFieldOutputKeyFromDBKey(string $dbKey, string $field): string;
+    public function getUniqueFieldOutputKeyByTypeName(string $dbKey, string $field): string;
     /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop
      */

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -13,9 +13,9 @@ interface FieldQueryInterpreterInterface extends \PoP\FieldQuery\FieldQueryInter
      * If two different fields for the same type have the same fieldOutputKey, then
      * add a counter to the second one, so each of them is unique.
      * That is to avoid overriding the previous value, as when doing:
-     * 
+     *
      *   ?query=posts.title|self.excerpt@title
-     * 
+     *
      * In this case, the value of the excerpt would override the value of the title,
      * since they both have fieldOutputKey "title"
      */

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -20,7 +20,7 @@ interface FieldQueryInterpreterInterface extends \PoP\FieldQuery\FieldQueryInter
      * since they both have fieldOutputKey "title"
      */
     public function getUniqueFieldOutputKey(TypeResolverInterface $typeResolver, string $field): string;
-    public function getUniqueFieldOutputKeyByTypeName(string $dbKey, string $field): string;
+    public function getUniqueFieldOutputKeyByTypeOutputName(string $dbKey, string $field): string;
     /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop
      */

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1041,7 +1041,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                             $schemaErrorFailingFields
                         );
                         foreach ($failingFields as $field) {
-                            $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                            $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($this, $field);
                             $dbItems[(string)$id][$fieldOutputKey] = null;
                         }
                     }
@@ -1249,7 +1249,6 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
                 $schemaWarnings,
             ) = $this->dissectFieldForSchema($field);
             if ($maybeWarnings = $fieldResolvers[0]->resolveSchemaValidationWarningDescriptions($this, $fieldName, $fieldArgs)) {
-                // $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
                 foreach ($maybeWarnings as $warning) {
                     $schemaWarnings[] = [
                         Tokens::PATH => [$field],
@@ -1277,7 +1276,6 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
             ) = $this->dissectFieldForSchema($field);
             $fieldSchemaDefinition = $fieldResolvers[0]->getSchemaDefinitionForField($this, $fieldName, $fieldArgs);
             if ($fieldSchemaDefinition[SchemaDefinition::ARGNAME_DEPRECATED] ?? null) {
-                // $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
                 $schemaDeprecations[] = [
                     Tokens::PATH => [$field],
                     Tokens::MESSAGE => $fieldSchemaDefinition[SchemaDefinition::ARGNAME_DEPRECATIONDESCRIPTION],

--- a/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/LoadCacheDirectiveResolver.php
@@ -76,7 +76,7 @@ class LoadCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
                 $cacheID = $this->getCacheID($typeResolver, $id, $field);
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                 if ($persistentCache->hasCache($cacheID, $cacheType)) {
                     $dbItems[(string)$id][$fieldOutputKey] = $persistentCache->getCache($cacheID, $cacheType);
                     $idsDataFieldsToRemove[(string)$id]['direct'][] = $field;

--- a/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/ConditionalOnContext/UseComponentModelCache/SchemaServices/DirectiveResolvers/SaveCacheDirectiveResolver.php
@@ -73,7 +73,7 @@ class SaveCacheDirectiveResolver extends AbstractGlobalDirectiveResolver
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
                 $cacheID = $this->getCacheID($typeResolver, $id, $field);
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                 if (!array_key_exists($fieldOutputKey, $dbItems[(string)$id])) {
                     $dbWarnings[(string)$id][] = [
                         Tokens::PATH => [$this->directive],

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver.php
@@ -111,7 +111,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
         // By making the property "propertyName:key", the "key" can be extracted and passed under expression `%key%` to the function
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
 
                 // Validate that the property exists
                 $isValueInDBItems = array_key_exists($fieldOutputKey, $dbItems[(string)$id] ?? []);
@@ -197,7 +197,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                             $fieldSkipOutputIfNull,
                             $fieldDirectives
                         );
-                        $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($arrayItemProperty);
+                        $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $arrayItemProperty);
                         // Place into the current object
                         $dbItems[(string)$id][$arrayItemPropertyOutputKey] = $value;
                         // Place it into list of fields to process
@@ -274,7 +274,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
             // 3. Compose the array from the results for each array item
             foreach ($idsDataFields as $id => $dataFields) {
                 foreach ($dataFields['direct'] as $field) {
-                    $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                    $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
                     $isValueInDBItems = array_key_exists($fieldOutputKey, $dbItems[(string)$id] ?? []);
                     $value = $isValueInDBItems ?
                         $dbItems[(string)$id][$fieldOutputKey] :
@@ -311,7 +311,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
                             $fieldDirectives
                         );
                         // Place the result of executing the function on the array item
-                        $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($arrayItemProperty);
+                        $arrayItemPropertyOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $arrayItemProperty);
                         $arrayItemValue = $dbItems[(string)$id][$arrayItemPropertyOutputKey];
                         // Remove this temporary property from $dbItems
                         unset($dbItems[(string)$id][$arrayItemPropertyOutputKey]);
@@ -399,7 +399,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayItemsDirectiveResolver extend
         $appendExpressions = $this->directiveArgsForSchema['appendExpressions'] ?? [];
         if ($addExpressions || $appendExpressions) {
             // The expressions may need `$value`, so add it
-            $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+            $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
             $isValueInDBItems = array_key_exists($fieldOutputKey, $dbItems[(string)$id] ?? []);
             $dbKey = $typeResolver->getTypeOutputName();
             $value = $isValueInDBItems ?

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -112,7 +112,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
         // Get the value from the object
         foreach ($idsDataFields as $id => $dataFields) {
             foreach ($dataFields['direct'] as $field) {
-                $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+                $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
 
                 // Validate that the property exists
                 $isValueInDBItems = array_key_exists($fieldOutputKey, $dbItems[(string)$id] ?? []);
@@ -260,7 +260,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
         array &$schemaWarnings,
         array &$schemaDeprecations
     ): void {
-        $fieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($field);
+        $fieldOutputKey = $this->fieldQueryInterpreter->getUniqueFieldOutputKey($typeResolver, $field);
         $isValueInDBItems = array_key_exists($fieldOutputKey, $dbItems[(string)$id] ?? []);
         $dbKey = $typeResolver->getTypeOutputName();
         $value = $isValueInDBItems ?

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/avatar-postauthors-layoutsbase.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/avatar-postauthors-layoutsbase.php
@@ -44,7 +44,10 @@ abstract class PoP_Module_Processor_PostAuthorAvatarLayoutsBase extends PoPEngin
         $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);
 
         $ret['avatar'] = array(
-            'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field),
+            'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $avatar_field
+            ),
             'size' => $avatar_size
         );
         $ret['url-field'] = $this->getUrlField($module, $props);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/useravatarlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/useravatarlayouts-base.php
@@ -39,7 +39,10 @@ abstract class PoP_Module_Processor_UserAvatarLayoutsBase extends PoPEngine_Quer
 
         $ret['url-field'] = $this->getUrlField($module);
         $ret['avatar'] = array(
-            'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field),
+            'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $avatar_field
+            ),
         );
 
         return $ret;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/abstract-classes/formcomponents/typeaheads/user-selectabletypeaheadalert-formcomponents-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/abstract-classes/formcomponents/typeaheads/user-selectabletypeaheadalert-formcomponents-base.php
@@ -12,7 +12,10 @@ abstract class PoP_Module_Processor_UserSelectableTypeaheadAlertFormComponentsBa
             $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);
 
             $ret['avatar'] = array(
-                'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field),
+                'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                    $this->getProp($module, $props, 'succeeding-typeResolver'),
+                    $avatar_field
+                ),
                 'size' => $avatar_size
             );
         }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/post-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/post-card-base.php
@@ -43,7 +43,10 @@ abstract class PoP_Module_Processor_PostCardLayoutsBase extends PoPEngine_QueryD
         $ret = parent::getImmutableConfiguration($module, $props);
 
         $ret['thumb'] = array(
-            'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($this->getThumbField($module, $props)),
+            'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $this->getThumbField($module, $props)
+            ),
         );
 
         return $ret;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
@@ -70,7 +70,10 @@ abstract class PoP_Module_Processor_UserCardLayoutsBase extends PoPEngine_QueryD
             $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);
 
             $ret['avatar'] = array(
-                'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field),
+                'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                    $this->getProp($module, $props, 'succeeding-typeResolver'),
+                    $avatar_field
+                ),
                 'size' => $avatar_size
             );
         }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postthumblayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postthumblayouts-base.php
@@ -96,7 +96,9 @@ abstract class PoP_Module_Processor_PostThumbLayoutsBase extends PoPEngine_Query
 
         $ret['url-field'] = $this->getUrlField($module);
         $ret['thumb'] = array(
-            'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($this->getThumbField($module, $props))
+            'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $this->getThumbField($module, $props))
         );
         if ($target = $this->getLinktarget($module, $props)) {
             $ret['link-target'] = $target;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/post-typeahead-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/post-typeahead-component-base.php
@@ -25,7 +25,9 @@ abstract class PoP_Module_Processor_PostTypeaheadComponentLayoutsBase extends Po
 
         $thumb = $this->getThumbField($module, $props);
         $ret['thumb'] = array(
-            'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($thumb),
+            'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $thumb),
         );
         
         return $ret;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-mention-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-mention-component-base.php
@@ -34,7 +34,10 @@ abstract class PoP_Module_Processor_UserMentionComponentLayoutsBase extends PoPE
             $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);
 
             $ret['avatar'] = array(
-                'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field),
+                'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                    $this->getProp($module, $props, 'succeeding-typeResolver'),
+                    $avatar_field
+                ),
                 'size' => $avatar_size
             );
         }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-typeahead-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-typeahead-component-base.php
@@ -38,7 +38,9 @@ abstract class PoP_Module_Processor_UserTypeaheadComponentLayoutsBase extends Po
             $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);
 
             $ret['avatar'] = array(
-                'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field),
+                'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $avatar_field),
                 'size' => $avatar_size
             );
         }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
@@ -55,7 +55,10 @@ abstract class PoP_Module_Processor_SocialMediaItemsBase extends PoPEngine_Query
         $ret[GD_JS_TITLES]['share'] = $title;
         $ret[GD_JS_FONTAWESOME] = $this->getFontawesome($module, $props);
         
-        $ret['shareurl-field'] = FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($this->getShareurlField($module, $props));
+        $ret['shareurl-field'] = FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+            $this->getProp($module, $props, 'succeeding-typeResolver'),
+            $this->getShareurlField($module, $props)
+        );
 
         if ($provider = $this->getProvider($module)) {
             $ret['provider'] = $provider;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/post-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/post-headers-base.php
@@ -58,7 +58,9 @@ abstract class PoP_Module_Processor_PostViewComponentHeadersBase extends PoPEngi
         }
 
         $ret['thumb'] = array(
-            'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($this->getThumbField($module, $props))
+            'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $this->getThumbField($module, $props))
         );
         
         return $ret;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/user-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/user-headers-base.php
@@ -48,7 +48,10 @@ abstract class PoP_Module_Processor_UserViewComponentHeadersBase extends PoPEngi
             $avatar_size = $this->getAvatarSize($module, $props);
             $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);
             $ret['avatar'] = array(
-                'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field),
+                'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                    $this->getProp($module, $props, 'succeeding-typeResolver'),
+                    $avatar_field
+                ),
                 'size' => $avatar_size
             );
         }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
@@ -85,7 +85,9 @@ abstract class PoP_Module_Processor_PostMapScriptCustomizationsBase extends PoP_
         $moduleprocessor_manager = ModuleProcessorManagerFacade::getInstance();
 
         $ret['thumb'] = array(
-            'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($this->getThumbField($module, $props)),
+            'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                $this->getProp($module, $props, 'succeeding-typeResolver'),
+                $this->getThumbField($module, $props)),
         );
 
         if ($authors_module = $this->getAuthorsModule($module)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/user-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/user-map-scriptcustomizations-base.php
@@ -46,11 +46,17 @@ abstract class PoP_Module_Processor_UserMapScriptCustomizationsBase extends PoP_
 
             $ret['avatars'] = array(
                 'sm' => array(
-                    'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field_sm),
+                    'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                        $this->getProp($module, $props, 'succeeding-typeResolver'),
+                        $avatar_field_sm
+                    ),
                     'size' => $avatar_size_sm
                 ),
                 'md' => array(
-                    'name' => FieldQueryInterpreterFacade::getInstance()->getFieldOutputKey($avatar_field_md),
+                    'name' => FieldQueryInterpreterFacade::getInstance()->getUniqueFieldOutputKeyByTypeResolverClass(
+                        $this->getProp($module, $props, 'succeeding-typeResolver'),
+                        $avatar_field_md
+                    ),
                     'size' => $avatar_size_md
                 )
             );

--- a/layers/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php
+++ b/layers/Schema/packages/customposts-wp/src/Overrides/TypeResolvers/CustomPostUnionTypeResolver.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostsWP\Overrides\TypeResolvers;
 
-class CustomPostUnionTypeResolver extends \PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver
+use PoPSchema\CustomPosts\TypeResolvers\CustomPostUnionTypeResolver as UpstreamCustomPostUnionTypeResolver;
+
+class CustomPostUnionTypeResolver extends UpstreamCustomPostUnionTypeResolver
 {
     /**
      * Overriding function to provide optimization:
@@ -26,5 +28,10 @@ class CustomPostUnionTypeResolver extends \PoPSchema\CustomPosts\TypeResolvers\C
             }
         }
         return $resultItemIDTargetTypeResolvers;
+    }
+
+    public function getIdFieldTypeResolverClass(): string
+    {
+        return UpstreamCustomPostUnionTypeResolver::class;
     }
 }


### PR DESCRIPTION
Obtain a unique fieldOutputKey for each combination of field and type. This is to avoid overriding a previous value with the same alias, but placed on a different iteration:

```graphql
{
  posts {
    title
    self {
      title: excerpt
    }
  }
```

In this query, the field "excerpt" has alias "title", and would override the title value from the previous iteration:

```json
{
  "data": {
    "post": {
      "id": 1,
      "title": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
      "self": {
        "title": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!"
      }
    }
  }
}
```

By keeping a registry of fields to fieldOutputNames, we can always provide a unique name, and avoid overriding the value.

This PR stores the two fields under different keys in the DB, making them unique. Running the same query now fixes the problem:

```json
{
  "data": {
    "post": {
      "id": 1,
      "title": "Hello world!",
      "self": {
        "title": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!"
      }
    }
  }
}
```

Please notice that this doesn't handle nested mutations, in that they will still reference the same field (`title`, `title` and `title`). For instance, this query:

```graphql
mutation {
  posts {
    id
    title
    update(title:"saranga") {
      title
      update(title:"Hello world again yeah!") {
        title
      }
    }
  }
}
```

...produces:

```json
{
  "data": {
    "posts": [
      {
        "id": 1,
        "title": "Hello world!",
        "update": {
          "title": "Hello world!",
          "update": {
            "title": "Hello world!"
          }
        }
      }
    ]
  }
}
```

So we need to assign aliases, to make them unique:

```graphql
mutation {
  posts {
    id
    title
    update(title:"saranga") {
      newTitle: title
      update(title:"Hello world again yeah!") {
        newTitle2: title
      }
    }
  }
}
```

...which produces:

```json
{
  "data": {
    "posts": [
      {
        "id": 1,
        "title": "Hello world!",
        "update": {
          "newTitle": "saranga",
          "update": {
            "newTitle2": "Hello world again yeah!"
          }
        }
      }
    ]
  }
}
```