### PR TITLE
Sort fields and connections together, alphabetically

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -118,6 +118,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
 
 - Allow to use unsafe default settings
+- Sort fields and connections together, alphabetically
 
 ## 0.8.1 - 21/07/2021
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -368,3 +368,9 @@ define( 'GRAPHQL_API_ENABLE_UNSAFE_DEFAULTS', true );
 ```
 
 Alternatively, we can define this same key/value as an environment variable.
+
+## Sort fields and connections together, alphabetically
+
+In the GraphQL schema, all connections were shown first, and only then all fields.
+
+Now, they are sorted all together.

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -371,6 +371,6 @@ Alternatively, we can define this same key/value as an environment variable.
 
 ## Sort fields and connections together, alphabetically
 
-In the GraphQL schema, all connections were shown first, and only then all fields.
+When retrieving the GraphQL schema via introspection, all connections were shown first, and only then all fields.
 
-Now, they are sorted all together.
+Now, they are sorted all together, making it easier to browse the fields in the GraphiQL Docs Explorer.

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasFieldsTypeTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasFieldsTypeTrait.php
@@ -66,6 +66,13 @@ trait HasFieldsTypeTrait
                 );
             }
         }
+
+        // Maybe sort fields and connections all together
+        if (ComponentConfiguration::sortSchemaAlphabetically()) {
+            uasort($this->fields, function (Field $a, Field $b): int {
+                return $a->getName() <=> $b->getName();
+            });
+        }
     }
     protected function getInterfaceNames()
     {


### PR DESCRIPTION
When retrieving the GraphQL schema via introspection, all connections were shown first, and only then all fields.

Now, they are sorted all together, making it easier to browse the fields in the GraphiQL Docs Explorer.