### PR TITLE
Reference persistent cache and memory cache via interface

### DIFF
--- a/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -10,7 +10,7 @@ use PoP\API\PersistedQueries\PersistedFragmentManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryManagerInterface;
 use PoP\API\Schema\SchemaDefinition;
 use PoP\API\TypeResolvers\EnumType\SchemaFieldShapeEnumTypeResolver;
-use PoP\ComponentModel\Cache\CacheInterface;
+use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaHelpers;
@@ -24,7 +24,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
-    protected CacheInterface $persistentCache;
+    protected PersistentCacheInterface $persistentCache;
     protected SchemaFieldShapeEnumTypeResolver $schemaOutputShapeEnumTypeResolver;
     protected ObjectScalarTypeResolver $objectScalarTypeResolver;
     protected PersistedFragmentManagerInterface $fragmentCatalogueManager;

--- a/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -11,7 +11,6 @@ use PoP\API\PersistedQueries\PersistedQueryManagerInterface;
 use PoP\API\Schema\SchemaDefinition;
 use PoP\API\TypeResolvers\EnumType\SchemaFieldShapeEnumTypeResolver;
 use PoP\ComponentModel\Cache\PersistentCacheInterface;
-use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaHelpers;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -36,12 +35,13 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ObjectScalarTypeResolver $objectScalarTypeResolver,
         PersistedFragmentManagerInterface $fragmentCatalogueManager,
         PersistedQueryManagerInterface $queryCatalogueManager,
+        PersistentCacheInterface $persistentCache,
     ): void {
         $this->schemaOutputShapeEnumTypeResolver = $schemaOutputShapeEnumTypeResolver;
         $this->objectScalarTypeResolver = $objectScalarTypeResolver;
         $this->fragmentCatalogueManager = $fragmentCatalogueManager;
         $this->queryCatalogueManager = $queryCatalogueManager;
-        $this->persistentCache = PersistentCacheFacade::getInstance();
+        $this->persistentCache = $persistentCache;
     }
 
     public function getObjectTypeResolverClassesToAttachTo(): array

--- a/layers/API/packages/api/src/Registries/SchemaDefinitionRegistry.php
+++ b/layers/API/packages/api/src/Registries/SchemaDefinitionRegistry.php
@@ -6,7 +6,7 @@ namespace PoP\API\Registries;
 
 use PoP\API\Cache\CacheTypes;
 use PoP\API\ComponentConfiguration;
