### PR TITLE
Removed prop `types-from-union-resolver-class`

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Hooks/QueryHookSet.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Hooks/QueryHookSet.php
@@ -66,7 +66,7 @@ class QueryHookSet extends AbstractHookSet
              */
             $customPostTypeServices = $this->customPostTypeRegistry->getCustomPostTypes();
             $query['post_type'] = array_diff(
-                $query['post_type'],
+                is_array($query['post_type']) ? $query['post_type'] : [$query['post_type']],
                 array_map(
                     fn (CustomPostTypeInterface $customPostTypeService) => $customPostTypeService->getCustomPostType(),
                     $customPostTypeServices

--- a/layers/Schema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/Schema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -6,7 +6,6 @@ namespace PoPSchema\CustomPostsWP\TypeAPIs;
 
 use PoPSchema\CustomPosts\ComponentConfiguration;
 use PoPSchema\CustomPosts\TypeAPIs\AbstractCustomPostTypeAPI as UpstreamAbstractCustomPostTypeAPI;
-use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
 use PoPSchema\CustomPosts\Types\Status;
 use PoPSchema\CustomPostsWP\TypeAPIs\CustomPostTypeAPIHelpers;
 use PoPSchema\CustomPostsWP\TypeAPIs\CustomPostTypeAPIUtils;
@@ -138,14 +137,9 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
         if (isset($query['custompost-types']) && !empty($query['custompost-types'])) {
             $query['post_type'] = $query['custompost-types'];
             unset($query['custompost-types']);
-        } elseif ($unionTypeResolverClass = $query['types-from-union-resolver-class'] ?? null) {
-            $query['post_type'] = CustomPostUnionTypeHelpers::getTargetTypeResolverCustomPostTypes(
-                $unionTypeResolverClass
-            );
-            unset($query['types-from-union-resolver-class']);
         }
         // Querying "attachment" doesn't work in an array!
-        if (isset($query['post_type']) && is_array($query['post_type'])) {
+        if (isset($query['post_type']) && is_array($query['post_type']) && count($query['post_type']) === 1) {
             $query['post_type'] = $query['post_type'][0];
         }
         if (isset($query['offset'])) {

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -129,7 +129,9 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
             case 'customPostCount':
             case 'unrestrictedCustomPostCount':
                 return [
-                    'types-from-union-resolver-class' => CustomPostUnionTypeResolver::class,
+                    'custompost-types' => CustomPostUnionTypeHelpers::getTargetTypeResolverCustomPostTypes(
+                        CustomPostUnionTypeResolver::class
+                    ),
                 ];
         }
         return [];

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -123,17 +123,6 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         string $fieldName,
         array $fieldArgs = []
     ): array {
-        switch ($fieldName) {
-            case 'customPosts':
-            case 'unrestrictedCustomPosts':
-            case 'customPostCount':
-            case 'unrestrictedCustomPostCount':
-                return [
-                    'custompost-types' => CustomPostUnionTypeHelpers::getTargetTypeResolverCustomPostTypes(
-                        CustomPostUnionTypeResolver::class
-                    ),
-                ];
-        }
         return [];
     }
 

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -93,18 +93,19 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
         string $fieldName,
         array $fieldArgs = []
     ): array {
+        $query = parent::getQuery($typeResolver, $resultItem, $fieldName, $fieldArgs);
+
         switch ($fieldName) {
             case 'customPost':
             case 'customPostBySlug':
             case 'unrestrictedCustomPost':
             case 'unrestrictedCustomPostBySlug':
-                return [
-                    'custompost-types' => CustomPostUnionTypeHelpers::getTargetTypeResolverCustomPostTypes(
-                        CustomPostUnionTypeResolver::class
-                    ),
-                ];
+                $query['custompost-types'] = CustomPostUnionTypeHelpers::getTargetTypeResolverCustomPostTypes(
+                    CustomPostUnionTypeResolver::class
+                );
+                break;
         }
-        return [];
+        return $query;
     }
 
     /**

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -85,31 +85,6 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
 
     /**
      * @param array<string, mixed> $fieldArgs
-     * @return array<string, mixed>
-     */
-    protected function getQuery(
-        TypeResolverInterface $typeResolver,
-        object $resultItem,
-        string $fieldName,
-        array $fieldArgs = []
-    ): array {
-        $query = parent::getQuery($typeResolver, $resultItem, $fieldName, $fieldArgs);
-
-        switch ($fieldName) {
-            case 'customPost':
-            case 'customPostBySlug':
-            case 'unrestrictedCustomPost':
-            case 'unrestrictedCustomPostBySlug':
-                $query['custompost-types'] = CustomPostUnionTypeHelpers::getTargetTypeResolverCustomPostTypes(
-                    CustomPostUnionTypeResolver::class
-                );
-                break;
-        }
-        return $query;
-    }
-
-    /**
-     * @param array<string, mixed> $fieldArgs
      * @param array<string, mixed>|null $variables
      * @param array<string, mixed>|null $expressions
      * @param array<string, mixed> $options

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -85,6 +85,30 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
 
     /**
      * @param array<string, mixed> $fieldArgs
+     * @return array<string, mixed>
+     */
+    protected function getQuery(
+        TypeResolverInterface $typeResolver,
+        object $resultItem,
+        string $fieldName,
+        array $fieldArgs = []
+    ): array {
+        switch ($fieldName) {
+            case 'customPost':
+            case 'customPostBySlug':
+            case 'unrestrictedCustomPost':
+            case 'unrestrictedCustomPostBySlug':
+                return [
+                    'custompost-types' => CustomPostUnionTypeHelpers::getTargetTypeResolverCustomPostTypes(
+                        CustomPostUnionTypeResolver::class
+                    ),
+                ];
+        }
+        return [];
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
      * @param array<string, mixed>|null $variables
      * @param array<string, mixed>|null $expressions
      * @param array<string, mixed> $options
@@ -106,9 +130,7 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
             case 'unrestrictedCustomPostBySlug':
                 $query = array_merge(
                     $this->convertFieldArgsToFilteringQueryArgs($typeResolver, $fieldName, $fieldArgs),
-                    [
-                        'types-from-union-resolver-class' => CustomPostUnionTypeResolver::class,
-                    ]
+                    $this->getQuery($typeResolver, $resultItem, $fieldName, $fieldArgs)
                 );
                 if ($posts = $customPostTypeAPI->getCustomPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS])) {
                     return $posts[0];

--- a/layers/Schema/packages/media-wp/src/TypeAPIs/MediaTypeAPI.php
+++ b/layers/Schema/packages/media-wp/src/TypeAPIs/MediaTypeAPI.php
@@ -212,7 +212,7 @@ class MediaTypeAPI extends AbstractCustomPostTypeAPI implements MediaTypeAPIInte
         /** @var WP_Post $mediaItem */
         return $gmt ? $mediaItem->post_modified_gmt : $mediaItem->post_modified;
     }
-    
+
     public function getMimeType(string | int | object $mediaObjectOrID): ?string
     {
         $mediaItem = $this->getCustomPostObject($mediaObjectOrID);


### PR DESCRIPTION
Initially could pass directly prop `custompost-types`, and then also removed this prop since the value is already set as default in the `customPostTypes` filterInput.