### PR TITLE
Remove commented code after "Automatically duplicate ACL entries from `Root` into `QueryRoot` and `MutationRoot`"

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginConfiguration.php
@@ -602,15 +602,6 @@ class PluginConfiguration extends AbstractMainPluginConfiguration
             $componentClassConfiguration[\GraphQLByPoP\GraphQLServer\Component::class][GraphQLServerEnvironment::ENABLE_NESTED_MUTATIONS] = true;
             // Do not disable redundant mutation fields in the root type
             $componentClassConfiguration[\PoP\Engine\Component::class][EngineEnvironment::DISABLE_REDUNDANT_ROOT_TYPE_MUTATION_FIELDS] = false;
-            /**
-             * Not needed anymore since duplicating Root entries into QueryRoot and MutationRoot
-             * when injecting them via "addEntriesForFields"
-             * 
-             * @see https://github.com/leoloso/PoP/pull/1045
-             */
-            // // Print the full schema, including all fields for Root, QueryRoot and MutationRoot
-            // // This is needed for the Field(/Directive) Printout, so that ACLs still work after toggling Nested mutations
-            // $componentClassConfiguration[\GraphQLByPoP\GraphQLServer\Component::class][GraphQLServerEnvironment::ADD_CONNECTION_FROM_ROOT_TO_QUERYROOT_AND_MUTATIONROOT] = true;
             // Allow disabling introspection via Access Control on field "__schema"
             $componentClassConfiguration[\GraphQLByPoP\GraphQLServer\Component::class][GraphQLServerEnvironment::EXPOSE_SCHEMA_INTROSPECTION_FIELD_IN_SCHEMA] = true;
             // Allow access to all entries for Root.option

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Hooks/NestedMutationHookSet.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Hooks/NestedMutationHookSet.php
@@ -24,32 +24,7 @@ class NestedMutationHookSet extends AbstractHookSet
             10,
             5
         );
-
-        /**
-         * Not needed anymore since duplicating Root entries into QueryRoot and MutationRoot
-         * when injecting them via "addEntriesForFields"
-         * 
-         * @see https://github.com/leoloso/PoP/pull/1045
-         */
-        // $this->hooksAPI->addFilter(
-        //     RootObjectTypeResolver::HOOK_DESCRIPTION,
-        //     array($this, 'getRootTypeDescription')
-        // );
     }
-
-    /**
-     * Not needed anymore since duplicating Root entries into QueryRoot and MutationRoot
-     * when injecting them via "addEntriesForFields"
-     * 
-     * @see https://github.com/leoloso/PoP/pull/1045
-     */
-    // public function getRootTypeDescription(string $description): string
-    // {
-    //     return sprintf(
-    //         $this->translationAPI->__('%s. Available when \'nested mutations\' is enabled', 'graphql-server'),
-    //         $description
-    //     );
-    // }
 
     /**
      * For the standard GraphQL server:

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/MutationRootObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/MutationRootObjectTypeResolver.php
@@ -60,13 +60,6 @@ class MutationRootObjectTypeResolver extends AbstractUseRootAsSourceForSchemaObj
 
     public function getSchemaTypeDescription(): ?string
     {
-        /**
-         * Not needed anymore since duplicating Root entries into QueryRoot and MutationRoot
-         * when injecting them via "addEntriesForFields"
-         * 
-         * @see https://github.com/leoloso/PoP/pull/1045
-         */
-        // return $this->translationAPI->__('Mutation type, starting from which mutations are executed. Available when \'nested mutations\' is disabled', 'graphql-server');
         return $this->translationAPI->__('Mutation type, starting from which mutations are executed', 'graphql-server');
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/QueryRootObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/QueryRootObjectTypeResolver.php
@@ -20,13 +20,6 @@ class QueryRootObjectTypeResolver extends AbstractUseRootAsSourceForSchemaObject
 
     public function getSchemaTypeDescription(): ?string
     {
-        /**
-         * Not needed anymore since duplicating Root entries into QueryRoot and MutationRoot
-         * when injecting them via "addEntriesForFields"
-         * 
-         * @see https://github.com/leoloso/PoP/pull/1045
-         */
-        // return $this->translationAPI->__('Query type, starting from which the query is executed. Available when \'nested mutations\' is disabled', 'graphql-server');
         return $this->translationAPI->__('Query type, starting from which the query is executed', 'graphql-server');
     }
 


### PR DESCRIPTION
Deleted commented code from implementing #1045