### PR TITLE
Remove `SchemaDefinition::TYPE_ID` as indicator of connection

### DIFF
--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -10,6 +10,7 @@ use PoP\ComponentModel\Directives\DirectiveTypes;
 use PoP\ComponentModel\TypeResolvers\Union\UnionTypeHelpers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalDirectiveResolver;
+use PoP\ComponentModel\Schema\SchemaHelpers;
 
 class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveResolver
 {
@@ -156,7 +157,8 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                 $relationalFieldOutputKey = $this->fieldQueryInterpreter->getFieldOutputKey($relationalField);
 
                 // Make sure the field is relational, and not a scalar or enum
-                if (!$relationalTypeResolver->isFieldOfRelationalType($relationalField)) {
+                $fieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($relationalField);
+                if (!SchemaHelpers::isRelationalFieldTypeResolverClass($fieldTypeResolverClass)) {
                     $dbErrors[(string)$id][] = [
                         Tokens::PATH => [$this->directive],
                         Tokens::MESSAGE => sprintf(
@@ -166,6 +168,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                     ];
                     continue;
                 }
+                $relationalFieldTypeResolverClass = $fieldTypeResolverClass;
 
                 // Validate that the current object has `relationalField` property set
                 // Since we are fetching from a relational object (placed one level below in the iteration stack), the value could've been set only in a previous iteration
@@ -192,8 +195,7 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                     }
                     continue;
                 }
-                
-                $relationalFieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($relationalField);
+
                 $relationalFieldTypeResolver = $this->instanceManager->getInstance((string)$relationalFieldTypeResolverClass);
                 $relationalFieldDBKey = $relationalFieldTypeResolver->getTypeOutputName();
                 $isUnionRelationalFieldDBKey = UnionTypeHelpers::isUnionType($relationalFieldDBKey);

--- a/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
+++ b/layers/API/packages/api/src/DirectiveResolvers/CopyRelationalResultsDirectiveResolver.php
@@ -192,6 +192,11 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                     }
                     continue;
                 }
+                
+                $relationalFieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($relationalField);
+                $relationalFieldTypeResolver = $this->instanceManager->getInstance((string)$relationalFieldTypeResolverClass);
+                $relationalFieldDBKey = $relationalFieldTypeResolver->getTypeOutputName();
+                $isUnionRelationalFieldDBKey = UnionTypeHelpers::isUnionType($relationalFieldDBKey);
                 for ($i = 0; $i < count($copyFromFields); $i++) {
                     $copyFromField = $copyFromFields[$i];
                     $copyToField = $copyToFields[$i] ?? $copyFromFields[$i];
@@ -215,10 +220,6 @@ class CopyRelationalResultsDirectiveResolver extends AbstractGlobalDirectiveReso
                     $dbItems[(string)$id][$copyToField] = [];
 
                     // Obtain the DBKey under which the relationalField is stored in the database
-                    $relationalFieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($relationalField);
-                    $relationalFieldTypeResolver = $this->instanceManager->getInstance((string)$relationalFieldTypeResolverClass);
-                    $relationalFieldDBKey = $relationalFieldTypeResolver->getTypeOutputName();
-                    $isUnionRelationalFieldDBKey = UnionTypeHelpers::isUnionType($relationalFieldDBKey);
                     if ($isUnionRelationalFieldDBKey) {
                         // If the relational type data resolver is union, we must use the corresponding IDs from $unionDBKeyIDs, which contain the type in addition to the ID
                         $relationalFieldIDs = $unionDBKeyIDs[$dbKey][(string)$id][$relationalFieldOutputKey];

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -67,16 +67,4 @@ abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverI
     // {
     //     return null;
     // }
-
-    /**
-     * This function is not called by the engine, to generate the schema.
-     * Instead, the resolver is obtained from the fieldResolver.
-     * To make sure that all fieldResolvers implementing the same interface
-     * return the expected type for the field, they can obtain it from the
-     * interface through this function.
-     */
-    public function getFieldTypeResolverClass(string $fieldName): ?string
-    {
-        return null;
-    }
 }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/ElementalFieldInterfaceResolver.php
@@ -29,10 +29,10 @@ class ElementalFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResolv
 
     public function getSchemaFieldType(string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'id' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
+            default => parent::getSchemaFieldType($fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(string $fieldName): ?int

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceResolverInterface.php
@@ -22,12 +22,4 @@ interface FieldInterfaceResolverInterface extends FieldInterfaceSchemaDefinition
     public function getMaybeNamespacedInterfaceName(): string;
     public function getSchemaInterfaceDescription(): ?string;
     // public function getSchemaInterfaceVersion(string $fieldName): ?string;
-    /**
-     * This function is not called by the engine, to generate the schema.
-     * Instead, the resolver is obtained from the fieldResolver.
-     * To make sure that all fieldResolvers implementing the same interface
-     * return the expected type for the field, they can obtain it from the
-     * interface through this function.
-     */
-    public function getFieldTypeResolverClass(string $fieldName): ?string;
 }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -12,6 +12,7 @@ interface FieldInterfaceSchemaDefinitionResolverInterface
     public function getSchemaFieldDescription(string $fieldName): ?string;
     public function getSchemaFieldArgs(string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(string $fieldName, array $fieldArgs = []): ?string;
+    public function resolveFieldTypeResolverClass(string $fieldName): ?string;
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -13,7 +13,6 @@ interface FieldInterfaceSchemaDefinitionResolverInterface
     public function getSchemaFieldArgs(string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(string $fieldName, array $fieldArgs = []): ?string;
     public function resolveFieldTypeResolverClass(string $fieldName): ?string;
-    public function isFieldOfRelationalType(string $fieldName): ?bool;
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverInterface.php
@@ -13,6 +13,7 @@ interface FieldInterfaceSchemaDefinitionResolverInterface
     public function getSchemaFieldArgs(string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(string $fieldName, array $fieldArgs = []): ?string;
     public function resolveFieldTypeResolverClass(string $fieldName): ?string;
+    public function isFieldOfRelationalType(string $fieldName): ?bool;
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -62,6 +62,14 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
         return null;
     }
 
+    public function resolveFieldTypeResolverClass(string $fieldName): ?string
+    {
+        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
+            return $schemaDefinitionResolver->resolveFieldTypeResolverClass($fieldName);
+        }
+        return null;
+    }
+
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
-use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 
 trait FieldInterfaceSchemaDefinitionResolverTrait
 {
@@ -70,22 +68,6 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
             return $schemaDefinitionResolver->resolveFieldTypeResolverClass($fieldName);
         }
         return null;
-    }
-
-    public function isFieldOfRelationalType(string $fieldName): ?bool
-    {
-        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
-            if ($schemaDefinitionResolver !== $this) {
-                return $schemaDefinitionResolver->isFieldOfRelationalType($fieldName);
-            }
-        }
-        $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($fieldName);
-        if ($fieldTypeResolverClass === null) {
-            return null;
-        }
-        $instanceManager = InstanceManagerFacade::getInstance();
-        $fieldTypeResolver = $instanceManager->getInstance($fieldTypeResolverClass);
-        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceSchemaDefinitionResolverTrait.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
+use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 
 trait FieldInterfaceSchemaDefinitionResolverTrait
 {
@@ -68,6 +70,22 @@ trait FieldInterfaceSchemaDefinitionResolverTrait
             return $schemaDefinitionResolver->resolveFieldTypeResolverClass($fieldName);
         }
         return null;
+    }
+
+    public function isFieldOfRelationalType(string $fieldName): ?bool
+    {
+        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver()) {
+            if ($schemaDefinitionResolver !== $this) {
+                return $schemaDefinitionResolver->isFieldOfRelationalType($fieldName);
+            }
+        }
+        $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($fieldName);
+        if ($fieldTypeResolverClass === null) {
+            return null;
+        }
+        $instanceManager = InstanceManagerFacade::getInstance();
+        $fieldTypeResolver = $instanceManager->getInstance($fieldTypeResolverClass);
+        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/SelfFieldInterfaceSchemaDefinitionResolverTrait.php
@@ -46,6 +46,11 @@ trait SelfFieldInterfaceSchemaDefinitionResolverTrait
         return null;
     }
 
+    public function resolveFieldTypeResolverClass(string $fieldName): ?string
+    {
+        return null;
+    }
+
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -472,8 +472,9 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
         return $schemaDefinition;
     }
 
