### PR TITLE
Clicking on "Save Changes" on the Settings page will always regenerate the schema

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -155,6 +155,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Validate constraints for field and directive arguments
 - Added options "default limit" and "max limit" for Posts and Pages
 - Performance improvement: Avoid regenerating the container when the schema is modified
+- Clicking on "Save Changes" on the Settings page will always regenerate the schema
 - Prettyprint GraphQL queries in the module docs
 
 ### Fixed

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -556,6 +556,12 @@ When a Schema Configuration, Access Control List or Cache Control List is modifi
 
 From `v0.9`, the service container and the schema both have independent timestamps tracking their state, and they can be purged independently. Hence, modifying the schema will only purge the corresponding cached files, and there will be an improvement in performance when editing any of the CPTs provided in the plugin.
 
+## Clicking on "Save Changes" on the Settings page will always regenerate the schema
+
+If we are testing an extension and the schema is cached, it must be purged. To do so, we can modify some value in the Settings page and save, which would regenerate the schema. But this required some value to be modified.
+
+From `v0.9` it is not needed to modify any value on the Settings. Just clicking on the "Save Changes" button will always regenerate the schema.
+
 ## Prettyprint GraphQL queries in the module docs
 
 The GraphQL queries in the module documentation are now prettyprinted:

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -317,7 +317,7 @@ class SettingsMenuPage extends AbstractPluginMenuPage
                     which makes "update_option_{$option}" not be triggered when there are no changes
                     @see wp-includes/option.php
                 -->
-                <input type="hidden" name="<?php echo self::SETTINGS_FIELD?>[timestamp]" value="<?php echo time() ?>">
+                <input type="hidden" name="<?php echo self::SETTINGS_FIELD?>[last_saved_timestamp]" value="<?php echo time() ?>">
                 <!-- Panels -->
                 <?php
                 $sectionClass = $printWithTabs ? 'tab-content' : '';

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -310,6 +310,14 @@ class SettingsMenuPage extends AbstractPluginMenuPage
             <form method="post" action="options.php">
                 <!-- Artificial input as flag that the form belongs to this plugin -->
                 <input type="hidden" name="<?php echo self::FORM_ORIGIN ?>" value="<?php echo self::SETTINGS_FIELD ?>" />
+                <!--
+                    Artificial input to trigger the update of the form always, as to always purge the container/operational cache
+                    (eg: to include 3rd party extensions in the service container, or new Gutenberg blocks)
+                    This is needed because "If the new and old values are the same, no need to update."
+                    which makes "update_option_{$option}" not be triggered when there are no changes
+                    @see wp-includes/option.php
+                -->
+                <input type="hidden" name="<?php echo self::SETTINGS_FIELD?>[timestamp]" value="<?php echo time() ?>">
                 <!-- Panels -->
                 <?php
                 $sectionClass = $printWithTabs ? 'tab-content' : '';


### PR DESCRIPTION
If we are testing an extension and the schema is cached, it must be purged. To do so, we can modify some value in the Settings page and save, which would regenerate the schema. But this required some value to be modified.

From `v0.9` it is not needed to modify any value on the Settings. Just clicking on the "Save Changes" button will always regenerate the schema.