### PR TITLE
Added function `isFieldOfRelationalType` to check if a TypeResolver is Relational

### DIFF
--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -156,7 +156,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                 $relationalFieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($relationalField);
 
                 // Make sure the field is relational, and not a scalar or enum
-                if (!$relationalTypeResolver->isRelationalType($relationalField)) {
+                if (!$relationalTypeResolver->isFieldOfRelationalType($relationalField)) {
                     $dbErrors[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(

--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -157,6 +157,19 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                      * it is "post-1".
                      */
                     $relationalFieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($relationalField);
+
+                    // Make sure the field is relational, and not a scalar or enum
+                    if (!$relationalTypeResolver->isRelationalType($relationalField)) {
+                        $dbErrors[(string)$id][] = [
+                            Tokens::PATH => [$this->directive],
+                            Tokens::MESSAGE => sprintf(
+                                $this->translationAPI->__('Field \'%s\' is not a connection, so it cannot have data properties', 'component-model'),
+                                $relationalFieldOutputKey
+                            ),
+                        ];
+                        continue;
+                    }
+
                     // Validate that the current object has `relationalField` property set
                     // Since we are fetching from a relational object (placed one level below in the iteration stack), the value could've been set only in a previous iteration
                     // Then it must be in $previousDBItems (it can't be in $dbItems unless set by chance, because the same IDs were involved for a possibly different query)

--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -133,68 +133,68 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
         $dbKey = $relationalTypeResolver->getTypeOutputName();
 
         // Copy the data from each of the relational object fields to the current object
-        for ($i = 0; $i < count($copyFromFields); $i++) {
-            $copyFromField = $copyFromFields[$i];
-            $copyToField = $copyToFields[$i] ?? $copyFromFields[$i];
-            foreach ($idsDataFields as $id => $dataFields) {
-                foreach ($dataFields['direct'] as $relationalField) {
-                    /**
-                     * The data is stored under the field's output key.
-                     *
-                     * Watch out! Must fetch content under the already-used field's output key,
-                     * so must use `getFieldOutputKey` instead of `getUniqueFieldOutputKey`,
-                     * otherwise it will not find the value since it will produce a different entry.
-                     *
-                     * For instance:
-                     *
-                     *     /?postId=1
-                     *       &query=
-                     *         post($postId)@post.content|date(d/m/Y)@date;
-                     *         post($postId)@post<copyRelationalResults([content,date],[postContent,postDate])>
-                     *
-                     * In this query, the unique field output key for "post($postId)@post"
-                     * is "post" and for "post($postId)@post<copyRelationalResults([content,date],[postContent,postDate])>"
-                     * it is "post-1".
-                     */
-                    $relationalFieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($relationalField);
+        foreach ($idsDataFields as $id => $dataFields) {
+            foreach ($dataFields['direct'] as $relationalField) {
+                /**
+                 * The data is stored under the field's output key.
+                 *
+                 * Watch out! Must fetch content under the already-used field's output key,
+                 * so must use `getFieldOutputKey` instead of `getUniqueFieldOutputKey`,
+                 * otherwise it will not find the value since it will produce a different entry.
+                 *
+                 * For instance:
+                 *
+                 *     /?postId=1
+                 *       &query=
+                 *         post($postId)@post.content|date(d/m/Y)@date;
+                 *         post($postId)@post<copyRelationalResults([content,date],[postContent,postDate])>
+                 *
+                 * In this query, the unique field output key for "post($postId)@post"
+                 * is "post" and for "post($postId)@post<copyRelationalResults([content,date],[postContent,postDate])>"
+                 * it is "post-1".
+                 */
+                $relationalFieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($relationalField);
 
-                    // Make sure the field is relational, and not a scalar or enum
-                    if (!$relationalTypeResolver->isRelationalType($relationalField)) {
+                // Make sure the field is relational, and not a scalar or enum
+                if (!$relationalTypeResolver->isRelationalType($relationalField)) {
+                    $dbErrors[(string)$id][] = [
+                        Tokens::PATH => [$this->directive],
+                        Tokens::MESSAGE => sprintf(
+                            $this->translationAPI->__('Field \'%s\' is not a connection, so it cannot have data properties', 'component-model'),
+                            $relationalFieldOutputKey
+                        ),
+                    ];
+                    continue;
+                }
+
+                // Validate that the current object has `relationalField` property set
+                // Since we are fetching from a relational object (placed one level below in the iteration stack), the value could've been set only in a previous iteration
+                // Then it must be in $previousDBItems (it can't be in $dbItems unless set by chance, because the same IDs were involved for a possibly different query)
+                if (!array_key_exists($relationalFieldOutputKey, $previousDBItems[$dbKey][(string)$id] ?? [])) {
+                    if ($relationalFieldOutputKey != $relationalField) {
                         $dbErrors[(string)$id][] = [
                             Tokens::PATH => [$this->directive],
                             Tokens::MESSAGE => sprintf(
-                                $this->translationAPI->__('Field \'%s\' is not a connection, so it cannot have data properties', 'component-model'),
-                                $relationalFieldOutputKey
+                                $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
+                                $relationalFieldOutputKey,
+                                $id
                             ),
                         ];
-                        continue;
+                    } else {
+                        $dbErrors[(string)$id][] = [
+                            Tokens::PATH => [$this->directive],
+                            Tokens::MESSAGE => sprintf(
+                                $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
+                                $relationalField,
+                                $id
+                            ),
+                        ];
                     }
-
-                    // Validate that the current object has `relationalField` property set
-                    // Since we are fetching from a relational object (placed one level below in the iteration stack), the value could've been set only in a previous iteration
-                    // Then it must be in $previousDBItems (it can't be in $dbItems unless set by chance, because the same IDs were involved for a possibly different query)
-                    if (!array_key_exists($relationalFieldOutputKey, $previousDBItems[$dbKey][(string)$id] ?? [])) {
-                        if ($relationalFieldOutputKey != $relationalField) {
-                            $dbErrors[(string)$id][] = [
-                                Tokens::PATH => [$this->directive],
-                                Tokens::MESSAGE => sprintf(
-                                    $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
-                                    $relationalFieldOutputKey,
-                                    $id
-                                ),
-                            ];
-                        } else {
-                            $dbErrors[(string)$id][] = [
-                                Tokens::PATH => [$this->directive],
-                                Tokens::MESSAGE => sprintf(
-                                    $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
-                                    $relationalField,
-                                    $id
-                                ),
-                            ];
-                        }
-                        continue;
-                    }
+                    continue;
+                }
+                for ($i = 0; $i < count($copyFromFields); $i++) {
+                    $copyFromField = $copyFromFields[$i];
+                    $copyToField = $copyToFields[$i] ?? $copyFromFields[$i];
 
                     // If the destination field already exists, warn that it will be overriden
                     $isTargetValueInDBItems = array_key_exists($copyToField, $dbItems[(string)$id] ?? []);

--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -178,8 +178,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                             $dbErrors[(string)$id][] = [
                                 Tokens::PATH => [$this->directive],
                                 Tokens::MESSAGE => sprintf(
-                                    $this->translationAPI->__('Field \'%s\' (under property \'%s\') hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
-                                    $relationalField,
+                                    $this->translationAPI->__('Field \'%s\' hadn\'t been set for object with ID \'%s\', so no data can be copied', 'component-model'),
                                     $relationalFieldOutputKey,
                                     $id
                                 ),

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -427,7 +427,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
                 $schemaDefinition[SchemaDefinition::ARGNAME_VERSION] = $version;
             }
         }
-        if (!is_null($this->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName))) {
+        if ($this->isFieldOfRelationalType($relationalTypeResolver, $fieldName)) {
             $schemaDefinition[SchemaDefinition::ARGNAME_RELATIONAL] = true;
         }
         if (!is_null($this->resolveFieldMutationResolverClass($relationalTypeResolver, $fieldName))) {
@@ -722,6 +722,16 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
     {
         return null;
+    }
+
+    final protected function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $field): ?bool
+    {
+        $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($relationalTypeResolver, $field);
+        if ($fieldTypeResolverClass === null) {
+            return null;
+        }
+        $fieldTypeResolver = $this->instanceManager->getInstance($fieldTypeResolverClass);
+        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
     }
 
     public function resolveFieldMutationResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string

--- a/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
@@ -24,9 +24,6 @@ class DataloadHelperService implements DataloadHelperServiceInterface
     public function getTypeResolverClassFromSubcomponentDataField(RelationalTypeResolverInterface $relationalTypeResolver, string $subcomponent_data_field): ?string
     {
         $subcomponent_typeResolver_class = $relationalTypeResolver->resolveFieldTypeResolverClass($subcomponent_data_field);
-        // if (!$subcomponent_typeResolver_class && \PoP\ComponentModel\Environment::failIfSubcomponentTypeDataLoaderUndefined()) {
-        //     throw new \Exception(sprintf('There is no default typeResolver set for field  "%s" from typeResolver "%s" and typeResolver "%s" (%s)', $subcomponent_data_field, $typeResolver_class, $typeResolverClass, RequestUtils::getRequestedFullURL()));
-        // }
         // If this field doesn't have a typeResolver, show a schema error
         // But if there are no FieldResolvers, then skip adding an error here, since that error will have been added already
         // Otherwise, there will appear 2 error messages:

--- a/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
@@ -23,13 +23,12 @@ class DataloadHelperService implements DataloadHelperServiceInterface
 
     public function getTypeResolverClassFromSubcomponentDataField(RelationalTypeResolverInterface $relationalTypeResolver, string $subcomponent_data_field): ?string
     {
-        $subcomponent_typeResolver_class = $relationalTypeResolver->resolveFieldTypeResolverClass($subcomponent_data_field);
         // If this field doesn't have a typeResolver, show a schema error
         // But if there are no FieldResolvers, then skip adding an error here, since that error will have been added already
         // Otherwise, there will appear 2 error messages:
         // 1. No FieldResolver
         // 2. No FieldDefaultTypeDataLoader
-        if (!$subcomponent_typeResolver_class && $relationalTypeResolver->hasFieldResolversForField($subcomponent_data_field)) {
+        if (!$relationalTypeResolver->isFieldOfRelationalType($subcomponent_data_field) && $relationalTypeResolver->hasFieldResolversForField($subcomponent_data_field)) {
             // If there is an alias, store the results under this. Otherwise, on the fieldName+fieldArgs
             $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getFieldOutputKey($subcomponent_data_field);
             $this->feedbackMessageStore->addSchemaError(
@@ -41,7 +40,7 @@ class DataloadHelperService implements DataloadHelperServiceInterface
                 )
             );
         }
-        return $subcomponent_typeResolver_class;
+        return $relationalTypeResolver->resolveFieldTypeResolverClass($subcomponent_data_field);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -122,7 +122,8 @@ class SchemaHelpers
         if ($type == SchemaDefinition::TYPE_ID) {
             $instanceManager = InstanceManagerFacade::getInstance();
             // The type may not be implemented yet (eg: Category), then skip
-            if ($fieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($fieldName)) {
+            if ($relationalTypeResolver->isFieldOfRelationalType($fieldName)) {
+                $fieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($fieldName);
                 $fieldTypeResolver = $instanceManager->getInstance((string)$fieldTypeResolverClass);
                 $type = $fieldTypeResolver->getMaybeNamespacedTypeName();
             }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1309,7 +1309,7 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         return null;
     }
 
-    public function isRelationalType(string $field): ?bool
+    public function isFieldOfRelationalType(string $field): ?bool
     {
         $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($field);
         if ($fieldTypeResolverClass === null) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1309,6 +1309,16 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         return null;
     }
 
+    public function isRelationalType(string $field): ?bool
+    {
+        $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($field);
+        if ($fieldTypeResolverClass === null) {
+            return null;
+        }
+        $fieldTypeResolver = $this->instanceManager->getInstance($fieldTypeResolverClass);
+        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
+    }
+
     /**
      * @param array<string, mixed>|null $variables
      * @param array<string, mixed>|null $expressions

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1763,7 +1763,8 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         // Add subfield schema if it is deep, and this typeResolver has not been processed yet
         if ($options['deep'] ?? null) {
             // If this field is relational, then add its own schema
-            if ($fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($fieldName)) {
+            if ($this->isFieldOfRelationalType($fieldName)) {
+                $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($fieldName);
                 $fieldTypeResolver = $this->instanceManager->getInstance($fieldTypeResolverClass);
                 $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_SCHEMA] = $fieldTypeResolver->getSchemaDefinition($stackMessages, $generalMessages, $options);
             }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
@@ -62,6 +62,7 @@ interface RelationalTypeResolverInterface extends TypeResolverInterface
     public function getSchemaFieldArgs(string $field): ?array;
     public function enableOrderedSchemaFieldArgs(string $field): bool;
     public function resolveFieldTypeResolverClass(string $field): ?string;
+    public function isRelationalType(string $field): ?bool;
     /**
      * @param array<string, mixed>|null $variables
      * @param array<string, mixed>|null $expressions

--- a/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
@@ -62,7 +62,7 @@ interface RelationalTypeResolverInterface extends TypeResolverInterface
     public function getSchemaFieldArgs(string $field): ?array;
     public function enableOrderedSchemaFieldArgs(string $field): bool;
     public function resolveFieldTypeResolverClass(string $field): ?string;
-    public function isRelationalType(string $field): ?bool;
+    public function isFieldOfRelationalType(string $field): ?bool;
     /**
      * @param array<string, mixed>|null $variables
      * @param array<string, mixed>|null $expressions


### PR DESCRIPTION
In advance of having function `resolveFieldTypeResolverClass` return not only relational type resolvers, but also interfaces/enums/scalars.