### PR TITLE
Removed `SKIP_MAX_LIMIT`

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/AbstractListOfCPTEntitiesRootFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/AbstractListOfCPTEntitiesRootFieldResolver.php
@@ -73,8 +73,6 @@ abstract class AbstractListOfCPTEntitiesRootFieldResolver extends AbstractQuerya
         ];
         $options = [
             SchemaCommonsQueryOptions::RETURN_TYPE => ReturnTypes::IDS,
-            // Do not use the limit set in the settings for custom posts
-            SchemaCommonsQueryOptions::SKIP_MAX_LIMIT => true,
             // With this flag, the hook will not remove the private CPTs
             QueryOptions::ALLOW_QUERYING_PRIVATE_CPTS => true,
         ];

--- a/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/Schema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -149,17 +149,7 @@ abstract class AbstractCategoryTypeAPI extends TaxonomyTypeAPI implements Catego
             // Same param name, so do nothing
         }
         if (isset($query['limit'])) {
-            // Maybe restrict the limit, if higher than the max limit
-            // Allow to not limit by max when querying from within the application
             $limit = (int) $query['limit'];
-            if (!isset($options[QueryOptions::SKIP_MAX_LIMIT]) || !$options[QueryOptions::SKIP_MAX_LIMIT]) {
-                $limit = $this->queriedObjectHelperService->getLimitOrMaxLimit(
-                    $limit,
-                    ComponentConfiguration::getCategoryListMaxLimit()
-                );
-            }
-
-            // Assign the limit as the required attribute
             // To bring all results, get_categories needs "number => 0" instead of -1
             $query['number'] = ($limit == -1) ? 0 : $limit;
             unset($query['limit']);

--- a/layers/Schema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
+++ b/layers/Schema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
@@ -135,15 +135,7 @@ class CommentTypeAPI implements CommentTypeAPIInterface
         }
         // For the comments, if there's no limit then it brings all results
         if (isset($query['limit'])) {
-            // Maybe restrict the limit, if higher than the max limit
-            // Allow to not limit by max when querying from within the application
             $limit = (int) $query['limit'];
-            if (!isset($options[QueryOptions::SKIP_MAX_LIMIT]) || !$options[QueryOptions::SKIP_MAX_LIMIT]) {
-                $limit = $this->queriedObjectHelperService->getLimitOrMaxLimit(
-                    $limit,
-                    ComponentConfiguration::getCommentListMaxLimit()
-                );
-            }
             // To bring all results, must use "number => 0" instead of -1
             $query['number'] = ($limit == -1) ? 0 : $limit;
             unset($query['limit']);

--- a/layers/Schema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/Schema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -151,17 +151,7 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
             // Same param name, so do nothing
         }
         if (isset($query['limit'])) {
-            // Maybe restrict the limit, if higher than the max limit
-            // Allow to not limit by max when querying from within the application
             $limit = (int) $query['limit'];
-            if (!isset($options[QueryOptions::SKIP_MAX_LIMIT]) || !$options[QueryOptions::SKIP_MAX_LIMIT]) {
-                $limit = $this->queriedObjectHelperService->getLimitOrMaxLimit(
-                    $limit,
-                    $this->getCustomPostListMaxLimit()
-                );
-            }
-
-            // Assign the limit as the required attribute
             $query['posts_per_page'] = $limit;
             unset($query['limit']);
         }

--- a/layers/Schema/packages/schema-commons/src/Constants/QueryOptions.php
+++ b/layers/Schema/packages/schema-commons/src/Constants/QueryOptions.php
@@ -7,5 +7,4 @@ namespace PoPSchema\SchemaCommons\Constants;
 class QueryOptions
 {
     public const RETURN_TYPE = 'return-type';
-    public const SKIP_MAX_LIMIT = 'skip-max-limit';
 }

--- a/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
+++ b/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
@@ -150,17 +150,7 @@ abstract class AbstractTagTypeAPI extends TaxonomyTypeAPI implements TagTypeAPII
             // Same param name, so do nothing
         }
         if (isset($query['limit'])) {
-            // Maybe restrict the limit, if higher than the max limit
-            // Allow to not limit by max when querying from within the application
             $limit = (int) $query['limit'];
-            if (!isset($options[QueryOptions::SKIP_MAX_LIMIT]) || !$options[QueryOptions::SKIP_MAX_LIMIT]) {
-                $limit = $this->queriedObjectHelperService->getLimitOrMaxLimit(
-                    $limit,
-                    ComponentConfiguration::getTagListMaxLimit()
-                );
-            }
-
-            // Assign the limit as the required attribute
             // To bring all results, get_tags needs "number => 0" instead of -1
             $query['number'] = ($limit == -1) ? 0 : $limit;
             unset($query['limit']);

--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -176,17 +176,7 @@ class UserTypeAPI extends AbstractUserTypeAPI
             // Same param name, so do nothing
         }
         if (isset($query['limit'])) {
-            // Maybe restrict the limit, if higher than the max limit
-            // Allow to not limit by max when querying from within the application
             $limit = (int) $query['limit'];
-            if (!isset($options[QueryOptions::SKIP_MAX_LIMIT]) || !$options[QueryOptions::SKIP_MAX_LIMIT]) {
-                $limit = $this->queriedObjectHelperService->getLimitOrMaxLimit(
-                    $limit,
-                    ComponentConfiguration::getUserListMaxLimit()
-                );
-            }
-
-            // Assign the limit as the required attribute
             $query['number'] = $limit;
             unset($query['limit']);
         }


### PR DESCRIPTION
Since #1007 the limit can be enforced via setting field/directive argument constraints in the resolvers, so no need to validate it in the API code anymore.

This is good since the API is also used by the application's inner functionality.