-use PoP\ComponentModel\Cache\CacheInterface;
+use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
@@ -21,7 +21,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 class SchemaDefinitionRegistry implements SchemaDefinitionRegistryInterface
 {
-    protected CacheInterface $persistentCache;
+    protected PersistentCacheInterface $persistentCache;
     protected FeedbackMessageStoreInterface $feedbackMessageStore;
     protected FieldQueryInterpreterInterface $fieldQueryInterpreter;
     protected TranslationAPIInterface $translationAPI;

--- a/layers/API/packages/api/src/Registries/SchemaDefinitionRegistry.php
+++ b/layers/API/packages/api/src/Registries/SchemaDefinitionRegistry.php
@@ -8,7 +8,6 @@ use PoP\API\Cache\CacheTypes;
 use PoP\API\ComponentConfiguration;
 use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\ComponentModel\ErrorHandling\Error;
-use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\Instances\InstanceManagerInterface;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\FeedbackMessageStoreInterface;
@@ -35,6 +34,7 @@ class SchemaDefinitionRegistry implements SchemaDefinitionRegistryInterface
         FieldQueryInterpreterInterface $fieldQueryInterpreter,
         TranslationAPIInterface $translationAPI,
         InstanceManagerInterface $instanceManager,
+        PersistentCacheInterface $persistentCache,
         RootObjectTypeResolver $rootTypeResolver,
         Root $root,
     ): void {
@@ -42,9 +42,9 @@ class SchemaDefinitionRegistry implements SchemaDefinitionRegistryInterface
         $this->fieldQueryInterpreter = $fieldQueryInterpreter;
         $this->translationAPI = $translationAPI;
         $this->instanceManager = $instanceManager;
+        $this->persistentCache = $persistentCache;
         $this->rootTypeResolver = $rootTypeResolver;
         $this->root = $root;
-        $this->persistentCache = PersistentCacheFacade::getInstance();
     }
 
     /**

--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -4,7 +4,7 @@ services:
         autowire: true
         autoconfigure: true
 
-    memory_cache_item_pool:
+    transient_cache_item_pool:
         class: \Symfony\Component\Cache\Adapter\ArrayAdapter
 
     PoP\ComponentModel\Cache\CacheConfigurationManagerInterface:
@@ -29,10 +29,10 @@ services:
     PoP\ComponentModel\Engine\DataloadingEngineInterface:
         class: \PoP\ComponentModel\Engine\DataloadingEngine
 
-    memory_cache:
+    transient_cache:
         class: \PoP\ComponentModel\Cache\Cache
         arguments:
-            $cacheItemPool: '@memory_cache_item_pool'
+            $cacheItemPool: '@transient_cache_item_pool'
 
     PoP\ComponentModel\ModelInstance\ModelInstanceInterface:
         class: \PoP\ComponentModel\ModelInstance\ModelInstance

--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -29,6 +29,11 @@ services:
     PoP\ComponentModel\Engine\DataloadingEngineInterface:
         class: \PoP\ComponentModel\Engine\DataloadingEngine
 
+    PoP\ComponentModel\Cache\PersistentCacheInterface:
+        class: \PoP\ComponentModel\Cache\Cache
+        arguments:
+            $cacheItemPool: '@persistent_cache_item_pool'
+
     PoP\ComponentModel\Cache\TransientCacheInterface:
         class: \PoP\ComponentModel\Cache\Cache
         arguments:

--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -29,7 +29,7 @@ services:
     PoP\ComponentModel\Engine\DataloadingEngineInterface:
         class: \PoP\ComponentModel\Engine\DataloadingEngine
 
-    transient_cache:
+    PoP\ComponentModel\Cache\TransientCacheInterface:
         class: \PoP\ComponentModel\Cache\Cache
         arguments:
             $cacheItemPool: '@transient_cache_item_pool'

--- a/layers/Engine/packages/component-model/src/Cache/Cache.php
+++ b/layers/Engine/packages/component-model/src/Cache/Cache.php
@@ -10,7 +10,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
-class Cache implements CacheInterface
+class Cache implements PersistentCacheInterface, TransientCacheInterface, CacheInterface
 {
     use ReplaceCurrentExecutionDataWithPlaceholdersTrait;
 

--- a/layers/Engine/packages/component-model/src/Cache/PersistentCacheInterface.php
+++ b/layers/Engine/packages/component-model/src/Cache/PersistentCacheInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Cache;
+
+interface PersistentCacheInterface extends CacheInterface
+{
+}

--- a/layers/Engine/packages/component-model/src/Cache/TransientCacheInterface.php
+++ b/layers/Engine/packages/component-model/src/Cache/TransientCacheInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Cache;
+
+interface TransientCacheInterface extends CacheInterface
+{
+}

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Engine;
 
 use Exception;
-use PoP\ComponentModel\Cache\CacheInterface;
+use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\ComponentModel\CheckpointProcessors\CheckpointProcessorManagerInterface;
 use PoP\ComponentModel\ComponentConfiguration;
 use PoP\ComponentModel\ComponentInfo;
@@ -116,7 +116,7 @@ class Engine implements EngineInterface
     protected DataloadHelperServiceInterface $dataloadHelperService;
     protected EntryModuleManagerInterface $entryModuleManager;
     protected RequestHelperServiceInterface $requestHelperService;
-    protected ?CacheInterface $persistentCache = null;
+    protected ?PersistentCacheInterface $persistentCache = null;
 
     #[Required]
     public function autowireEngine(
@@ -135,7 +135,7 @@ class Engine implements EngineInterface
         DataloadHelperServiceInterface $dataloadHelperService,
         EntryModuleManagerInterface $entryModuleManager,
         RequestHelperServiceInterface $requestHelperService,
-        ?CacheInterface $persistentCache = null
+        ?PersistentCacheInterface $persistentCache = null
     ): void {
         $this->translationAPI = $translationAPI;
         $this->hooksAPI = $hooksAPI;

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -116,7 +116,7 @@ class Engine implements EngineInterface
     protected DataloadHelperServiceInterface $dataloadHelperService;
     protected EntryModuleManagerInterface $entryModuleManager;
     protected RequestHelperServiceInterface $requestHelperService;
-    protected ?PersistentCacheInterface $persistentCache = null;
+    protected PersistentCacheInterface $persistentCache;
 
     #[Required]
     public function autowireEngine(
@@ -135,7 +135,7 @@ class Engine implements EngineInterface
         DataloadHelperServiceInterface $dataloadHelperService,
         EntryModuleManagerInterface $entryModuleManager,
         RequestHelperServiceInterface $requestHelperService,
-        ?PersistentCacheInterface $persistentCache = null
+        PersistentCacheInterface $persistentCache,
     ): void {
         $this->translationAPI = $translationAPI;
         $this->hooksAPI = $hooksAPI;

--- a/layers/Engine/packages/component-model/src/Facades/Cache/MemoryManagerFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/MemoryManagerFacade.php
@@ -14,7 +14,7 @@ class MemoryManagerFacade
         /**
          * @var CacheInterface
          */
