### PR TITLE
Decouple `FieldInterfaceResolverInterface` from `FieldInterfaceSchemaDefinitionResolverInterface`

### DIFF
--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/AbstractFieldInterfaceResolver.php
@@ -14,7 +14,7 @@ use PoP\Hooks\HooksAPIInterface;
 use PoP\LooseContracts\NameResolverInterface;
 use PoP\Translation\TranslationAPIInterface;
 
-abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverInterface
+abstract class AbstractFieldInterfaceResolver implements FieldInterfaceResolverInterface, FieldInterfaceSchemaDefinitionResolverInterface
 {
     use WithVersionConstraintFieldOrDirectiveResolverTrait;
 

--- a/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldInterfaceResolvers/FieldInterfaceResolverInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldInterfaceResolvers;
 
-use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceSchemaDefinitionResolverInterface;
-
-interface FieldInterfaceResolverInterface extends FieldInterfaceSchemaDefinitionResolverInterface
+interface FieldInterfaceResolverInterface
 {
     /**
      * Get an array with the fieldNames that the fieldResolver must implement

--- a/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/InterfaceSchemaDefinitionResolverAdapter.php
@@ -6,7 +6,7 @@ namespace PoP\ComponentModel\Resolvers;
 
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
-use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
+use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceSchemaDefinitionResolverInterface;
 
 /**
  * A TypeResolver may be useful when retrieving the schema from a FieldResolver,
@@ -17,7 +17,7 @@ use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
  */
 class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionResolverInterface
 {
-    public function __construct(protected FieldInterfaceResolverInterface $fieldInterfaceResolver)
+    public function __construct(protected FieldInterfaceSchemaDefinitionResolverInterface $fieldInterfaceSchemaDefinitionResolver)
     {
     }
 
@@ -41,32 +41,32 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
 
     public function getSchemaFieldType(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): string
     {
-        return $this->fieldInterfaceResolver->getSchemaFieldType($fieldName);
+        return $this->fieldInterfaceSchemaDefinitionResolver->getSchemaFieldType($fieldName);
     }
 
     public function getSchemaFieldTypeModifiers(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?int
     {
-        return $this->fieldInterfaceResolver->getSchemaFieldTypeModifiers($fieldName);
+        return $this->fieldInterfaceSchemaDefinitionResolver->getSchemaFieldTypeModifiers($fieldName);
     }
 
     public function getSchemaFieldDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
     {
-        return $this->fieldInterfaceResolver->getSchemaFieldDescription($fieldName);
+        return $this->fieldInterfaceSchemaDefinitionResolver->getSchemaFieldDescription($fieldName);
     }
 
     public function getSchemaFieldArgs(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): array
     {
-        return $this->fieldInterfaceResolver->getSchemaFieldArgs($fieldName);
+        return $this->fieldInterfaceSchemaDefinitionResolver->getSchemaFieldArgs($fieldName);
     }
 
     public function getSchemaFieldDeprecationDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName, array $fieldArgs = []): ?string
     {
-        return $this->fieldInterfaceResolver->getSchemaFieldDeprecationDescription($fieldName, $fieldArgs);
+        return $this->fieldInterfaceSchemaDefinitionResolver->getSchemaFieldDeprecationDescription($fieldName, $fieldArgs);
     }
 
     public function getFieldTypeResolverClass(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?string
     {
-        return $this->fieldInterfaceResolver->getFieldTypeResolverClass($fieldName);
+        return $this->fieldInterfaceSchemaDefinitionResolver->getFieldTypeResolverClass($fieldName);
     }
 
     public function validateFieldArgument(
@@ -75,11 +75,11 @@ class InterfaceSchemaDefinitionResolverAdapter implements FieldSchemaDefinitionR
         string $fieldArgName,
         mixed $fieldArgValue
     ): array {
-        return $this->fieldInterfaceResolver->validateFieldArgument($fieldName, $fieldArgName, $fieldArgValue);
+        return $this->fieldInterfaceSchemaDefinitionResolver->validateFieldArgument($fieldName, $fieldArgName, $fieldArgValue);
     }
 
     public function addSchemaDefinitionForField(array &$schemaDefinition, RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): void
     {
-        $this->fieldInterfaceResolver->addSchemaDefinitionForField($schemaDefinition, $fieldName);
+        $this->fieldInterfaceSchemaDefinitionResolver->addSchemaDefinitionForField($schemaDefinition, $fieldName);
     }
 }

--- a/layers/Engine/packages/component-model/src/Resolvers/QueryableInterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/QueryableInterfaceSchemaDefinitionResolverAdapter.php
@@ -13,7 +13,7 @@ class QueryableInterfaceSchemaDefinitionResolverAdapter extends InterfaceSchemaD
     public function getFieldDataFilteringModule(RelationalTypeResolverInterface $relationalTypeResolver, string $fieldName): ?array
     {
         /** @var QueryableFieldInterfaceSchemaDefinitionResolverInterface */
-        $fieldInterfaceResolver = $this->fieldInterfaceResolver;
-        return $fieldInterfaceResolver->getFieldDataFilteringModule($fieldName);
+        $fieldInterfaceSchemaDefinitionResolver = $this->fieldInterfaceSchemaDefinitionResolver;
+        return $fieldInterfaceSchemaDefinitionResolver->getFieldDataFilteringModule($fieldName);
     }
 }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/CustomPostFieldResolver.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Users\ConditionalOnComponent\CustomPosts\FieldResolvers;
 
-use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceResolverInterface;
-use PoP\ComponentModel\FieldInterfaceResolvers\FieldInterfaceSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\FieldResolvers\AbstractDBDataFieldResolver;
-use PoP\ComponentModel\FieldResolvers\FieldSchemaDefinitionResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoPSchema\CustomPosts\FieldInterfaceResolvers\IsCustomPostFieldInterfaceResolver;
 use PoPSchema\Users\ConditionalOnComponent\CustomPosts\Facades\CustomPostUserTypeAPIFacade;


### PR DESCRIPTION
Do not extend from it, so that `FieldInterfaceResolverInterface` can extend from `AttachableExtensionInterface` in the next PR