-    final public function getSchemaDefinitionResolverForField(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?FieldSchemaDefinitionResolverInterface
+    final public function getSchemaDefinitionResolverForField(RelationalTypeResolverInterface $relationalTypeResolver, string $field): ?FieldSchemaDefinitionResolverInterface
     {
+        $fieldName = $this->fieldQueryInterpreter->getFieldName($field);
         // First check if the value was cached
         $key = $relationalTypeResolver->getNamespacedTypeName() . '|' . $fieldName;
         if (!isset($this->schemaDefinitionResolverForFieldCache[$key])) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -719,11 +719,6 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
         return $fieldArgs;
     }
 
-    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
-    {
-        return null;
-    }
-
     final protected function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $field): ?bool
     {
         $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($relationalTypeResolver, $field);

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -374,8 +374,9 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
         // If we found a resolver for this fieldName, get all its properties from it
         $schemaDefinitionResolver = $this->getSchemaDefinitionResolverForField($relationalTypeResolver, $fieldName);
         if ($schemaDefinitionResolver !== null) {
-            if ($schemaDefinitionResolver->isFieldOfRelationalType($relationalTypeResolver, $fieldName)) {
-                $fieldTypeResolverClass = $schemaDefinitionResolver->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
+            $fieldTypeResolverClass = $schemaDefinitionResolver->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
+            if (SchemaHelpers::isRelationalFieldTypeResolverClass($fieldTypeResolverClass)) {
+                $schemaDefinition[SchemaDefinition::ARGNAME_RELATIONAL] = true;
                 $fieldTypeResolver = $this->instanceManager->getInstance((string)$fieldTypeResolverClass);
                 $type = $fieldTypeResolver->getMaybeNamespacedTypeName();
             } else {
@@ -434,9 +435,6 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
             if ($version = $this->getSchemaFieldVersion($relationalTypeResolver, $fieldName)) {
                 $schemaDefinition[SchemaDefinition::ARGNAME_VERSION] = $version;
             }
-        }
-        if ($this->isFieldOfRelationalType($relationalTypeResolver, $fieldName)) {
-            $schemaDefinition[SchemaDefinition::ARGNAME_RELATIONAL] = true;
         }
         if (!is_null($this->resolveFieldMutationResolverClass($relationalTypeResolver, $fieldName))) {
             $schemaDefinition[SchemaDefinition::ARGNAME_FIELD_IS_MUTATION] = true;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -339,8 +339,6 @@ trait AliasSchemaFieldResolverTrait
     /**
      * Proxy pattern: execute same function on the aliased FieldResolver,
      * for the aliased $fieldName
-     *
-     * @param array<string, mixed> $fieldArgs
      */
     public function resolveFieldTypeResolverClass(
         RelationalTypeResolverInterface $relationalTypeResolver,
@@ -348,6 +346,21 @@ trait AliasSchemaFieldResolverTrait
     ): ?string {
         $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
         return $aliasedFieldResolver->resolveFieldTypeResolverClass(
+            $relationalTypeResolver,
+            $this->getAliasedFieldName($fieldName)
+        );
+    }
+
+    /**
+     * Proxy pattern: execute same function on the aliased FieldResolver,
+     * for the aliased $fieldName
+     */
+    public function isFieldOfRelationalType(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        string $fieldName
+    ): ?bool {
+        $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
+        return $aliasedFieldResolver->isFieldOfRelationalType(
             $relationalTypeResolver,
             $this->getAliasedFieldName($fieldName)
         );

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AliasSchemaFieldResolverTrait.php
@@ -350,19 +350,4 @@ trait AliasSchemaFieldResolverTrait
             $this->getAliasedFieldName($fieldName)
         );
     }
-
-    /**
-     * Proxy pattern: execute same function on the aliased FieldResolver,
-     * for the aliased $fieldName
-     */
-    public function isFieldOfRelationalType(
-        RelationalTypeResolverInterface $relationalTypeResolver,
-        string $fieldName
-    ): ?bool {
-        $aliasedFieldResolver = $this->getAliasedFieldResolverInstance();
-        return $aliasedFieldResolver->isFieldOfRelationalType(
-            $relationalTypeResolver,
-            $this->getAliasedFieldName($fieldName)
-        );
-    }
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ElementalFieldResolver.php
@@ -37,11 +37,10 @@ class ElementalFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'id' => SchemaDefinition::TYPE_ID,
-            'self' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -36,6 +36,7 @@ interface FieldResolverInterface extends AttachableExtensionInterface
      * be exposed to the user (eg: "accessControlLists")
      */
     public function skipAddingToSchemaDefinition(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): bool;
+    public function getSchemaDefinitionResolverForField(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?FieldSchemaDefinitionResolverInterface;
     public function getSchemaDefinitionForField(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): array;
     public function getSchemaFieldVersion(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
     /**
@@ -76,6 +77,7 @@ interface FieldResolverInterface extends AttachableExtensionInterface
         string $fieldName
     ): bool;
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
+    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool;
     public function resolveFieldMutationResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
     public function resolveSchemaValidationWarningDescriptions(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): ?array;
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -77,7 +77,6 @@ interface FieldResolverInterface extends AttachableExtensionInterface
         string $fieldName
     ): bool;
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
-    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool;
     public function resolveFieldMutationResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
     public function resolveSchemaValidationWarningDescriptions(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): ?array;
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -36,7 +36,7 @@ interface FieldResolverInterface extends AttachableExtensionInterface
      * be exposed to the user (eg: "accessControlLists")
      */
     public function skipAddingToSchemaDefinition(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): bool;
-    public function getSchemaDefinitionResolverForField(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?FieldSchemaDefinitionResolverInterface;
+    public function getSchemaDefinitionResolverForField(RelationalTypeResolverInterface $relationalTypeResolver, string $field): ?FieldSchemaDefinitionResolverInterface;
     public function getSchemaDefinitionForField(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): array;
     public function getSchemaFieldVersion(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -15,6 +15,7 @@ interface FieldSchemaDefinitionResolverInterface
     public function getSchemaFieldDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): ?string;
+    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -16,6 +16,7 @@ interface FieldSchemaDefinitionResolverInterface
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): ?string;
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
+    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool;
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverInterface.php
@@ -16,7 +16,6 @@ interface FieldSchemaDefinitionResolverInterface
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array;
     public function getSchemaFieldDeprecationDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): ?string;
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string;
-    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool;
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -62,6 +62,14 @@ trait FieldSchemaDefinitionResolverTrait
         return null;
     }
 
+    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
+    {
+        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($relationalTypeResolver)) {
+            return $schemaDefinitionResolver->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
+        }
+        return null;
+    }
+
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
@@ -68,6 +69,22 @@ trait FieldSchemaDefinitionResolverTrait
             return $schemaDefinitionResolver->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
         }
         return null;
+    }
+
+    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool
+    {
+        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($relationalTypeResolver)) {
+            if ($schemaDefinitionResolver !== $this) {
+                return $schemaDefinitionResolver->isFieldOfRelationalType($relationalTypeResolver, $fieldName);
+            }
+        }
+        $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
+        if ($fieldTypeResolverClass === null) {
+            return null;
+        }
+        $instanceManager = InstanceManagerFacade::getInstance();
+        $fieldTypeResolver = $instanceManager->getInstance($fieldTypeResolverClass);
+        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers;
 
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\SchemaDefinitionServiceFacade;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\Resolvers\WithVersionConstraintFieldOrDirectiveResolverTrait;
@@ -69,22 +68,6 @@ trait FieldSchemaDefinitionResolverTrait
             return $schemaDefinitionResolver->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
         }
         return null;