-        $service = ContainerBuilderFactory::getInstance()->get('memory_cache');
+        $service = ContainerBuilderFactory::getInstance()->get('transient_cache');
         return $service;
     }
 }

--- a/layers/Engine/packages/component-model/src/Facades/Cache/MemoryManagerFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/MemoryManagerFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Facades\Cache;
 
 use PoP\ComponentModel\Cache\CacheInterface;
+use PoP\ComponentModel\Cache\TransientCacheInterface;
 use PoP\Root\Container\ContainerBuilderFactory;
 
 class MemoryManagerFacade
@@ -14,7 +15,7 @@ class MemoryManagerFacade
         /**
          * @var CacheInterface
          */
-        $service = ContainerBuilderFactory::getInstance()->get('transient_cache');
+        $service = ContainerBuilderFactory::getInstance()->get(TransientCacheInterface::class);
         return $service;
     }
 }

--- a/layers/Engine/packages/component-model/src/Facades/Cache/MemoryManagerItemPoolFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/MemoryManagerItemPoolFacade.php
@@ -14,7 +14,7 @@ class MemoryManagerItemPoolFacade
         /**
          * @var CacheItemPoolInterface
          */
-        $service = ContainerBuilderFactory::getInstance()->get('memory_cache_item_pool');
+        $service = ContainerBuilderFactory::getInstance()->get('transient_cache_item_pool');
         return $service;
     }
 }

--- a/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheFacade.php
@@ -9,12 +9,12 @@ use PoP\Root\Container\ContainerBuilderFactory;
 
 class PersistentCacheFacade
 {
-    public static function getInstance(): ?PersistentCacheInterface
+    public static function getInstance(): PersistentCacheInterface
     {
-        $containerBuilderFactory = ContainerBuilderFactory::getInstance();
-        if ($containerBuilderFactory->has(PersistentCacheInterface::class)) {
-            return $containerBuilderFactory->get(PersistentCacheInterface::class);
-        }
-        return null;
+        /**
+         * @var PersistentCacheInterface
+         */
+        $service = ContainerBuilderFactory::getInstance()->get(PersistentCacheInterface::class);
+        return $service;
     }
 }

--- a/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Facades\Cache;
 
 use PoP\ComponentModel\Cache\CacheInterface;
+use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\Root\Container\ContainerBuilderFactory;
 
 class PersistentCacheFacade
