### PR TITLE
Rename "unrestricted" fields to "ForAdmin"

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -1210,7 +1210,8 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
         /**
          * If the error happened from requesting a version that doesn't exist, show an appropriate error message
          */
-        if (Environment::enableSemanticVersionConstraints()
+        if (
+            Environment::enableSemanticVersionConstraints()
             && ($versionConstraint = $fieldArgs[SchemaDefinition::ARGNAME_VERSION_CONSTRAINT] ?? null)
         ) {
             $errorMessage = sprintf(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -10,15 +10,15 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Fetch entities by slug and path:
   - `Root.postBySlug: Post`
-  - `Root.unrestrictedPostBySlug: Post` ("admin" field)
+  - `Root.postBySlugForAdmin: Post` ("admin" field)
   - `Root.customPostBySlug: CustomPostUnion`
-  - `Root.unrestrictedCustomPostBySlug: CustomPostUnion` ("admin" field)
+  - `Root.customPostBySlugForAdmin: CustomPostUnion` ("admin" field)
   - `Root.genericCustomPostBySlug: GenericCustomPost`
-  - `Root.unrestrictedGenericCustomPostBySlug: GenericCustomPost` ("admin" field)
+  - `Root.genericCustomPostBySlugForAdmin: GenericCustomPost` ("admin" field)
   - `Root.pageBySlug: Page`
-  - `Root.unrestrictedPageBySlug: Page` ("admin" field)
+  - `Root.pageBySlugForAdmin: Page` ("admin" field)
   - `Root.pageByPath: Page`
-  - `Root.unrestrictedPageByPath: Page` ("admin" field)
+  - `Root.pageByPathForAdmin: Page` ("admin" field)
   - `Root.postCategoryBySlug: PostCategory`
   - `Root.postTagBySlug: PostTag`
   - `Root.mediaItemBySlug: MediaItem`
@@ -39,8 +39,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   `Page.parentPage: Page`
   `Page.childPages: [Page]!`
   `Page.childPageCount: Int!`
-  `Page.unrestrictedChildPages: [Page]!`
-  `Page.unrestrictedChildPageCount: Int!`
+  `Page.childPagesForAdmin: [Page]!`
+  `Page.childPageCountForAdmin: Int!`
   `Page.menuOrder: Int!`
 - Filter field `pages` via new arguments:
   - `parentIDs: [ID]`
@@ -79,8 +79,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - `Root.userByUsername: User`
   - `Root.userByEmail: User` ("admin" field)
 - Filter users by email:
-  - `Root.unrestrictedUsers: [User]!` ("admin" field)
-  - `Root.unrestrictedUserCount: Int!` ("admin" field)
+  - `Root.usersForAdmin: [User]!` ("admin" field)
+  - `Root.userCountForAdmin: Int!` ("admin" field)
 - Query properties for users:
   - `User.nicename: String!`
   - `User.nickname: String!`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -45,7 +45,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Filter field `pages` via new arguments:
   - `parentIDs: [ID]`
   - `parentID: ID`
-- Added fields to retrieve comments and their number (and also their "unrestricted" versions):
+- Added fields to retrieve comments and their number (and also their "admin" versions):
   - `Root.comment: Comment`
   - `Root.comments: [Comment]!`
   - `Root.commentCount: Int!`
@@ -142,6 +142,39 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 
 - Fixed newlines removed from GraphQL query after refreshing browser ([#972](https://github.com/leoloso/PoP/pull/972))
+
+### Breaking changes
+
+Renamed all the "admin" fields. Instead of prepending them with "unrestricted", now they are appended "ForAdmin":
+
+Root:
+
+- `unrestrictedPost` => `postForAdmin`
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`
+- `unrestrictedCustomPost` => `customPostForAdmin`
+- `unrestrictedCustomPosts` => `customPostsForAdmin`
+- `unrestrictedCustomPostCount` => `customPostCountForAdmin`
+- `unrestrictedPage` => `pageForAdmin`
+- `unrestrictedPages` => `pagesForAdmin`
+- `unrestrictedPageCount` => `pageCountForAdmin`
+
+User:
+
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`
+- `unrestrictedCustomPosts` => `customPostsForAdmin`
+- `unrestrictedCustomPostCount` => `customPostCountForAdmin`
+
+PostCategory:
+
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`
+
+PostTag:
+
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`
 
 ## 0.8.1 - 21/07/2021
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
@@ -128,7 +128,7 @@ GraphQL API is extensible, and ships with the following modules (organized by ca
 <tr><td><a href="docs/en/modules/interactive-schema-for-custom-endpoints.md">Interactive Schema for Custom Endpoints</a></td><td>Enable custom endpoints to be attached their own Interactive schema client, to visualize the custom schema subset</td></tr>
 <tr><td><a href="docs/en/modules/graphiql-explorer.md">GraphiQL Explorer</a></td><td>Add the Explorer widget to the GraphiQL client, to simplify coding the query (by point-and-clicking on the fields)</td></tr>
 <tr><th colspan="2"><br/>Schema Type</th></tr>
-<tr><td><a href="docs/en/modules/schema-admin-schema.md">Admin for the Schema</a></td><td>Add "unrestricted" fields to the GraphQL schema (such as <code>Root.unrestrictedPosts</code>, <code>Root.roles</code>, and others), to be used by the admin only</td></tr>
+<tr><td><a href="docs/en/modules/schema-admin-schema.md">Admin for the Schema</a></td><td>Add "unrestricted" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only</td></tr>
 <tr><td><a href="docs/en/modules/schema-customposts.md">Schema Custom Posts</a></td><td>Base functionality for all custom posts</td></tr>
 <tr><td><a href="docs/en/modules/schema-generic-customposts.md">Schema Generic Custom Posts</a></td><td>Query any custom post type (added to the schema or not), through a generic type <code>GenericCustomPost</code></td></tr>
 <tr><td>Schema Posts</td><td>Query posts, through type <code>Post</code> added to the schema</td></tr>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
@@ -128,7 +128,7 @@ GraphQL API is extensible, and ships with the following modules (organized by ca
 <tr><td><a href="docs/en/modules/interactive-schema-for-custom-endpoints.md">Interactive Schema for Custom Endpoints</a></td><td>Enable custom endpoints to be attached their own Interactive schema client, to visualize the custom schema subset</td></tr>
 <tr><td><a href="docs/en/modules/graphiql-explorer.md">GraphiQL Explorer</a></td><td>Add the Explorer widget to the GraphiQL client, to simplify coding the query (by point-and-clicking on the fields)</td></tr>
 <tr><th colspan="2"><br/>Schema Type</th></tr>
-<tr><td><a href="docs/en/modules/schema-admin-schema.md">Admin for the Schema</a></td><td>Add "unrestricted" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only</td></tr>
+<tr><td><a href="docs/en/modules/schema-admin-schema.md">Admin for the Schema</a></td><td>Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only</td></tr>
 <tr><td><a href="docs/en/modules/schema-customposts.md">Schema Custom Posts</a></td><td>Base functionality for all custom posts</td></tr>
 <tr><td><a href="docs/en/modules/schema-generic-customposts.md">Schema Generic Custom Posts</a></td><td>Query any custom post type (added to the schema or not), through a generic type <code>GenericCustomPost</code></td></tr>
 <tr><td>Schema Posts</td><td>Query posts, through type <code>Post</code> added to the schema</td></tr>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/README.md
@@ -128,7 +128,7 @@ GraphQL API is extensible, and ships with the following modules (organized by ca
 <tr><td><a href="docs/en/modules/interactive-schema-for-custom-endpoints.md">Interactive Schema for Custom Endpoints</a></td><td>Enable custom endpoints to be attached their own Interactive schema client, to visualize the custom schema subset</td></tr>
 <tr><td><a href="docs/en/modules/graphiql-explorer.md">GraphiQL Explorer</a></td><td>Add the Explorer widget to the GraphiQL client, to simplify coding the query (by point-and-clicking on the fields)</td></tr>
 <tr><th colspan="2"><br/>Schema Type</th></tr>
-<tr><td><a href="docs/en/modules/schema-admin-schema.md">Admin for the Schema</a></td><td>Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only</td></tr>
+<tr><td><a href="docs/en/modules/schema-admin-schema.md">Admin for the Schema</a></td><td>Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), which expose private data</td></tr>
 <tr><td><a href="docs/en/modules/schema-customposts.md">Schema Custom Posts</a></td><td>Base functionality for all custom posts</td></tr>
 <tr><td><a href="docs/en/modules/schema-generic-customposts.md">Schema Generic Custom Posts</a></td><td>Query any custom post type (added to the schema or not), through a generic type <code>GenericCustomPost</code></td></tr>
 <tr><td>Schema Posts</td><td>Query posts, through type <code>Post</code> added to the schema</td></tr>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
@@ -52,7 +52,7 @@ const SchemaConfigAdminSchemaCard = ( props ) => {
 						<em>{ __('Add admin fields to the schema?', 'graphql-api') }</em>
 						<InfoTooltip
 							{ ...props }
-							text={ __('Add "unrestricted" fields to the GraphQL schema (such as "Root.postsForAdmin", "User.roles", and others), to be used by the admin only', 'graphql-api') }
+							text={ __('Add "admin" fields to the GraphQL schema (such as "Root.postsForAdmin", "User.roles", and others), to be used by the admin only', 'graphql-api') }
 						/>
 						{ !isSelected && (
 							<>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
@@ -52,7 +52,7 @@ const SchemaConfigAdminSchemaCard = ( props ) => {
 						<em>{ __('Add admin fields to the schema?', 'graphql-api') }</em>
 						<InfoTooltip
 							{ ...props }
-							text={ __('Add "unrestricted" fields to the GraphQL schema (such as "Root.unrestrictedPosts", "User.roles", and others), to be used by the admin only', 'graphql-api') }
+							text={ __('Add "unrestricted" fields to the GraphQL schema (such as "Root.postsForAdmin", "User.roles", and others), to be used by the admin only', 'graphql-api') }
 						/>
 						{ !isSelected && (
 							<>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
@@ -32,7 +32,7 @@ const SchemaConfigAdminSchemaCard = ( props ) => {
 			value: ATTRIBUTE_VALUE_DEFAULT,
 		},
 		{
-			label: __('Add "unrestricted" admin fields to the schema', 'graphql-api'),
+			label: __('Add "admin" fields to the schema', 'graphql-api'),
 			value: ATTRIBUTE_VALUE_ENABLED,
 		},
 		{
@@ -61,10 +61,10 @@ const SchemaConfigAdminSchemaCard = ( props ) => {
 									<span>🟡 { __('Default', 'graphql-api') }</span>
 								}
 								{ enabledConst == ATTRIBUTE_VALUE_ENABLED &&
-									<span>✅ { __('Add "unrestricted" admin fields', 'graphql-api') }</span>
+									<span>✅ { __('Add "admin" fields', 'graphql-api') }</span>
 								}
 								{ enabledConst == ATTRIBUTE_VALUE_DISABLED &&
-									<span>❌ { __('Do not add fields', 'graphql-api') }</span>
+									<span>❌ { __('Do not add admin fields', 'graphql-api') }</span>
 								}
 							</>
 						) }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/schema-config-admin-schema/src/schema-config-admin-schema-card.js
@@ -52,7 +52,7 @@ const SchemaConfigAdminSchemaCard = ( props ) => {
 						<em>{ __('Add admin fields to the schema?', 'graphql-api') }</em>
 						<InfoTooltip
 							{ ...props }
-							text={ __('Add "admin" fields to the GraphQL schema (such as "Root.postsForAdmin", "User.roles", and others), to be used by the admin only', 'graphql-api') }
+							text={ __('Add "admin" fields to the GraphQL schema (such as "Root.postsForAdmin", "User.roles", and others), which expose private data', 'graphql-api') }
 						/>
 						{ !isSelected && (
 							<>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-admin-schema.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-admin-schema.md
@@ -1,6 +1,6 @@
 # Schema for the Admin
 
-Add "unrestricted" admin fields to the GraphQL schema, which may expose private data.
+Add "admin" fields to the GraphQL schema, which may expose private data.
 
 The GraphQL schema must strike a balance between public and private fields, as to avoid exposing private information in a public API.
 
@@ -10,7 +10,7 @@ For instance, to access post data, we have field:
 
 With this module, we can also access post data via field:
 
-- `Root.postsForAdmin`: exposes public and private data, by allowing us to fetch posts with any status (`"publish"`, `"draft"`, `"pending"`, `"trash"`).
+- `Root.postsForAdmin`: exposes public and private data, by allowing us to fetch posts with any status (`"publish"`, `"draft"`, `"pending"`, `"trash"`) via the field argument `status`.
 
 ## List of admin fields
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-admin-schema.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-admin-schema.md
@@ -10,7 +10,7 @@ For instance, to access post data, we have field:
 
 With this module, we can also access post data via field:
 
-- `Root.unrestrictedPosts`: exposes public and private data, by fetching posts with any status (`"publish"`, `"draft"`, `"pending"`, `"trash"`).
+- `Root.postsForAdmin`: exposes public and private data, by allowing us to fetch posts with any status (`"publish"`, `"draft"`, `"pending"`, `"trash"`).
 
 ## List of admin fields
 
@@ -18,59 +18,59 @@ The following fields will be added to the GraphQL schema:
 
 **Root:**
 
-- `unrestrictedPost`
-- `unrestrictedPostBySlug`
-- `unrestrictedPosts`
-- `unrestrictedPostCount`
-- `unrestrictedCustomPost`
-- `unrestrictedCustomPostBySlug`
-- `unrestrictedCustomPosts`
-- `unrestrictedCustomPostCount`
-- `unrestrictedGenericCustomPost`
-- `unrestrictedGenericCustomPostBySlug`
-- `unrestrictedPage`
-- `unrestrictedPageBySlug`
-- `unrestrictedPages`
-- `unrestrictedPageCount`
-- `unrestrictedComments`
-- `unrestrictedCommentCount`
+- `postForAdmin`
+- `postBySlugForAdmin`
+- `postsForAdmin`
+- `postCountForAdmin`
+- `customPostForAdmin`
+- `customPostBySlugForAdmin`
+- `customPostsForAdmin`
+- `customPostCountForAdmin`
+- `genericCustomPostForAdmin`
+- `genericCustomPostBySlugForAdmin`
+- `pageForAdmin`
+- `pageBySlugForAdmin`
+- `pagesForAdmin`
+- `pageCountForAdmin`
+- `commentsForAdmin`
+- `commentCountForAdmin`
 - `roles`
 - `capabilities`
 
 **User:**
 
-- `unrestrictedPosts`
-- `unrestrictedPostCount`
-- `unrestrictedCustomPosts`
-- `unrestrictedCustomPostCount`
+- `postsForAdmin`
+- `postCountForAdmin`
+- `customPostsForAdmin`
+- `customPostCountForAdmin`
 - `roles`
 - `capabilities`
 
 **PostCategory:**
 
-- `unrestrictedPosts`
-- `unrestrictedPostCount`
+- `postsForAdmin`
+- `postCountForAdmin`
 
 **PostTag:**
 
-- `unrestrictedPosts`
-- `unrestrictedPostCount`
+- `postsForAdmin`
+- `postCountForAdmin`
 
 **Custom Posts:**
 
-- `unrestrictedComments`
-- `unrestrictedCommentCount`
+- `commentsForAdmin`
+- `commentCountForAdmin`
 
 **Comments:**
 
-- `unrestrictedResponses`
-- `unrestrictedResponseCount`
+- `responsesForAdmin`
+- `responseCountForAdmin`
 
 ---
 
 Please notice the naming convention:
 
-- If the field exposes public + private data, then the field name starts with `"unrestricted"`, such as `Root.posts` and `Root.unrestrictedPosts`
+- If the field exposes public + private data, then the field name starts with `"unrestricted"`, such as `Root.posts` and `Root.postsForAdmin`
 - If the field only exposes private data, then it doesn't need start with `"unrestricted"`, such as `User.roles`
 
 ## How to use

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-admin-schema.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-admin-schema.md
@@ -70,8 +70,8 @@ The following fields will be added to the GraphQL schema:
 
 Please notice the naming convention:
 
-- If the field exposes public + private data, then the field name starts with `"unrestricted"`, such as `Root.posts` and `Root.postsForAdmin`
-- If the field only exposes private data, then it doesn't need start with `"unrestricted"`, such as `User.roles`
+- If the field exposes public + private data, then the field name ends with `"ForAdmin"`, such as `Root.posts` and `Root.postsForAdmin`
+- If the field only exposes private data, then it doesn't need end with `"ForAdmin"`, such as `User.roles`
 
 ## How to use
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-configuration.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-configuration.md
@@ -12,7 +12,7 @@ The schema can be configured with the following elements (more items can also pr
 Modules can define their own configuration to be applied in the schema through their own option blocks, including:
 
 - Setting the schema as public or private
-- Enabling "unrestricted" fields for the admin
+- Enabling "admin" fields exposing private data
 - Namespacing the schema
 - Using nested mutations
 
@@ -62,7 +62,7 @@ These inputs in the body of the editor are shipped with the plugin (more inputs 
 </tr>
 <tr>
     <td><strong>Schema for the Admin</strong></td>
-    <td>Add "unrestricted" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>User.roles</code>, and others), to be used by the admin only. If <code>"Default"</code> is selected, the value selected in the Settings is used.</td>
+    <td>Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>User.roles</code>, and others), to be used by the admin only. If <code>"Default"</code> is selected, the value selected in the Settings is used.</td>
 </tr>
 <tr>
     <td><strong>Public/Private Schema</strong></td>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-configuration.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-configuration.md
@@ -62,7 +62,7 @@ These inputs in the body of the editor are shipped with the plugin (more inputs 
 </tr>
 <tr>
     <td><strong>Schema for the Admin</strong></td>
-    <td>Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>User.roles</code>, and others), to be used by the admin only. If <code>"Default"</code> is selected, the value selected in the Settings is used.</td>
+    <td>Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>User.roles</code>, and others), which expose private data. If <code>"Default"</code> is selected, the value selected in the Settings is used.</td>
 </tr>
 <tr>
     <td><strong>Public/Private Schema</strong></td>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-configuration.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-configuration.md
@@ -62,7 +62,7 @@ These inputs in the body of the editor are shipped with the plugin (more inputs 
 </tr>
 <tr>
     <td><strong>Schema for the Admin</strong></td>
-    <td>Add "unrestricted" fields to the GraphQL schema (such as <code>Root.unrestrictedPosts</code>, <code>User.roles</code>, and others), to be used by the admin only. If <code>"Default"</code> is selected, the value selected in the Settings is used.</td>
+    <td>Add "unrestricted" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>User.roles</code>, and others), to be used by the admin only. If <code>"Default"</code> is selected, the value selected in the Settings is used.</td>
 </tr>
 <tr>
     <td><strong>Public/Private Schema</strong></td>

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -14,15 +14,15 @@ Let's see what new elements have been added.
 The following fields have been added to the root:
 
 - `Root.postBySlug: Post`
-- `Root.unrestrictedPostBySlug: Post` ("admin" field)
+- `Root.postBySlugForAdmin: Post` ("admin" field)
 - `Root.customPostBySlug: CustomPostUnion`
-- `Root.unrestrictedCustomPostBySlug: CustomPostUnion` ("admin" field)
+- `Root.customPostBySlugForAdmin: CustomPostUnion` ("admin" field)
 - `Root.genericCustomPostBySlug: GenericCustomPost`
-- `Root.unrestrictedGenericCustomPostBySlug: GenericCustomPost` ("admin" field)
+- `Root.genericCustomPostBySlugForAdmin: GenericCustomPost` ("admin" field)
 - `Root.pageBySlug: Page`
-- `Root.unrestrictedPageBySlug: Page` ("admin" field)
+- `Root.pageBySlugForAdmin: Page` ("admin" field)
 - `Root.pageByPath: Page`
-- `Root.unrestrictedPageByPath: Page` ("admin" field)
+- `Root.pageByPathForAdmin: Page` ("admin" field)
 - `Root.postCategoryBySlug: PostCategory`
 - `Root.postTagBySlug: PostTag`
 - `Root.mediaItemBySlug: MediaItem`
@@ -91,8 +91,8 @@ Added fields to `Page` to fetch the parent and children, and the menu order:
 - `parentPage: Page`
 - `childPages: [Page]!`
 - `childPageCount: Int!`
-- `unrestrictedChildPages: [Page]!`
-- `unrestrictedChildPageCount: Int!`
+- `childPagesForAdmin: [Page]!`
+- `childPageCountForAdmin: Int!`
 - `menuOrder: Int!`
 
 Filter field `pages` via new arguments:
@@ -169,8 +169,8 @@ Fetch a user by different means:
 
 Created the "admin" version of field `users`, enabling to filter users by email:
 
-- `Root.unrestrictedUsers: [User]!`
-- `Root.unrestrictedUserCount: Int!`
+- `Root.usersForAdmin: [User]!`
+- `Root.userCountForAdmin: Int!`
 
 Query properties for users:
 
@@ -376,7 +376,7 @@ Whitelist additional entries by default:
 The GraphQL API for WordPress provides safe default settings:
 
 - The single endpoint is disabled
-- The "unrestricted" fields (such as `unrestrictedPosts`, to fetch posts with status `"draft"`) are not added to the schema
+- The "unrestricted" fields (such as `postsForAdmin`, to fetch posts with status `"draft"`) are not added to the schema
 - Only a handful of the settings options and meta keys (for posts, users, etc) can be queried
 - The number of entities that can be queried at once is limited (for posts, users, etc)
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -1,8 +1,8 @@
 # Release Notes: 0.9
 
-## Further Completed the GraphQL Schema
+## GraphQL Schema Bonanza
 
-Additional entities from the WordPress data model have been added to the GraphQL schema:
+The GraphQL schema mapping the WordPress data model has been completed! 🎉
 
 <!-- Add this image! -->
 <!-- <a href="../../images/graphql-schema-v09.png" target="_blank">![GraphQL schema](../../images/graphql-schema-v09.png)</a> -->
@@ -399,3 +399,36 @@ Now, they are sorted all together, making it easier to browse the fields in the 
 ## Fixed issues
 
 - Fixed newlines removed from GraphQL query after refreshing browser ([#972](https://github.com/leoloso/PoP/pull/972))
+
+## Breaking changes
+
+Renamed all the "admin" fields. Instead of prepending them with "unrestricted", now they are appended "ForAdmin":
+
+Root:
+
+- `unrestrictedPost` => `postForAdmin`
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`
+- `unrestrictedCustomPost` => `customPostForAdmin`
+- `unrestrictedCustomPosts` => `customPostsForAdmin`
+- `unrestrictedCustomPostCount` => `customPostCountForAdmin`
+- `unrestrictedPage` => `pageForAdmin`
+- `unrestrictedPages` => `pagesForAdmin`
+- `unrestrictedPageCount` => `pageCountForAdmin`
+
+User:
+
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`
+- `unrestrictedCustomPosts` => `customPostsForAdmin`
+- `unrestrictedCustomPostCount` => `customPostCountForAdmin`
+
+PostCategory:
+
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`
+
+PostTag:
+
+- `unrestrictedPosts` => `postsForAdmin`
+- `unrestrictedPostCount` => `postCountForAdmin`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -123,7 +123,7 @@ fragment PageProps on Page {
 
 ### Comments
 
-Added fields to retrieve comments and their number (and also their "unrestricted" versions):
+Added fields to retrieve comments and their number (and also their "admin" versions):
 
 - `Root.comment: Comment`
 - `Root.comments: [Comment]!`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -376,7 +376,7 @@ Whitelist additional entries by default:
 The GraphQL API for WordPress provides safe default settings:
 
 - The single endpoint is disabled
-- The "unrestricted" fields (such as `postsForAdmin`, to fetch posts with status `"draft"`) are not added to the schema
+- The "admin" fields (such as `postsForAdmin`, to fetch posts with status `"draft"`) are not added to the schema
 - Only a handful of the settings options and meta keys (for posts, users, etc) can be queried
 - The number of entities that can be queried at once is limited (for posts, users, etc)
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Component.php
@@ -112,7 +112,7 @@ class Component extends AbstractPluginComponent
             self::initServices(dirname(__DIR__), '/ConditionalOnContext/Admin');
 
             // The WordPress editor can access the full GraphQL schema,
-            // including "unrestricted" admin fields, so cache it individually.
+            // including "admin" fields, so cache it individually.
             // Retrieve this service from the SystemContainer
             $systemInstanceManager = SystemInstanceManagerFacade::getInstance();
             /** @var EndpointHelpers */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/Services/EndpointResolvers/AdminEndpointResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/Services/EndpointResolvers/AdminEndpointResolver.php
@@ -108,7 +108,7 @@ class AdminEndpointResolver extends AbstractEndpointResolver
                  * for Gutenberg blocks which require some field that must necessarily be enabled.
                  * This GraphQL schema is not modified by user preferences:
                  * - All types/directives are always in the schema
-                 * - The "unrestricted" admin fields are in the schema
+                 * - The "admin" fields are in the schema
                  * - Nested mutations enabled, without removing the redundant fields in the Root
                  * - No namespacing
                  */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -482,7 +482,7 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
                     $option
                 ),
                 Properties::TITLE => \__('Add admin fields to schema?', 'graphql-api'),
-                Properties::DESCRIPTION => \__('Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only.<hr/><strong>Watch out: Enable only if needed!</strong><br/>These fields can expose sensitive information, so they should be enabled only when the API is not publicly exposed (such as when using a local WordPress instance, to build a static site).', 'graphql-api'),
+                Properties::DESCRIPTION => \__('Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), which expose private data.<hr/><strong>Watch out: Enable only if needed!</strong><br/>These fields can expose sensitive information, so they should be enabled only when the API is not publicly exposed (such as when using a local WordPress instance, to build a static site).', 'graphql-api'),
                 Properties::TYPE => Properties::TYPE_BOOL,
             ];
             $option = self::OPTION_ADD_SELF_FIELD_TO_SCHEMA;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -482,7 +482,7 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
                     $option
                 ),
                 Properties::TITLE => \__('Add admin fields to schema?', 'graphql-api'),
-                Properties::DESCRIPTION => \__('Add "unrestricted" fields to the GraphQL schema (such as <code>Root.unrestrictedPosts</code>, <code>Root.roles</code>, and others), to be used by the admin only.<hr/><strong>Watch out: Enable only if needed!</strong><br/>These fields can expose sensitive information, so they should be enabled only when the API is not publicly exposed (such as when using a local WordPress instance, to build a static site).', 'graphql-api'),
+                Properties::DESCRIPTION => \__('Add "unrestricted" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only.<hr/><strong>Watch out: Enable only if needed!</strong><br/>These fields can expose sensitive information, so they should be enabled only when the API is not publicly exposed (such as when using a local WordPress instance, to build a static site).', 'graphql-api'),
                 Properties::TYPE => Properties::TYPE_BOOL,
             ];
             $option = self::OPTION_ADD_SELF_FIELD_TO_SCHEMA;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -225,7 +225,7 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
         $userTypeResolver = $this->userTypeResolver;
         switch ($module) {
             case self::SCHEMA_ADMIN_SCHEMA:
-                return \__('Add "unrestricted" admin fields to the schema', 'graphql-api');
+                return \__('Add "admin" fields to the schema', 'graphql-api');
             case self::SCHEMA_GENERIC_CUSTOMPOSTS:
                 return sprintf(
                     \__('Query any custom post type (added to the schema or not), through a generic type <code>%1$s</code>', 'graphql-api'),

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaTypeModuleResolver.php
@@ -482,7 +482,7 @@ class SchemaTypeModuleResolver extends AbstractModuleResolver
                     $option
                 ),
                 Properties::TITLE => \__('Add admin fields to schema?', 'graphql-api'),
-                Properties::DESCRIPTION => \__('Add "unrestricted" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only.<hr/><strong>Watch out: Enable only if needed!</strong><br/>These fields can expose sensitive information, so they should be enabled only when the API is not publicly exposed (such as when using a local WordPress instance, to build a static site).', 'graphql-api'),
+                Properties::DESCRIPTION => \__('Add "admin" fields to the GraphQL schema (such as <code>Root.postsForAdmin</code>, <code>Root.roles</code>, and others), to be used by the admin only.<hr/><strong>Watch out: Enable only if needed!</strong><br/>These fields can expose sensitive information, so they should be enabled only when the API is not publicly exposed (such as when using a local WordPress instance, to build a static site).', 'graphql-api'),
                 Properties::TYPE => Properties::TYPE_BOOL,
             ];
             $option = self::OPTION_ADD_SELF_FIELD_TO_SCHEMA;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Overrides/Services/ConfigurationCache/CacheConfigurationManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Overrides/Services/ConfigurationCache/CacheConfigurationManager.php
@@ -38,7 +38,7 @@ class CacheConfigurationManager implements CacheConfigurationManagerInterface
         // admin/non-admin screens have different services enabled
         $suffix = \is_admin() ?
             // The WordPress editor can access the full GraphQL schema,
-            // including "unrestricted" admin fields, so cache it individually
+            // including "admin" fields, so cache it individually
             'a' . ($this->endpointHelpers->isRequestingAdminFixedSchemaGraphQLEndpoint() ? 'u' : 'c')
             : 'c';
         $timestamp .= '_' . $suffix;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -585,7 +585,7 @@ class PluginConfiguration extends AbstractMainPluginConfiguration
         /** @var EndpointHelpers */
         $endpointHelpers = $systemInstanceManager->getInstance(EndpointHelpers::class);
         if ($endpointHelpers->isRequestingAdminFixedSchemaGraphQLEndpoint()) {
-            // Enable the "unrestricted" admin fields
+            // Enable the "admin" fields
             $componentClassConfiguration[\PoP\ComponentModel\Component::class][ComponentModelEnvironment::ENABLE_ADMIN_SCHEMA] = true;
             // Enable Nested mutations
             $componentClassConfiguration[\GraphQLByPoP\GraphQLServer\Component::class][GraphQLServerEnvironment::ENABLE_NESTED_MUTATIONS] = true;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/EndpointHelpers.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/Helpers/EndpointHelpers.php
@@ -81,7 +81,7 @@ class EndpointHelpers
 
     /**
      * GraphQL endpoint to be used in the WordPress editor.
-     * It has the full schema, including "unrestricted" admin fields.
+     * It has the full schema, including "admin" fields.
      */
     public function getAdminFixedSchemaGraphQLEndpoint(): string
     {

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostListCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostListCategoryFieldResolver.php
@@ -17,8 +17,8 @@ abstract class AbstractCustomPostListCategoryFieldResolver extends AbstractCusto
         $descriptions = [
             'customPosts' => $this->translationAPI->__('Custom posts which contain this category', 'pop-categories'),
             'customPostCount' => $this->translationAPI->__('Number of custom posts which contain this category', 'pop-categories'),
-            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts which contain this category', 'pop-categories'),
-            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts which contain this category', 'pop-categories'),
+            'customPostsForAdmin' => $this->translationAPI->__('[Unrestricted] Custom posts which contain this category', 'pop-categories'),
+            'customPostCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of custom posts which contain this category', 'pop-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -41,8 +41,8 @@ abstract class AbstractCustomPostListCategoryFieldResolver extends AbstractCusto
         switch ($fieldName) {
             case 'customPosts':
             case 'customPostCount':
-            case 'unrestrictedCustomPosts':
-            case 'unrestrictedCustomPostCount':
+            case 'customPostsForAdmin':
+            case 'customPostCountForAdmin':
                 $query[$this->getQueryProperty()] = [$typeResolver->getID($category)];
                 break;
         }

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -32,8 +32,8 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             'hasComments',
             'commentCount',
             'comments',
-            'unrestrictedCommentCount',
-            'unrestrictedComments',
+            'commentCountForAdmin',
+            'commentsForAdmin',
         ];
     }
 
@@ -44,8 +44,8 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             'hasComments' => SchemaDefinition::TYPE_BOOL,
             'commentCount' => SchemaDefinition::TYPE_INT,
             'comments' => SchemaDefinition::TYPE_ID,
-            'unrestrictedCommentCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedComments' => SchemaDefinition::TYPE_ID,
+            'commentCountForAdmin' => SchemaDefinition::TYPE_INT,
+            'commentsForAdmin' => SchemaDefinition::TYPE_ID,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
@@ -56,10 +56,10 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             'areCommentsOpen',
             'hasComments',
             'commentCount',
-            'unrestrictedCommentCount'
+            'commentCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'comments',
-            'unrestrictedComments'
+            'commentsForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($fieldName),
@@ -73,8 +73,8 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             'hasComments' => $this->translationAPI->__('Does the custom post have comments?', 'pop-comments'),
             'commentCount' => $this->translationAPI->__('Number of comments added to the custom post', 'pop-comments'),
             'comments' => $this->translationAPI->__('Comments added to the custom post', 'pop-comments'),
-            'unrestrictedCommentCount' => $this->translationAPI->__('[Unrestricted] Number of comments added to the custom post', 'pop-comments'),
-            'unrestrictedComments' => $this->translationAPI->__('[Unrestricted] Comments added to the custom post', 'pop-comments'),
+            'commentCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of comments added to the custom post', 'pop-comments'),
+            'commentsForAdmin' => $this->translationAPI->__('[Unrestricted] Comments added to the custom post', 'pop-comments'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }
@@ -90,11 +90,11 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
                 CommentFilterInputContainerModuleProcessor::class,
                 CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_COMMENTCOUNT
             ],
-            'unrestrictedComments' => [
+            'commentsForAdmin' => [
                 CommentFilterInputContainerModuleProcessor::class,
                 CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_ADMINCOMMENTS
             ],
-            'unrestrictedCommentCount' => [
+            'commentCountForAdmin' => [
                 CommentFilterInputContainerModuleProcessor::class,
                 CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_ADMINCOMMENTCOUNT
             ],
@@ -114,7 +114,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
         ];
         switch ($fieldName) {
             case 'comments':
-            case 'unrestrictedComments':
+            case 'commentsForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -134,7 +134,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
                     ]
                 );
             case 'commentCount':
-            case 'unrestrictedCommentCount':
+            case 'commentCountForAdmin':
                 return $filterInputNameDefaultValues;
         }
         return parent::getFieldDataFilteringDefaultValues($fieldName);

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -73,8 +73,8 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             'date',
             'responses',
             'responseCount',
-            'unrestrictedResponses',
-            'unrestrictedResponseCount',
+            'responsesForAdmin',
+            'responseCountForAdmin',
         ];
     }
 
@@ -94,8 +94,8 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             'date' => SchemaDefinition::TYPE_DATE,
             'responses' => SchemaDefinition::TYPE_ID,
             'responseCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedResponses' => SchemaDefinition::TYPE_ID,
-            'unrestrictedResponseCount' => SchemaDefinition::TYPE_INT,
+            'responsesForAdmin' => SchemaDefinition::TYPE_ID,
+            'responseCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -111,10 +111,10 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             'status',
             'date',
             'responseCount',
-            'unrestrictedResponseCount'
+            'responseCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'responses',
-            'unrestrictedResponses'
+            'responsesForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
@@ -137,8 +137,8 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             'date' => $this->translationAPI->__('Date when the comment was added', 'pop-comments'),
             'responses' => $this->translationAPI->__('Responses to the comment', 'pop-comments'),
             'responseCount' => $this->translationAPI->__('Number of responses to the comment', 'pop-comments'),
-            'unrestrictedResponses' => $this->translationAPI->__('[Unrestricted] Responses to the comment', 'pop-comments'),
-            'unrestrictedResponseCount' => $this->translationAPI->__('[Unrestricted] Number of responses to the comment', 'pop-comments'),
+            'responsesForAdmin' => $this->translationAPI->__('[Unrestricted] Responses to the comment', 'pop-comments'),
+            'responseCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of responses to the comment', 'pop-comments'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -148,8 +148,8 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
         return match ($fieldName) {
             'responses' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_RESPONSES],
             'responseCount' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_RESPONSECOUNT],
-            'unrestrictedResponses' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSES],
-            'unrestrictedResponseCount' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSECOUNT],
+            'responsesForAdmin' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSES],
+            'responseCountForAdmin' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSECOUNT],
             'date' => [CommonFilterInputContainerModuleProcessor::class, CommonFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_GMTDATE_AS_STRING],
             default => parent::getFieldDataFilteringModule($typeResolver, $fieldName),
         };
@@ -159,7 +159,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'responses':
-            case 'unrestrictedResponses':
+            case 'responsesForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -240,11 +240,11 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
         );
         switch ($fieldName) {
             case 'responses':
-            case 'unrestrictedResponses':
+            case 'responsesForAdmin':
                 return $this->commentTypeAPI->getComments($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'responseCount':
-            case 'unrestrictedResponseCount':
+            case 'responseCountForAdmin':
                 return $this->commentTypeAPI->getCommentCount($query);
         }
 
@@ -259,7 +259,7 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
 
             case 'parent':
             case 'responses':
-            case 'unrestrictedResponses':
+            case 'responsesForAdmin':
                 return CommentTypeResolver::class;
         }
 

--- a/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
@@ -108,11 +108,11 @@ class CustomPostFieldResolver extends AbstractQueryableFieldResolver
         );
         switch ($fieldName) {
             case 'commentCount':
-            case 'unrestrictedCommentCount':
+            case 'commentCountForAdmin':
                 return $this->commentTypeAPI->getCommentCount($query);
 
             case 'comments':
-            case 'unrestrictedComments':
+            case 'commentsForAdmin':
                 return $this->commentTypeAPI->getComments($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
         }
 
@@ -123,7 +123,7 @@ class CustomPostFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'comments':
-            case 'unrestrictedComments':
+            case 'commentsForAdmin':
                 return CommentTypeResolver::class;
         }
 

--- a/layers/Schema/packages/comments/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/RootFieldResolver.php
@@ -65,9 +65,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
             'comment',
             'commentCount',
             'comments',
-            'unrestrictedComment',
-            'unrestrictedCommentCount',
-            'unrestrictedComments',
+            'commentForAdmin',
+            'commentCountForAdmin',
+            'commentsForAdmin',
         ];
     }
 
@@ -77,9 +77,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
             'comment' => SchemaDefinition::TYPE_ID,
             'comments' => SchemaDefinition::TYPE_ID,
             'commentCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedComment' => SchemaDefinition::TYPE_ID,
-            'unrestrictedComments' => SchemaDefinition::TYPE_ID,
-            'unrestrictedCommentCount' => SchemaDefinition::TYPE_INT,
+            'commentForAdmin' => SchemaDefinition::TYPE_ID,
+            'commentsForAdmin' => SchemaDefinition::TYPE_ID,
+            'commentCountForAdmin' => SchemaDefinition::TYPE_INT,
             default => parent::getSchemaFieldType($typeResolver, $fieldName),
         };
     }
@@ -88,10 +88,10 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
     {
         return match ($fieldName) {
             'commentCount',
-            'unrestrictedCommentCount'
+            'commentCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'comments',
-            'unrestrictedComments'
+            'commentsForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
@@ -102,7 +102,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'comments':
-            case 'unrestrictedComments':
+            case 'commentsForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -128,9 +128,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
             'comment' => $this->translationAPI->__('Comment with a specific ID', 'pop-comments'),
             'commentCount' => $this->translationAPI->__('Number of comments on the site', 'pop-comments'),
             'comments' => $this->translationAPI->__('Comments on the site', 'pop-comments'),
-            'unrestrictedComment' => $this->translationAPI->__('[Unrestricted] Comment with a specific ID', 'pop-comments'),
-            'unrestrictedCommentCount' => $this->translationAPI->__('[Unrestricted] Number of comments on the site', 'pop-comments'),
-            'unrestrictedComments' => $this->translationAPI->__('[Unrestricted] Comments on the site', 'pop-comments'),
+            'commentForAdmin' => $this->translationAPI->__('[Unrestricted] Comment with a specific ID', 'pop-comments'),
+            'commentCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of comments on the site', 'pop-comments'),
+            'commentsForAdmin' => $this->translationAPI->__('[Unrestricted] Comments on the site', 'pop-comments'),
             default => parent::getSchemaFieldDescription($typeResolver, $fieldName),
         };
     }
@@ -141,9 +141,9 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
             'comment' => [CommonFilterInputContainerModuleProcessor::class, CommonFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ENTITY_BY_ID],
             'comments' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_COMMENTS],
             'commentCount' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_COMMENTCOUNT],
-            'unrestrictedComment' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_COMMENT_BY_ID_STATUS],
-            'unrestrictedComments' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTS],
-            'unrestrictedCommentCount' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTCOUNT],
+            'commentForAdmin' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_COMMENT_BY_ID_STATUS],
+            'commentsForAdmin' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTS],
+            'commentCountForAdmin' => [CommentFilterInputContainerModuleProcessor::class, CommentFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTCOUNT],
             default => parent::getFieldDataFilteringModule($typeResolver, $fieldName),
         };
     }
@@ -166,15 +166,15 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         $query = $this->convertFieldArgsToFilteringQueryArgs($typeResolver, $fieldName, $fieldArgs);
         switch ($fieldName) {
             case 'commentCount':
-            case 'unrestrictedCommentCount':
+            case 'commentCountForAdmin':
                 return $this->commentTypeAPI->getCommentCount($query);
 
             case 'comments':
-            case 'unrestrictedComments':
+            case 'commentsForAdmin':
                 return $this->commentTypeAPI->getComments($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'comment':
-            case 'unrestrictedComment':
+            case 'commentForAdmin':
                 /**
                  * Only from the mapped CPTs, otherwise we may get an error when
                  * the custom post to which the comment was added, is not accesible
@@ -205,8 +205,8 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         switch ($fieldName) {
             case 'comment':
             case 'comments':
-            case 'unrestrictedComment':
-            case 'unrestrictedComments':
+            case 'commentForAdmin':
+            case 'commentsForAdmin':
                 return CommentTypeResolver::class;
         }
 

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -25,16 +25,16 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         return [
             'customPosts',
             'customPostCount',
-            'unrestrictedCustomPosts',
-            'unrestrictedCustomPostCount',
+            'customPostsForAdmin',
+            'customPostCountForAdmin',
         ];
     }
 
     public function getAdminFieldNames(): array
     {
         return [
-            'unrestrictedCustomPosts',
-            'unrestrictedCustomPostCount',
+            'customPostsForAdmin',
+            'customPostCountForAdmin',
         ];
     }
 
@@ -43,8 +43,8 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         $types = [
             'customPosts' => SchemaDefinition::TYPE_ID,
             'customPostCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedCustomPosts' => SchemaDefinition::TYPE_ID,
-            'unrestrictedCustomPostCount' => SchemaDefinition::TYPE_INT,
+            'customPostsForAdmin' => SchemaDefinition::TYPE_ID,
+            'customPostCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -53,10 +53,10 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
     {
         return match ($fieldName) {
             'customPostCount',
-            'unrestrictedCustomPostCount'
+            'customPostCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'customPosts',
-            'unrestrictedCustomPosts'
+            'customPostsForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
@@ -68,8 +68,8 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         $descriptions = [
             'customPosts' => $this->translationAPI->__('Custom posts', 'pop-posts'),
             'customPostCount' => $this->translationAPI->__('Number of custom posts', 'pop-posts'),
-            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts', 'pop-posts'),
-            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts', 'pop-posts'),
+            'customPostsForAdmin' => $this->translationAPI->__('[Unrestricted] Custom posts', 'pop-posts'),
+            'customPostCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of custom posts', 'pop-posts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -81,7 +81,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
                 CustomPostFilterInputContainerModuleProcessor::class,
                 CustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_UNIONCUSTOMPOSTLIST
             ],
-            'unrestrictedCustomPosts' => [
+            'customPostsForAdmin' => [
                 CustomPostFilterInputContainerModuleProcessor::class,
                 CustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINUNIONCUSTOMPOSTLIST
             ],
@@ -89,7 +89,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
                 CustomPostFilterInputContainerModuleProcessor::class,
                 CustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_UNIONCUSTOMPOSTCOUNT
             ],
-            'unrestrictedCustomPostCount' => [
+            'customPostCountForAdmin' => [
                 CustomPostFilterInputContainerModuleProcessor::class,
                 CustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINUNIONCUSTOMPOSTCOUNT
             ],
@@ -101,7 +101,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
     {
         switch ($fieldName) {
             case 'customPosts':
-            case 'unrestrictedCustomPosts':
+            case 'customPostsForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -148,11 +148,11 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
         );
         switch ($fieldName) {
             case 'customPosts':
-            case 'unrestrictedCustomPosts':
+            case 'customPostsForAdmin':
                 return $customPostTypeAPI->getCustomPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'customPostCount':
-            case 'unrestrictedCustomPostCount':
+            case 'customPostCountForAdmin':
                 return $customPostTypeAPI->getCustomPostCount($query);
         }
 
@@ -163,7 +163,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
     {
         switch ($fieldName) {
             case 'customPosts':
-            case 'unrestrictedCustomPosts':
+            case 'customPostsForAdmin':
                 return CustomPostUnionTypeHelpers::getCustomPostUnionOrTargetTypeResolverClass(CustomPostUnionTypeResolver::class);
         }
 

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -33,8 +33,8 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
             [
                 'customPost',
                 'customPostBySlug',
-                'unrestrictedCustomPost',
-                'unrestrictedCustomPostBySlug',
+                'customPostForAdmin',
+                'customPostBySlugForAdmin',
             ]
         );
     }
@@ -44,8 +44,8 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
         return array_merge(
             parent::getAdminFieldNames(),
             [
-                'unrestrictedCustomPost',
-                'unrestrictedCustomPostBySlug',
+                'customPostForAdmin',
+                'customPostBySlugForAdmin',
             ]
         );
     }
@@ -55,8 +55,8 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
         $descriptions = [
             'customPost' => $this->translationAPI->__('Custom post with a specific ID', 'customposts'),
             'customPostBySlug' => $this->translationAPI->__('Custom post with a specific slug', 'customposts'),
-            'unrestrictedCustomPost' => $this->translationAPI->__('[Unrestricted] Custom post with a specific ID', 'customposts'),
-            'unrestrictedCustomPostBySlug' => $this->translationAPI->__('[Unrestricted] Custom post with a specific slug', 'customposts'),
+            'customPostForAdmin' => $this->translationAPI->__('[Unrestricted] Custom post with a specific ID', 'customposts'),
+            'customPostBySlugForAdmin' => $this->translationAPI->__('[Unrestricted] Custom post with a specific slug', 'customposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -66,8 +66,8 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
         $types = [
             'customPost' => SchemaDefinition::TYPE_ID,
             'customPostBySlug' => SchemaDefinition::TYPE_ID,
-            'unrestrictedCustomPost' => SchemaDefinition::TYPE_ID,
-            'unrestrictedCustomPostBySlug' => SchemaDefinition::TYPE_ID,
+            'customPostForAdmin' => SchemaDefinition::TYPE_ID,
+            'customPostBySlugForAdmin' => SchemaDefinition::TYPE_ID,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -76,9 +76,9 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
     {
         return match ($fieldName) {
             'customPost' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_UNIONTYPE],
-            'unrestrictedCustomPost' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS_UNIONTYPE],
+            'customPostForAdmin' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS_UNIONTYPE],
             'customPostBySlug' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_UNIONTYPE],
-            'unrestrictedCustomPostBySlug' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_STATUS_UNIONTYPE],
+            'customPostBySlugForAdmin' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_STATUS_UNIONTYPE],
             default => parent::getFieldDataFilteringModule($typeResolver, $fieldName),
         };
     }
@@ -102,8 +102,8 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
         switch ($fieldName) {
             case 'customPost':
             case 'customPostBySlug':
-            case 'unrestrictedCustomPost':
-            case 'unrestrictedCustomPostBySlug':
+            case 'customPostForAdmin':
+            case 'customPostBySlugForAdmin':
                 $query = array_merge(
                     $this->convertFieldArgsToFilteringQueryArgs($typeResolver, $fieldName, $fieldArgs),
                     $this->getQuery($typeResolver, $resultItem, $fieldName, $fieldArgs)
@@ -122,8 +122,8 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
         switch ($fieldName) {
             case 'customPost':
             case 'customPostBySlug':
-            case 'unrestrictedCustomPost':
-            case 'unrestrictedCustomPostBySlug':
+            case 'customPostForAdmin':
+            case 'customPostBySlugForAdmin':
                 return CustomPostUnionTypeHelpers::getCustomPostUnionOrTargetTypeResolverClass(CustomPostUnionTypeResolver::class);
         }
 

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -38,10 +38,10 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
             'genericCustomPostBySlug',
             'genericCustomPosts',
             'genericCustomPostCount',
-            'unrestrictedGenericCustomPost',
-            'unrestrictedGenericCustomPostBySlug',
-            'unrestrictedGenericCustomPosts',
-            'unrestrictedGenericCustomPostCount',
+            'genericCustomPostForAdmin',
+            'genericCustomPostBySlugForAdmin',
+            'genericCustomPostsForAdmin',
+            'genericCustomPostCountForAdmin',
         ];
     }
 
@@ -52,10 +52,10 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
             'genericCustomPostBySlug' => $this->translationAPI->__('Custom post with a specific slug', 'generic-customposts'),
             'genericCustomPosts' => $this->translationAPI->__('Custom posts', 'generic-customposts'),
             'genericCustomPostCount' => $this->translationAPI->__('Number of custom posts', 'generic-customposts'),
-            'unrestrictedGenericCustomPost' => $this->translationAPI->__('[Unrestricted] Custom post with a specific ID', 'generic-customposts'),
-            'unrestrictedGenericCustomPostBySlug' => $this->translationAPI->__('[Unrestricted] Custom post with a specific slug', 'generic-customposts'),
-            'unrestrictedGenericCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts', 'generic-customposts'),
-            'unrestrictedGenericCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts', 'generic-customposts'),
+            'genericCustomPostForAdmin' => $this->translationAPI->__('[Unrestricted] Custom post with a specific ID', 'generic-customposts'),
+            'genericCustomPostBySlugForAdmin' => $this->translationAPI->__('[Unrestricted] Custom post with a specific slug', 'generic-customposts'),
+            'genericCustomPostsForAdmin' => $this->translationAPI->__('[Unrestricted] Custom posts', 'generic-customposts'),
+            'genericCustomPostCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of custom posts', 'generic-customposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -67,10 +67,10 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
             'genericCustomPostBySlug' => SchemaDefinition::TYPE_ID,
             'genericCustomPosts' => SchemaDefinition::TYPE_ID,
             'genericCustomPostCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedGenericCustomPost' => SchemaDefinition::TYPE_ID,
-            'unrestrictedGenericCustomPostBySlug' => SchemaDefinition::TYPE_ID,
-            'unrestrictedGenericCustomPosts' => SchemaDefinition::TYPE_ID,
-            'unrestrictedGenericCustomPostCount' => SchemaDefinition::TYPE_INT,
+            'genericCustomPostForAdmin' => SchemaDefinition::TYPE_ID,
+            'genericCustomPostBySlugForAdmin' => SchemaDefinition::TYPE_ID,
+            'genericCustomPostsForAdmin' => SchemaDefinition::TYPE_ID,
+            'genericCustomPostCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -79,10 +79,10 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
     {
         return match ($fieldName) {
             'genericCustomPostCount',
-            'unrestrictedGenericCustomPostCount'
+            'genericCustomPostCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'genericCustomPosts',
-            'unrestrictedGenericCustomPosts'
+            'genericCustomPostsForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
         };
@@ -99,11 +99,11 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
                 GenericCustomPostFilterInputContainerModuleProcessor::class,
                 GenericCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_GENERICCUSTOMPOSTCOUNT
             ],
-            'unrestrictedGenericCustomPosts' => [
+            'genericCustomPostsForAdmin' => [
                 GenericCustomPostFilterInputContainerModuleProcessor::class,
                 GenericCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINGENERICCUSTOMPOSTLIST
             ],
-            'unrestrictedGenericCustomPostCount' => [
+            'genericCustomPostCountForAdmin' => [
                 GenericCustomPostFilterInputContainerModuleProcessor::class,
                 GenericCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINGENERICCUSTOMPOSTCOUNT
             ],
@@ -111,7 +111,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_GENERICTYPE
             ],
-            'unrestrictedGenericCustomPost' => [
+            'genericCustomPostForAdmin' => [
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS_GENERICTYPE
             ],
@@ -119,7 +119,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_GENERICTYPE
             ],
-            'unrestrictedGenericCustomPostBySlug' => [
+            'genericCustomPostBySlugForAdmin' => [
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_STATUS_GENERICTYPE
             ],
@@ -131,7 +131,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'genericCustomPosts':
-            case 'unrestrictedGenericCustomPosts':
+            case 'genericCustomPostsForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -155,13 +155,13 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
     ): array {
         switch ($fieldName) {
             case 'genericCustomPost':
-            case 'unrestrictedGenericCustomPost':
+            case 'genericCustomPostForAdmin':
             case 'genericCustomPostBySlug':
-            case 'unrestrictedGenericCustomPostBySlug':
+            case 'genericCustomPostBySlugForAdmin':
             case 'genericCustomPosts':
-            case 'unrestrictedGenericCustomPosts':
+            case 'genericCustomPostsForAdmin':
             case 'genericCustomPostCount':
-            case 'unrestrictedGenericCustomPostCount':
+            case 'genericCustomPostCountForAdmin':
                 return [
                     'custompost-types' => ComponentConfiguration::getGenericCustomPostTypes(),
                 ];
@@ -192,17 +192,17 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
         switch ($fieldName) {
             case 'genericCustomPost':
             case 'genericCustomPostBySlug':
-            case 'unrestrictedGenericCustomPost':
-            case 'unrestrictedGenericCustomPostBySlug':
+            case 'genericCustomPostForAdmin':
+            case 'genericCustomPostBySlugForAdmin':
                 if ($customPosts = $customPostTypeAPI->getCustomPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS])) {
                     return $customPosts[0];
                 }
                 return null;
             case 'genericCustomPosts':
-            case 'unrestrictedGenericCustomPosts':
+            case 'genericCustomPostsForAdmin':
                 return $customPostTypeAPI->getCustomPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
             case 'genericCustomPostCount':
-            case 'unrestrictedGenericCustomPostCount':
+            case 'genericCustomPostCountForAdmin':
                 return $customPostTypeAPI->getCustomPostCount($query);
         }
 
@@ -215,9 +215,9 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
             case 'genericCustomPost':
             case 'genericCustomPostBySlug':
             case 'genericCustomPosts':
-            case 'unrestrictedGenericCustomPost':
-            case 'unrestrictedGenericCustomPostBySlug':
-            case 'unrestrictedGenericCustomPosts':
+            case 'genericCustomPostForAdmin':
+            case 'genericCustomPostBySlugForAdmin':
+            case 'genericCustomPostsForAdmin':
                 return GenericCustomPostTypeResolver::class;
         }
 

--- a/layers/Schema/packages/pages/src/FieldResolvers/PageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/PageFieldResolver.php
@@ -30,16 +30,16 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
             'parentPage',
             'childPages',
             'childPageCount',
-            'unrestrictedChildPages',
-            'unrestrictedChildPageCount',
+            'childPagesForAdmin',
+            'childPageCountForAdmin',
         ];
     }
 
     public function getAdminFieldNames(): array
     {
         return [
-            'unrestrictedChildPages',
-            'unrestrictedChildPageCount',
+            'childPagesForAdmin',
+            'childPageCountForAdmin',
         ];
     }
 
@@ -49,8 +49,8 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
             'parentPage' => $this->translationAPI->__('Parent page', 'pages'),
             'childPages' => $this->translationAPI->__('Child pages', 'pages'),
             'childPageCount' => $this->translationAPI->__('Number of child pages', 'pages'),
-            'unrestrictedChildPages' => $this->translationAPI->__('[Unrestricted] Child pages', 'pages'),
-            'unrestrictedChildPageCount' => $this->translationAPI->__('[Unrestricted] Number of child pages', 'pages'),
+            'childPagesForAdmin' => $this->translationAPI->__('[Unrestricted] Child pages', 'pages'),
+            'childPageCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of child pages', 'pages'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -61,8 +61,8 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
             'parentPage' => SchemaDefinition::TYPE_ID,
             'childPages' => SchemaDefinition::TYPE_ID,
             'childPageCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedChildPages' => SchemaDefinition::TYPE_ID,
-            'unrestrictedChildPageCount' => SchemaDefinition::TYPE_INT,
+            'childPagesForAdmin' => SchemaDefinition::TYPE_ID,
+            'childPageCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -71,10 +71,10 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
     {
         return match ($fieldName) {
             'childPageCount',
-            'unrestrictedChildPageCount'
+            'childPageCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'childPages',
-            'unrestrictedChildPages'
+            'childPagesForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
@@ -92,11 +92,11 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
                 CustomPostFilterInputContainerModuleProcessor::class,
                 CustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOSTLISTCOUNT
             ],
-            'unrestrictedChildPages' => [
+            'childPagesForAdmin' => [
                 CustomPostFilterInputContainerModuleProcessor::class,
                 CustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINCUSTOMPOSTLISTLIST
             ],
-            'unrestrictedChildPageCount' => [
+            'childPageCountForAdmin' => [
                 CustomPostFilterInputContainerModuleProcessor::class,
                 CustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINCUSTOMPOSTLISTCOUNT
             ],
@@ -108,7 +108,7 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'childPages':
-            case 'unrestrictedChildPages':
+            case 'childPagesForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -150,10 +150,10 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
         );
         switch ($fieldName) {
             case 'childPages':
-            case 'unrestrictedChildPages':
+            case 'childPagesForAdmin':
                 return $pageTypeAPI->getPages($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
             case 'childPageCount':
-            case 'unrestrictedChildPageCount':
+            case 'childPageCountForAdmin':
                 return $pageTypeAPI->getPageCount($query);
         }
 
@@ -165,7 +165,7 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
         switch ($fieldName) {
             case 'parentPage':
             case 'childPages':
-            case 'unrestrictedChildPages':
+            case 'childPagesForAdmin':
                 return PageTypeResolver::class;
         }
 

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -34,20 +34,20 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
             'pageBySlug',
             'pages',
             'pageCount',
-            'unrestrictedPage',
-            'unrestrictedPageBySlug',
-            'unrestrictedPages',
-            'unrestrictedPageCount',
+            'pageForAdmin',
+            'pageBySlugForAdmin',
+            'pagesForAdmin',
+            'pageCountForAdmin',
         ];
     }
 
     public function getAdminFieldNames(): array
     {
         return [
-            'unrestrictedPage',
-            'unrestrictedPageBySlug',
-            'unrestrictedPages',
-            'unrestrictedPageCount',
+            'pageForAdmin',
+            'pageBySlugForAdmin',
+            'pagesForAdmin',
+            'pageCountForAdmin',
         ];
     }
 
@@ -58,10 +58,10 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
             'pageBySlug' => $this->translationAPI->__('Page with a specific slug', 'pages'),
             'pages' => $this->translationAPI->__('Pages', 'pages'),
             'pageCount' => $this->translationAPI->__('Number of pages', 'pages'),
-            'unrestrictedPage' => $this->translationAPI->__('[Unrestricted] Page with a specific ID', 'pages'),
-            'unrestrictedPageBySlug' => $this->translationAPI->__('[Unrestricted] Page with a specific slug', 'pages'),
-            'unrestrictedPages' => $this->translationAPI->__('[Unrestricted] Pages', 'pages'),
-            'unrestrictedPageCount' => $this->translationAPI->__('[Unrestricted] Number of pages', 'pages'),
+            'pageForAdmin' => $this->translationAPI->__('[Unrestricted] Page with a specific ID', 'pages'),
+            'pageBySlugForAdmin' => $this->translationAPI->__('[Unrestricted] Page with a specific slug', 'pages'),
+            'pagesForAdmin' => $this->translationAPI->__('[Unrestricted] Pages', 'pages'),
+            'pageCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of pages', 'pages'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -73,10 +73,10 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
             'pageBySlug' => SchemaDefinition::TYPE_ID,
             'pages' => SchemaDefinition::TYPE_ID,
             'pageCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedPage' => SchemaDefinition::TYPE_ID,
-            'unrestrictedPageBySlug' => SchemaDefinition::TYPE_ID,
-            'unrestrictedPages' => SchemaDefinition::TYPE_ID,
-            'unrestrictedPageCount' => SchemaDefinition::TYPE_INT,
+            'pageForAdmin' => SchemaDefinition::TYPE_ID,
+            'pageBySlugForAdmin' => SchemaDefinition::TYPE_ID,
+            'pagesForAdmin' => SchemaDefinition::TYPE_ID,
+            'pageCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -85,10 +85,10 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     {
         return match ($fieldName) {
             'pageCount',
-            'unrestrictedPageCount'
+            'pageCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'pages',
-            'unrestrictedPages'
+            'pagesForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
@@ -106,11 +106,11 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
                 PageFilterInputContainerModuleProcessor::class,
                 PageFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_PAGELISTCOUNT
             ],
-            'unrestrictedPages' => [
+            'pagesForAdmin' => [
                 PageFilterInputContainerModuleProcessor::class,
                 PageFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINPAGELISTLIST
             ],
-            'unrestrictedPageCount' => [
+            'pageCountForAdmin' => [
                 PageFilterInputContainerModuleProcessor::class,
                 PageFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINPAGELISTCOUNT
             ],
@@ -118,7 +118,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
                 CommonFilterInputContainerModuleProcessor::class,
                 CommonFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ENTITY_BY_ID
             ],
-            'unrestrictedPage' => [
+            'pageForAdmin' => [
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS
             ],
@@ -126,7 +126,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
                 CommonFilterInputContainerModuleProcessor::class,
                 CommonFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ENTITY_BY_SLUG
             ],
-            'unrestrictedPageBySlug' => [
+            'pageBySlugForAdmin' => [
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_STATUS
             ],
@@ -138,7 +138,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'pages':
-            case 'unrestrictedPages':
+            case 'pagesForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -170,17 +170,17 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         switch ($fieldName) {
             case 'page':
             case 'pageBySlug':
-            case 'unrestrictedPage':
-            case 'unrestrictedPageBySlug':
+            case 'pageForAdmin':
+            case 'pageBySlugForAdmin':
                 if ($pages = $pageTypeAPI->getPages($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS])) {
                     return $pages[0];
                 }
                 return null;
             case 'pages':
-            case 'unrestrictedPages':
+            case 'pagesForAdmin':
                 return $pageTypeAPI->getPages($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
             case 'pageCount':
-            case 'unrestrictedPageCount':
+            case 'pageCountForAdmin':
                 return $pageTypeAPI->getPageCount($query);
         }
 
@@ -193,9 +193,9 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
             case 'page':
             case 'pageBySlug':
             case 'pages':
-            case 'unrestrictedPage':
-            case 'unrestrictedPageBySlug':
-            case 'unrestrictedPages':
+            case 'pageForAdmin':
+            case 'pageBySlugForAdmin':
+            case 'pagesForAdmin':
                 return PageTypeResolver::class;
         }
 

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/PostCategoryListFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/PostCategoryListFieldResolver.php
@@ -20,8 +20,8 @@ class PostCategoryListFieldResolver extends AbstractPostFieldResolver
         $descriptions = [
             'posts' => $this->translationAPI->__('Posts which contain this category', 'post-categories'),
             'postCount' => $this->translationAPI->__('Number of posts which contain this category', 'post-categories'),
-            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts which contain this category', 'post-categories'),
-            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts which contain this category', 'post-categories'),
+            'postsForAdmin' => $this->translationAPI->__('[Unrestricted] Posts which contain this category', 'post-categories'),
+            'postCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of posts which contain this category', 'post-categories'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -42,8 +42,8 @@ class PostCategoryListFieldResolver extends AbstractPostFieldResolver
         switch ($fieldName) {
             case 'posts':
             case 'postCount':
-            case 'unrestrictedPosts':
-            case 'unrestrictedPostCount':
+            case 'postsForAdmin':
+            case 'postCountForAdmin':
                 $query['category-ids'] = [$typeResolver->getID($category)];
                 break;
         }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagListFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/PostTagListFieldResolver.php
@@ -20,8 +20,8 @@ class PostTagListFieldResolver extends AbstractPostFieldResolver
         $descriptions = [
             'posts' => $this->translationAPI->__('Posts which contain this tag', 'pop-taxonomies'),
             'postCount' => $this->translationAPI->__('Number of posts which contain this tag', 'pop-taxonomies'),
-            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts which contain this tag', 'pop-taxonomies'),
-            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts which contain this tag', 'pop-taxonomies'),
+            'postsForAdmin' => $this->translationAPI->__('[Unrestricted] Posts which contain this tag', 'pop-taxonomies'),
+            'postCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of posts which contain this tag', 'pop-taxonomies'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -42,8 +42,8 @@ class PostTagListFieldResolver extends AbstractPostFieldResolver
         switch ($fieldName) {
             case 'posts':
             case 'postCount':
-            case 'unrestrictedPosts':
-            case 'unrestrictedPostCount':
+            case 'postsForAdmin':
+            case 'postCountForAdmin':
                 $query['tag-ids'] = [$typeResolver->getID($tag)];
                 break;
         }

--- a/layers/Schema/packages/posts/src/ConditionalOnComponent/Users/FieldResolvers/PostUserFieldResolver.php
+++ b/layers/Schema/packages/posts/src/ConditionalOnComponent/Users/FieldResolvers/PostUserFieldResolver.php
@@ -20,8 +20,8 @@ class PostUserFieldResolver extends AbstractPostFieldResolver
         $descriptions = [
             'posts' => $this->translationAPI->__('Posts by the user', 'users'),
             'postCount' => $this->translationAPI->__('Number of posts by the user', 'users'),
-            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts by the user', 'users'),
-            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts by the user', 'users'),
+            'postsForAdmin' => $this->translationAPI->__('[Unrestricted] Posts by the user', 'users'),
+            'postCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of posts by the user', 'users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -42,8 +42,8 @@ class PostUserFieldResolver extends AbstractPostFieldResolver
         switch ($fieldName) {
             case 'posts':
             case 'postCount':
-            case 'unrestrictedPosts':
-            case 'unrestrictedPostCount':
+            case 'postsForAdmin':
+            case 'postCountForAdmin':
                 $query['authors'] = [$typeResolver->getID($user)];
                 break;
         }

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -24,16 +24,16 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         return [
             'posts',
             'postCount',
-            'unrestrictedPosts',
-            'unrestrictedPostCount',
+            'postsForAdmin',
+            'postCountForAdmin',
         ];
     }
 
     public function getAdminFieldNames(): array
     {
         return [
-            'unrestrictedPosts',
-            'unrestrictedPostCount',
+            'postsForAdmin',
+            'postCountForAdmin',
         ];
     }
 
@@ -42,8 +42,8 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         $types = [
             'posts' => SchemaDefinition::TYPE_ID,
             'postCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedPosts' => SchemaDefinition::TYPE_ID,
-            'unrestrictedPostCount' => SchemaDefinition::TYPE_INT,
+            'postsForAdmin' => SchemaDefinition::TYPE_ID,
+            'postCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -52,10 +52,10 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
     {
         return match ($fieldName) {
             'postCount',
-            'unrestrictedPostCount'
+            'postCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'posts',
-            'unrestrictedPosts'
+            'postsForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default
                 => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
@@ -67,8 +67,8 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         $descriptions = [
             'posts' => $this->translationAPI->__('Posts', 'pop-posts'),
             'postCount' => $this->translationAPI->__('Number of posts', 'pop-posts'),
-            'unrestrictedPosts' => $this->translationAPI->__('[Unrestricted] Posts', 'pop-posts'),
-            'unrestrictedPostCount' => $this->translationAPI->__('[Unrestricted] Number of posts', 'pop-posts'),
+            'postsForAdmin' => $this->translationAPI->__('[Unrestricted] Posts', 'pop-posts'),
+            'postCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of posts', 'pop-posts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -78,8 +78,8 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         return match ($fieldName) {
             'posts' => [PostFilterInputContainerModuleProcessor::class, PostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_POSTS],
             'postCount' => [PostFilterInputContainerModuleProcessor::class, PostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_POSTCOUNT],
-            'unrestrictedPosts' => [PostFilterInputContainerModuleProcessor::class, PostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINPOSTS],
-            'unrestrictedPostCount' => [PostFilterInputContainerModuleProcessor::class, PostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINPOSTCOUNT],
+            'postsForAdmin' => [PostFilterInputContainerModuleProcessor::class, PostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINPOSTS],
+            'postCountForAdmin' => [PostFilterInputContainerModuleProcessor::class, PostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINPOSTCOUNT],
             default => parent::getFieldDataFilteringModule($typeResolver, $fieldName),
         };
     }
@@ -88,7 +88,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'posts':
-            case 'unrestrictedPosts':
+            case 'postsForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -135,11 +135,11 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
         );
         switch ($fieldName) {
             case 'posts':
-            case 'unrestrictedPosts':
+            case 'postsForAdmin':
                 return $postTypeAPI->getPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'postCount':
-            case 'unrestrictedPostCount':
+            case 'postCountForAdmin':
                 return $postTypeAPI->getPostCount($query);
         }
 
@@ -150,7 +150,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'posts':
-            case 'unrestrictedPosts':
+            case 'postsForAdmin':
                 return PostTypeResolver::class;
         }
 

--- a/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
@@ -28,9 +28,9 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
             parent::getFieldNamesToResolve(),
             [
                 'post',
-                'unrestrictedPost',
+                'postForAdmin',
                 'postBySlug',
-                'unrestrictedPostBySlug',
+                'postBySlugForAdmin',
             ]
         );
     }
@@ -40,8 +40,8 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
         return array_merge(
             parent::getAdminFieldNames(),
             [
-                'unrestrictedPost',
-                'unrestrictedPostBySlug',
+                'postForAdmin',
+                'postBySlugForAdmin',
             ]
         );
     }
@@ -51,8 +51,8 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
         $descriptions = [
             'post' => $this->translationAPI->__('Post with a specific ID', 'posts'),
             'postBySlug' => $this->translationAPI->__('Post with a specific slug', 'posts'),
-            'unrestrictedPost' => $this->translationAPI->__('[Unrestricted] Post with a specific ID', 'posts'),
-            'unrestrictedPostBySlug' => $this->translationAPI->__('[Unrestricted] Post with a specific slug', 'posts'),
+            'postForAdmin' => $this->translationAPI->__('[Unrestricted] Post with a specific ID', 'posts'),
+            'postBySlugForAdmin' => $this->translationAPI->__('[Unrestricted] Post with a specific slug', 'posts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -62,8 +62,8 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
         $types = [
             'post' => SchemaDefinition::TYPE_ID,
             'postBySlug' => SchemaDefinition::TYPE_ID,
-            'unrestrictedPost' => SchemaDefinition::TYPE_ID,
-            'unrestrictedPostBySlug' => SchemaDefinition::TYPE_ID,
+            'postForAdmin' => SchemaDefinition::TYPE_ID,
+            'postBySlugForAdmin' => SchemaDefinition::TYPE_ID,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -75,7 +75,7 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
                 CommonFilterInputContainerModuleProcessor::class,
                 CommonFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ENTITY_BY_ID
             ],
-            'unrestrictedPost' => [
+            'postForAdmin' => [
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS
             ],
@@ -83,7 +83,7 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
                 CommonFilterInputContainerModuleProcessor::class,
                 CommonFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ENTITY_BY_SLUG
             ],
-            'unrestrictedPostBySlug' => [
+            'postBySlugForAdmin' => [
                 CommonCustomPostFilterInputContainerModuleProcessor::class,
                 CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_STATUS
             ],
@@ -111,8 +111,8 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
         switch ($fieldName) {
             case 'post':
             case 'postBySlug':
-            case 'unrestrictedPost':
-            case 'unrestrictedPostBySlug':
+            case 'postForAdmin':
+            case 'postBySlugForAdmin':
                 if ($posts = $postTypeAPI->getPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS])) {
                     return $posts[0];
                 }
@@ -126,9 +126,9 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
     {
         switch ($fieldName) {
             case 'post':
-            case 'unrestrictedPost':
+            case 'postForAdmin':
             case 'postBySlug':
-            case 'unrestrictedPostBySlug':
+            case 'postBySlugForAdmin':
                 return PostTypeResolver::class;
         }
 

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostListTagFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostListTagFieldResolver.php
@@ -17,8 +17,8 @@ abstract class AbstractCustomPostListTagFieldResolver extends AbstractCustomPost
         $descriptions = [
             'customPosts' => $this->translationAPI->__('Custom posts which contain this tag', 'pop-tags'),
             'customPostCount' => $this->translationAPI->__('Number of custom posts which contain this tag', 'pop-tags'),
-            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts which contain this tag', 'pop-tags'),
-            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts which contain this tag', 'pop-tags'),
+            'customPostsForAdmin' => $this->translationAPI->__('[Unrestricted] Custom posts which contain this tag', 'pop-tags'),
+            'customPostCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of custom posts which contain this tag', 'pop-tags'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -41,8 +41,8 @@ abstract class AbstractCustomPostListTagFieldResolver extends AbstractCustomPost
         switch ($fieldName) {
             case 'customPosts':
             case 'customPostCount':
-            case 'unrestrictedCustomPosts':
-            case 'unrestrictedCustomPostCount':
+            case 'customPostsForAdmin':
+            case 'customPostCountForAdmin':
                 $query[$this->getQueryProperty()] = [$typeResolver->getID($tag)];
                 break;
         }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostListUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostListUserFieldResolver.php
@@ -20,8 +20,8 @@ class CustomPostListUserFieldResolver extends AbstractCustomPostListFieldResolve
         $descriptions = [
             'customPosts' => $this->translationAPI->__('Custom posts by the user', 'pop-users'),
             'customPostCount' => $this->translationAPI->__('Number of custom posts by the user', 'pop-users'),
-            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts by the user', 'pop-users'),
-            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts by the user', 'pop-users'),
+            'customPostsForAdmin' => $this->translationAPI->__('[Unrestricted] Custom posts by the user', 'pop-users'),
+            'customPostCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of custom posts by the user', 'pop-users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -42,8 +42,8 @@ class CustomPostListUserFieldResolver extends AbstractCustomPostListFieldResolve
         switch ($fieldName) {
             case 'customPosts':
             case 'customPostCount':
-            case 'unrestrictedCustomPosts':
-            case 'unrestrictedCustomPostCount':
+            case 'customPostsForAdmin':
+            case 'customPostCountForAdmin':
                 $query['authors'] = [$typeResolver->getID($user)];
                 break;
         }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostUserListFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostUserListFieldResolver.php
@@ -20,8 +20,8 @@ class CustomPostUserListFieldResolver extends AbstractCustomPostListFieldResolve
         $descriptions = [
             'customPosts' => $this->translationAPI->__('Custom posts by the user', 'users'),
             'customPostCount' => $this->translationAPI->__('Number of custom posts by the user', 'users'),
-            'unrestrictedCustomPosts' => $this->translationAPI->__('[Unrestricted] Custom posts by the user', 'users'),
-            'unrestrictedCustomPostCount' => $this->translationAPI->__('[Unrestricted] Number of custom posts by the user', 'users'),
+            'customPostsForAdmin' => $this->translationAPI->__('[Unrestricted] Custom posts by the user', 'users'),
+            'customPostCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of custom posts by the user', 'users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -42,8 +42,8 @@ class CustomPostUserListFieldResolver extends AbstractCustomPostListFieldResolve
         switch ($fieldName) {
             case 'customPosts':
             case 'customPostCount':
-            case 'unrestrictedCustomPosts':
-            case 'unrestrictedCustomPostCount':
+            case 'customPostsForAdmin':
+            case 'customPostCountForAdmin':
                 $query['authors'] = [$typeResolver->getID($user)];
                 break;
         }

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -52,16 +52,16 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         return [
             'users',
             'userCount',
-            'unrestrictedUsers',
-            'unrestrictedUserCount',
+            'usersForAdmin',
+            'userCountForAdmin',
         ];
     }
 
     public function getAdminFieldNames(): array
     {
         return [
-            'unrestrictedUsers',
-            'unrestrictedUserCount',
+            'usersForAdmin',
+            'userCountForAdmin',
         ];
     }
 
@@ -70,8 +70,8 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         $types = [
             'users' => SchemaDefinition::TYPE_ID,
             'userCount' => SchemaDefinition::TYPE_INT,
-            'unrestrictedUsers' => SchemaDefinition::TYPE_ID,
-            'unrestrictedUserCount' => SchemaDefinition::TYPE_INT,
+            'usersForAdmin' => SchemaDefinition::TYPE_ID,
+            'userCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -80,10 +80,10 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
     {
         return match ($fieldName) {
             'userCount',
-            'unrestrictedUserCount'
+            'userCountForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'users',
-            'unrestrictedUsers'
+            'usersForAdmin'
                 => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
             default => parent::getSchemaFieldTypeModifiers($typeResolver, $fieldName),
         };
@@ -94,8 +94,8 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         $descriptions = [
             'users' => $this->translationAPI->__('Users', 'pop-users'),
             'userCount' => $this->translationAPI->__('Number of users', 'pop-users'),
-            'unrestrictedUsers' => $this->translationAPI->__('[Unrestricted] Users', 'pop-users'),
-            'unrestrictedUserCount' => $this->translationAPI->__('[Unrestricted] Number of users', 'pop-users'),
+            'usersForAdmin' => $this->translationAPI->__('[Unrestricted] Users', 'pop-users'),
+            'userCountForAdmin' => $this->translationAPI->__('[Unrestricted] Number of users', 'pop-users'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -105,8 +105,8 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         return match ($fieldName) {
             'users' => [UserFilterInputContainerModuleProcessor::class, UserFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_USERS],
             'userCount' => [UserFilterInputContainerModuleProcessor::class, UserFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_USERCOUNT],
-            'unrestrictedUsers' => [UserFilterInputContainerModuleProcessor::class, UserFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINUSERS],
-            'unrestrictedUserCount' => [UserFilterInputContainerModuleProcessor::class, UserFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINUSERCOUNT],
+            'usersForAdmin' => [UserFilterInputContainerModuleProcessor::class, UserFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINUSERS],
+            'userCountForAdmin' => [UserFilterInputContainerModuleProcessor::class, UserFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_ADMINUSERCOUNT],
             default => parent::getFieldDataFilteringModule($typeResolver, $fieldName),
         };
     }
@@ -115,7 +115,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'users':
-            case 'unrestrictedUsers':
+            case 'usersForAdmin':
                 $limitFilterInputName = FilterInputHelper::getFilterInputName([
                     CommonFilterInputModuleProcessor::class,
                     CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_LIMIT
@@ -145,11 +145,11 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
         $query = $this->convertFieldArgsToFilteringQueryArgs($typeResolver, $fieldName, $fieldArgs);
         switch ($fieldName) {
             case 'users':
-            case 'unrestrictedUsers':
+            case 'usersForAdmin':
                 return $this->userTypeAPI->getUsers($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'userCount':
-            case 'unrestrictedUserCount':
+            case 'userCountForAdmin':
                 return $this->userTypeAPI->getUserCount($query);
         }
 
@@ -160,7 +160,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'users':
-            case 'unrestrictedUsers':
+            case 'usersForAdmin':
                 return UserTypeResolver::class;
         }
 

--- a/layers/WPSchema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/WPSchema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -23,14 +23,14 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     {
         return [
             'pageByPath',
-            'unrestrictedPageByPath',
+            'pageByPathForAdmin',
         ];
     }
 
     public function getAdminFieldNames(): array
     {
         return [
-            'unrestrictedPageByPath',
+            'pageByPathForAdmin',
         ];
     }
 
@@ -38,7 +38,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     {
         $descriptions = [
             'pageByPath' => $this->translationAPI->__('Page with a specific URL path', 'pages'),
-            'unrestrictedPageByPath' => $this->translationAPI->__('[Unrestricted] Page with a specific URL path', 'pages'),
+            'pageByPathForAdmin' => $this->translationAPI->__('[Unrestricted] Page with a specific URL path', 'pages'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($typeResolver, $fieldName);
     }
@@ -47,7 +47,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     {
         $types = [
             'pageByPath' => SchemaDefinition::TYPE_ID,
-            'unrestrictedPageByPath' => SchemaDefinition::TYPE_ID,
+            'pageByPathForAdmin' => SchemaDefinition::TYPE_ID,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($typeResolver, $fieldName);
     }
@@ -57,7 +57,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         $schemaFieldArgs = parent::getSchemaFieldArgs($typeResolver, $fieldName);
         switch ($fieldName) {
             case 'pageByPath':
-            case 'unrestrictedPageByPath':
+            case 'pageByPathForAdmin':
                 return array_merge(
                     $schemaFieldArgs,
                     [
@@ -91,7 +91,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         $pageTypeAPI = PageTypeAPIFacade::getInstance();
         switch ($fieldName) {
             case 'pageByPath':
-            case 'unrestrictedPageByPath':
+            case 'pageByPathForAdmin':
                 /** @var WP_Post|null */
                 $page = \get_page_by_path($fieldArgs['path']);
                 if ($page === null) {
@@ -100,7 +100,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
                 // Check the status is allowed
                 if ($fieldName === 'pageByPath' && $page->post_status !== "publish") {
                     return null;
-                } elseif ($fieldName === 'unrestrictedPageByPath') {
+                } elseif ($fieldName === 'pageByPathForAdmin') {
                     return null;
                 }
                 return $page->ID;
@@ -113,7 +113,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     {
         switch ($fieldName) {
             case 'pageByPath':
-            case 'unrestrictedPageByPath':
+            case 'pageByPathForAdmin':
                 return PageTypeResolver::class;
         }
 


### PR DESCRIPTION
Renamed all the "admin" fields. Instead of prepending them with "unrestricted", now they are appended "ForAdmin".

For instance, these fields from the `QueryRoot` have been renamed like this:

- `unrestrictedPost` => `postForAdmin`
- `unrestrictedPosts` => `postsForAdmin`
- `unrestrictedPostCount` => `postCountForAdmin`
- `unrestrictedCustomPost` => `customPostForAdmin`
- `unrestrictedCustomPosts` => `customPostsForAdmin`
- `unrestrictedCustomPostCount` => `customPostCountForAdmin`
- `unrestrictedPage` => `pageForAdmin`
- `unrestrictedPages` => `pagesForAdmin`
- `unrestrictedPageCount` => `pageCountForAdmin`