-    }
-
-    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool
-    {
-        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolverForField($relationalTypeResolver, $fieldName)) {
-            if ($schemaDefinitionResolver !== $this) {
-                return $schemaDefinitionResolver->isFieldOfRelationalType($relationalTypeResolver, $fieldName);
-            }
-        }
-        $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
-        if ($fieldTypeResolverClass === null) {
-            return null;
-        }
-        $instanceManager = InstanceManagerFacade::getInstance();
-        $fieldTypeResolver = $instanceManager->getInstance($fieldTypeResolverClass);
-        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldSchemaDefinitionResolverTrait.php
@@ -73,7 +73,7 @@ trait FieldSchemaDefinitionResolverTrait
 
     public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool
     {
-        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolver($relationalTypeResolver)) {
+        if ($schemaDefinitionResolver = $this->getSchemaDefinitionResolverForField($relationalTypeResolver, $fieldName)) {
             if ($schemaDefinitionResolver !== $this) {
                 return $schemaDefinitionResolver->isFieldOfRelationalType($relationalTypeResolver, $fieldName);
             }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/SelfFieldSchemaDefinitionResolverTrait.php
@@ -50,6 +50,11 @@ trait SelfFieldSchemaDefinitionResolverTrait
         return null;
     }
 
+    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
+    {
+        return null;
+    }
+
     public function validateFieldArgument(
         RelationalTypeResolverInterface $relationalTypeResolver,
         string $fieldName,

--- a/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\HelperServices;
 
-use PoP\ComponentModel\ModuleProcessors\ModuleProcessorManagerInterface;
-use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\ModuleProcessors\ModuleProcessorManagerInterface;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
+use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaHelpers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Translation\TranslationAPIInterface;
 
@@ -28,7 +29,8 @@ class DataloadHelperService implements DataloadHelperServiceInterface
         // Otherwise, there will appear 2 error messages:
         // 1. No FieldResolver
         // 2. No FieldDefaultTypeDataLoader
-        if (!$relationalTypeResolver->isFieldOfRelationalType($subcomponent_data_field) && $relationalTypeResolver->hasFieldResolversForField($subcomponent_data_field)) {
+        $subcomponentFieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($subcomponent_data_field);
+        if (!SchemaHelpers::isRelationalFieldTypeResolverClass($subcomponentFieldTypeResolverClass) && $relationalTypeResolver->hasFieldResolversForField($subcomponent_data_field)) {
             // If there is an alias, store the results under this. Otherwise, on the fieldName+fieldArgs
             $subcomponent_data_field_outputkey = $this->fieldQueryInterpreter->getFieldOutputKey($subcomponent_data_field);
             $this->feedbackMessageStore->addSchemaError(
@@ -40,7 +42,7 @@ class DataloadHelperService implements DataloadHelperServiceInterface
                 )
             );
         }
-        return $relationalTypeResolver->resolveFieldTypeResolverClass($subcomponent_data_field);
+        return $subcomponentFieldTypeResolverClass;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -64,6 +64,11 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->getSchemaFieldDeprecationDescription($fieldName, $fieldArgs);
     }
 
+    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
+    {
+        return $this->fieldInterfaceResolver->resolveFieldTypeResolverClass($fieldName);
+    }
+
     public function validateFieldArgument(
         RelationalTypeResolverInterface $relationalTypeResolver,
         string $fieldName,

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -69,6 +69,11 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->resolveFieldTypeResolverClass($fieldName);
     }
 
+    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool
+    {
+        return $this->fieldInterfaceResolver->isFieldOfRelationalType($fieldName);
+    }
+
     public function validateFieldArgument(
         RelationalTypeResolverInterface $relationalTypeResolver,
         string $fieldName,

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -69,11 +69,6 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         return $this->fieldInterfaceResolver->resolveFieldTypeResolverClass($fieldName);
     }
 
-    public function isFieldOfRelationalType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?bool
-    {
-        return $this->fieldInterfaceResolver->isFieldOfRelationalType($fieldName);
-    }
-
     public function validateFieldArgument(
         RelationalTypeResolverInterface $relationalTypeResolver,
         string $fieldName,

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Schema;
 
+use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class SchemaHelpers
 {
@@ -106,5 +109,19 @@ class SchemaHelpers
             }
         }
         return $enumValueDefinitions;
+    }
+
+    /**
+     * Indicate if a FieldTypeResolver class is of the Relational type
+     */
+    public static function isRelationalFieldTypeResolverClass(?string $fieldTypeResolverClass): ?bool
+    {
+        if ($fieldTypeResolverClass === null) {
+            return null;
+        }
+        $instanceManager = InstanceManagerFacade::getInstance();
+        /** @var TypeResolverInterface */
+        $fieldTypeResolver = $instanceManager->getInstance($fieldTypeResolverClass);
+        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
     }
 }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -111,23 +111,18 @@ class SchemaHelpers
     }
 
     /**
-     * If the internal type is "id", convert it to its type name
+     * Obtain the TypeName from the TypeResolver
      */
     public static function getTypeNameFromTypeResolver(
-        string $type,
         RelationalTypeResolverInterface $relationalTypeResolver,
         string $fieldName
-    ): string {
-        // If the type is an ID, replace it with the actual type the ID references
-        if ($type == SchemaDefinition::TYPE_ID) {
-            $instanceManager = InstanceManagerFacade::getInstance();
-            // The type may not be implemented yet (eg: Category), then skip
-            if ($relationalTypeResolver->isFieldOfRelationalType($fieldName)) {
-                $fieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($fieldName);
-                $fieldTypeResolver = $instanceManager->getInstance((string)$fieldTypeResolverClass);
-                $type = $fieldTypeResolver->getMaybeNamespacedTypeName();
-            }
+    ): ?string {
+        $instanceManager = InstanceManagerFacade::getInstance();
+        if ($relationalTypeResolver->isFieldOfRelationalType($fieldName)) {
+            $fieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($fieldName);
+            $fieldTypeResolver = $instanceManager->getInstance((string)$fieldTypeResolverClass);
+            return $fieldTypeResolver->getMaybeNamespacedTypeName();
         }
-        return $type;
+        return null;
     }
 }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -113,7 +113,7 @@ class SchemaHelpers
     /**
      * If the internal type is "id", convert it to its type name
      */
-    public static function convertTypeIDToTypeName(
+    public static function getTypeNameFromTypeResolver(
         string $type,
         RelationalTypeResolverInterface $relationalTypeResolver,
         string $fieldName

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Schema;
 
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 
 class SchemaHelpers
 {
@@ -108,21 +106,5 @@ class SchemaHelpers
             }
         }
         return $enumValueDefinitions;
-    }
-
-    /**
-     * Obtain the TypeName from the TypeResolver
-     */
-    public static function getTypeNameFromTypeResolver(
-        RelationalTypeResolverInterface $relationalTypeResolver,
-        string $fieldName
-    ): ?string {
-        $instanceManager = InstanceManagerFacade::getInstance();
-        if ($relationalTypeResolver->isFieldOfRelationalType($fieldName)) {
-            $fieldTypeResolverClass = $relationalTypeResolver->resolveFieldTypeResolverClass($fieldName);
-            $fieldTypeResolver = $instanceManager->getInstance((string)$fieldTypeResolverClass);
-            return $fieldTypeResolver->getMaybeNamespacedTypeName();
-        }
-        return null;
     }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1302,7 +1302,7 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
                 $validField,
                 $fieldName,
             ) = $this->dissectFieldForSchema($field);
-            return $fieldResolvers[0]->resolveFieldTypeResolverClass($this, $fieldName);
+            return $fieldResolvers[0]->getSchemaDefinitionResolverForField($this, $field)?->resolveFieldTypeResolverClass($this, $fieldName);
         }
 
         return null;
