### PR TITLE
Restrict CPTs in comments

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -61,6 +61,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - `excludeCustomPostIDs: [ID]`
   - `customPostAuthorIDs: [ID!]`
   - `excludeCustomPostAuthorIDs: [ID]`
+  - `customPostTypes: [String!]`
   - `dateFrom: Date`
   - `dateTo: Date`
   - `excludeAuthorIDs: [ID]`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -142,6 +142,7 @@ Added field arguments to filter `comments`:
 - `excludeCustomPostIDs: [ID]`
 - `customPostAuthorIDs: [ID!]`
 - `excludeCustomPostAuthorIDs: [ID]`
+- `customPostTypes: [String!]`
 - `dateFrom: Date`
 - `dateTo: Date`
 - `excludeAuthorIDs: [ID]`

--- a/layers/Schema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
+++ b/layers/Schema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
@@ -113,6 +113,10 @@ class CommentTypeAPI implements CommentTypeAPIInterface
             $query['post__not_in'] = $query['customPostIDs'];
             unset($query['customPostIDs']);
         }
+        if (isset($query['custompost-types'])) {
+            $query['post_type'] = $query['custompost-types'];
+            unset($query['custompost-types']);
+        }
         // Comment parent ID
         // Pass "0" to retrieve 1st layer of comments added to the post
         if (isset($query['parent-id'])) {

--- a/layers/Schema/packages/comments/src/ModuleProcessors/CommentFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/comments/src/ModuleProcessors/CommentFilterInputContainerModuleProcessor.php
@@ -9,6 +9,7 @@ use PoPSchema\Comments\ModuleProcessors\FormInputs\FilterInputModuleProcessor;
 use PoPSchema\SchemaCommons\ModuleProcessors\AbstractFilterInputContainerModuleProcessor;
 use PoPSchema\SchemaCommons\ModuleProcessors\FormInputs\CommonFilterInputModuleProcessor;
 use PoPSchema\SchemaCommons\ModuleProcessors\FormInputs\CommonFilterMultipleInputModuleProcessor;
+use PoPSchema\CustomPosts\ModuleProcessors\FormInputs\FilterInputModuleProcessor as CustomPostFilterInputModuleProcessor;
 
 class CommentFilterInputContainerModuleProcessor extends AbstractFilterInputContainerModuleProcessor
 {
@@ -66,6 +67,7 @@ class CommentFilterInputContainerModuleProcessor extends AbstractFilterInputCont
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOST_ID],
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOST_IDS],
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_EXCLUDE_CUSTOMPOST_IDS],
+            [CustomPostFilterInputModuleProcessor::class, CustomPostFilterInputModuleProcessor::MODULE_FILTERINPUT_UNIONCUSTOMPOSTTYPES],
         ];
         $adminCommentFilterInputModules = [
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_COMMENT_STATUS],


### PR DESCRIPTION
Query comment from the mapped CPTs only, otherwise we may get an error when the custom post to which the comment was added, is not accesible via field `Comment.customPost`:

```graphql
comments {
  customPost {
    id
  }
}
```

For this reason, `Root.comments` was added argument `customPostTypes`, and `Root.comment` directly executes the query with the list of mapped CPTs.
