### PR TITLE
Remove code used to avoid circular dependencies in container (not needed anymore)

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionService.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinitionService.php
@@ -12,16 +12,14 @@ use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
 
 class SchemaDefinitionService implements SchemaDefinitionServiceInterface
 {
-    /**
-     * Can't use autowiring or it produces a circular reference exception
-     */
-    protected ?AnyScalarScalarTypeResolver $anyScalarScalarTypeResolver = null;
+    protected AnyScalarScalarTypeResolver $anyScalarScalarTypeResolver;
     protected InstanceManagerInterface $instanceManager;
 
     #[Required]
-    public function autowireSchemaDefinitionService(InstanceManagerInterface $instanceManager)
+    public function autowireSchemaDefinitionService(InstanceManagerInterface $instanceManager, AnyScalarScalarTypeResolver $anyScalarScalarTypeResolver)
     {
         $this->instanceManager = $instanceManager;
+        $this->anyScalarScalarTypeResolver = $anyScalarScalarTypeResolver;
     }
 
     public function getTypeSchemaKey(TypeResolverInterface $typeResolver): string
@@ -43,9 +41,6 @@ class SchemaDefinitionService implements SchemaDefinitionServiceInterface
      */
     public function getDefaultTypeResolver(): ConcreteTypeResolverInterface
     {
-        if ($this->anyScalarScalarTypeResolver === null) {
-            $this->anyScalarScalarTypeResolver = $this->instanceManager->getInstance(AnyScalarScalarTypeResolver::class);
-        }
         return $this->anyScalarScalarTypeResolver;
     }
 }