@@ -1310,12 +1310,16 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
 
     public function isFieldOfRelationalType(string $field): ?bool
     {
-        $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($field);
-        if ($fieldTypeResolverClass === null) {
-            return null;
+        // Get the value from a fieldResolver, from the first one that resolves it
+        if ($fieldResolvers = $this->getFieldResolversForField($field)) {
+            list(
+                $validField,
+                $fieldName,
+            ) = $this->dissectFieldForSchema($field);
+            return $fieldResolvers[0]->getSchemaDefinitionResolverForField($this, $field)?->isFieldOfRelationalType($this, $fieldName);
         }
-        $fieldTypeResolver = $this->instanceManager->getInstance($fieldTypeResolverClass);
-        return $fieldTypeResolver instanceof RelationalTypeResolverInterface;
+
+        return null;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -23,6 +23,7 @@ use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
+use PoP\ComponentModel\Schema\SchemaHelpers;
 use PoP\ComponentModel\Schema\SchemaNamespacingServiceInterface;
 use PoP\ComponentModel\TypeResolverDecorators\TypeResolverDecoratorInterface;
 use PoP\ComponentModel\TypeResolvers\FieldHelpers;
@@ -1308,20 +1309,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         return null;
     }
 
-    public function isFieldOfRelationalType(string $field): ?bool
-    {
-        // Get the value from a fieldResolver, from the first one that resolves it
-        if ($fieldResolvers = $this->getFieldResolversForField($field)) {
-            list(
-                $validField,
-                $fieldName,
-            ) = $this->dissectFieldForSchema($field);
-            return $fieldResolvers[0]->getSchemaDefinitionResolverForField($this, $field)?->isFieldOfRelationalType($this, $fieldName);
-        }
-
-        return null;
-    }
-
     /**
      * @param array<string, mixed>|null $variables
      * @param array<string, mixed>|null $expressions
@@ -1766,8 +1753,8 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         // Add subfield schema if it is deep, and this typeResolver has not been processed yet
         if ($options['deep'] ?? null) {
             // If this field is relational, then add its own schema
-            if ($this->isFieldOfRelationalType($fieldName)) {
-                $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($fieldName);
+            $fieldTypeResolverClass = $this->resolveFieldTypeResolverClass($fieldName);
+            if (SchemaHelpers::isRelationalFieldTypeResolverClass($fieldTypeResolverClass)) {
                 $fieldTypeResolver = $this->instanceManager->getInstance($fieldTypeResolverClass);
                 $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_SCHEMA] = $fieldTypeResolver->getSchemaDefinition($stackMessages, $generalMessages, $options);
             }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -23,7 +23,6 @@ use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
-use PoP\ComponentModel\Schema\SchemaHelpers;
 use PoP\ComponentModel\Schema\SchemaNamespacingServiceInterface;
 use PoP\ComponentModel\TypeResolverDecorators\TypeResolverDecoratorInterface;
 use PoP\ComponentModel\TypeResolvers\FieldHelpers;
@@ -1770,16 +1769,10 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             }
         }
         // Convert the field type from its internal representation (eg: "array:id") to the type (eg: "array:Post")
-        if ($options['useTypeName'] ?? null) {
-            // The type is mandatory. If not provided, use the default one
-            $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? $this->schemaDefinitionService->getDefaultType();
-            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeNameFromTypeResolver($this, $fieldName) ?? $type;
-        } else {
+        if (!($options['useTypeName'] ?? null) && ($types = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_SCHEMA] ?? null)) {
             // Display the type under entry "referencedType"
-            if ($types = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_SCHEMA] ?? null) {
-                $typeNames = array_keys($types);
-                $fieldSchemaDefinition[SchemaDefinition::ARGNAME_REFERENCED_TYPE] = $typeNames[0];
-            }
+            $typeNames = array_keys($types);
+            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_REFERENCED_TYPE] = $typeNames[0];
         }
         $isGlobal = $fieldResolver->isGlobal($this, $fieldName);
         $isConnection = isset($fieldSchemaDefinition[SchemaDefinition::ARGNAME_RELATIONAL]) && $fieldSchemaDefinition[SchemaDefinition::ARGNAME_RELATIONAL];

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1773,7 +1773,7 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         if ($options['useTypeName'] ?? null) {
             // The type is mandatory. If not provided, use the default one
             $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? $this->schemaDefinitionService->getDefaultType();
-            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeNameFromTypeResolver($type, $this, $fieldName);
+            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeNameFromTypeResolver($this, $fieldName) ?? $type;
         } else {
             // Display the type under entry "referencedType"
             if ($types = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_SCHEMA] ?? null) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1773,7 +1773,7 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         if ($options['useTypeName'] ?? null) {
             // The type is mandatory. If not provided, use the default one
             $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] ?? $this->schemaDefinitionService->getDefaultType();
-            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::convertTypeIDToTypeName($type, $this, $fieldName);
+            $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeNameFromTypeResolver($type, $this, $fieldName);
         } else {
             // Display the type under entry "referencedType"
             if ($types = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_SCHEMA] ?? null) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
@@ -62,7 +62,6 @@ interface RelationalTypeResolverInterface extends TypeResolverInterface
     public function getSchemaFieldArgs(string $field): ?array;
     public function enableOrderedSchemaFieldArgs(string $field): bool;
     public function resolveFieldTypeResolverClass(string $field): ?string;
-    public function isFieldOfRelationalType(string $field): ?bool;
     /**
      * @param array<string, mixed>|null $variables
      * @param array<string, mixed>|null $expressions

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/AbstractListOfCPTEntitiesRootFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/AbstractListOfCPTEntitiesRootFieldResolver.php
@@ -38,11 +38,6 @@ abstract class AbstractListOfCPTEntitiesRootFieldResolver extends AbstractQuerya
         return true;
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        return SchemaDefinition::TYPE_ID;
-    }
-
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         return SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/DirectiveFieldResolver.php
@@ -35,14 +35,13 @@ class DirectiveFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'name' => SchemaDefinition::TYPE_STRING,
             'description' => SchemaDefinition::TYPE_STRING,
-            'args' => SchemaDefinition::TYPE_ID,
             'locations' => SchemaDefinition::TYPE_ENUM,
             'isRepeatable' => SchemaDefinition::TYPE_BOOL,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/FieldFieldResolver.php
@@ -35,16 +35,15 @@ class FieldFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'name' => SchemaDefinition::TYPE_STRING,
             'description' => SchemaDefinition::TYPE_STRING,
-            'args' => SchemaDefinition::TYPE_ID,
             'type' => SchemaDefinition::TYPE_STRING,
             'isDeprecated' => SchemaDefinition::TYPE_BOOL,
             'deprecationReason' => SchemaDefinition::TYPE_STRING,
             'extensions' => SchemaDefinition::TYPE_OBJECT,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/InputValueFieldResolver.php
@@ -30,13 +30,12 @@ class InputValueFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'name' => SchemaDefinition::TYPE_STRING,
             'description' => SchemaDefinition::TYPE_STRING,
-            'type' => SchemaDefinition::TYPE_ID,
             'defaultValue' => SchemaDefinition::TYPE_STRING,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RegisterQueryAndMutationRootsRootFieldResolver.php
@@ -7,7 +7,6 @@ namespace GraphQLByPoP\GraphQLServer\FieldResolvers;
 use GraphQLByPoP\GraphQLServer\ComponentConfiguration;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\Engine\TypeResolvers\Object\RootTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\Object\QueryRootTypeResolver;
@@ -54,15 +53,6 @@ class RegisterQueryAndMutationRootsRootFieldResolver extends AbstractDBDataField
             'mutationRoot' => $this->translationAPI->__('Get the Mutation Root type', 'graphql-server'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'queryRoot' => SchemaDefinition::TYPE_ID,
-            'mutationRoot' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/RootFieldResolver.php
@@ -36,15 +36,6 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            '__schema' => SchemaDefinition::TYPE_ID,
-            '__type' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/SchemaFieldResolver.php
@@ -31,19 +31,6 @@ class SchemaFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'queryType' => SchemaDefinition::TYPE_ID,
-            'mutationType' => SchemaDefinition::TYPE_ID,
-            'subscriptionType' => SchemaDefinition::TYPE_ID,
-            'types' => SchemaDefinition::TYPE_ID,
-            'directives' => SchemaDefinition::TYPE_ID,
-            'type' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         return match ($fieldName) {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/TypeFieldResolver.php
@@ -49,19 +49,13 @@ class TypeFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'kind' => SchemaDefinition::TYPE_ENUM,
             'name' => SchemaDefinition::TYPE_STRING,
             'description' => SchemaDefinition::TYPE_STRING,
-            'fields' => SchemaDefinition::TYPE_ID,
-            'interfaces' => SchemaDefinition::TYPE_ID,
-            'possibleTypes' => SchemaDefinition::TYPE_ID,
-            'enumValues' => SchemaDefinition::TYPE_ID,
-            'inputFields' => SchemaDefinition::TYPE_ID,
-            'ofType' => SchemaDefinition::TYPE_ID,
             'extensions' => SchemaDefinition::TYPE_OBJECT,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/CustomPostAndUserFieldResolver.php
@@ -33,11 +33,10 @@ class CustomPostAndUserFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'hasLocation' => SchemaDefinition::TYPE_BOOL,
-            'location' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/CustomPostFieldResolver.php
@@ -27,14 +27,6 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'locations' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         return match($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/EventFieldResolver.php
@@ -35,16 +35,14 @@ class EventFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
-            'locations' => SchemaDefinition::TYPE_ID,
-            'categories' => SchemaDefinition::TYPE_ID,
+        return match($fieldName) {
             'dates' => SchemaDefinition::TYPE_STRING,
             'times' => SchemaDefinition::TYPE_STRING,
             'startDateReadable' => SchemaDefinition::TYPE_STRING,
             'daterange' => SchemaDefinition::TYPE_OBJECT,
             'daterangetime' => SchemaDefinition::TYPE_OBJECT,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/UserFieldResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoPSchema\Locations\FieldResolvers;
 
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoPSchema\Locations\TypeResolvers\Object\LocationTypeResolver;
@@ -25,14 +24,6 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return [
             'locations',
         ];
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'locations' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/CustomPostFieldResolver.php
@@ -35,12 +35,11 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
-            'highlights' => SchemaDefinition::TYPE_ID,
+        return match($fieldName) {
             'hasHighlights' => SchemaDefinition::TYPE_BOOL,
             'highlightsCount' => SchemaDefinition::TYPE_INT,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/HighlightFieldResolver.php
@@ -35,14 +35,13 @@ class HighlightFieldResolver extends AbstractDBDataFieldResolver
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match($fieldName) {
             'title' => SchemaDefinition::TYPE_STRING,
             'excerpt' => SchemaDefinition::TYPE_STRING,
             'content' => SchemaDefinition::TYPE_STRING,
-            'highlightedpost' => SchemaDefinition::TYPE_ID,
             'highlightedPostURL' => SchemaDefinition::TYPE_URL,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -24,6 +24,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
     public function getFieldNamesToResolve(): array
     {
         return [
+            'commentObject',
             'commentObjectID',
             'icon',
             'url',
@@ -33,18 +34,19 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'commentObjectID' => SchemaDefinition::TYPE_ID,
             'icon' => SchemaDefinition::TYPE_STRING,
             'url' => SchemaDefinition::TYPE_URL,
             'message' => SchemaDefinition::TYPE_STRING,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [
+            'commentObject',
             'commentObjectID',
         ];
         if (in_array($fieldName, $nonNullableFieldNames)) {
@@ -57,6 +59,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
     {
         $translationAPI = TranslationAPIFacade::getInstance();
         $descriptions = [
+            'commentObject' => $translationAPI->__('', ''),
             'commentObjectID' => $translationAPI->__('', ''),
             'icon' => $translationAPI->__('', ''),
             'url' => $translationAPI->__('', ''),
@@ -107,6 +110,7 @@ class PoP_AddComments_DataLoad_FieldResolver_Notifications extends AbstractDBDat
         switch ($fieldName) {
             // Specific fields to be used by the subcomponents, based on a combination of Object Type + Action
             // Needed to, for instance, load the comment immediately, already from the notification
+            case 'commentObject':
             case 'commentObjectID':
                 switch ($notification->action) {
                     case AAL_POP_ACTION_COMMENT_ADDED:

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -55,19 +55,18 @@ class PoP_Application_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldRe
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
-			'favicon' => SchemaDefinition::TYPE_OBJECT,
+        return match ($fieldName) {
+            'favicon' => SchemaDefinition::TYPE_OBJECT,
             'thumb' => SchemaDefinition::TYPE_OBJECT,
             'thumbFullSrc' => SchemaDefinition::TYPE_URL,
-            'authors' => SchemaDefinition::TYPE_ID,
             'topics' => SchemaDefinition::TYPE_STRING,
             'hasTopics' => SchemaDefinition::TYPE_BOOL,
             'appliesto' => SchemaDefinition::TYPE_STRING,
             'hasAppliesto' => SchemaDefinition::TYPE_BOOL,
             'hasUserpostactivity' => SchemaDefinition::TYPE_BOOL,
             'userPostActivityCount' => SchemaDefinition::TYPE_INT,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -34,15 +34,14 @@ class GD_ContentCreation_DataLoad_FieldResolver_Posts extends AbstractDBDataFiel
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        $types = [
+        return match ($fieldName) {
             'titleEdit' => SchemaDefinition::TYPE_STRING,
             'contentEditor' => SchemaDefinition::TYPE_STRING,
             'contentEdit' => SchemaDefinition::TYPE_STRING,
             'editURL' => SchemaDefinition::TYPE_URL,
             'deleteURL' => SchemaDefinition::TYPE_URL,
-            'coauthors' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
+            default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
+        };
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -32,9 +32,7 @@ class PoP_RelatedPosts_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'references' => SchemaDefinition::TYPE_ID,
             'hasReferences' => SchemaDefinition::TYPE_BOOL,
-            'referencedby' => SchemaDefinition::TYPE_ID,
             'hasReferencedBy' => SchemaDefinition::TYPE_BOOL,
             'referencedByCount' => SchemaDefinition::TYPE_INT,
         ];

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -1,6 +1,5 @@
 <?php
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Translation\Facades\TranslationAPIFacade;
@@ -19,14 +18,6 @@ class GD_DataLoad_FieldResolver_Comments extends AbstractDBDataFieldResolver
         return [
             'taggedusers',
         ];
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'taggedusers' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -33,8 +33,6 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Posts extends AbstractDBDataFieldR
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'taggedusers' => SchemaDefinition::TYPE_ID,
-            'recommendedby' => SchemaDefinition::TYPE_ID,
             'recommendPostCount' => SchemaDefinition::TYPE_INT,
             'upvotePostCount' => SchemaDefinition::TYPE_INT,
             'downvotePostCount' => SchemaDefinition::TYPE_INT,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -32,9 +32,6 @@ class GD_SocialNetwork_DataLoad_FieldResolver_Users extends AbstractDBDataFieldR
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'recommendsCustomPosts' => SchemaDefinition::TYPE_ID,
-            'followers' => SchemaDefinition::TYPE_ID,
-            'following' => SchemaDefinition::TYPE_ID,
             'followersCount' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -26,7 +26,6 @@ class FieldResolver_CommunityUsers extends AbstractDBDataFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'members' => SchemaDefinition::TYPE_ID,
             'hasMembers' => SchemaDefinition::TYPE_BOOL,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -40,8 +40,6 @@ class GD_UserCommunities_DataLoad_FieldResolver_Users extends AbstractDBDataFiel
             'memberprivileges' => SchemaDefinition::TYPE_ENUM,
             'membertags' => SchemaDefinition::TYPE_ENUM,
             'isCommunity' => SchemaDefinition::TYPE_BOOL,
-            'communities' => SchemaDefinition::TYPE_ID,
-            'activeCommunities' => SchemaDefinition::TYPE_ID,
             'hasActiveCommunities' => SchemaDefinition::TYPE_BOOL,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
+++ b/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/NotificationFieldResolver.php
@@ -60,6 +60,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
             'objectSubtype',
             'objectName',
             'objectID',
+            'user',
             'userID',
             'websiteURL',
             'userCaps',
@@ -123,6 +124,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
             'action',
             'objectType',
             'objectID',
+            'user',
             'userID',
             'histTime',
             'histTimeNogmt',
@@ -151,6 +153,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
             'objectSubtype' => $this->translationAPI->__('', ''),
             'objectName' => $this->translationAPI->__('', ''),
             'objectID' => $this->translationAPI->__('', ''),
+            'user' => $this->translationAPI->__('', ''),
             'userID' => $this->translationAPI->__('', ''),
             'websiteURL' => $this->translationAPI->__('', ''),
             'userCaps' => $this->translationAPI->__('', ''),
@@ -227,6 +230,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
                 return $notification->object_name;
             case 'objectID':
                 return $notification->object_id;
+            case 'user':
             case 'userID':
                 return $notification->user_id;
             case 'websiteURL':
@@ -329,7 +333,7 @@ class NotificationFieldResolver extends AbstractDBDataFieldResolver
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
     {
         switch ($fieldName) {
-            case 'userID':
+            case 'user':
                 return UserTypeResolver::class;
         }
 

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/CustomPostFieldResolver.php
@@ -38,7 +38,6 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'stances' => SchemaDefinition::TYPE_ID,
             'hasStances' => SchemaDefinition::TYPE_BOOL,
             'stanceProCount' => SchemaDefinition::TYPE_INT,
             'stanceNeutralCount' => SchemaDefinition::TYPE_INT,

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/StanceFieldResolver.php
@@ -48,7 +48,6 @@ class StanceFieldResolver extends AbstractDBDataFieldResolver
             'title' => SchemaDefinition::TYPE_STRING,
             'excerpt' => SchemaDefinition::TYPE_STRING,
             'content' => SchemaDefinition::TYPE_STRING,
-            'stancetarget' => SchemaDefinition::TYPE_ID,
             'hasStanceTarget' => SchemaDefinition::TYPE_BOOL,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCategoryFieldResolver.php
@@ -43,7 +43,6 @@ abstract class AbstractCategoryFieldResolver extends AbstractDBDataFieldResolver
             'name' => SchemaDefinition::TYPE_STRING,
             'slug' => SchemaDefinition::TYPE_STRING,
             'description' => SchemaDefinition::TYPE_STRING,
-            'parentCategory' => SchemaDefinition::TYPE_ID,
             'count' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractChildCategoryFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractChildCategoryFieldResolver.php
@@ -34,7 +34,6 @@ abstract class AbstractChildCategoryFieldResolver extends AbstractQueryableField
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'childCategories' => SchemaDefinition::TYPE_ID,
             'childCategoryCount' => SchemaDefinition::TYPE_INT,
             'childCategoryNames' => SchemaDefinition::TYPE_STRING,
         ];
@@ -166,8 +165,6 @@ abstract class AbstractChildCategoryFieldResolver extends AbstractQueryableField
     {
         switch ($fieldName) {
             case 'childCategory':
-            case 'childCategoryBySlug':
-            case 'childCategories':
                 return $this->getCategoryTypeResolverClass();
         }
 

--- a/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -34,7 +34,6 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'categories' => SchemaDefinition::TYPE_ID,
             'categoryCount' => SchemaDefinition::TYPE_INT,
             'categoryNames' => SchemaDefinition::TYPE_STRING,
         ];

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CommentFieldResolver.php
@@ -8,7 +8,6 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\Hooks\HooksAPIInterface;
@@ -61,14 +60,6 @@ class CommentFieldResolver extends AbstractDBDataFieldResolver
             'reply' => $this->translationAPI->__('Reply a comment with another comment', 'comment-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'reply' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\CommentMutations\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoPSchema\Comments\TypeResolvers\Object\CommentTypeResolver;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
@@ -33,14 +32,6 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
             'addComment' => $this->translationAPI->__('Add a comment to the custom post', 'comment-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'addComment' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoPSchema\CommentMutations\FieldResolvers;
 
 use PoP\Engine\TypeResolvers\Object\RootTypeResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoPSchema\Comments\TypeResolvers\Object\CommentTypeResolver;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoPSchema\CommentMutations\Schema\SchemaDefinitionHelpers;
@@ -38,15 +37,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
             'replyComment' => $this->translationAPI->__('Reply a comment with another comment', 'comment-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'addCommentToCustomPost' => SchemaDefinition::TYPE_ID,
-            'replyComment' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array

--- a/layers/Schema/packages/comment-mutations/src/FieldResolvers/UserStateRootFieldResolver.php
+++ b/layers/Schema/packages/comment-mutations/src/FieldResolvers/UserStateRootFieldResolver.php
@@ -74,8 +74,6 @@ class UserStateRootFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         return match ($fieldName) {
-            'myComment' => SchemaDefinition::TYPE_ID,
-            'myComments' => SchemaDefinition::TYPE_ID,
             'myCommentCount' => SchemaDefinition::TYPE_INT,
             default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
         };

--- a/layers/Schema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/CommentUserFieldResolver.php
+++ b/layers/Schema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/CommentUserFieldResolver.php
@@ -8,7 +8,6 @@ use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\Hooks\HooksAPIInterface;
@@ -51,14 +50,6 @@ class CommentUserFieldResolver extends AbstractDBDataFieldResolver
         return [
             'author',
         ];
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'author' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -177,14 +177,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
         return $errors;
     }
 
-    /**
-     * This function is not called by the engine, to generate the schema.
-     * Instead, the resolver is obtained from the fieldResolver.
-     * To make sure that all fieldResolvers implementing the same interface
-     * return the expected type for the field, they can obtain it from the
-     * interface through this function.
-     */
-    public function getFieldTypeResolverClass(string $fieldName): ?string
+    public function resolveFieldTypeResolverClass(string $fieldName): ?string
     {
         switch ($fieldName) {
             case 'comments':
@@ -192,6 +185,6 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
                 return CommentTypeResolver::class;
         }
 
-        return parent::getFieldTypeResolverClass($fieldName);
+        return parent::resolveFieldTypeResolverClass($fieldName);
     }
 }

