### PR TITLE
Deal with instances not class strings for many functions

### DIFF
--- a/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForFieldsTrait.php
+++ b/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForFieldsTrait.php
@@ -18,11 +18,13 @@ trait AccessControlConfigurableMandatoryDirectivesForFieldsTrait
 
     /**
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
+     * 
+     * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
      */
     final protected function getMatchingEntries(
         array $entryList,
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
-        array $interfaceTypeResolverClasses,
+        array $interfaceTypeResolvers,
         string $fieldName
     ): array {
         /**
@@ -35,11 +37,15 @@ trait AccessControlConfigurableMandatoryDirectivesForFieldsTrait
             return $this->getUpstreamMatchingEntries(
                 $entryList,
                 $objectTypeOrInterfaceTypeResolver,
-                $interfaceTypeResolverClasses,
+                $interfaceTypeResolvers,
                 $fieldName
             );
         }
         $objectTypeOrInterfaceTypeResolverClass = get_class($objectTypeOrInterfaceTypeResolver);
+        $interfaceTypeResolverClasses = array_map(
+            'get_class',
+            $interfaceTypeResolvers
+        );
         $individualControlSchemaMode = $this->getSchemaMode();
         $matchNullControlEntry = $this->doesSchemaModeProcessNullControlEntry();
         return array_filter(

--- a/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForFieldsTrait.php
+++ b/layers/Engine/packages/access-control/src/ConfigurationEntries/AccessControlConfigurableMandatoryDirectivesForFieldsTrait.php
@@ -18,7 +18,7 @@ trait AccessControlConfigurableMandatoryDirectivesForFieldsTrait
 
     /**
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
-     * 
+     *
      * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
      */
     final protected function getMatchingEntries(

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
@@ -67,7 +67,6 @@ abstract class AbstractAccessControlForFieldsHookSet extends AbstractCMSBootHook
         bool $include,
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         // Because there may be several hooks chained, if any of them has already rejected the field, then already return that response
@@ -79,7 +78,6 @@ abstract class AbstractAccessControlForFieldsHookSet extends AbstractCMSBootHook
         return !$this->removeFieldName(
             $objectTypeOrInterfaceTypeResolver,
             $objectTypeOrInterfaceTypeFieldResolver,
-            $interfaceTypeResolverClasses,
             $fieldName,
         );
     }
@@ -93,7 +91,6 @@ abstract class AbstractAccessControlForFieldsHookSet extends AbstractCMSBootHook
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         return true;

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -38,14 +38,13 @@ abstract class AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet 
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         // Obtain all entries for the current combination of [typeResolver or interfaceTypeResolverClass]/fieldName
         foreach (
             $this->getEntries(
                 $objectTypeOrInterfaceTypeResolver,
-                $interfaceTypeResolverClasses,
+                $objectTypeOrInterfaceTypeFieldResolver,
                 $fieldName
             ) as $entry
         ) {

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -32,8 +32,6 @@ abstract class AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet 
 
     /**
      * Remove fieldName "roles" if the user is not logged in
-     *
-     * @param string[] $interfaceTypeResolverClasses
      */
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,

--- a/layers/Engine/packages/access-control/src/Hooks/AccessControlConfigurableMandatoryDirectivesForFieldsHookSetTrait.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AccessControlConfigurableMandatoryDirectivesForFieldsHookSetTrait.php
@@ -16,7 +16,6 @@ trait AccessControlConfigurableMandatoryDirectivesForFieldsHookSetTrait
         bool $include,
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         /**
@@ -29,7 +28,7 @@ trait AccessControlConfigurableMandatoryDirectivesForFieldsHookSetTrait
             if (
                 empty($this->getEntries(
                     $objectTypeOrInterfaceTypeResolver,
-                    $interfaceTypeResolverClasses,
+                    $objectTypeOrInterfaceTypeFieldResolver,
                     $fieldName
                 ))
             ) {
@@ -44,7 +43,6 @@ trait AccessControlConfigurableMandatoryDirectivesForFieldsHookSetTrait
             $include,
             $objectTypeOrInterfaceTypeResolver,
             $objectTypeOrInterfaceTypeFieldResolver,
-            $interfaceTypeResolverClasses,
             $fieldName
         );
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\FieldResolvers;
 
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
+use PoP\ComponentModel\FieldResolvers\InterfaceType\InterfaceTypeFieldResolverInterface;
 
 interface FieldResolverInterface extends AttachableExtensionInterface
 {
@@ -24,9 +25,9 @@ interface FieldResolverInterface extends AttachableExtensionInterface
      */
     public function getPartiallyImplementedInterfaceTypeResolverClasses(): array;
     /**
-     * A list of classes of all the interfaces the fieldResolver implements
-     *
-     * @return string[]
+     * The interfaces the fieldResolver implements
+     * 
+     * @return InterfaceTypeFieldResolverInterface[]
      */
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array;
+    public function getImplementedInterfaceTypeFieldResolvers(): array;
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -6,6 +6,7 @@ namespace PoP\ComponentModel\FieldResolvers;
 
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionInterface;
 use PoP\ComponentModel\FieldResolvers\InterfaceType\InterfaceTypeFieldResolverInterface;
+use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 
 interface FieldResolverInterface extends AttachableExtensionInterface
 {
@@ -21,9 +22,9 @@ interface FieldResolverInterface extends AttachableExtensionInterface
      * That's why this function is "partially" implemented: the Interface
      * may be completely implemented or not.
      *
-     * @return string[]
+     * @return InterfaceTypeResolverInterface[]
      */
-    public function getPartiallyImplementedInterfaceTypeResolverClasses(): array;
+    public function getPartiallyImplementedInterfaceTypeResolvers(): array;
     /**
      * The interfaces the fieldResolver implements
      * 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/FieldResolverInterface.php
@@ -27,7 +27,7 @@ interface FieldResolverInterface extends AttachableExtensionInterface
     public function getPartiallyImplementedInterfaceTypeResolvers(): array;
     /**
      * The interfaces the fieldResolver implements
-     * 
+     *
      * @return InterfaceTypeFieldResolverInterface[]
      */
     public function getImplementedInterfaceTypeFieldResolvers(): array;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
@@ -6,6 +6,7 @@ namespace PoP\ComponentModel\FieldResolvers\InterfaceType;
 
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 use PoP\ComponentModel\FieldResolvers\AbstractFieldResolver;
+use PoP\ComponentModel\FieldResolvers\InterfaceType\InterfaceTypeFieldResolverInterface;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Registries\TypeRegistryInterface;
 use PoP\ComponentModel\Resolvers\EnumTypeSchemaDefinitionResolverTrait;
@@ -63,7 +64,12 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
         return $this->getFieldNamesToImplement();
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    /**
+     * The interfaces the fieldResolver implements
+     * 
+     * @return InterfaceTypeFieldResolverInterface[]
+     */
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [];
     }
@@ -132,14 +138,11 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
      */
     protected function getInterfaceTypeFieldSchemaDefinitionResolverClass(string $fieldName): ?string
     {
-        foreach ($this->getImplementedInterfaceTypeFieldResolverClasses() as $implementedInterfaceTypeFieldResolverClass) {
-            /** @var InterfaceTypeFieldResolverInterface */
-            $implementedInterfaceTypeFieldResolver = $this->instanceManager->getInstance($implementedInterfaceTypeFieldResolverClass);
-            ;
+        foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $implementedInterfaceTypeFieldResolver) {
             if (!in_array($fieldName, $implementedInterfaceTypeFieldResolver->getFieldNamesToImplement())) {
                 continue;
             }
-            return $implementedInterfaceTypeFieldResolverClass;
+            return $implementedInterfaceTypeFieldResolver;
         }
         return null;
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
@@ -107,36 +107,24 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
     }
 
     /**
-     * @return string[]
-     */
-    final public function getPartiallyImplementedInterfaceTypeResolverClasses(): array
-    {
-        return array_map(
-            'get_class',
-            $this->getPartiallyImplementedInterfaceTypeResolvers()
-        );
-    }
-
-    /**
      * By default, the resolver is this same object, unless function
-     * `getInterfaceTypeFieldSchemaDefinitionResolverClass` is
+     * `getInterfaceTypeFieldSchemaDefinitionResolver` is
      * implemented
      */
     protected function getSchemaDefinitionResolver(string $fieldName): InterfaceTypeFieldSchemaDefinitionResolverInterface
     {
-        if ($interfaceTypeFieldSchemaDefinitionResolverClass = $this->getInterfaceTypeFieldSchemaDefinitionResolverClass($fieldName)) {
-            /** @var InterfaceTypeFieldSchemaDefinitionResolverInterface */
-            return $this->instanceManager->getInstance($interfaceTypeFieldSchemaDefinitionResolverClass);
+        if ($interfaceTypeFieldSchemaDefinitionResolver = $this->getInterfaceTypeFieldSchemaDefinitionResolver($fieldName)) {
+            return $interfaceTypeFieldSchemaDefinitionResolver;
         }
         return $this;
     }
 
     /**
-     * Retrieve the class of some InterfaceTypeFieldSchemaDefinitionResolverInterface
+     * Retrieve the InterfaceTypeFieldSchemaDefinitionResolverInterface
      * By default, if the InterfaceTypeFieldResolver implements an interface,
      * it is used as SchemaDefinitionResolver for the matching fields
      */
-    protected function getInterfaceTypeFieldSchemaDefinitionResolverClass(string $fieldName): ?string
+    protected function getInterfaceTypeFieldSchemaDefinitionResolver(string $fieldName): ?InterfaceTypeFieldSchemaDefinitionResolverInterface
     {
         foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $implementedInterfaceTypeFieldResolver) {
             if (!in_array($fieldName, $implementedInterfaceTypeFieldResolver->getFieldNamesToImplement())) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
@@ -66,7 +66,7 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
 
     /**
      * The interfaces the fieldResolver implements
-     * 
+     *
      * @return InterfaceTypeFieldResolverInterface[]
      */
     public function getImplementedInterfaceTypeFieldResolvers(): array
@@ -130,6 +130,7 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
             if (!in_array($fieldName, $implementedInterfaceTypeFieldResolver->getFieldNamesToImplement())) {
                 continue;
             }
+            /** @var InterfaceTypeFieldSchemaDefinitionResolverInterface */
             return $implementedInterfaceTypeFieldResolver;
         }
         return null;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -92,7 +92,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
     {
         $fieldNames = [];
 
-        foreach ($this->getInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
+        foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
             $fieldNames = array_merge(
                 $fieldNames,
                 $interfaceTypeFieldResolver->getFieldNamesToImplement()
@@ -277,16 +277,6 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
     public function isGlobal(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): bool
     {
         return false;
-    }
-
-    /**
-     * Implement all the fieldNames defined in the interfaces
-     *
-     * @return InterfaceTypeFieldResolverInterface[]
-     */
-    public function getInterfaceTypeFieldResolvers(): array
-    {
-        return $this->getImplementedInterfaceTypeFieldResolvers();
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -30,6 +30,7 @@ use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\Versioning\VersioningHelpers;
@@ -107,7 +108,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
      * That's why this function is "partially" implemented: the Interface
      * may be completely implemented or not.
      *
-     * @return string[]
+     * @return InterfaceTypeResolverInterface[]
      */
     final public function getPartiallyImplementedInterfaceTypeResolvers(): array
     {
@@ -154,6 +155,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         string $fieldName
     ): ObjectTypeFieldSchemaDefinitionResolverInterface | InterfaceTypeFieldSchemaDefinitionResolverInterface {
         if ($interfaceTypeFieldSchemaDefinitionResolver = $this->getInterfaceTypeFieldSchemaDefinitionResolver($objectTypeResolver, $fieldName)) {
+            /** @var InterfaceTypeFieldSchemaDefinitionResolverInterface */
             return $interfaceTypeFieldSchemaDefinitionResolver;
         }
         return $this;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -167,7 +167,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
     protected function getInterfaceTypeFieldSchemaDefinitionResolver(
         ObjectTypeResolverInterface $objectTypeResolver,
         string $fieldName
-    ): ?string {
+    ): ?InterfaceTypeFieldResolverInterface {
         foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $implementedInterfaceTypeFieldResolver) {
             if (!in_array($fieldName, $implementedInterfaceTypeFieldResolver->getFieldNamesToImplement())) {
                 continue;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -77,7 +77,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         return $this->getObjectTypeResolverClassesToAttachTo();
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [];
     }
@@ -112,12 +112,10 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
     final public function getPartiallyImplementedInterfaceTypeResolverClasses(): array
     {
         $interfaceTypeResolverClasses = [];
-        foreach ($this->getImplementedInterfaceTypeFieldResolverClasses() as $interfaceTypeFieldResolverClass) {
-            /** @var InterfaceTypeFieldResolverInterface */
-            $interfaceTypeFieldResolver = $this->instanceManager->getInstance($interfaceTypeFieldResolverClass);
+        foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
             $interfaceTypeResolverClasses = array_merge(
                 $interfaceTypeResolverClasses,
-                $interfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolverClasses()
+                $interfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers()
             );
         }
         return array_values(array_unique($interfaceTypeResolverClasses));
@@ -171,14 +169,11 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         ObjectTypeResolverInterface $objectTypeResolver,
         string $fieldName
     ): ?string {
-        foreach ($this->getImplementedInterfaceTypeFieldResolverClasses() as $implementedInterfaceTypeFieldResolverClass) {
-            /** @var InterfaceTypeFieldResolverInterface */
-            $implementedInterfaceTypeFieldResolver = $this->instanceManager->getInstance($implementedInterfaceTypeFieldResolverClass);
-            ;
+        foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $implementedInterfaceTypeFieldResolver) {
             if (!in_array($fieldName, $implementedInterfaceTypeFieldResolver->getFieldNamesToImplement())) {
                 continue;
             }
-            return $implementedInterfaceTypeFieldResolverClass;
+            return $implementedInterfaceTypeFieldResolver;
         }
         return null;
     }
@@ -290,12 +285,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
      */
     public function getInterfaceTypeFieldResolvers(): array
     {
-        return array_map(
-            function (string $class) {
-                return $this->instanceManager->getInstance($class);
-            },
-            $this->getImplementedInterfaceTypeFieldResolverClasses()
-        );
+        return $this->getImplementedInterfaceTypeFieldResolvers();
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -113,12 +113,12 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
     {
         $interfaceTypeResolvers = [];
         foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
-            $interfaceTypeResolvers = array_merge(
-                $interfaceTypeResolvers,
-                $interfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers()
-            );
+            // Add under class as to mimick `array_unique` for object
+            foreach ($interfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers() as $partiallyImplementedInterfaceTypeResolver) {
+                $interfaceTypeResolvers[get_class($partiallyImplementedInterfaceTypeResolver)] = $partiallyImplementedInterfaceTypeResolver;
+            }
         }
-        return array_values(array_unique($interfaceTypeResolvers));
+        return array_values($interfaceTypeResolvers);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -91,14 +91,12 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
     public function getFieldNamesFromInterfaces(): array
     {
         $fieldNames = [];
-
         foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
             $fieldNames = array_merge(
                 $fieldNames,
                 $interfaceTypeFieldResolver->getFieldNamesToImplement()
             );
         }
-
         return array_values(array_unique($fieldNames));
     }
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -109,16 +109,16 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
      *
      * @return string[]
      */
-    final public function getPartiallyImplementedInterfaceTypeResolverClasses(): array
+    final public function getPartiallyImplementedInterfaceTypeResolvers(): array
     {
-        $interfaceTypeResolverClasses = [];
+        $interfaceTypeResolvers = [];
         foreach ($this->getImplementedInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
-            $interfaceTypeResolverClasses = array_merge(
-                $interfaceTypeResolverClasses,
+            $interfaceTypeResolvers = array_merge(
+                $interfaceTypeResolvers,
                 $interfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers()
             );
         }
-        return array_values(array_unique($interfaceTypeResolverClasses));
+        return array_values(array_unique($interfaceTypeResolvers));
     }
 
     /**
@@ -146,26 +146,25 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
 
     /**
      * By default, the resolver is this same object, unless function
-     * `getInterfaceTypeFieldSchemaDefinitionResolverClass` is
+     * `getInterfaceTypeFieldSchemaDefinitionResolver` is
      * implemented
      */
     protected function doGetSchemaDefinitionResolver(
         ObjectTypeResolverInterface $objectTypeResolver,
         string $fieldName
     ): ObjectTypeFieldSchemaDefinitionResolverInterface | InterfaceTypeFieldSchemaDefinitionResolverInterface {
-        if ($interfaceTypeFieldSchemaDefinitionResolverClass = $this->getInterfaceTypeFieldSchemaDefinitionResolverClass($objectTypeResolver, $fieldName)) {
-            /** @var InterfaceTypeFieldSchemaDefinitionResolverInterface */
-            return $this->instanceManager->getInstance($interfaceTypeFieldSchemaDefinitionResolverClass);
+        if ($interfaceTypeFieldSchemaDefinitionResolver = $this->getInterfaceTypeFieldSchemaDefinitionResolver($objectTypeResolver, $fieldName)) {
+            return $interfaceTypeFieldSchemaDefinitionResolver;
         }
         return $this;
     }
 
     /**
-     * Retrieve the class of some InterfaceTypeFieldSchemaDefinitionResolverInterface
+     * Retrieve the InterfaceTypeFieldSchemaDefinitionResolverInterface
      * By default, if the ObjectTypeFieldResolver implements an interface,
      * it is used as SchemaDefinitionResolver for the matching fields
      */
-    protected function getInterfaceTypeFieldSchemaDefinitionResolverClass(
+    protected function getInterfaceTypeFieldSchemaDefinitionResolver(
         ObjectTypeResolverInterface $objectTypeResolver,
         string $fieldName
     ): ?string {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ElementalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ElementalObjectTypeFieldResolver.php
@@ -4,22 +4,49 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
-use PoP\Translation\TranslationAPIInterface;
-use PoP\Hooks\HooksAPIInterface;
-use PoP\ComponentModel\Instances\InstanceManagerInterface;
-use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
-use PoP\LooseContracts\NameResolverInterface;
-use PoP\Engine\CMS\CMSServiceInterface;
-use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
-use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\Engine\EngineInterface;
 use PoP\ComponentModel\FieldResolvers\InterfaceType\ElementalInterfaceTypeFieldResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
+use PoP\ComponentModel\Instances\InstanceManagerInterface;
+use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\AbstractObjectTypeResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\CMS\CMSServiceInterface;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\LooseContracts\NameResolverInterface;
+use PoP\Translation\TranslationAPIInterface;
 
 class ElementalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
+    public function __construct(
+        TranslationAPIInterface $translationAPI,
+        HooksAPIInterface $hooksAPI,
+        InstanceManagerInterface $instanceManager,
+        FieldQueryInterpreterInterface $fieldQueryInterpreter,
+        NameResolverInterface $nameResolver,
+        CMSServiceInterface $cmsService,
+        SemverHelperServiceInterface $semverHelperService,
+        SchemaDefinitionServiceInterface $schemaDefinitionService,
+        EngineInterface $engine,
+        protected ElementalInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver,
+    ) {
+        parent::__construct(
+            $translationAPI,
+            $hooksAPI,
+            $instanceManager,
+            $fieldQueryInterpreter,
+            $nameResolver,
+            $cmsService,
+            $semverHelperService,
+            $schemaDefinitionService,
+            $engine,
+        );
+    }
+    
     public function getObjectTypeResolverClassesToAttachTo(): array
     {
         return [
@@ -27,10 +54,10 @@ class ElementalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            ElementalInterfaceTypeFieldResolver::class,
+            $this->elementalInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ElementalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ElementalObjectTypeFieldResolver.php
@@ -46,7 +46,7 @@ class ElementalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             $engine,
         );
     }
-    
+
     public function getObjectTypeResolverClassesToAttachTo(): array
     {
         return [

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -787,7 +787,10 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             [
                 get_class($this->getTypeResolverToCalculateSchema()),
             ],
-            $this->getAllImplementedInterfaceTypeResolverClasses()
+            array_map(
+                'get_class',
+                $this->getAllImplementedInterfaceTypeResolvers()
+            )
         );
         foreach ($classes as $class) {
             $typeResolverDecorators = array_merge(
@@ -1274,7 +1277,10 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             [
                 get_class($this->getTypeResolverToCalculateSchema()),
             ],
-            $this->getAllImplementedInterfaceTypeResolverClasses()
+            array_map(
+                'get_class',
+                $this->getAllImplementedInterfaceTypeResolvers()
+            )
         );
         foreach ($classes as $class) {
             // Iterate classes from the current class towards the parent classes until finding typeResolver that satisfies processing this field
@@ -1301,16 +1307,5 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         $directiveNameResolvers = $this->filterDirectiveNameResolvers($directiveNameResolvers);
 
         return $directiveNameResolvers;
-    }
-
-    /**
-     * @return string[]
-     */
-    final public function getAllImplementedInterfaceTypeResolverClasses(): array
-    {
-        return array_map(
-            'get_class',
-            $this->getAllImplementedInterfaceTypeResolvers()
-        );
     }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ExcludeFieldNamesFromSchemaTypeResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ExcludeFieldNamesFromSchemaTypeResolverTrait.php
@@ -45,31 +45,21 @@ trait ExcludeFieldNamesFromSchemaTypeResolverTrait
 
         // Execute a hook, allowing to filter them out (eg: removing fieldNames from a private schema)
         // Also pass the Interfaces defining the field
-        $interfaceTypeResolverClasses = $objectTypeOrInterfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolverClasses();
         $fieldNames = array_filter(
             $fieldNames,
             fn ($fieldName) => $this->isFieldNameResolvedByObjectTypeFieldResolver(
                 $objectTypeOrInterfaceTypeResolver,
                 $objectTypeOrInterfaceTypeFieldResolver,
                 $fieldName,
-                $interfaceTypeResolverClasses,
             )
         );
         return $fieldNames;
     }
 
-    /**
-     * $interfaceTypeResolverClasses is the list of all the interfaces implemented
-     * by the objectTypeOrInterfaceTypeFieldResolver, and not only those ones containing the fieldName.
-     * This is because otherwise we'd need to call `$interfaceTypeResolver->getFieldNamesToImplement()`
-     * to find out the list of Interfaces containing $fieldName, however this function relies
-     * on the InterfaceTypeFieldResolver once again, so we'd get a recursion.
-     */
     protected function isFieldNameResolvedByObjectTypeFieldResolver(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        string $fieldName,
-        array $interfaceTypeResolverClasses
+        string $fieldName
     ): bool {
         // Execute 2 filters: a generic one, and a specific one
         if (
@@ -78,7 +68,6 @@ trait ExcludeFieldNamesFromSchemaTypeResolverTrait
                 true,
                 $objectTypeOrInterfaceTypeResolver,
                 $objectTypeOrInterfaceTypeFieldResolver,
-                $interfaceTypeResolverClasses,
                 $fieldName
             )
         ) {
@@ -87,7 +76,6 @@ trait ExcludeFieldNamesFromSchemaTypeResolverTrait
                 true,
                 $objectTypeOrInterfaceTypeResolver,
                 $objectTypeOrInterfaceTypeFieldResolver,
-                $interfaceTypeResolverClasses,
                 $fieldName
             );
         }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
@@ -91,14 +91,14 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
     public function getAllInterfaceTypeFieldResolvers(): array
     {
         if ($this->interfaceTypeFieldResolvers === null) {
-            $this->interfaceTypeFieldResolvers = [];
-            foreach ($this->getAllInterfaceTypeFieldResolversByField() as $fieldName => $interfaceTypeFieldResolvers) {
-                $this->interfaceTypeFieldResolvers = array_merge(
-                    $this->interfaceTypeFieldResolvers,
-                    $interfaceTypeFieldResolvers
-                );
+            $interfaceTypeFieldResolvers = [];
+            foreach ($this->getAllInterfaceTypeFieldResolversByField() as $fieldName => $interfaceTypeFieldResolversByField) {
+                // Add under class as to mimick `array_unique` for object
+                foreach ($interfaceTypeFieldResolversByField as $interfaceTypeFieldResolver) {
+                    $interfaceTypeFieldResolvers[get_class($interfaceTypeFieldResolver)] = $interfaceTypeFieldResolver;
+                }
             }
-            $this->interfaceTypeFieldResolvers = array_values(array_unique($this->interfaceTypeFieldResolvers));
+            $this->interfaceTypeFieldResolvers = array_values($interfaceTypeFieldResolvers);
         }
         return $this->interfaceTypeFieldResolvers;
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
@@ -90,30 +90,17 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
      */
     public function getAllInterfaceTypeFieldResolvers(): array
     {
-        return array_map(
-            fn (string $interfaceTypeFieldResolverClass) => $this->instanceManager->getInstance($interfaceTypeFieldResolverClass),
-            $this->getAllInterfaceTypeFieldResolverClasses()
-        );
-    }
-
-    /**
-     * Produce an array of all the attached ObjectTypeFieldResolverInterfaces
-     *
-     * @return string[]
-     */
-    public function getAllInterfaceTypeFieldResolverClasses(): array
-    {
-        if ($this->interfaceTypeFieldResolverClasses === null) {
-            $this->interfaceTypeFieldResolverClasses = [];
-            foreach ($this->getAllInterfaceTypeFieldResolverClassesByField() as $fieldName => $interfaceTypeFieldResolverClasses) {
-                $this->interfaceTypeFieldResolverClasses = array_merge(
-                    $this->interfaceTypeFieldResolverClasses,
-                    $interfaceTypeFieldResolverClasses
+        if ($this->interfaceTypeFieldResolvers === null) {
+            $this->interfaceTypeFieldResolvers = [];
+            foreach ($this->getAllInterfaceTypeFieldResolversByField() as $fieldName => $interfaceTypeFieldResolvers) {
+                $this->interfaceTypeFieldResolvers = array_merge(
+                    $this->interfaceTypeFieldResolvers,
+                    $interfaceTypeFieldResolvers
                 );
             }
-            $this->interfaceTypeFieldResolverClasses = array_values(array_unique($this->interfaceTypeFieldResolverClasses));
+            $this->interfaceTypeFieldResolvers = array_values(array_unique($this->interfaceTypeFieldResolvers));
         }
-        return $this->interfaceTypeFieldResolverClasses;
+        return $this->interfaceTypeFieldResolvers;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
@@ -69,7 +69,7 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
         foreach ($this->getAllInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
             $implementedInterfaceTypeFieldResolverClasses = array_merge(
                 $implementedInterfaceTypeFieldResolverClasses,
-                $interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolverClasses()
+                $interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers()
             );
         }
         $implementedInterfaceTypeFieldResolverClasses = array_values(array_unique($implementedInterfaceTypeFieldResolverClasses));
@@ -193,7 +193,10 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
                     // The interfaces implemented by the InterfaceTypeFieldResolver can have, themselves, InterfaceTypeFieldResolvers attached to them
                     $classStack = array_values(array_unique(array_merge(
                         $classStack,
-                        $interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolverClasses()
+                        array_map(
+                            'get_class',
+                            $interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers()
+                        ),
                     )));
                 }
                 // Otherwise, continue iterating for the class parents

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
@@ -105,20 +105,6 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
 
     /**
      * Produce an array of all the interface's fieldNames and, for each,
-     * a list of all the InterfaceTypeFieldResolver classes
-     *
-     * @return array<string, string[]>
-     */
-    final public function getAllInterfaceTypeFieldResolverClassesByField(): array
-    {
-        return array_map(
-            fn (array $interfaceTypeFieldResolvers) => array_map('get_class', $interfaceTypeFieldResolvers),
-            $this->getAllInterfaceTypeFieldResolversByField()
-        );
-    }
-
-    /**
-     * Produce an array of all the interface's fieldNames and, for each,
      * a list of all the ObjectTypeFieldResolverInterfaces
      *
      * @return array<string, InterfaceTypeFieldResolverInterface[]>

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
@@ -67,20 +67,19 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
     {
         $implementedInterfaceTypeFieldResolvers = [];
         foreach ($this->getAllInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
-            $implementedInterfaceTypeFieldResolvers = array_merge(
-                $implementedInterfaceTypeFieldResolvers,
-                $interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers()
-            );
+            // Add under class as to mimick `array_unique` for object
+            foreach ($interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers() as $implementedInterfaceTypeFieldResolver) {
+                $implementedInterfaceTypeFieldResolvers[get_class($implementedInterfaceTypeFieldResolver)] = $implementedInterfaceTypeFieldResolver;
+            }
         }
-        $implementedInterfaceTypeFieldResolvers = array_values(array_unique($implementedInterfaceTypeFieldResolvers));
         $implementedInterfaceTypeResolvers = [];
         foreach ($implementedInterfaceTypeFieldResolvers as $implementedInterfaceTypeFieldResolver) {
-            $implementedInterfaceTypeResolvers = array_merge(
-                $implementedInterfaceTypeResolvers,
-                $implementedInterfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers()
-            );
+            // Add under class as to mimick `array_unique` for object
+            foreach ($implementedInterfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers() as $partiallyImplementedInterfaceTypeResolver) {
+                $implementedInterfaceTypeResolvers[get_class($partiallyImplementedInterfaceTypeResolver)] = $partiallyImplementedInterfaceTypeResolver;
+            }
         }
-        return array_values(array_unique($implementedInterfaceTypeResolvers));
+        return array_values($implementedInterfaceTypeResolvers);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
@@ -28,9 +28,9 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
      */
     private array $fieldNamesResolvedByInterfaceTypeFieldResolver = [];
     /**
-     * @var string[]|null
+     * @var InterfaceTypeFieldResolverInterface[]|null
      */
-    protected ?array $interfaceTypeFieldResolverClasses = null;
+    protected ?array $interfaceTypeFieldResolvers = null;
 
     /**
      * The list of the fieldNames to implement in the Interface,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/AbstractInterfaceTypeResolver.php
@@ -61,44 +61,26 @@ abstract class AbstractInterfaceTypeResolver extends AbstractTypeResolver implem
     /**
      * Interfaces "partially" implemented by this Interface
      *
-     * @return string[]
-     */
-    public function getPartiallyImplementedInterfaceTypeResolverClasses(): array
-    {
-        $implementedInterfaceTypeFieldResolverClasses = [];
-        foreach ($this->getAllInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
-            $implementedInterfaceTypeFieldResolverClasses = array_merge(
-                $implementedInterfaceTypeFieldResolverClasses,
-                $interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers()
-            );
-        }
-        $implementedInterfaceTypeFieldResolverClasses = array_values(array_unique($implementedInterfaceTypeFieldResolverClasses));
-        /** @var InterfaceTypeFieldResolverInterface[] */
-        $implementedInterfaceTypeFieldResolvers = array_map(
-            fn (string $interfaceTypeFieldResolverClass) => $this->instanceManager->getInstance($interfaceTypeFieldResolverClass),
-            $implementedInterfaceTypeFieldResolverClasses
-        );
-        $implementedInterfaceTypeResolverClasses = [];
-        foreach ($implementedInterfaceTypeFieldResolvers as $implementedInterfaceTypeFieldResolver) {
-            $implementedInterfaceTypeResolverClasses = array_merge(
-                $implementedInterfaceTypeResolverClasses,
-                $implementedInterfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolverClasses()
-            );
-        }
-        return array_values(array_unique($implementedInterfaceTypeResolverClasses));
-    }
-
-    /**
-     * Interfaces "partially" implemented by this Interface
-     *
      * @return InterfaceTypeResolverInterface[]
      */
     public function getPartiallyImplementedInterfaceTypeResolvers(): array
     {
-        return array_map(
-            fn (string $interfaceTypeResolverClass) => $this->instanceManager->getInstance($interfaceTypeResolverClass),
-            $this->getPartiallyImplementedInterfaceTypeResolverClasses()
-        );
+        $implementedInterfaceTypeFieldResolvers = [];
+        foreach ($this->getAllInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
+            $implementedInterfaceTypeFieldResolvers = array_merge(
+                $implementedInterfaceTypeFieldResolvers,
+                $interfaceTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers()
+            );
+        }
+        $implementedInterfaceTypeFieldResolvers = array_values(array_unique($implementedInterfaceTypeFieldResolvers));
+        $implementedInterfaceTypeResolvers = [];
+        foreach ($implementedInterfaceTypeFieldResolvers as $implementedInterfaceTypeFieldResolver) {
+            $implementedInterfaceTypeResolvers = array_merge(
+                $implementedInterfaceTypeResolvers,
+                $implementedInterfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers()
+            );
+        }
+        return array_values(array_unique($implementedInterfaceTypeResolvers));
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/InterfaceTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/InterfaceTypeResolverInterface.php
@@ -37,12 +37,6 @@ interface InterfaceTypeResolverInterface extends TypeResolverInterface
      */
     public function getAllInterfaceTypeFieldResolvers(): array;
     /**
-     * Produce an array of all the attached ObjectTypeFieldResolverInterface classes
-     *
-     * @return string[]
-     */
-    public function getAllInterfaceTypeFieldResolverClasses(): array;
-    /**
      * Interfaces "partially" implemented by this Interface
      *
      * @return InterfaceTypeResolverInterface[]

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/InterfaceTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/InterfaceTypeResolverInterface.php
@@ -45,12 +45,6 @@ interface InterfaceTypeResolverInterface extends TypeResolverInterface
     /**
      * Interfaces "partially" implemented by this Interface
      *
-     * @return string[]
-     */
-    public function getPartiallyImplementedInterfaceTypeResolverClasses(): array;
-    /**
-     * Interfaces "partially" implemented by this Interface
-     *
      * @return InterfaceTypeResolverInterface[]
      */
     public function getPartiallyImplementedInterfaceTypeResolvers(): array;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/InterfaceTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/InterfaceTypeResolverInterface.php
@@ -24,13 +24,6 @@ interface InterfaceTypeResolverInterface extends TypeResolverInterface
      */
     public function getAllInterfaceTypeFieldResolversByField(): array;
     /**
-     * Produce an array of all the interface's fieldNames and, for each,
-     * a list of all the ObjectTypeFieldResolverInterface classes
-     *
-     * @return array<string, string[]>
-     */
-    public function getAllInterfaceTypeFieldResolverClassesByField(): array;
-    /**
      * Produce an array of all the attached ObjectTypeFieldResolverInterfaces
      *
      * @return InterfaceTypeFieldResolverInterface[]

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -50,7 +50,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
      */
     private array $fieldNamesResolvedByObjectTypeFieldResolver = [];
     /**
-     * @var string[]|null
+     * @var InterfaceTypeFieldResolverInterface[]|null
      */
     protected ?array $interfaceTypeFieldResolvers = null;
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -865,15 +865,15 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
             // Sort the found units by their priority, and then add to the stack of all units, for all classes
             // Higher priority means they execute first!
             array_multisort($classTypeResolverPriorities, SORT_DESC, SORT_NUMERIC, $classObjectTypeFieldResolvers);
-            $objectTypeFieldResolvers = array_merge(
-                $objectTypeFieldResolvers,
-                $classObjectTypeFieldResolvers
-            );
+            // Add under class as to mimick `array_unique` for object
+            foreach ($classObjectTypeFieldResolvers as $classObjectTypeFieldResolver) {
+                $objectTypeFieldResolvers[get_class($classObjectTypeFieldResolver)] = $classObjectTypeFieldResolver;
+            }
             // Continue iterating for the class parents
         } while ($class = get_parent_class($class));
 
         // Return all the units that resolve the fieldName
-        return $objectTypeFieldResolvers;
+        return array_values($objectTypeFieldResolvers);
     }
 
     protected function calculateFieldNamesToResolve(): array

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -789,27 +789,23 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
      */
     private function calculateAllImplementedInterfaceTypeResolvers(): array
     {
-        $interfaceTypeResolverClasses = [];
+        $interfaceTypeResolvers = [];
         foreach ($this->getAllImplementedInterfaceTypeFieldResolvers() as $interfaceTypeFieldResolver) {
-            $interfaceTypeResolverClasses = array_merge(
-                $interfaceTypeResolverClasses,
-                $interfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolverClasses()
+            $interfaceTypeResolvers = array_merge(
+                $interfaceTypeResolvers,
+                $interfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers()
             );
         }
-        $interfaceTypeResolverClasses = array_values(array_unique($interfaceTypeResolverClasses));
+        $interfaceTypeResolvers = array_values(array_unique($interfaceTypeResolvers));
         // Every InterfaceTypeResolver can be injected fields from many InterfaceTypeFieldResolvers
         // Make sure that this typeResolver implements all these InterfaceTypeFieldResolver
         // If not, the type does not fully satisfy the Interface
-        $interfaceTypeResolvers = array_map(
-            fn (string $interfaceTypeResolverClass) => $this->instanceManager->getInstance($interfaceTypeResolverClass),
-            $interfaceTypeResolverClasses
-        );
-        $implementedInterfaceTypeFieldResolverClasses = $this->getAllImplementedInterfaceTypeFieldResolverClasses();
+        $implementedInterfaceTypeFieldResolvers = $this->getAllImplementedInterfaceTypeFieldResolvers();
         return array_filter(
             $interfaceTypeResolvers,
             fn (InterfaceTypeResolverInterface $interfaceTypeResolver) => array_diff(
-                $interfaceTypeResolver->getAllInterfaceTypeFieldResolverClasses(),
-                $implementedInterfaceTypeFieldResolverClasses
+                $interfaceTypeResolver->getAllInterfaceTypeFieldResolvers(),
+                $implementedInterfaceTypeFieldResolvers
             ) === [],
         );
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -52,7 +52,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
     /**
      * @var string[]|null
      */
-    protected ?array $interfaceTypeFieldResolverClasses = null;
+    protected ?array $interfaceTypeFieldResolvers = null;
 
     /**
      * Watch out! This function will be overridden for the UnionTypeResolver
@@ -740,37 +740,29 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
      */
     final protected function getAllImplementedInterfaceTypeFieldResolvers(): array
     {
-        return array_map(
-            fn (string $interfaceTypeFieldResolverClass) => $this->instanceManager->getInstance($interfaceTypeFieldResolverClass),
-            $this->getAllImplementedInterfaceTypeFieldResolverClasses()
-        );
-    }
-
-    final protected function getAllImplementedInterfaceTypeFieldResolverClasses(): array
-    {
-        if ($this->interfaceTypeFieldResolverClasses === null) {
-            $this->interfaceTypeFieldResolverClasses = $this->calculateAllImplementedInterfaceTypeFieldResolverClasses();
+        if ($this->interfaceTypeFieldResolvers === null) {
+            $this->interfaceTypeFieldResolvers = $this->calculateAllImplementedInterfaceTypeFieldResolverClasses();
         }
-        return $this->interfaceTypeFieldResolverClasses;
+        return $this->interfaceTypeFieldResolvers;
     }
 
     private function calculateAllImplementedInterfaceTypeFieldResolverClasses(): array
     {
-        $interfaceTypeFieldResolverClasses = [];
+        $interfaceTypeFieldResolvers = [];
         $processedObjectTypeFieldResolverClasses = [];
         foreach ($this->getAllObjectTypeFieldResolvers() as $fieldName => $objectTypeFieldResolvers) {
             foreach ($objectTypeFieldResolvers as $objectTypeFieldResolver) {
                 $objectTypeFieldResolverClass = get_class($objectTypeFieldResolver);
                 if (!in_array($objectTypeFieldResolverClass, $processedObjectTypeFieldResolverClasses)) {
                     $processedObjectTypeFieldResolverClasses[] = $objectTypeFieldResolverClass;
-                    $interfaceTypeFieldResolverClasses = array_merge(
-                        $interfaceTypeFieldResolverClasses,
+                    $interfaceTypeFieldResolvers = array_merge(
+                        $interfaceTypeFieldResolvers,
                         $objectTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers()
                     );
                 }
             }
         }
-        return array_values(array_unique($interfaceTypeFieldResolverClasses));
+        return array_values(array_unique($interfaceTypeFieldResolvers));
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -765,7 +765,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
                     $processedObjectTypeFieldResolverClasses[] = $objectTypeFieldResolverClass;
                     $interfaceTypeFieldResolverClasses = array_merge(
                         $interfaceTypeFieldResolverClasses,
-                        $objectTypeFieldResolver->getImplementedInterfaceTypeFieldResolverClasses()
+                        $objectTypeFieldResolver->getImplementedInterfaceTypeFieldResolvers()
                     );
                 }
             }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -741,12 +741,15 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
     final protected function getAllImplementedInterfaceTypeFieldResolvers(): array
     {
         if ($this->interfaceTypeFieldResolvers === null) {
-            $this->interfaceTypeFieldResolvers = $this->calculateAllImplementedInterfaceTypeFieldResolverClasses();
+            $this->interfaceTypeFieldResolvers = $this->calculateAllImplementedInterfaceTypeFieldResolvers();
         }
         return $this->interfaceTypeFieldResolvers;
     }
 
-    private function calculateAllImplementedInterfaceTypeFieldResolverClasses(): array
+    /**
+     * @return InterfaceTypeFieldResolverInterface[]
+     */
+    private function calculateAllImplementedInterfaceTypeFieldResolvers(): array
     {
         $interfaceTypeFieldResolvers = [];
         $processedObjectTypeFieldResolverClasses = [];

--- a/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
@@ -19,10 +19,6 @@ interface RelationalTypeResolverInterface extends ConcreteTypeResolverInterface
     public function getID(object $object): string | int | null;
     public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface;
     /**
-     * @return string[]
-     */
-    public function getAllImplementedInterfaceTypeResolverClasses(): array;
-    /**
      * @return InterfaceTypeResolverInterface[]
      */
     public function getAllImplementedInterfaceTypeResolvers(): array;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php
@@ -294,7 +294,8 @@ abstract class AbstractUnionTypeResolver extends AbstractRelationalTypeResolver 
                 $notImplementingInterfaceTypeResolvers = array_filter(
                     $objectTypeResolvers,
                     fn (ObjectTypeResolverInterface $objectTypeResolver) => !in_array(
-                        $interfaceTypeResolverClass, array_map(
+                        $interfaceTypeResolverClass,
+                        array_map(
                             'get_class',
                             $objectTypeResolver->getAllImplementedInterfaceTypeResolvers()
                         )

--- a/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php
@@ -293,7 +293,12 @@ abstract class AbstractUnionTypeResolver extends AbstractRelationalTypeResolver 
                 $interfaceTypeResolverClass = get_class($interfaceTypeResolver);
                 $notImplementingInterfaceTypeResolvers = array_filter(
                     $objectTypeResolvers,
-                    fn (ObjectTypeResolverInterface $objectTypeResolver) => !in_array($interfaceTypeResolverClass, $objectTypeResolver->getAllImplementedInterfaceTypeResolverClasses())
+                    fn (ObjectTypeResolverInterface $objectTypeResolver) => !in_array(
+                        $interfaceTypeResolverClass, array_map(
+                            'get_class',
+                            $objectTypeResolver->getAllImplementedInterfaceTypeResolvers()
+                        )
+                    )
                 );
                 if ($notImplementingInterfaceTypeResolvers) {
                     throw new Exception(

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
@@ -33,16 +33,13 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
 
     /**
      * Configuration entries
-     * 
-     * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
      */
     final protected function getEntries(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
         string $fieldName
     ): array {
-        return $this->getMatchingEntries(
-            $this->getConfigurationEntries(),
+        return $this->getEntriesByTypeAndInterfaces(
             $objectTypeOrInterfaceTypeResolver,
             /**
              * Pass the list of all the interfaces implemented by the objectTypeOrInterfaceTypeFieldResolver,
@@ -52,6 +49,24 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
              * on the InterfaceTypeFieldResolver once again, so we'd get a recursion.
              */
             $objectTypeOrInterfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers(),
+            $fieldName
+        );
+    }
+
+    /**
+     * Configuration entries
+     * 
+     * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
+     */
+    final protected function getEntriesByTypeAndInterfaces(
+        ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
+        array $interfaceTypeResolvers,
+        string $fieldName
+    ): array {
+        return $this->getMatchingEntries(
+            $this->getConfigurationEntries(),
+            $objectTypeOrInterfaceTypeResolver,
+            $interfaceTypeResolvers,
             $fieldName
         );
     }

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
@@ -55,7 +55,7 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
 
     /**
      * Configuration entries
-     * 
+     *
      * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
      */
     final protected function getEntriesByTypeAndInterfaces(
@@ -73,7 +73,7 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
 
     /**
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
-     * 
+     *
      * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
      */
     final protected function getMatchingEntries(

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/ConfigurationEntries/ConfigurableMandatoryDirectivesForFieldsTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\MandatoryDirectivesByConfiguration\ConfigurationEntries;
 
+use PoP\ComponentModel\FieldResolvers\InterfaceType\InterfaceTypeFieldResolverInterface;
+use PoP\ComponentModel\FieldResolvers\ObjectType\ObjectTypeFieldResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 
@@ -31,30 +33,45 @@ trait ConfigurableMandatoryDirectivesForFieldsTrait
 
     /**
      * Configuration entries
+     * 
+     * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
      */
     final protected function getEntries(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
-        array $interfaceTypeResolverClasses,
+        ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
         string $fieldName
     ): array {
         return $this->getMatchingEntries(
             $this->getConfigurationEntries(),
             $objectTypeOrInterfaceTypeResolver,
-            $interfaceTypeResolverClasses,
+            /**
+             * Pass the list of all the interfaces implemented by the objectTypeOrInterfaceTypeFieldResolver,
+             * and not only those ones containing the fieldName.
+             * This is because otherwise we'd need to call `$interfaceTypeResolver->getFieldNamesToImplement()`
+             * to find out the list of Interfaces containing $fieldName, however this function relies
+             * on the InterfaceTypeFieldResolver once again, so we'd get a recursion.
+             */
+            $objectTypeOrInterfaceTypeFieldResolver->getPartiallyImplementedInterfaceTypeResolvers(),
             $fieldName
         );
     }
 
     /**
      * Filter all the entries from the list which apply to the passed typeResolver and fieldName
+     * 
+     * @param InterfaceTypeResolverInterface[] $interfaceTypeResolvers
      */
     final protected function getMatchingEntries(
         array $entryList,
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
-        array $interfaceTypeResolverClasses,
+        array $interfaceTypeResolvers,
         string $fieldName
     ): array {
         $objectTypeOrInterfaceTypeResolverClass = get_class($objectTypeOrInterfaceTypeResolver);
+        $interfaceTypeResolverClasses = array_map(
+            'get_class',
+            $interfaceTypeResolvers
+        );
         return array_filter(
             $entryList,
             fn (array $entry) => (

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/RelationalTypeResolverDecorators/ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/RelationalTypeResolverDecorators/ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait.php
@@ -37,14 +37,10 @@ trait ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTra
                 $interfaceTypeResolvers,
                 fn (InterfaceTypeResolverInterface $interfaceTypeResolver) => in_array($fieldName, $interfaceTypeResolver->getFieldNamesToImplement()),
             ));
-            $interfaceTypeResolverClassesForField = array_map(
-                'get_class',
-                $interfaceTypeResolversForField
-            );
             foreach (
                 $this->getEntries(
                     $objectTypeResolver,
-                    $interfaceTypeResolverClassesForField,
+                    $interfaceTypeResolversForField,
                     $fieldName
                 ) as $entry
             ) {

--- a/layers/Engine/packages/mandatory-directives-by-configuration/src/RelationalTypeResolverDecorators/ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/src/RelationalTypeResolverDecorators/ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait.php
@@ -38,7 +38,7 @@ trait ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTra
                 fn (InterfaceTypeResolverInterface $interfaceTypeResolver) => in_array($fieldName, $interfaceTypeResolver->getFieldNamesToImplement()),
             ));
             foreach (
-                $this->getEntries(
+                $this->getEntriesByTypeAndInterfaces(
                     $objectTypeResolver,
                     $interfaceTypeResolversForField,
                     $fieldName

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Hooks/NestedMutationHookSet.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Hooks/NestedMutationHookSet.php
@@ -38,7 +38,7 @@ class NestedMutationHookSet extends AbstractHookSet
             HookHelpers::getHookNameToFilterField(),
             array($this, 'maybeFilterFieldName'),
             10,
-            5
+            4
         );
     }
 
@@ -51,7 +51,6 @@ class NestedMutationHookSet extends AbstractHookSet
         bool $include,
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         $vars = ApplicationState::getVars();

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/AbstractUseRootAsSourceForSchemaObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/AbstractUseRootAsSourceForSchemaObjectTypeResolver.php
@@ -62,8 +62,7 @@ abstract class AbstractUseRootAsSourceForSchemaObjectTypeResolver extends Abstra
     protected function isFieldNameResolvedByObjectTypeFieldResolver(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        string $fieldName,
-        array $interfaceTypeResolverClasses,
+        string $fieldName
     ): bool {
         if (
             $objectTypeOrInterfaceTypeFieldResolver instanceof ObjectTypeFieldResolverInterface
@@ -74,8 +73,7 @@ abstract class AbstractUseRootAsSourceForSchemaObjectTypeResolver extends Abstra
         return parent::isFieldNameResolvedByObjectTypeFieldResolver(
             $objectTypeOrInterfaceTypeResolver,
             $objectTypeOrInterfaceTypeFieldResolver,
-            $fieldName,
-            $interfaceTypeResolverClasses
+            $fieldName
         );
     }
 }

--- a/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/InterfaceType/IsCustomPostInterfaceTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/InterfaceType/IsCustomPostInterfaceTypeFieldResolver.php
@@ -7,15 +7,18 @@ namespace PoPSchema\CustomPosts\FieldResolvers\InterfaceType;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Registries\TypeRegistryInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\Schema\SchemaNamespacingServiceInterface;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\Engine\CMS\CMSServiceInterface;
+use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\Hooks\HooksAPIInterface;
 use PoP\LooseContracts\NameResolverInterface;
 use PoP\Translation\TranslationAPIInterface;
 use PoPSchema\QueriedObject\FieldResolvers\InterfaceType\QueryableInterfaceTypeFieldResolver;
 use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\DateScalarTypeResolver;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\URLScalarTypeResolver;
 
 class IsCustomPostInterfaceTypeFieldResolver extends QueryableInterfaceTypeFieldResolver
 {
@@ -27,7 +30,11 @@ class IsCustomPostInterfaceTypeFieldResolver extends QueryableInterfaceTypeField
         CMSServiceInterface $cmsService,
         SchemaNamespacingServiceInterface $schemaNamespacingService,
         TypeRegistryInterface $typeRegistry,
+        SchemaDefinitionServiceInterface $schemaDefinitionService,
+        URLScalarTypeResolver $urlScalarTypeResolver,
+        StringScalarTypeResolver $stringScalarTypeResolver,
         protected DateScalarTypeResolver $dateScalarTypeResolver,
+        protected QueryableInterfaceTypeFieldResolver $queryableInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -37,13 +44,16 @@ class IsCustomPostInterfaceTypeFieldResolver extends QueryableInterfaceTypeField
             $cmsService,
             $schemaNamespacingService,
             $typeRegistry,
+            $schemaDefinitionService,
+            $urlScalarTypeResolver,
+            $stringScalarTypeResolver,
         );
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            QueryableInterfaceTypeFieldResolver::class,
+            $this->queryableInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -4,24 +4,58 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Engine\EngineInterface;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\HelperServices\SemverHelperServiceInterface;
+use PoP\ComponentModel\Instances\InstanceManagerInterface;
+use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
+use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\Engine\Facades\Formatters\DateFormatterFacade;
+use PoP\Hooks\HooksAPIInterface;
+use PoP\LooseContracts\NameResolverInterface;
+use PoP\Translation\TranslationAPIInterface;
 use PoPSchema\CustomPosts\Facades\CustomPostTypeAPIFacade;
 use PoPSchema\CustomPosts\FieldResolvers\InterfaceType\IsCustomPostInterfaceTypeFieldResolver;
 use PoPSchema\CustomPosts\TypeAPIs\CustomPostTypeAPIInterface;
 
 abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
+    public function __construct(
+        TranslationAPIInterface $translationAPI,
+        HooksAPIInterface $hooksAPI,
+        InstanceManagerInterface $instanceManager,
+        FieldQueryInterpreterInterface $fieldQueryInterpreter,
+        NameResolverInterface $nameResolver,
+        CMSServiceInterface $cmsService,
+        SemverHelperServiceInterface $semverHelperService,
+        SchemaDefinitionServiceInterface $schemaDefinitionService,
+        EngineInterface $engine,
+        protected IsCustomPostInterfaceTypeFieldResolver $isCustomPostInterfaceTypeFieldResolver,
+    ) {
+        parent::__construct(
+            $translationAPI,
+            $hooksAPI,
+            $instanceManager,
+            $fieldQueryInterpreter,
+            $nameResolver,
+            $cmsService,
+            $semverHelperService,
+            $schemaDefinitionService,
+            $engine,
+        );
+    }
+
     public function getFieldNamesToResolve(): array
     {
         return [];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            IsCustomPostInterfaceTypeFieldResolver::class,
+            $this->isCustomPostInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
@@ -36,6 +36,7 @@ abstract class AbstractCategoryObjectTypeFieldResolver extends AbstractObjectTyp
         EngineInterface $engine,
         protected StringScalarTypeResolver $stringScalarTypeResolver,
         protected IntScalarTypeResolver $intScalarTypeResolver,
+        protected QueryableInterfaceTypeFieldResolver $queryableInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -50,10 +51,10 @@ abstract class AbstractCategoryObjectTypeFieldResolver extends AbstractObjectTyp
         );
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            QueryableInterfaceTypeFieldResolver::class,
+            $this->queryableInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -32,6 +32,7 @@ class CommentObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         SchemaDefinitionServiceInterface $schemaDefinitionService,
         EngineInterface $engine,
         protected CommentMetaTypeAPIInterface $commentMetaAPI,
+        protected WithMetaInterfaceTypeFieldResolver $withMetaInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -53,10 +54,10 @@ class CommentObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            WithMetaInterfaceTypeFieldResolver::class,
+            $this->withMetaInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -36,6 +36,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeField
         EngineInterface $engine,
         ModuleProcessorManagerInterface $moduleProcessorManager,
         protected CommentTypeAPIInterface $commentTypeAPI,
+        protected CommentableInterfaceTypeFieldResolver $commentableInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -58,10 +59,10 @@ class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeField
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            CommentableInterfaceTypeFieldResolver::class,
+            $this->commentableInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -32,6 +32,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         SchemaDefinitionServiceInterface $schemaDefinitionService,
         EngineInterface $engine,
         protected CustomPostMediaTypeAPIInterface $customPostMediaTypeAPI,
+        protected SupportingFeaturedImageInterfaceTypeFieldResolver $supportingFeaturedImageInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -53,10 +54,10 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            SupportingFeaturedImageInterfaceTypeFieldResolver::class,
+            $this->supportingFeaturedImageInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -32,6 +32,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         SchemaDefinitionServiceInterface $schemaDefinitionService,
         EngineInterface $engine,
         protected CustomPostMetaTypeAPIInterface $customPostMetaAPI,
+        protected WithMetaInterfaceTypeFieldResolver $withMetaInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -53,10 +54,10 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            WithMetaInterfaceTypeFieldResolver::class,
+            $this->withMetaInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/customposts/src/FieldResolvers/InterfaceType/IsCustomPostInterfaceTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/InterfaceType/IsCustomPostInterfaceTypeFieldResolver.php
@@ -44,6 +44,7 @@ class IsCustomPostInterfaceTypeFieldResolver extends AbstractQueryableSchemaInte
         protected BooleanScalarTypeResolver $booleanScalarTypeResolver,
         protected DateScalarTypeResolver $dateScalarTypeResolver,
         protected StringScalarTypeResolver $stringScalarTypeResolver,
+        protected QueryableInterfaceTypeFieldResolver $queryableInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -64,10 +65,10 @@ class IsCustomPostInterfaceTypeFieldResolver extends AbstractQueryableSchemaInte
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            QueryableInterfaceTypeFieldResolver::class,
+            $this->queryableInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -35,6 +35,8 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
         EngineInterface $engine,
         protected CustomPostTypeAPIInterface $customPostTypeAPI,
         protected DateFormatterInterface $dateFormatter,
+        protected QueryableInterfaceTypeFieldResolver $queryableInterfaceTypeFieldResolver,
+        protected IsCustomPostInterfaceTypeFieldResolver $isCustomPostInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -54,11 +56,11 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
         return [];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            QueryableInterfaceTypeFieldResolver::class,
-            IsCustomPostInterfaceTypeFieldResolver::class,
+            $this->queryableInterfaceTypeFieldResolver,
+            $this->isCustomPostInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
@@ -36,6 +36,7 @@ abstract class AbstractTagObjectTypeFieldResolver extends AbstractObjectTypeFiel
         EngineInterface $engine,
         protected IntScalarTypeResolver $intScalarTypeResolver,
         protected StringScalarTypeResolver $stringScalarTypeResolver,
+        protected QueryableInterfaceTypeFieldResolver $queryableInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -50,10 +51,10 @@ abstract class AbstractTagObjectTypeFieldResolver extends AbstractObjectTypeFiel
         );
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            QueryableInterfaceTypeFieldResolver::class,
+            $this->queryableInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
@@ -32,6 +32,7 @@ class TaxonomyObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         SchemaDefinitionServiceInterface $schemaDefinitionService,
         EngineInterface $engine,
         protected TaxonomyMetaTypeAPIInterface $taxonomyMetaAPI,
+        protected WithMetaInterfaceTypeFieldResolver $withMetaInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -53,10 +54,10 @@ class TaxonomyObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            WithMetaInterfaceTypeFieldResolver::class,
+            $this->withMetaInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
@@ -47,7 +47,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet 
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName,
     ): bool {
         // If the user is not logged in, then remove the field
@@ -60,7 +59,7 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet 
         if (
             $matchingEntries = $this->getEntries(
                 $objectTypeOrInterfaceTypeResolver,
-                $interfaceTypeResolverClasses,
+                $objectTypeOrInterfaceTypeFieldResolver,
                 $fieldName
             )
         ) {

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
@@ -47,7 +47,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet extend
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         // If the user is not logged in, then remove the field
@@ -60,7 +59,7 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet extend
         if (
             $matchingEntries = $this->getEntries(
                 $objectTypeOrInterfaceTypeResolver,
-                $interfaceTypeResolverClasses,
+                $objectTypeOrInterfaceTypeFieldResolver,
                 $fieldName
             )
         ) {

--- a/layers/Schema/packages/user-roles-access-control/src/RelationalTypeResolverDecorators/ValidateDoesLoggedInUserHaveCapabilityPublicSchemaRelationalTypeResolverDecoratorTrait.php
+++ b/layers/Schema/packages/user-roles-access-control/src/RelationalTypeResolverDecorators/ValidateDoesLoggedInUserHaveCapabilityPublicSchemaRelationalTypeResolverDecoratorTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace PoPSchema\UserRolesAccessControl\RelationalTypeResolverDecorators;
 
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
-use PoP\ComponentModel\Facades\Instances\InstanceManagerFacade;
 use PoP\ComponentModel\Facades\Schema\FieldQueryInterpreterFacade;
-use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 
 trait ValidateDoesLoggedInUserHaveCapabilityPublicSchemaRelationalTypeResolverDecoratorTrait
 {

--- a/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractDisableFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-state-access-control/src/Hooks/AbstractDisableFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -19,7 +19,6 @@ abstract class AbstractDisableFieldsIfUserIsNotLoggedInAccessControlForFieldsInP
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         /**

--- a/layers/Schema/packages/user-state-access-control/src/Hooks/DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-state-access-control/src/Hooks/DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -41,7 +41,6 @@ class DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSc
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
-        array $interfaceTypeResolverClasses,
         string $fieldName
     ): bool {
         return $objectTypeOrInterfaceTypeFieldResolver instanceof AbstractUserStateObjectTypeFieldResolver;

--- a/layers/Schema/packages/user-state-access-control/src/Hooks/DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-state-access-control/src/Hooks/DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -35,8 +35,6 @@ class DisableUserStateFieldsIfUserIsNotLoggedInAccessControlForFieldsInPrivateSc
     }
     /**
      * Remove the fieldNames if the fieldResolver is an instance of the "user state" one
-     *
-     * @param string[] $interfaceTypeResolverClasses
      */
     protected function removeFieldName(
         ObjectTypeResolverInterface | InterfaceTypeResolverInterface $objectTypeOrInterfaceTypeResolver,

--- a/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -32,6 +32,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         SchemaDefinitionServiceInterface $schemaDefinitionService,
         EngineInterface $engine,
         protected UserMetaTypeAPIInterface $userMetaAPI,
+        protected WithMetaInterfaceTypeFieldResolver $withMetaInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -53,10 +54,10 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            WithMetaInterfaceTypeFieldResolver::class,
+            $this->withMetaInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -33,6 +33,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         SchemaDefinitionServiceInterface $schemaDefinitionService,
         EngineInterface $engine,
         protected CustomPostUserTypeAPIInterface $customPostUserTypeAPI,
+        protected WithAuthorInterfaceTypeFieldResolver $withAuthorInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -54,10 +55,10 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            WithAuthorInterfaceTypeFieldResolver::class,
+            $this->withAuthorInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/Schema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -41,6 +41,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         protected EmailScalarTypeResolver $emailScalarTypeResolver,
         protected StringScalarTypeResolver $stringScalarTypeResolver,
         protected URLScalarTypeResolver $urlScalarTypeResolver,
+        protected QueryableInterfaceTypeFieldResolver $queryableInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -62,10 +63,10 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            QueryableInterfaceTypeFieldResolver::class,
+            $this->queryableInterfaceTypeFieldResolver,
         ];
     }
 

--- a/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -36,7 +36,8 @@ class MediaObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResol
         EngineInterface $engine,
         ModuleProcessorManagerInterface $moduleProcessorManager,
         protected CMSHelperServiceInterface $cmsHelperService,
-        protected DateFormatterInterface $dateFormatter
+        protected DateFormatterInterface $dateFormatter,
+        protected QueryableInterfaceTypeFieldResolver $queryableInterfaceTypeFieldResolver,
     ) {
         parent::__construct(
             $translationAPI,
@@ -59,10 +60,10 @@ class MediaObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResol
         ];
     }
 
-    public function getImplementedInterfaceTypeFieldResolverClasses(): array
+    public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            QueryableInterfaceTypeFieldResolver::class,
+            $this->queryableInterfaceTypeFieldResolver,
         ];
     }
 


### PR DESCRIPTION
Removed "Class" from the following functions:

- getImplementedInterfaceTypeFieldResolverClasses
- getInterfaceTypeFieldSchemaDefinitionResolverClass
- getPartiallyImplementedInterfaceTypeResolverClasses
- getAllInterfaceTypeFieldResolverClasses
- getAllInterfaceTypeFieldResolverClassesByField
- getAllImplementedInterfaceTypeFieldResolverClasses
- getAllImplementedInterfaceTypeResolverClasses
- calculateAllImplementedInterfaceTypeFieldResolverClasses

Now, instead of dealing with class strings, we deal with the object instances directly.