### PR TITLE
Decouple `IsCustomPostFieldInterfaceResolver` from `QueryableFieldInterfaceResolver`

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -988,7 +988,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
      * Return the object implementing the schema definition for this DirectiveResolver.
      * By default, it is this same object
      */
-    public function getSchemaDefinitionResolver(RelationalTypeResolverInterface $relationalTypeResolver): SchemaDirectiveResolverInterface
+    protected function getSchemaDefinitionResolver(RelationalTypeResolverInterface $relationalTypeResolver): SchemaDirectiveResolverInterface
     {
         return $this;
     }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -107,10 +107,6 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface
         array &$schemaTraces
     ): void;
     /**
-     * Get an instance of the object defining the schema for this fieldResolver
-     */
-    public function getSchemaDefinitionResolver(RelationalTypeResolverInterface $relationalTypeResolver): SchemaDirectiveResolverInterface;
-    /**
      * A directive can decide to not be added to the schema, eg: when it is repeated/implemented several times
      */
     public function skipAddingToSchemaDefinition(): bool;

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -42,7 +42,7 @@ abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverI
      * Return the object implementing the schema definition for this FieldResolver.
      * By default, it is this same object
      */
-    public function getSchemaDefinitionResolver(string $fieldName): FieldInterfaceSchemaDefinitionResolverInterface
+    protected function getSchemaDefinitionResolver(string $fieldName): FieldInterfaceSchemaDefinitionResolverInterface
     {
         if ($fieldInterfaceSchemaDefinitionResolverClass = $this->getFieldInterfaceSchemaDefinitionResolverClass($fieldName)) {
             /** @var FieldInterfaceSchemaDefinitionResolverInterface */

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -42,7 +42,7 @@ abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverI
      * Return the object implementing the schema definition for this FieldResolver.
      * By default, it is this same object
      */
-    final public function getSchemaDefinitionResolver(string $fieldName): FieldInterfaceSchemaDefinitionResolverInterface
+    public function getSchemaDefinitionResolver(string $fieldName): FieldInterfaceSchemaDefinitionResolverInterface
     {
         if ($fieldInterfaceSchemaDefinitionResolverClass = $this->getFieldInterfaceSchemaDefinitionResolverClass($fieldName)) {
             /** @var FieldInterfaceSchemaDefinitionResolverInterface */

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -39,12 +39,24 @@ abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverI
     }
 
     /**
-     * Return the object implementing the schema definition for this FieldInterfaceResolver.
+     * Return the object implementing the schema definition for this FieldResolver.
      * By default, it is this same object
      */
-    public function getSchemaDefinitionResolver(string $fieldName): FieldInterfaceSchemaDefinitionResolverInterface
+    final public function getSchemaDefinitionResolver(string $fieldName): FieldInterfaceSchemaDefinitionResolverInterface
     {
+        if ($fieldInterfaceSchemaDefinitionResolverClass = $this->getFieldInterfaceSchemaDefinitionResolverClass($fieldName)) {
+            /** @var FieldInterfaceSchemaDefinitionResolverInterface */
+            return $this->instanceManager->getInstance($fieldInterfaceSchemaDefinitionResolverClass);
+        }
         return $this;
+    }
+
+    /**
+     * Retrieve the class of some FieldInterfaceSchemaDefinitionResolverInterface
+     */
+    protected function getFieldInterfaceSchemaDefinitionResolverClass(string $fieldName): ?string
+    {
+        return null;
     }
 
     public function getSchemaFieldType(string $fieldName): string

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractQueryableSchemaFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractQueryableSchemaFieldInterfaceResolver.php
@@ -14,7 +14,6 @@ abstract class AbstractQueryableSchemaFieldInterfaceResolver extends AbstractFie
     {
         /** @var QueryableFieldInterfaceSchemaDefinitionResolverInterface */
         $schemaDefinitionResolver = $this->getSchemaDefinitionResolver($fieldName);
-        // Avoid recursion when the Interface is its own DefinitionResolver
         if ($schemaDefinitionResolver !== $this) {
             return $schemaDefinitionResolver->getFieldDataFilteringModule($fieldName);
         }

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractQueryableSchemaFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractQueryableSchemaFieldInterfaceResolver.php
@@ -17,7 +17,6 @@ abstract class AbstractQueryableSchemaFieldInterfaceResolver extends AbstractFie
         if ($schemaDefinitionResolver !== $this) {
             return $schemaDefinitionResolver->getFieldDataFilteringModule($fieldName);
         }
-
         return null;
     }
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -49,7 +49,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
      */
     protected array $schemaDefinitionForFieldCache = [];
     /**
-     * @var array<string, FieldSchemaDefinitionResolverInterface|null>
+     * @var array<string, FieldSchemaDefinitionResolverInterface>
      */
     protected array $fieldInterfaceSchemaDefinitionResolverCache = [];
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/AbstractFieldResolver.php
@@ -96,7 +96,7 @@ abstract class AbstractFieldResolver implements FieldResolverInterface, FieldSch
     /**
      * Return the object implementing the schema definition for this FieldResolver.
      */
-    final public function getSchemaDefinitionResolver(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): FieldSchemaDefinitionResolverInterface
+    final protected function getSchemaDefinitionResolver(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): FieldSchemaDefinitionResolverInterface
     {
         $fieldOrFieldInterfaceSchemaDefinitionResolver = $this->doGetSchemaDefinitionResolver($relationalTypeResolver, $fieldName);
         if ($fieldOrFieldInterfaceSchemaDefinitionResolver instanceof FieldInterfaceSchemaDefinitionResolverInterface) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -27,10 +27,6 @@ interface FieldResolverInterface extends AttachableExtensionInterface
      */
     public function getFieldNamesFromInterfaces(): array;
     /**
-     * Get an instance of the object defining the schema for this fieldResolver
-     */
-    public function getSchemaDefinitionResolver(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): FieldSchemaDefinitionResolverInterface;
-    /**
      * Fields may not be directly visible in the schema,
      * eg: because they are used only by the application, and must not
      * be exposed to the user (eg: "accessControlLists")

--- a/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldInterfaceResolvers/IsCustomPostFieldInterfaceResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\FieldInterfaceResolvers;
 
+use PoP\ComponentModel\FieldInterfaceResolvers\AbstractQueryableSchemaFieldInterfaceResolver;
 use PoP\ComponentModel\FieldInterfaceResolvers\EnumTypeFieldInterfaceSchemaDefinitionResolverTrait;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaHelpers;
@@ -14,7 +15,7 @@ use PoPSchema\CustomPosts\Types\Status;
 use PoPSchema\QueriedObject\FieldInterfaceResolvers\QueryableFieldInterfaceResolver;
 use PoPSchema\SchemaCommons\ModuleProcessors\CommonFilterInputContainerModuleProcessor;
 
-class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
+class IsCustomPostFieldInterfaceResolver extends AbstractQueryableSchemaFieldInterfaceResolver
 {
     use EnumTypeFieldInterfaceSchemaDefinitionResolverTrait;
 
@@ -30,26 +31,41 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
         ];
     }
 
+    public function getFieldNamesToImplement(): array
+    {
+        return [
+            'url',
+            'urlPath',
+            'slug',
+            'content',
+            'status',
+            'isStatus',
+            'date',
+            'modified',
+            'title',
+            'excerpt',
+            'customPostType',
+        ];
+    }
+
+    /**
+     * Get the Schema Definition from the Interface
+     */
+    protected function getFieldInterfaceSchemaDefinitionResolverClass(string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'url',
+            'urlPath',
+            'slug'
+                => QueryableFieldInterfaceResolver::class,
+            default
+                => parent::getFieldInterfaceSchemaDefinitionResolverClass($fieldName),
+        };
+    }
+
     public function getSchemaInterfaceDescription(): ?string
     {
         return $this->translationAPI->__('Entities representing a custom post', 'customposts');
-    }
-
-    public function getFieldNamesToImplement(): array
-    {
-        return array_merge(
-            parent::getFieldNamesToImplement(),
-            [
-                'content',
-                'status',
-                'isStatus',
-                'date',
-                'modified',
-                'title',
-                'excerpt',
-                'customPostType',
-            ]
-        );
     }
 
     public function getSchemaFieldType(string $fieldName): string
@@ -88,6 +104,9 @@ class IsCustomPostFieldInterfaceResolver extends QueryableFieldInterfaceResolver
     public function getSchemaFieldDescription(string $fieldName): ?string
     {
         $descriptions = [
+            'url' => $this->translationAPI->__('Custom post URL', 'customposts'),
+            'urlPath' => $this->translationAPI->__('Custom post URL path', 'customposts'),
+            'slug' => $this->translationAPI->__('Custom post slug', 'customposts'),
             'content' => $this->translationAPI->__('Custom post content', 'customposts'),
             'status' => $this->translationAPI->__('Custom post status', 'customposts'),
             'isStatus' => $this->translationAPI->__('Is the custom post in the given status?', 'customposts'),

--- a/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
+++ b/layers/Schema/packages/queriedobject/src/FieldInterfaceResolvers/QueryableFieldInterfaceResolver.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PoPSchema\QueriedObject\FieldInterfaceResolvers;
 
-use PoP\ComponentModel\FieldInterfaceResolvers\AbstractQueryableSchemaFieldInterfaceResolver;
+use PoP\ComponentModel\FieldInterfaceResolvers\AbstractFieldInterfaceResolver;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 
-class QueryableFieldInterfaceResolver extends AbstractQueryableSchemaFieldInterfaceResolver
+class QueryableFieldInterfaceResolver extends AbstractFieldInterfaceResolver
 {
     public function getInterfaceName(): string
     {


### PR DESCRIPTION
Added `getFieldInterfaceSchemaDefinitionResolverClass` to `AbstractFieldInterfaceResolver`, so that an Interface can return the schema configuration from another interface.

In this case, `IsCustomPostFieldInterfaceResolver` returns the one from `QueryableFieldInterfaceResolver`