--- a/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/comments/src/FieldInterfaceResolvers/CommentableFieldInterfaceResolver.php
@@ -10,6 +10,7 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoPSchema\Comments\ComponentConfiguration;
 use PoPSchema\Comments\ModuleProcessors\CommentFilterInputContainerModuleProcessor;
+use PoPSchema\Comments\TypeResolvers\Object\CommentTypeResolver;
 use PoPSchema\SchemaCommons\FormInputs\OrderFormInput;
 use PoPSchema\SchemaCommons\ModuleProcessors\FormInputs\CommonFilterInputModuleProcessor;
 use PoPSchema\SchemaCommons\Resolvers\WithLimitFieldArgResolverTrait;
@@ -46,9 +47,7 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
             'areCommentsOpen' => SchemaDefinition::TYPE_BOOL,
             'hasComments' => SchemaDefinition::TYPE_BOOL,
             'commentCount' => SchemaDefinition::TYPE_INT,
-            'comments' => SchemaDefinition::TYPE_ID,
             'commentCountForAdmin' => SchemaDefinition::TYPE_INT,
-            'commentsForAdmin' => SchemaDefinition::TYPE_ID,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
     }
@@ -176,5 +175,23 @@ class CommentableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInte
                 break;
         }
         return $errors;
+    }
+
+    /**
+     * This function is not called by the engine, to generate the schema.
+     * Instead, the resolver is obtained from the fieldResolver.
+     * To make sure that all fieldResolvers implementing the same interface
+     * return the expected type for the field, they can obtain it from the
+     * interface through this function.
+     */
+    public function getFieldTypeResolverClass(string $fieldName): ?string
+    {
+        switch ($fieldName) {
+            case 'comments':
+            case 'commentsForAdmin':
+                return CommentTypeResolver::class;
+        }
+
+        return parent::getFieldTypeResolverClass($fieldName);
     }
 }