@@ -12,8 +13,8 @@ class PersistentCacheFacade
     public static function getInstance(): ?CacheInterface
     {
         $containerBuilderFactory = ContainerBuilderFactory::getInstance();
-        if ($containerBuilderFactory->has('persistent_cache')) {
-            return $containerBuilderFactory->get('persistent_cache');
+        if ($containerBuilderFactory->has(PersistentCacheInterface::class)) {
+            return $containerBuilderFactory->get(PersistentCacheInterface::class);
         }
         return null;
     }

--- a/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheFacade.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Facades\Cache;
 
-use PoP\ComponentModel\Cache\CacheInterface;
 use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\Root\Container\ContainerBuilderFactory;
 
 class PersistentCacheFacade
 {
-    public static function getInstance(): ?CacheInterface
+    public static function getInstance(): ?PersistentCacheInterface
     {
         $containerBuilderFactory = ContainerBuilderFactory::getInstance();
         if ($containerBuilderFactory->has(PersistentCacheInterface::class)) {

--- a/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheItemPoolFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/PersistentCacheItemPoolFacade.php
@@ -9,12 +9,12 @@ use Psr\Cache\CacheItemPoolInterface;
 
 class PersistentCacheItemPoolFacade
 {
-    public static function getInstance(): ?CacheItemPoolInterface
+    public static function getInstance(): CacheItemPoolInterface
     {
-        $containerBuilderFactory = ContainerBuilderFactory::getInstance();
-        if ($containerBuilderFactory->has('persistent_cache_item_pool')) {
-            return $containerBuilderFactory->get('persistent_cache_item_pool');
-        }
-        return null;
+        /**
+         * @var CacheItemPoolInterface
+         */
+        $service = ContainerBuilderFactory::getInstance()->get('persistent_cache_item_pool');
+        return $service;
     }
 }

--- a/layers/Engine/packages/component-model/src/Facades/Cache/TransientCacheManagerFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/TransientCacheManagerFacade.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Facades\Cache;
 
-use PoP\ComponentModel\Cache\CacheInterface;
 use PoP\ComponentModel\Cache\TransientCacheInterface;
 use PoP\Root\Container\ContainerBuilderFactory;
 
 class TransientCacheManagerFacade
 {
-    public static function getInstance(): CacheInterface
+    public static function getInstance(): TransientCacheInterface
     {
         /**
-         * @var CacheInterface
+         * @var TransientCacheInterface
          */
         $service = ContainerBuilderFactory::getInstance()->get(TransientCacheInterface::class);
         return $service;

--- a/layers/Engine/packages/component-model/src/Facades/Cache/TransientCacheManagerFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/TransientCacheManagerFacade.php
@@ -8,7 +8,7 @@ use PoP\ComponentModel\Cache\CacheInterface;
 use PoP\ComponentModel\Cache\TransientCacheInterface;
 use PoP\Root\Container\ContainerBuilderFactory;
 
-class MemoryManagerFacade
+class TransientCacheManagerFacade
 {
     public static function getInstance(): CacheInterface
     {

--- a/layers/Engine/packages/component-model/src/Facades/Cache/TransientCacheManagerItemPoolFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/Cache/TransientCacheManagerItemPoolFacade.php
@@ -7,7 +7,7 @@ namespace PoP\ComponentModel\Facades\Cache;
 use PoP\Root\Container\ContainerBuilderFactory;
 use Psr\Cache\CacheItemPoolInterface;
 
-class MemoryManagerItemPoolFacade
+class TransientCacheManagerItemPoolFacade
 {
     public static function getInstance(): CacheItemPoolInterface
     {

--- a/layers/Engine/packages/engine/config/services.yaml
+++ b/layers/Engine/packages/engine/config/services.yaml
@@ -9,10 +9,10 @@ services:
         arguments:
             $cacheItemPool: '@persistent_cache_item_pool'
 
-    memory_cache:
+    transient_cache:
         class: \PoP\Engine\Cache\Cache
         arguments:
-            $cacheItemPool: '@memory_cache_item_pool'
+            $cacheItemPool: '@transient_cache_item_pool'
 
     PoP\Engine\ObjectModels\Root:
         class: \PoP\Engine\ObjectModels\Root

--- a/layers/Engine/packages/engine/config/services.yaml
+++ b/layers/Engine/packages/engine/config/services.yaml
@@ -9,7 +9,7 @@ services:
         arguments:
             $cacheItemPool: '@persistent_cache_item_pool'
 
-    transient_cache:
+    PoP\ComponentModel\Cache\TransientCacheInterface:
         class: \PoP\Engine\Cache\Cache
         arguments:
             $cacheItemPool: '@transient_cache_item_pool'

--- a/layers/Engine/packages/engine/config/services.yaml
+++ b/layers/Engine/packages/engine/config/services.yaml
@@ -4,7 +4,7 @@ services:
         autowire: true
         autoconfigure: true
 
-    persistent_cache:
+    PoP\ComponentModel\Cache\PersistentCacheInterface:
         class: \PoP\Engine\Cache\Cache
         arguments:
             $cacheItemPool: '@persistent_cache_item_pool'

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -17,7 +17,7 @@ use GraphQLByPoP\GraphQLServer\Schema\SchemaHelpers;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\QueryRootObjectTypeResolver;
 use PoP\API\ComponentConfiguration as APIComponentConfiguration;
 use PoP\API\Registries\SchemaDefinitionRegistryInterface;
-use PoP\ComponentModel\Cache\CacheInterface;
+use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\ComponentModel\Directives\DirectiveTypes;
 use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\Schema\SchemaDefinition;
@@ -29,7 +29,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegistryInterface
 {
-    protected CacheInterface $persistentCache;
+    protected PersistentCacheInterface $persistentCache;
     /**
      * @var array<string, mixed>
      */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -19,7 +19,6 @@ use PoP\API\ComponentConfiguration as APIComponentConfiguration;
 use PoP\API\Registries\SchemaDefinitionRegistryInterface;
 use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\ComponentModel\Directives\DirectiveTypes;
-use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\State\ApplicationState;
@@ -56,13 +55,14 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
         QueryRootObjectTypeResolver $queryRootObjectTypeResolver,
         SchemaDefinitionRegistryInterface $schemaDefinitionRegistry,
         GraphQLSchemaDefinitionServiceInterface $graphQLSchemaDefinitionService,
+        PersistentCacheInterface $persistentCache,
     ): void {
         $this->translationAPI = $translationAPI;
         $this->schemaDefinitionService = $schemaDefinitionService;
         $this->queryRootObjectTypeResolver = $queryRootObjectTypeResolver;
         $this->schemaDefinitionRegistry = $schemaDefinitionRegistry;
         $this->graphQLSchemaDefinitionService = $graphQLSchemaDefinitionService;
-        $this->persistentCache = PersistentCacheFacade::getInstance();
+        $this->persistentCache = $persistentCache;
     }
 
     /**

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-webplatform/kernel/pop-engine.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-webplatform/kernel/pop-engine.php
@@ -49,9 +49,9 @@ class PoPWebPlatform_Engine extends \PoP\ConfigurationComponentModel\Engine\Engi
         $moduleprocessor_manager = ModuleProcessorManagerFacade::getInstance();
         $processor = $moduleprocessor_manager->getProcessor($module);
 
+        $cachemanager = null;
         if ($useCache = ComponentModelComponentConfiguration::useComponentModelCache()) {
             $cachemanager = PersistentCacheFacade::getInstance();
-            $useCache = !is_null($cachemanager);
         }
 
         // From the state we know if to process static/staful content or both

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/js-resourceloader-processor.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/js-resourceloader-processor.php
@@ -1,5 +1,5 @@
 <?php
-use PoP\ComponentModel\Facades\Cache\MemoryManagerFacade;
+use PoP\ComponentModel\Facades\Cache\TransientCacheManagerFacade;
 
 class PoP_JSResourceLoaderProcessor extends PoP_ResourceLoaderProcessor {
 
@@ -73,7 +73,7 @@ class PoP_JSResourceLoaderProcessor extends PoP_ResourceLoaderProcessor {
 		// If these resources have been marked as 'noncritical', then defer loading them
 		if (PoP_WebPlatform_ServerUtils::useProgressiveBooting()) {
 
-			$memorymanager = MemoryManagerFacade::getInstance();
+			$memorymanager = TransientCacheManagerFacade::getInstance();
 			if ($noncritical_resources = $memorymanager->getComponentModelCache($model_instance_id, POP_MEMORYTYPE_NONCRITICALRESOURCES)) {
 
 				return in_array($resource, $noncritical_resources);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-processor-utils.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-processor-utils.php
@@ -1,6 +1,6 @@
 <?php
 
-use PoP\ComponentModel\Facades\Cache\MemoryManagerFacade;
+use PoP\ComponentModel\Facades\Cache\TransientCacheManagerFacade;
 use PoP\ComponentModel\Facades\Engine\EngineFacade;
 use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
 use PoP\ComponentModel\Misc\GeneralUtils;
@@ -230,7 +230,7 @@ class PoP_ResourceLoaderProcessorUtils {
         // bundle(group)s, which are calculated all at the beginning, and created all later together; if we don't
         // keep the $model_instance_id, we don't know what non-critical resources belong to which generation process
         if ($noncritical_resources) {
-            $memorymanager = MemoryManagerFacade::getInstance();
+            $memorymanager = TransientCacheManagerFacade::getInstance();
             $memorymanager->storeComponentModelCache($model_instance_id, POP_MEMORYTYPE_NONCRITICALRESOURCES, $noncritical_resources);
         }
 
@@ -719,7 +719,7 @@ class PoP_ResourceLoaderProcessorUtils {
         // We also need to get the dynamic-templates and save it on the vars cache.
         // It will be needed from there when doing `function isDefer(array $resource, $model_instance_id)`
         if ($dynamic_template_resources = $entry_processorresourcedecorator->getDynamicTemplateResourcesMergedmoduletree($entryModule, $entry_model_props)) {
-            $memorymanager = MemoryManagerFacade::getInstance();
+            $memorymanager = TransientCacheManagerFacade::getInstance();
             $memorymanager->storeComponentModelCache($model_instance_id, POP_MEMORYTYPE_DYNAMICTEMPLATERESOURCES, $dynamic_template_resources);
         }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-scriptsandstyles-utils.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-scriptsandstyles-utils.php
@@ -1,7 +1,7 @@
 <?php
 
 use PoP\ComponentModel\ComponentConfiguration as ComponentModelComponentConfiguration;
-use PoP\ComponentModel\Facades\Cache\MemoryManagerFacade;
+use PoP\ComponentModel\Facades\Cache\TransientCacheManagerFacade;
 use PoP\ComponentModel\Facades\Cache\PersistentCacheFacade;
 use PoP\ComponentModel\Facades\Engine\EngineFacade;
 use PoP\ComponentModel\Facades\ModuleProcessors\ModuleProcessorManagerFacade;
@@ -280,7 +280,7 @@ class PoPWebPlatform_ResourceLoader_ScriptsAndStylesUtils {
         // Check if the list of scripts has been cached in pop-cache/ first
         // If so, just return it from there directly
         global $pop_resourceloader_generatedfilesmanager, $pop_resourceloaderprocessor_manager;
-        $memorymanager = MemoryManagerFacade::getInstance();
+        $memorymanager = TransientCacheManagerFacade::getInstance();
 
         if (!$model_instance_id) {
             $model_instance_id = \PoP\ComponentModel\Facades\ModelInstance\ModelInstanceFacade::getInstance()->getModelInstanceId();
@@ -405,7 +405,7 @@ class PoPWebPlatform_ResourceLoader_ScriptsAndStylesUtils {
         if (PoP_WebPlatform_ServerUtils::useProgressiveBooting()) {
 
             // If these resources have been marked as 'noncritical', then defer loading them
-            $memorymanager = MemoryManagerFacade::getInstance();
+            $memorymanager = TransientCacheManagerFacade::getInstance();
             if ($noncritical_resources = $memorymanager->getComponentModelCache($model_instance_id, POP_MEMORYTYPE_NONCRITICALRESOURCES)) {
 
                 $defer_resources = array_values(

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-scriptsandstyles-utils.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-scriptsandstyles-utils.php
@@ -17,9 +17,9 @@ class PoPWebPlatform_ResourceLoader_ScriptsAndStylesUtils {
         // Check if the list of scripts has been cached in pop-cache/ first
         // If so, just return it from there directly
         global $pop_resourceloader_generatedfilesmanager, $pop_resourceloaderprocessor_manager;
+        $cachemanager = null;
         if ($useCache = ComponentModelComponentConfiguration::useComponentModelCache()) {
             $cachemanager = PersistentCacheFacade::getInstance();
-            $useCache = !is_null($cachemanager);
         }
 
         if (!$model_instance_id) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-scriptsandstyles-utils.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/resourceloader-scriptsandstyles-utils.php
@@ -573,14 +573,14 @@ class PoPWebPlatform_ResourceLoader_ScriptsAndStylesUtils {
                     // Lazy load the object
                     if (is_null(self::$dynamic_module_resources)) {
 
+                        $cachemanager = null;
                         if ($useCache = ComponentModelComponentConfiguration::useComponentModelCache()) {
                             $cachemanager = PersistentCacheFacade::getInstance();
-                            $useCache = !is_null($cachemanager);
                         }
 
                         // Check if results are already on the cache
                         if ($useCache) {
-                            self::$dynamic_module_resources = $cachemanager->getComponentModelCacheByModelInstance(POP_CACHETYPE_DYNAMICMODULERESOURCES);
+                            self::$dynamic_module_resources = $cachemanager->getCacheByModelInstance(POP_CACHETYPE_DYNAMICMODULERESOURCES);
                         }
                         if (!self::$dynamic_module_resources) {
 
@@ -593,11 +593,12 @@ class PoPWebPlatform_ResourceLoader_ScriptsAndStylesUtils {
                             $moduleprocessor_manager = ModuleProcessorManagerFacade::getInstance();
                             $processor = $moduleprocessor_manager->getProcessor($entryModule);
                             $processorresourcedecorator = $pop_resourcemoduledecoratorprocessor_manager->getProcessorDecorator($processor);
-                            self::$dynamic_module_resources = $processorresourcedecorator->getDynamicResourcesMergedmoduletree($entryModule, $props);
+                            // @todo Check where $props comes from. Temporarily replaced with [] to avoid IDE error
+                            self::$dynamic_module_resources = $processorresourcedecorator->getDynamicResourcesMergedmoduletree($entryModule, []/*$props*/);
 
                             // And store them on the cache
                             if ($useCache) {
-                                $cachemanager->storeComponentModelCacheByModelInstance(POP_CACHETYPE_DYNAMICMODULERESOURCES, self::$dynamic_module_resources);
+                                $cachemanager->storeCacheByModelInstance(POP_CACHETYPE_DYNAMICMODULERESOURCES, self::$dynamic_module_resources);
                             }
                         }
                     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/template-resourceloader-processor.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-resourceloader/kernel/resourceloaders/processor/template-resourceloader-processor.php
@@ -1,5 +1,5 @@
 <?php
-use PoP\ComponentModel\Facades\Cache\MemoryManagerFacade;
+use PoP\ComponentModel\Facades\Cache\TransientCacheManagerFacade;
 use PoP\Hooks\Facades\HooksAPIFacade;
 
 abstract class PoP_TemplateResourceLoaderProcessor extends PoP_JSResourceLoaderProcessor {
@@ -52,7 +52,7 @@ abstract class PoP_TemplateResourceLoaderProcessor extends PoP_JSResourceLoaderP
 
 			// Instead of checking from the current dynamic-templates, get the value from the resource-cache,
 			// so that it also works for when generating the bundle(group) files during the /generate-theme/ process
-			$memorymanager = MemoryManagerFacade::getInstance();
+			$memorymanager = TransientCacheManagerFacade::getInstance();
 			if ($dynamic_template_resources = $memorymanager->getComponentModelCache($model_instance_id, POP_MEMORYTYPE_DYNAMICTEMPLATERESOURCES)) {
 
 				// Comment Leo 20/11/2017: taking a very aggressive approach: make all templates be deferred,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-ssr/kernel/functions/engine-initialization-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-ssr/kernel/functions/engine-initialization-hooks.php
@@ -138,9 +138,9 @@ class PoP_SSR_EngineInitialization_Hooks
 
         // Get the static data properties
         // First check if there's a cache stored
+        $cachemanager = null;
         if ($useCache = ComponentModelComponentConfiguration::useComponentModelCache()) {
             $cachemanager = PersistentCacheFacade::getInstance();
-            $useCache = !is_null($cachemanager);
         }
         $dynamic_data_properties = null;
         if ($useCache) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-ssr/kernel/functions/engine-initialization-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-ssr/kernel/functions/engine-initialization-hooks.php
@@ -181,7 +181,7 @@ class PoP_SSR_EngineInitialization_Hooks
         $data['dbData'] = $dynamicdatabases;
     }
 
-    protected function addDynamicDatabaseEntries(&$data, &$dynamicdatabases, $dbobjectids, RelationalTypeResolverInterface $subcomponentTypeResolver, array $data_properties)
+    protected function addDynamicDatabaseEntries(&$data, &$dynamicdatabases, $dbobjectids, RelationalTypeResolverInterface $relationalTypeResolver, array $data_properties)
     {
         if ($data_properties['data-fields'] ?? null) {
             $instanceManager = InstanceManagerFacade::getInstance();


### PR DESCRIPTION
Instead of referencing them via names `persistent_cache` and `memory_cache` in `services.yaml`, create an interface for each: `PersistentCacheInterface` and `TransientCacheInterface`, and use those to define the services.