--- a/layers/Engine/packages/engine/src/Schema/SchemaDefinitionService.php
+++ b/layers/Engine/packages/engine/src/Schema/SchemaDefinitionService.php
@@ -8,13 +8,17 @@ use PoP\ComponentModel\Schema\SchemaDefinitionService as ComponentModelSchemaDef
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ObjectType\RootObjectTypeResolver;
+use Symfony\Contracts\Service\Attribute\Required;
 
 class SchemaDefinitionService extends ComponentModelSchemaDefinitionService implements SchemaDefinitionServiceInterface
 {
-    /**
-     * Can't use autowiring or it produces a circular reference exception
-     */
-    protected ?RootObjectTypeResolver $rootObjectTypeResolver = null;
+    protected RootObjectTypeResolver $rootObjectTypeResolver;
+
+    #[Required]
+    public function autowireEngineSchemaDefinitionService(RootObjectTypeResolver $rootObjectTypeResolver)
+    {
+        $this->rootObjectTypeResolver = $rootObjectTypeResolver;
+    }
 
     public function getTypeResolverTypeSchemaKey(RelationalTypeResolverInterface $relationalTypeResolver): string
     {
@@ -29,9 +33,6 @@ class SchemaDefinitionService extends ComponentModelSchemaDefinitionService impl
 
     public function getRootTypeResolver(): ObjectTypeResolverInterface
     {
-        if ($this->rootObjectTypeResolver === null) {
-            $this->rootObjectTypeResolver = $this->instanceManager->getInstance(RootObjectTypeResolver::class);
-        }
         return $this->rootObjectTypeResolver;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Schema/GraphQLSchemaDefinitionService.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Schema/GraphQLSchemaDefinitionService.php
@@ -4,21 +4,26 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\Schema;
 
-use PoP\ComponentModel\State\ApplicationState;
-use PoP\Engine\Schema\SchemaDefinitionService;
-use PoP\API\ComponentConfiguration as APIComponentConfiguration;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\QueryRootObjectTypeResolver;
-use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\MutationRootObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\Schema\GraphQLSchemaDefinitionServiceInterface;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\MutationRootObjectTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\QueryRootObjectTypeResolver;
+use PoP\API\ComponentConfiguration as APIComponentConfiguration;
+use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\Schema\SchemaDefinitionService;
+use Symfony\Contracts\Service\Attribute\Required;
 
 class GraphQLSchemaDefinitionService extends SchemaDefinitionService implements GraphQLSchemaDefinitionServiceInterface
 {
-    /**
-     * Can't use autowiring or it produces a circular reference exception
-     */
-    protected ?QueryRootObjectTypeResolver $queryRootObjectTypeResolver = null;
-    protected ?MutationRootObjectTypeResolver $mutationRootObjectTypeResolver = null;
+    protected QueryRootObjectTypeResolver $queryRootObjectTypeResolver;
+    protected MutationRootObjectTypeResolver $mutationRootObjectTypeResolver;
+
+    #[Required]
+    public function autowireGraphQLSchemaDefinitionService(QueryRootObjectTypeResolver $queryRootObjectTypeResolver, MutationRootObjectTypeResolver $mutationRootObjectTypeResolver)
+    {
+        $this->queryRootObjectTypeResolver = $queryRootObjectTypeResolver;
+        $this->mutationRootObjectTypeResolver = $mutationRootObjectTypeResolver;
+    }
 
     public function getQueryRootTypeSchemaKey(): string
     {
@@ -37,9 +42,6 @@ class GraphQLSchemaDefinitionService extends SchemaDefinitionService implements 
             return $this->getRootTypeResolver();
         }
 
-        if ($this->queryRootObjectTypeResolver === null) {
-            $this->queryRootObjectTypeResolver = $this->instanceManager->getInstance(QueryRootObjectTypeResolver::class);
-        }
         return $this->queryRootObjectTypeResolver;
     }
 
@@ -65,9 +67,6 @@ class GraphQLSchemaDefinitionService extends SchemaDefinitionService implements 
             return $this->getRootTypeResolver();
         }
 
-        if ($this->mutationRootObjectTypeResolver === null) {
-            $this->mutationRootObjectTypeResolver = $this->instanceManager->getInstance(MutationRootObjectTypeResolver::class);
-        }
         return $this->mutationRootObjectTypeResolver;
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/SchemaObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/SchemaObjectTypeResolver.php
@@ -4,17 +4,21 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
 use GraphQLByPoP\GraphQLServer\ObjectModels\Schema;
 use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaTypeDataLoader;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\AbstractIntrospectionObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 class SchemaObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
 {
-    /**
-     * Can't inject in constructor because of a circular reference
-     */
-    protected ?SchemaTypeDataLoader $schemaTypeDataLoader = null;
+    protected SchemaTypeDataLoader $schemaTypeDataLoader;
+
+    #[Required]
+    public function autowireSchemaObjectTypeResolver(SchemaTypeDataLoader $schemaTypeDataLoader)
+    {
+        $this->schemaTypeDataLoader = $schemaTypeDataLoader;
+    }
 
     public function getTypeName(): string
     {
@@ -35,9 +39,6 @@ class SchemaObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
 
     public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
     {
-        if ($this->schemaTypeDataLoader === null) {
-            $this->schemaTypeDataLoader = $this->instanceManager->getInstance(SchemaTypeDataLoader::class);
-        }
         return $this->schemaTypeDataLoader;
     }
 }

--- a/layers/Schema/packages/customposts/src/TypeResolvers/UnionType/CustomPostUnionTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/UnionType/CustomPostUnionTypeResolver.php
@@ -23,17 +23,16 @@ use PoPSchema\CustomPosts\RelationalTypeDataLoaders\UnionType\CustomPostUnionTyp
 
 class CustomPostUnionTypeResolver extends AbstractUnionTypeResolver
 {
-    /**
-     * Can't inject in constructor because of a circular reference
-     */
-    protected ?CustomPostUnionTypeDataLoader $customPostUnionTypeDataLoader = null;
+    protected CustomPostUnionTypeDataLoader $customPostUnionTypeDataLoader;
     protected InterfaceTypeResolverInterface $interfaceTypeResolver;
 
     #[Required]
     public function autowireCustomPostUnionTypeResolver(
         InterfaceTypeResolverInterface $interfaceTypeResolver,
+        CustomPostUnionTypeDataLoader $customPostUnionTypeDataLoader,
     ) {
         $this->interfaceTypeResolver = $interfaceTypeResolver;
+        $this->customPostUnionTypeDataLoader = $customPostUnionTypeDataLoader;
     }
 
     public function getTypeName(): string
@@ -48,9 +47,6 @@ class CustomPostUnionTypeResolver extends AbstractUnionTypeResolver
 
     public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
     {
-        if ($this->customPostUnionTypeDataLoader === null) {
-            $this->customPostUnionTypeDataLoader = $this->instanceManager->getInstance(CustomPostUnionTypeDataLoader::class);
-        }
         return $this->customPostUnionTypeDataLoader;
     }
 


### PR DESCRIPTION
After #1102 circular dependencies via function `__construct` don't happen anymore, so the code to avoid them can be removed.