--- a/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CommentFieldResolver.php
@@ -91,16 +91,12 @@ class CommentFieldResolver extends AbstractQueryableFieldResolver
             'authorName' => SchemaDefinition::TYPE_STRING,
             'authorURL' => SchemaDefinition::TYPE_URL,
             'authorEmail' => SchemaDefinition::TYPE_EMAIL,
-            'customPost' => SchemaDefinition::TYPE_ID,
             'customPostID' => SchemaDefinition::TYPE_ID,
             'approved' => SchemaDefinition::TYPE_BOOL,
             'type' => SchemaDefinition::TYPE_STRING,
             'status' => SchemaDefinition::TYPE_ENUM,
-            'parent' => SchemaDefinition::TYPE_ID,
             'date' => SchemaDefinition::TYPE_DATE,
-            'responses' => SchemaDefinition::TYPE_ID,
             'responseCount' => SchemaDefinition::TYPE_INT,
-            'responsesForAdmin' => SchemaDefinition::TYPE_ID,
             'responseCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
@@ -16,7 +16,6 @@ use PoP\LooseContracts\NameResolverInterface;
 use PoP\Translation\TranslationAPIInterface;
 use PoPSchema\Comments\FieldInterfaceResolvers\CommentableFieldInterfaceResolver;
 use PoPSchema\Comments\TypeAPIs\CommentTypeAPIInterface;
-use PoPSchema\Comments\TypeResolvers\Object\CommentTypeResolver;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 use PoPSchema\SchemaCommons\Constants\QueryOptions;
@@ -124,7 +123,9 @@ class CustomPostFieldResolver extends AbstractQueryableFieldResolver
         switch ($fieldName) {
             case 'comments':
             case 'commentsForAdmin':
-                return CommentTypeResolver::class;
+                /** @var CommentableFieldInterfaceResolver */
+                $fieldInterfaceResolver = $this->instanceManager->getInstance(CommentableFieldInterfaceResolver::class);
+                return $fieldInterfaceResolver->getFieldTypeResolverClass($fieldName);
         }
 
         return parent::resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/CustomPostFieldResolver.php
@@ -117,17 +117,4 @@ class CustomPostFieldResolver extends AbstractQueryableFieldResolver
 
         return parent::resolveValue($relationalTypeResolver, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
     }
-
-    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
-    {
-        switch ($fieldName) {
-            case 'comments':
-            case 'commentsForAdmin':
-                /** @var CommentableFieldInterfaceResolver */
-                $fieldInterfaceResolver = $this->instanceManager->getInstance(CommentableFieldInterfaceResolver::class);
-                return $fieldInterfaceResolver->getFieldTypeResolverClass($fieldName);
-        }
-
-        return parent::resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
-    }
 }

--- a/layers/Schema/packages/comments/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/RootFieldResolver.php
@@ -77,11 +77,7 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         return match ($fieldName) {
-            'comment' => SchemaDefinition::TYPE_ID,
-            'comments' => SchemaDefinition::TYPE_ID,
             'commentCount' => SchemaDefinition::TYPE_INT,
-            'commentForAdmin' => SchemaDefinition::TYPE_ID,
-            'commentsForAdmin' => SchemaDefinition::TYPE_ID,
             'commentCountForAdmin' => SchemaDefinition::TYPE_INT,
             default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
         };

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -40,14 +40,6 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'setCategories' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [

--- a/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
+++ b/layers/Schema/packages/custompost-category-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
@@ -44,14 +44,6 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            $this->getSetCategoriesFieldName() => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
         switch ($fieldName) {

--- a/layers/Schema/packages/custompost-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMutations\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoPSchema\CustomPostMutations\MutationResolvers\MutationInputProperties;
@@ -25,14 +24,6 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
             'update' => $this->translationAPI->__('Update the custom post', 'custompost-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'update' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array

--- a/layers/Schema/packages/custompost-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/custompost-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -44,9 +44,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'myCustomPosts' => SchemaDefinition::TYPE_ID,
             'myCustomPostCount' => SchemaDefinition::TYPE_INT,
-            'myCustomPost' => SchemaDefinition::TYPE_ID,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractCustomPostFieldResolver.php
@@ -39,14 +39,6 @@ abstract class AbstractCustomPostFieldResolver extends AbstractDBDataFieldResolv
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'setTags' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [

--- a/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
+++ b/layers/Schema/packages/custompost-tag-mutations/src/FieldResolvers/AbstractRootFieldResolver.php
@@ -43,14 +43,6 @@ abstract class AbstractRootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            $this->getSetTagsFieldName() => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
         switch ($fieldName) {

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/CustomPostFieldResolver.php
@@ -67,15 +67,6 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'setFeaturedImage' => SchemaDefinition::TYPE_ID,
-            'removeFeaturedImage' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
         $nonNullableFieldNames = [

--- a/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -70,15 +70,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'setFeaturedImageOnCustomPost' => SchemaDefinition::TYPE_ID,
-            'removeFeaturedImageFromCustomPost' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
         $setRemoveFeaturedImageSchemaFieldArgs = [

--- a/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldInterfaceResolvers/SupportingFeaturedImageFieldInterfaceResolver.php
@@ -58,20 +58,13 @@ class SupportingFeaturedImageFieldInterfaceResolver extends AbstractSchemaFieldI
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }
 
-    /**
-     * This function is not called by the engine, to generate the schema.
-     * Instead, the resolver is obtained from the fieldResolver.
-     * To make sure that all fieldResolvers implementing the same interface
-     * return the expected type for the field, they can obtain it from the
-     * interface through this function.
-     */
-    public function getFieldTypeResolverClass(string $fieldName): ?string
+    public function resolveFieldTypeResolverClass(string $fieldName): ?string
     {
         switch ($fieldName) {
             case 'featuredImage':
                 return MediaTypeResolver::class;
         }
 
-        return parent::getFieldTypeResolverClass($fieldName);
+        return parent::resolveFieldTypeResolverClass($fieldName);
     }
 }

--- a/layers/Schema/packages/custompostmedia/src/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldResolvers/CustomPostFieldResolver.php
@@ -97,18 +97,4 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
         return parent::resolveValue($relationalTypeResolver, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
     }
-
-    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
-    {
-        switch ($fieldName) {
-            case 'featuredImage':
-                /**
-                 * @var SupportingFeaturedImageFieldInterfaceResolver
-                 */
-                $fieldInterfaceResolver = $this->instanceManager->getInstance(SupportingFeaturedImageFieldInterfaceResolver::class);
-                return $fieldInterfaceResolver->getFieldTypeResolverClass($fieldName);
-        }
-
-        return parent::resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
-    }
 }

--- a/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/AbstractCustomPostListFieldResolver.php
@@ -44,9 +44,7 @@ abstract class AbstractCustomPostListFieldResolver extends AbstractQueryableFiel
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'customPosts' => SchemaDefinition::TYPE_ID,
             'customPostCount' => SchemaDefinition::TYPE_INT,
-            'customPostsForAdmin' => SchemaDefinition::TYPE_ID,
             'customPostCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/RootCustomPostListFieldResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\TypeResolvers\Object\RootTypeResolver;
 use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
@@ -59,17 +58,6 @@ class RootCustomPostListFieldResolver extends AbstractCustomPostListFieldResolve
             'customPostBySlugForAdmin' => $this->translationAPI->__('[Unrestricted] Custom post with a specific slug', 'customposts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'customPost' => SchemaDefinition::TYPE_ID,
-            'customPostBySlug' => SchemaDefinition::TYPE_ID,
-            'customPostForAdmin' => SchemaDefinition::TYPE_ID,
-            'customPostBySlugForAdmin' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getFieldDataFilteringModule(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?array

--- a/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
+++ b/layers/Schema/packages/generic-customposts/src/FieldResolvers/RootGenericCustomPostFieldResolver.php
@@ -66,13 +66,7 @@ class RootGenericCustomPostFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'genericCustomPost' => SchemaDefinition::TYPE_ID,
-            'genericCustomPostBySlug' => SchemaDefinition::TYPE_ID,
-            'genericCustomPosts' => SchemaDefinition::TYPE_ID,
             'genericCustomPostCount' => SchemaDefinition::TYPE_INT,
-            'genericCustomPostForAdmin' => SchemaDefinition::TYPE_ID,
-            'genericCustomPostBySlugForAdmin' => SchemaDefinition::TYPE_ID,
-            'genericCustomPostsForAdmin' => SchemaDefinition::TYPE_ID,
             'genericCustomPostCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/MediaUserFieldResolver.php
+++ b/layers/Schema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/MediaUserFieldResolver.php
@@ -53,14 +53,6 @@ class MediaUserFieldResolver extends AbstractDBDataFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'author' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
     {
         $descriptions = [

--- a/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -80,8 +80,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'mediaItem' => SchemaDefinition::TYPE_ID,
-            'mediaItems' => SchemaDefinition::TYPE_ID,
             'mediaItemCount' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
@@ -199,16 +197,5 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         }
 
         return parent::resolveValue($relationalTypeResolver, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
-    }
-
-    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
-    {
-        switch ($fieldName) {
-            case 'mediaItems':
-            case 'mediaItem':
-                return MediaTypeResolver::class;
-        }
-
-        return parent::resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
     }
 }

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuFieldResolver.php
@@ -7,7 +7,6 @@ namespace PoPSchema\Menus\FieldResolvers;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
 use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
-use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -61,7 +60,6 @@ class MenuFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'items' => SchemaDefinition::TYPE_ID,
             'itemDataEntries' => SchemaDefinition::TYPE_OBJECT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/MenuItemFieldResolver.php
@@ -71,7 +71,6 @@ class MenuItemFieldResolver extends AbstractDBDataFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'children' => SchemaDefinition::TYPE_ID,
             'localURLPath' => SchemaDefinition::TYPE_STRING,
             'label' => SchemaDefinition::TYPE_STRING,
             'title' => SchemaDefinition::TYPE_STRING,

--- a/layers/Schema/packages/menus/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/menus/src/FieldResolvers/RootFieldResolver.php
@@ -44,8 +44,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'menu' => SchemaDefinition::TYPE_ID,
-            'menus' => SchemaDefinition::TYPE_ID,
             'menuCount' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/pages/src/FieldResolvers/PageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/PageFieldResolver.php
@@ -61,10 +61,7 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'parentPage' => SchemaDefinition::TYPE_ID,
-            'childPages' => SchemaDefinition::TYPE_ID,
             'childPageCount' => SchemaDefinition::TYPE_INT,
-            'childPagesForAdmin' => SchemaDefinition::TYPE_ID,
             'childPageCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/Schema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -72,13 +72,7 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'page' => SchemaDefinition::TYPE_ID,
-            'pageBySlug' => SchemaDefinition::TYPE_ID,
-            'pages' => SchemaDefinition::TYPE_ID,
             'pageCount' => SchemaDefinition::TYPE_INT,
-            'pageForAdmin' => SchemaDefinition::TYPE_ID,
-            'pageBySlugForAdmin' => SchemaDefinition::TYPE_ID,
-            'pagesForAdmin' => SchemaDefinition::TYPE_ID,
             'pageCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
+++ b/layers/Schema/packages/post-categories/src/FieldResolvers/RootPostCategoryFieldResolver.php
@@ -43,9 +43,6 @@ class RootPostCategoryFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'postCategory' => SchemaDefinition::TYPE_ID,
-            'postCategoryBySlug' => SchemaDefinition::TYPE_ID,
-            'postCategories' => SchemaDefinition::TYPE_ID,
             'postCategoryCount' => SchemaDefinition::TYPE_INT,
             'postCategoryNames' => SchemaDefinition::TYPE_STRING,
         ];

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoPSchema\PostMutations\FieldResolvers;
 
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\ComponentConfiguration as EngineComponentConfiguration;
 use PoP\Engine\TypeResolvers\Object\RootTypeResolver;
@@ -41,15 +40,6 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
             'updatePost' => $this->translationAPI->__('Update a post', 'post-mutations'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'createPost' => SchemaDefinition::TYPE_ID,
-            'updatePost' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array

--- a/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
+++ b/layers/Schema/packages/post-mutations/src/FieldResolvers/RootQueryableFieldResolver.php
@@ -43,9 +43,7 @@ class RootQueryableFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'myPosts' => SchemaDefinition::TYPE_ID,
             'myPostCount' => SchemaDefinition::TYPE_INT,
-            'myPost' => SchemaDefinition::TYPE_ID,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }

--- a/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
+++ b/layers/Schema/packages/post-tags/src/FieldResolvers/RootPostTagFieldResolver.php
@@ -43,9 +43,6 @@ class RootPostTagFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'postTag' => SchemaDefinition::TYPE_ID,
-            'postTagBySlug' => SchemaDefinition::TYPE_ID,
-            'postTags' => SchemaDefinition::TYPE_ID,
             'postTagCount' => SchemaDefinition::TYPE_INT,
             'postTagNames' => SchemaDefinition::TYPE_STRING,
         ];

--- a/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/AbstractPostFieldResolver.php
@@ -43,9 +43,7 @@ abstract class AbstractPostFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'posts' => SchemaDefinition::TYPE_ID,
             'postCount' => SchemaDefinition::TYPE_INT,
-            'postsForAdmin' => SchemaDefinition::TYPE_ID,
             'postCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
+++ b/layers/Schema/packages/posts/src/FieldResolvers/RootPostFieldResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\Posts\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\TypeResolvers\Object\RootTypeResolver;
 use PoPSchema\CustomPosts\ModuleProcessors\CommonCustomPostFilterInputContainerModuleProcessor;
@@ -55,17 +54,6 @@ class RootPostFieldResolver extends AbstractPostFieldResolver
             'postBySlugForAdmin' => $this->translationAPI->__('[Unrestricted] Post with a specific slug', 'posts'),
         ];
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'post' => SchemaDefinition::TYPE_ID,
-            'postBySlug' => SchemaDefinition::TYPE_ID,
-            'postForAdmin' => SchemaDefinition::TYPE_ID,
-            'postBySlugForAdmin' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getFieldDataFilteringModule(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?array

--- a/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/AbstractCustomPostQueryableFieldResolver.php
@@ -33,7 +33,6 @@ abstract class AbstractCustomPostQueryableFieldResolver extends AbstractQueryabl
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'tags' => SchemaDefinition::TYPE_ID,
             'tagCount' => SchemaDefinition::TYPE_INT,
             'tagNames' => SchemaDefinition::TYPE_STRING,
         ];

--- a/layers/Schema/packages/user-avatars/src/FieldResolvers/UserFieldResolver.php
+++ b/layers/Schema/packages/user-avatars/src/FieldResolvers/UserFieldResolver.php
@@ -9,7 +9,6 @@ use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
-use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\Hooks\HooksAPIInterface;
@@ -58,14 +57,6 @@ class UserFieldResolver extends AbstractDBDataFieldResolver
         return [
             'avatar',
         ];
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'avatar' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string

--- a/layers/Schema/packages/user-roles-wp/src/Overrides/FieldResolvers/RolesFieldResolverTrait.php
+++ b/layers/Schema/packages/user-roles-wp/src/Overrides/FieldResolvers/RolesFieldResolverTrait.php
@@ -4,20 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserRolesWP\Overrides\FieldResolvers;
 
-use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoPSchema\UserRolesWP\TypeResolvers\Object\UserRoleTypeResolver;
 
 trait RolesFieldResolverTrait
 {
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'roles' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
     {
         switch ($fieldName) {

--- a/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/Schema/packages/user-state-mutations/src/FieldResolvers/RootFieldResolver.php
@@ -37,15 +37,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'loginUser' => SchemaDefinition::TYPE_ID,
-            'logoutUser' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
         switch ($fieldName) {

--- a/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
+++ b/layers/Schema/packages/user-state/src/FieldResolvers/RootMeFieldResolver.php
@@ -25,14 +25,6 @@ class RootMeFieldResolver extends AbstractUserStateFieldResolver
         ];
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'me' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
     {
         $descriptions = [

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -94,15 +94,4 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
         return parent::resolveValue($relationalTypeResolver, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
     }
-
-    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
-    {
-        switch ($fieldName) {
-            case 'author':
-                $fieldInterfaceResolver = $this->getWithAuthorFieldInterfaceResolverInstance();
-                return $fieldInterfaceResolver->getFieldTypeResolverClass($fieldName);
-        }
-
-        return parent::resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
-    }
 }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -94,4 +94,15 @@ class CustomPostFieldResolver extends AbstractDBDataFieldResolver
 
         return parent::resolveValue($relationalTypeResolver, $resultItem, $fieldName, $fieldArgs, $variables, $expressions, $options);
     }
+
+    public function resolveFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
+    {
+        switch ($fieldName) {
+            case 'author':
+                $fieldInterfaceResolver = $this->getWithAuthorFieldInterfaceResolverInstance();
+                return $fieldInterfaceResolver->resolveFieldTypeResolverClass($fieldName);
+        }
+
+        return parent::resolveFieldTypeResolverClass($relationalTypeResolver, $fieldName);
+    }
 }

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -28,14 +28,6 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
         ];
     }
 
-    public function getSchemaFieldType(string $fieldName): string
-    {
-        $types = [
-            'author' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($fieldName);
-    }
-
     public function getSchemaFieldTypeModifiers(string $fieldName): ?int
     {
         switch ($fieldName) {

--- a/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
+++ b/layers/Schema/packages/users/src/FieldInterfaceResolvers/WithAuthorFieldInterfaceResolver.php
@@ -45,20 +45,13 @@ class WithAuthorFieldInterfaceResolver extends AbstractSchemaFieldInterfaceResol
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($fieldName);
     }
 
-    /**
-     * This function is not called by the engine, to generate the schema.
-     * Instead, the resolver is obtained from the fieldResolver.
-     * To make sure that all fieldResolvers implementing the same interface
-     * return the expected type for the field, they can obtain it from the
-     * interface through this function.
-     */
-    public function getFieldTypeResolverClass(string $fieldName): ?string
+    public function resolveFieldTypeResolverClass(string $fieldName): ?string
     {
         switch ($fieldName) {
             case 'author':
                 return UserTypeResolver::class;
         }
 
-        return parent::getFieldTypeResolverClass($fieldName);
+        return parent::resolveFieldTypeResolverClass($fieldName);
     }
 }

--- a/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/AbstractUserFieldResolver.php
@@ -71,9 +71,7 @@ abstract class AbstractUserFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'users' => SchemaDefinition::TYPE_ID,
             'userCount' => SchemaDefinition::TYPE_INT,
-            'usersForAdmin' => SchemaDefinition::TYPE_ID,
             'userCountForAdmin' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);

--- a/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/RootUserFieldResolver.php
@@ -53,16 +53,6 @@ class RootUserFieldResolver extends AbstractUserFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'user' => SchemaDefinition::TYPE_ID,
-            'userByUsername' => SchemaDefinition::TYPE_ID,
-            'userByEmail' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($relationalTypeResolver, $fieldName);

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/RootFieldResolver.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\TypeResolvers\Object\RootTypeResolver;
+use PoP\Multisite\ObjectFacades\SiteObjectFacade;
 use PoP\Multisite\TypeResolvers\Object\SiteTypeResolver;
 
 class RootFieldResolver extends AbstractDBDataFieldResolver
@@ -24,15 +25,6 @@ class RootFieldResolver extends AbstractDBDataFieldResolver
             'sites',
             'site',
         ];
-    }
-
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'sites' => SchemaDefinition::TYPE_ID,
-            'site' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int

--- a/layers/WPSchema/packages/media/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/RootFieldResolver.php
@@ -70,7 +70,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         return match ($fieldName) {
-            'mediaItemBySlug' => SchemaDefinition::TYPE_ID,
             'imageSizeNames' => SchemaDefinition::TYPE_STRING,
             default => parent::getSchemaFieldType($relationalTypeResolver, $fieldName),
         };

--- a/layers/WPSchema/packages/menus/src/FieldResolvers/RootFieldResolver.php
+++ b/layers/WPSchema/packages/menus/src/FieldResolvers/RootFieldResolver.php
@@ -34,15 +34,6 @@ class RootFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'menuByLocation' => SchemaDefinition::TYPE_ID,
-            'menuBySlug' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
         switch ($fieldName) {

--- a/layers/WPSchema/packages/pages/src/FieldResolvers/PageFieldResolver.php
+++ b/layers/WPSchema/packages/pages/src/FieldResolvers/PageFieldResolver.php
@@ -36,7 +36,7 @@ class PageFieldResolver extends AbstractQueryableFieldResolver
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
         $types = [
-            'menuOrder' => SchemaDefinition::TYPE_ID,
+            'menuOrder' => SchemaDefinition::TYPE_INT,
         ];
         return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
     }

--- a/layers/WPSchema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
+++ b/layers/WPSchema/packages/pages/src/FieldResolvers/RootPageFieldResolver.php
@@ -43,15 +43,6 @@ class RootPageFieldResolver extends AbstractQueryableFieldResolver
         return $descriptions[$fieldName] ?? parent::getSchemaFieldDescription($relationalTypeResolver, $fieldName);
     }
 
-    public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
-    {
-        $types = [
-            'pageByPath' => SchemaDefinition::TYPE_ID,
-            'pageByPathForAdmin' => SchemaDefinition::TYPE_ID,
-        ];
-        return $types[$fieldName] ?? parent::getSchemaFieldType($relationalTypeResolver, $fieldName);
-    }
-
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
         $schemaFieldArgs = parent::getSchemaFieldArgs($relationalTypeResolver, $fieldName);


### PR DESCRIPTION
Instead, use directly `resolveFieldTypeResolverClass`.

In addition, added `resolveFieldTypeResolverClass` to the interface. Eg: `CommentableFieldInterfaceResolver` now indicates that field `comments` is resolved with `CommentTypeResolver`, and this info can be then removed from the FieldResolver.