### PR TITLE
Deal with the resolver object in SchemaFieldArgs

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -29,6 +29,7 @@ use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\FieldQuery\QueryHelpers;
 use PoP\Hooks\HooksAPIInterface;
+use PoP\Root\Environment as RootEnvironment;
 use PoP\Translation\TranslationAPIInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -987,6 +988,9 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface, 
                     $schemaTraces
                 );
             } catch (Exception $e) {
+                if (RootEnvironment::isApplicationEnvironmentDev()) {
+                    throw $e;
+                }
                 $failureMessage = sprintf(
                     $this->translationAPI->__('Resolving directive \'%s\' produced an exception, with message: \'%s\'', 'component-model'),
                     $this->directive,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -693,6 +693,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         ];
 
         $fieldTypeResolver = $this->getFieldTypeResolver($objectTypeResolver, $fieldName);
+        $schemaDefinition[SchemaDefinition::ARGNAME_TYPE_RESOLVER] = $fieldTypeResolver;
         if ($fieldTypeResolver instanceof RelationalTypeResolverInterface) {
             $type = $fieldTypeResolver->getMaybeNamespacedTypeName();
             $schemaDefinition[SchemaDefinition::ARGNAME_RELATIONAL] = true;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -711,7 +711,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
             // Scalar type
             $type = $fieldTypeResolver->getMaybeNamespacedTypeName();
         }
-        $schemaDefinition[SchemaDefinition::ARGNAME_TYPE] = $type;
+        $schemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] = $type;
 
         // Use bitwise operators to extract the applied modifiers
         // @see https://www.php.net/manual/en/language.operators.bitwise.php#91291

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -133,7 +133,7 @@ trait FieldOrDirectiveResolverTrait
              * Whenever the value may be an array, the server will skip those validations
              * to check if an input is array or not (and throw an error).
              */
-            $fieldOrDirectiveArgType = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+            $fieldOrDirectiveArgType = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
             $fieldOrDirectiveArgMayBeArray = in_array($fieldOrDirectiveArgType, [
                 SchemaDefinition::TYPE_INPUT_OBJECT,
                 SchemaDefinition::TYPE_OBJECT,
@@ -322,7 +322,7 @@ trait FieldOrDirectiveResolverTrait
              * Whenever the value may be an array, the server will skip those validations
              * to check if an input is array or not (and throw an error).
              */
-            $enumTypeFieldOrDirectiveArgType = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+            $enumTypeFieldOrDirectiveArgType = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
             $enumTypeFieldOrDirectiveArgMayBeArray = in_array($enumTypeFieldOrDirectiveArgType, [
                 SchemaDefinition::TYPE_INPUT_OBJECT,
                 SchemaDefinition::TYPE_OBJECT,

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -133,8 +133,8 @@ trait FieldOrDirectiveResolverTrait
              * Whenever the value may be an array, the server will skip those validations
              * to check if an input is array or not (and throw an error).
              */
-            $fieldOrDirectiveArgType = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
-            $fieldOrDirectiveArgMayBeArray = in_array($fieldOrDirectiveArgType, [
+            $fieldOrDirectiveArgTypeName = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+            $fieldOrDirectiveArgMayBeArray = in_array($fieldOrDirectiveArgTypeName, [
                 SchemaDefinition::TYPE_INPUT_OBJECT,
                 SchemaDefinition::TYPE_OBJECT,
                 SchemaDefinition::TYPE_MIXED,
@@ -322,8 +322,8 @@ trait FieldOrDirectiveResolverTrait
              * Whenever the value may be an array, the server will skip those validations
              * to check if an input is array or not (and throw an error).
              */
-            $enumTypeFieldOrDirectiveArgType = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
-            $enumTypeFieldOrDirectiveArgMayBeArray = in_array($enumTypeFieldOrDirectiveArgType, [
+            $enumTypeFieldOrDirectiveArgTypeName = $enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+            $enumTypeFieldOrDirectiveArgMayBeArray = in_array($enumTypeFieldOrDirectiveArgTypeName, [
                 SchemaDefinition::TYPE_INPUT_OBJECT,
                 SchemaDefinition::TYPE_OBJECT,
                 SchemaDefinition::TYPE_MIXED,

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -281,7 +281,15 @@ trait FieldOrDirectiveResolverTrait
         array $fieldOrDirectiveArgs,
         string $type
     ): array {
-        $key = serialize($enumTypeFieldOrDirectiveArgsSchemaDefinition) . '|' . $fieldOrDirectiveName . serialize($fieldOrDirectiveArgs);
+        // Remove the resolver before serialization, or it throws an error
+        $serializableEnumTypeFieldOrDirectiveArgsSchemaDefinition = array_map(
+            function (array $enumTypeFieldOrDirectiveArgSchemaDefinition): array {
+                unset($enumTypeFieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_RESOLVER]);
+                return $enumTypeFieldOrDirectiveArgSchemaDefinition;
+            },
+            $enumTypeFieldOrDirectiveArgsSchemaDefinition
+        );
+        $key = serialize($serializableEnumTypeFieldOrDirectiveArgsSchemaDefinition) . '|' . $fieldOrDirectiveName . serialize($fieldOrDirectiveArgs);
         if (!isset($this->enumValueArgumentValidationCache[$key])) {
             $this->enumValueArgumentValidationCache[$key] = $this->doValidateEnumFieldOrDirectiveArguments($enumTypeFieldOrDirectiveArgsSchemaDefinition, $fieldOrDirectiveName, $fieldOrDirectiveArgs, $type);
         }

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveSchemaDefinitionResolverTrait.php
@@ -23,7 +23,7 @@ trait FieldOrDirectiveSchemaDefinitionResolverTrait
             SchemaDefinition::ARGNAME_NAME => $argName,
         ];
         if ($argInputTypeResolver instanceof EnumTypeResolverInterface) {
-            $schemaFieldOrDirectiveArgDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaDefinition::TYPE_ENUM;
+            $schemaFieldOrDirectiveArgDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaDefinition::TYPE_ENUM;
             /** @var EnumTypeResolverInterface */
             $argEnumTypeResolver = $argInputTypeResolver;
             $schemaFieldOrDirectiveArgDefinition[SchemaDefinition::ARGNAME_ENUM_NAME] = $argEnumTypeResolver->getMaybeNamespacedTypeName();
@@ -31,7 +31,7 @@ trait FieldOrDirectiveSchemaDefinitionResolverTrait
                 $argEnumTypeResolver
             );
         } else {
-            $schemaFieldOrDirectiveArgDefinition[SchemaDefinition::ARGNAME_TYPE] = $argInputTypeResolver->getMaybeNamespacedTypeName();
+            $schemaFieldOrDirectiveArgDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] = $argInputTypeResolver->getMaybeNamespacedTypeName();
         }
         if ($argDescription !== null) {
             $schemaFieldOrDirectiveArgDefinition[SchemaDefinition::ARGNAME_DESCRIPTION] = $argDescription;

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveSchemaDefinitionResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveSchemaDefinitionResolverTrait.php
@@ -21,6 +21,7 @@ trait FieldOrDirectiveSchemaDefinitionResolverTrait
     ): array {
         $schemaFieldOrDirectiveArgDefinition = [
             SchemaDefinition::ARGNAME_NAME => $argName,
+            SchemaDefinition::ARGNAME_TYPE_RESOLVER => $argInputTypeResolver,
         ];
         if ($argInputTypeResolver instanceof EnumTypeResolverInterface) {
             $schemaFieldOrDirectiveArgDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaDefinition::TYPE_ENUM;

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1281,7 +1281,9 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         if (!array_key_exists($field, $this->fieldArgumentNameTypeResolversCache[$objectTypeResolverClass] ?? [])) {
             $this->fieldArgumentNameTypeResolversCache[$objectTypeResolverClass][$field] = $this->doGetFieldArgumentNameTypeResolvers($objectTypeResolver, $field);
         }
-        return $this->fieldArgumentNameTypeResolversCache[$objectTypeResolverClass][$field];
+        /** @var array<string, InputTypeResolverInterface>|null */
+        $fieldArgumentNameTypeResolvers = $this->fieldArgumentNameTypeResolversCache[$objectTypeResolverClass][$field];
+        return $fieldArgumentNameTypeResolvers;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -15,6 +15,7 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Resolvers\ResolverTypes;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\AbstractRelationalTypeResolver;
+use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
@@ -56,13 +57,13 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
      */
     private array $extractedDirectiveArgumentWarningsCache = [];
     /**
-     * @var array<string, array>
+     * @var array<string, array<string, array<string, array<string, InputTypeResolverInterface>|null>>>
      */
-    private array $fieldArgumentNameTypesCache = [];
+    private array $fieldArgumentNameTypeResolversCache = [];
     /**
-     * @var array<string, array>
+     * @var array<string, array<string, array<string, InputTypeResolverInterface>>>
      */
-    private array $directiveArgumentNameTypesCache = [];
+    private array $directiveArgumentNameTypeResolversCache = [];
     /**
      * @var array<string, array>
      */
@@ -346,13 +347,13 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         $directiveArgumentNameDefaultValues = $this->getDirectiveArgumentNameDefaultValues($directiveResolver, $relationalTypeResolver);
         // Iterate all the elements, and extract them into the array
         if ($directiveArgElems = QueryHelpers::getFieldArgElements($this->getFieldDirectiveArgs($fieldDirective))) {
-            $directiveArgumentNameTypes = $this->getDirectiveArgumentNameTypes($directiveResolver, $relationalTypeResolver);
+            $directiveArgumentNameTypeResolvers = $this->getDirectiveArgumentNameTypeResolvers($directiveResolver, $relationalTypeResolver);
             $orderedDirectiveArgNamesEnabled = $directiveResolver->enableOrderedSchemaDirectiveArgs($relationalTypeResolver);
             return $this->extractAndValidateFielOrDirectiveArguments(
                 $fieldDirective,
                 $directiveArgElems,
                 $orderedDirectiveArgNamesEnabled,
-                $directiveArgumentNameTypes,
+                $directiveArgumentNameTypeResolvers,
                 $directiveArgumentNameDefaultValues,
                 $variables,
                 $schemaErrors,
@@ -365,13 +366,18 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
     }
 
     /**
-     * Extract the arguments for either the field or directive. If the argument name has not been provided, attempt to deduce it from the schema, or show a warning if not possible
+     * Extract the arguments for either the field or directive.
+     * If the argument name has not been provided,
+     * attempt to deduce it from the schema,
+     * or show a warning if not possible
+     * 
+     * @param array<string, InputTypeResolverInterface> $fieldOrDirectiveArgumentNameTypeResolvers
      */
     protected function extractAndValidateFielOrDirectiveArguments(
         string $fieldOrDirective,
         array $fieldOrDirectiveArgElems,
         bool $orderedFieldOrDirectiveArgNamesEnabled,
-        array $fieldOrDirectiveArgumentNameTypes,
+        array $fieldOrDirectiveArgumentNameTypeResolvers,
         array $fieldOrDirectiveArgumentNameDefaultValues,
         ?array $variables,
         array &$schemaErrors,
@@ -379,7 +385,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         string $resolverType
     ): array {
         if ($orderedFieldOrDirectiveArgNamesEnabled) {
-            $orderedFieldOrDirectiveArgNames = array_keys($fieldOrDirectiveArgumentNameTypes);
+            $orderedFieldOrDirectiveArgNames = array_keys($fieldOrDirectiveArgumentNameTypeResolvers);
         }
         $fieldOrDirectiveArgs = [];
         $treatUndefinedFieldOrDirectiveArgsAsErrors = ComponentConfiguration::treatUndefinedFieldOrDirectiveArgsAsErrors();
@@ -448,7 +454,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                 $fieldOrDirectiveArgValue = trim(substr($fieldOrDirectiveArg, $separatorPos + strlen(QuerySyntax::SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR)));
                 // Validate that this argument exists in the schema, or show a warning if not
                 // But don't skip it! It may be that the engine accepts the property, it is just not documented!
-                if (!array_key_exists($fieldOrDirectiveArgName, $fieldOrDirectiveArgumentNameTypes)) {
+                if (!array_key_exists($fieldOrDirectiveArgName, $fieldOrDirectiveArgumentNameTypeResolvers)) {
                     $errorMessage = sprintf(
                         $this->translationAPI->__('On %1$s \'%2$s\', argument with name \'%3$s\' has not been documented in the schema', 'pop-component-model'),
                         $resolverType == ResolverTypes::FIELD ? $this->translationAPI->__('field', 'component-model') : $this->translationAPI->__('directive', 'component-model'),
@@ -539,22 +545,23 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         array &$schemaWarnings,
     ): ?array {
         // Iterate all the elements, and extract them into the array
-        $fieldOrDirectiveArgumentNameDefaultValues = $this->getFieldArgumentNameDefaultValues($objectTypeResolver, $field);
-        if ($fieldOrDirectiveArgumentNameDefaultValues === null) {
+        $fieldArgumentNameTypeResolvers = $this->getFieldArgumentNameTypeResolvers($objectTypeResolver, $field);
+        if ($fieldArgumentNameTypeResolvers === null) {
             $schemaErrors[] = [
                 Tokens::PATH => [$field],
                 Tokens::MESSAGE => $this->getNoFieldErrorMessage($objectTypeResolver, $field),
             ];
             return null;
         }
+        /** @var array */
+        $fieldOrDirectiveArgumentNameDefaultValues = $this->getFieldArgumentNameDefaultValues($objectTypeResolver, $field);
         if ($fieldArgElems = QueryHelpers::getFieldArgElements($this->getFieldArgs($field))) {
-            $fieldArgumentNameTypes = $this->getFieldArgumentNameTypes($objectTypeResolver, $field) ?? [];
             $orderedFieldArgNamesEnabled = $objectTypeResolver->enableOrderedSchemaFieldArgs($field);
             return $this->extractAndValidateFielOrDirectiveArguments(
                 $field,
                 $fieldArgElems,
                 $orderedFieldArgNamesEnabled,
-                $fieldArgumentNameTypes,
+                $fieldArgumentNameTypeResolvers,
                 $fieldOrDirectiveArgumentNameDefaultValues,
                 $variables,
                 $schemaErrors,
@@ -1188,17 +1195,23 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         return $this->castFieldArguments($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrorMessages, $objectErrors, false);
     }
 
-    protected function getDirectiveArgumentNameTypes(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver): array
+    /**
+     * @return array<string, InputTypeResolverInterface>
+     */
+    protected function getDirectiveArgumentNameTypeResolvers(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver): array
     {
         $relationalTypeResolverClass = get_class($relationalTypeResolver);
         $directiveResolverClass = get_class($directiveResolver);
-        if (!isset($this->directiveArgumentNameTypesCache[$directiveResolverClass][$relationalTypeResolverClass])) {
-            $this->directiveArgumentNameTypesCache[$directiveResolverClass][$relationalTypeResolverClass] = $this->doGetDirectiveArgumentNameTypes($directiveResolver, $relationalTypeResolver);
+        if (!isset($this->directiveArgumentNameTypeResolversCache[$directiveResolverClass][$relationalTypeResolverClass])) {
+            $this->directiveArgumentNameTypeResolversCache[$directiveResolverClass][$relationalTypeResolverClass] = $this->doGetDirectiveArgumentNameTypeResolvers($directiveResolver, $relationalTypeResolver);
         }
-        return $this->directiveArgumentNameTypesCache[$directiveResolverClass][$relationalTypeResolverClass];
+        return $this->directiveArgumentNameTypeResolversCache[$directiveResolverClass][$relationalTypeResolverClass];
     }
 
-    protected function doGetDirectiveArgumentNameTypes(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver): array
+    /**
+     * @return array<string, InputTypeResolverInterface>
+     */
+    protected function doGetDirectiveArgumentNameTypeResolvers(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver): array
     {
         // Get the fieldDirective argument types, to know to what type it will cast the value
         $directiveArgNameTypes = [];
@@ -1259,27 +1272,33 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         return $this->directiveSchemaDefinitionArgsCache[$directiveResolverClass][$relationalTypeResolverClass];
     }
 
-    protected function getFieldArgumentNameTypes(ObjectTypeResolverInterface $objectTypeResolver, string $field): ?array
+    /**
+     * @return array<string, InputTypeResolverInterface>|null
+     */
+    protected function getFieldArgumentNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $field): ?array
     {
         $objectTypeResolverClass = get_class($objectTypeResolver);
-        if (!array_key_exists($field, $this->fieldArgumentNameTypesCache[$objectTypeResolverClass] ?? [])) {
-            $this->fieldArgumentNameTypesCache[$objectTypeResolverClass][$field] = $this->doGetFieldArgumentNameTypes($objectTypeResolver, $field);
+        if (!array_key_exists($field, $this->fieldArgumentNameTypeResolversCache[$objectTypeResolverClass] ?? [])) {
+            $this->fieldArgumentNameTypeResolversCache[$objectTypeResolverClass][$field] = $this->doGetFieldArgumentNameTypeResolvers($objectTypeResolver, $field);
         }
-        return $this->fieldArgumentNameTypesCache[$objectTypeResolverClass][$field];
+        return $this->fieldArgumentNameTypeResolversCache[$objectTypeResolverClass][$field];
     }
 
-    protected function doGetFieldArgumentNameTypes(ObjectTypeResolverInterface $objectTypeResolver, string $field): ?array
+    /**
+     * @return array<string, InputTypeResolverInterface>|null
+     */
+    protected function doGetFieldArgumentNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $field): ?array
     {
         // Get the field argument types, to know to what type it will cast the value
         $fieldSchemaDefinitionArgs = $this->getFieldSchemaDefinitionArgs($objectTypeResolver, $field);
         if ($fieldSchemaDefinitionArgs === null) {
             return null;
         }
-        $fieldArgNameTypes = [];
+        $fieldArgNameTypeResolvers = [];
         foreach ($fieldSchemaDefinitionArgs as $fieldSchemaDefinitionArg) {
-            $fieldArgNameTypes[$fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE];
+            $fieldArgNameTypeResolvers[$fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE];
         }
-        return $fieldArgNameTypes;
+        return $fieldArgNameTypeResolvers;
     }
 
     protected function getFieldArgumentNameDefaultValues(ObjectTypeResolverInterface $objectTypeResolver, string $field): ?array
@@ -1366,23 +1385,24 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         // If any casting can't be done, show an error
         if ($failedCastingDirectiveArgErrorMessages) {
             $directiveName = $this->getFieldDirectiveName($fieldDirective);
-            $directiveArgNameTypes = $this->getDirectiveArgumentNameTypes($directiveResolver, $relationalTypeResolver);
+            $directiveArgNameTypeResolvers = $this->getDirectiveArgumentNameTypeResolvers($directiveResolver, $relationalTypeResolver);
             $directiveArgNameSchemaDefinition = $this->getDirectiveSchemaDefinitionArgs($directiveResolver, $relationalTypeResolver);
             $treatTypeCoercingFailuresAsErrors = ComponentConfiguration::treatTypeCoercingFailuresAsErrors();
             foreach (array_keys($failedCastingDirectiveArgErrorMessages) as $failedCastingDirectiveArgName) {
                 // If it is Error, also show the error message
                 $directiveArgIsArrayType = $directiveArgNameSchemaDefinition[$failedCastingDirectiveArgName][SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
                 $directiveArgIsArrayOfArraysType = $directiveArgNameSchemaDefinition[$failedCastingDirectiveArgName][SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
-                $composedDirectiveArgType = $directiveArgNameTypes[$failedCastingDirectiveArgName];
+                $composedDirectiveArgTypeResolver = $directiveArgNameTypeResolvers[$failedCastingDirectiveArgName];
+                $composedDirectiveArgTypeName = $composedDirectiveArgTypeResolver->getMaybeNamespacedTypeName();
                 if ($directiveArgIsArrayOfArraysType) {
-                    $composedDirectiveArgType = sprintf(
+                    $composedDirectiveArgTypeName = sprintf(
                         $this->translationAPI->__('array of arrays of %s', 'pop-component-model'),
-                        $composedDirectiveArgType
+                        $composedDirectiveArgTypeName
                     );
                 } elseif ($directiveArgIsArrayType) {
-                    $composedDirectiveArgType = sprintf(
+                    $composedDirectiveArgTypeName = sprintf(
                         $this->translationAPI->__('array of %s', 'pop-component-model'),
-                        $composedDirectiveArgType
+                        $composedDirectiveArgTypeName
                     );
                 }
                 if ($directiveArgErrorMessage = $failedCastingDirectiveArgErrorMessages[$failedCastingDirectiveArgName] ?? null) {
@@ -1391,7 +1411,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         $directiveName,
                         is_array($directiveArgs[$failedCastingDirectiveArgName]) ? json_encode($directiveArgs[$failedCastingDirectiveArgName]) : $directiveArgs[$failedCastingDirectiveArgName],
                         $failedCastingDirectiveArgName,
-                        $composedDirectiveArgType,
+                        $composedDirectiveArgTypeName,
                         $directiveArgErrorMessage
                     );
                 } else {
@@ -1400,7 +1420,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         $directiveName,
                         is_array($directiveArgs[$failedCastingDirectiveArgName]) ? json_encode($directiveArgs[$failedCastingDirectiveArgName]) : $directiveArgs[$failedCastingDirectiveArgName],
                         $failedCastingDirectiveArgName,
-                        $composedDirectiveArgType
+                        $composedDirectiveArgTypeName
                     );
                 }
                 // Either treat it as an error or a warning
@@ -1450,23 +1470,32 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         // If any casting can't be done, show an error
         if ($failedCastingFieldArgErrorMessages) {
             $fieldName = $this->getFieldName($field);
-            $fieldArgNameTypes = $this->getFieldArgumentNameTypes($objectTypeResolver, $field) ?? [];
-            $fieldArgNameSchemaDefinition = $this->getFieldSchemaDefinitionArgs($objectTypeResolver, $field) ?? [];
+            $fieldArgNameTypeResolvers = $this->getFieldArgumentNameTypeResolvers($objectTypeResolver, $field);
+            if ($fieldArgNameTypeResolvers === null) {
+                $schemaErrors[] = [
+                    Tokens::PATH => [$field],
+                    Tokens::MESSAGE => $this->getNoFieldErrorMessage($objectTypeResolver, $field),
+                ];
+                return $castedFieldArgs;
+            }
+            /** @var array */
+            $fieldArgNameSchemaDefinition = $this->getFieldSchemaDefinitionArgs($objectTypeResolver, $field);
             $treatTypeCoercingFailuresAsErrors = ComponentConfiguration::treatTypeCoercingFailuresAsErrors();
             foreach (array_keys($failedCastingFieldArgErrorMessages) as $failedCastingFieldArgName) {
                 // If it is Error, also show the error message
                 $fieldArgIsArrayType = $fieldArgNameSchemaDefinition[$failedCastingFieldArgName][SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
                 $fieldArgIsArrayOfArraysType = $fieldArgNameSchemaDefinition[$failedCastingFieldArgName][SchemaDefinition::ARGNAME_IS_ARRAY_OF_ARRAYS] ?? false;
-                $composedFieldArgType = $fieldArgNameTypes[$failedCastingFieldArgName];
+                $composedFieldArgTypeResolver = $fieldArgNameTypeResolvers[$failedCastingFieldArgName];
+                $composedFieldArgTypeName = $composedFieldArgTypeResolver->getMaybeNamespacedTypeName();
                 if ($fieldArgIsArrayOfArraysType) {
-                    $composedFieldArgType = sprintf(
+                    $composedFieldArgTypeName = sprintf(
                         $this->translationAPI->__('array of arrays of %s', 'pop-component-model'),
-                        $composedFieldArgType
+                        $composedFieldArgTypeName
                     );
                 } elseif ($fieldArgIsArrayType) {
-                    $composedFieldArgType = sprintf(
+                    $composedFieldArgTypeName = sprintf(
                         $this->translationAPI->__('array of %s', 'pop-component-model'),
-                        $composedFieldArgType
+                        $composedFieldArgTypeName
                     );
                 }
                 if ($fieldArgErrorMessage = $failedCastingFieldArgErrorMessages[$failedCastingFieldArgName] ?? null) {
@@ -1475,7 +1504,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         $fieldName,
                         is_array($fieldArgs[$failedCastingFieldArgName]) ? json_encode($fieldArgs[$failedCastingFieldArgName]) : $fieldArgs[$failedCastingFieldArgName],
                         $failedCastingFieldArgName,
-                        $composedFieldArgType,
+                        $composedFieldArgTypeName,
                         $fieldArgErrorMessage
                     );
                 } else {
@@ -1484,7 +1513,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         $fieldName,
                         is_array($fieldArgs[$failedCastingFieldArgName]) ? json_encode($fieldArgs[$failedCastingFieldArgName]) : $fieldArgs[$failedCastingFieldArgName],
                         $failedCastingFieldArgName,
-                        $composedFieldArgType
+                        $composedFieldArgTypeName
                     );
                 }
                 if ($treatTypeCoercingFailuresAsErrors) {

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -57,7 +57,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
      */
     private array $extractedDirectiveArgumentWarningsCache = [];
     /**
-     * @var array<string, array<string, array<string, array<string, InputTypeResolverInterface>|null>>>
+     * @var array<string, array<string, array<string, InputTypeResolverInterface>|null>>
      */
     private array $fieldArgumentNameTypeResolversCache = [];
     /**
@@ -370,7 +370,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
      * If the argument name has not been provided,
      * attempt to deduce it from the schema,
      * or show a warning if not possible
-     * 
+     *
      * @param array<string, InputTypeResolverInterface> $fieldOrDirectiveArgumentNameTypeResolvers
      */
     protected function extractAndValidateFielOrDirectiveArguments(

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -978,7 +978,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                  *
                  * In that case, assign type `MIXED`, which implies "Do not cast"
                  **/
-                $fieldOrDirectiveArgType = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_TYPE_NAME] ?? SchemaDefinition::TYPE_MIXED;
+                $fieldOrDirectiveArgTypeName = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_TYPE_NAME] ?? SchemaDefinition::TYPE_ANY_SCALAR;
                 // If not set, the return type is not an array
                 $fieldOrDirectiveArgIsArrayType = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
                 $fieldOrDirectiveArgIsNonNullArrayItemsType = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
@@ -999,7 +999,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                  * Whenever the value may be an array, the server will skip those validations
                  * to check if an input is array or not (and throw an error).
                  */
-                $fieldOrDirectiveArgMayBeArrayType = in_array($fieldOrDirectiveArgType, [
+                $fieldOrDirectiveArgMayBeArrayType = in_array($fieldOrDirectiveArgTypeName, [
                     SchemaDefinition::TYPE_INPUT_OBJECT,
                     SchemaDefinition::TYPE_OBJECT,
                     SchemaDefinition::TYPE_MIXED,
@@ -1116,7 +1116,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         // If it contains a null value, return it as is
                         fn (?array $arrayArgValueElem) => $arrayArgValueElem === null ? null : array_map(
                             fn (mixed $arrayOfArraysArgValueElem) => $arrayOfArraysArgValueElem === null ? null : $this->typeCastingExecuter->cast(
-                                $fieldOrDirectiveArgType,
+                                $fieldOrDirectiveArgTypeName,
                                 $arrayOfArraysArgValueElem
                             ),
                             $arrayArgValueElem
@@ -1134,7 +1134,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                     // If the value is an array, then cast each element to the item type
                     $argValue = $argValue === null ? null : array_map(
                         fn (mixed $arrayArgValueElem) => $arrayArgValueElem === null ? null : $this->typeCastingExecuter->cast(
-                            $fieldOrDirectiveArgType,
+                            $fieldOrDirectiveArgTypeName,
                             $arrayArgValueElem
                         ),
                         $argValue
@@ -1145,7 +1145,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                     );
                 } else {
                     // Otherwise, simply cast the given value directly
-                    $argValue = $argValue === null ? null : $this->typeCastingExecuter->cast($fieldOrDirectiveArgType, $argValue);
+                    $argValue = $argValue === null ? null : $this->typeCastingExecuter->cast($fieldOrDirectiveArgTypeName, $argValue);
                     if (GeneralUtils::isError($argValue)) {
                         /** @var Error $argValue */
                         $errorArgValues[] = $argValue;
@@ -1217,7 +1217,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         $directiveArgNameTypes = [];
         if ($directiveSchemaDefinitionArgs = $this->getDirectiveSchemaDefinitionArgs($directiveResolver, $relationalTypeResolver)) {
             foreach ($directiveSchemaDefinitionArgs as $directiveSchemaDefinitionArg) {
-                $directiveArgNameTypes[$directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE_NAME];
+                $directiveArgNameTypes[$directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE_RESOLVER];
             }
         }
         return $directiveArgNameTypes;
@@ -1296,7 +1296,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         }
         $fieldArgNameTypeResolvers = [];
         foreach ($fieldSchemaDefinitionArgs as $fieldSchemaDefinitionArg) {
-            $fieldArgNameTypeResolvers[$fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE_NAME];
+            $fieldArgNameTypeResolvers[$fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE_RESOLVER];
         }
         return $fieldArgNameTypeResolvers;
     }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -978,7 +978,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                  *
                  * In that case, assign type `MIXED`, which implies "Do not cast"
                  **/
-                $fieldOrDirectiveArgType = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_TYPE] ?? SchemaDefinition::TYPE_MIXED;
+                $fieldOrDirectiveArgType = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_TYPE_NAME] ?? SchemaDefinition::TYPE_MIXED;
                 // If not set, the return type is not an array
                 $fieldOrDirectiveArgIsArrayType = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_IS_ARRAY] ?? false;
                 $fieldOrDirectiveArgIsNonNullArrayItemsType = $fieldOrDirectiveArgSchemaDefinition[$argName][SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false;
@@ -1217,7 +1217,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         $directiveArgNameTypes = [];
         if ($directiveSchemaDefinitionArgs = $this->getDirectiveSchemaDefinitionArgs($directiveResolver, $relationalTypeResolver)) {
             foreach ($directiveSchemaDefinitionArgs as $directiveSchemaDefinitionArg) {
-                $directiveArgNameTypes[$directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE];
+                $directiveArgNameTypes[$directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $directiveSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE_NAME];
             }
         }
         return $directiveArgNameTypes;
@@ -1296,7 +1296,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         }
         $fieldArgNameTypeResolvers = [];
         foreach ($fieldSchemaDefinitionArgs as $fieldSchemaDefinitionArg) {
-            $fieldArgNameTypeResolvers[$fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE];
+            $fieldArgNameTypeResolvers[$fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_NAME]] = $fieldSchemaDefinitionArg[SchemaDefinition::ARGNAME_TYPE_NAME];
         }
         return $fieldArgNameTypeResolvers;
     }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -10,6 +10,7 @@ class SchemaDefinition
     const ARGNAME_NAME = 'name';
     const ARGNAME_NAMESPACED_NAME = 'namespacedName';
     const ARGNAME_ELEMENT_NAME = 'elementName';
+    const ARGNAME_TYPE_RESOLVER = 'typeResolver';
     const ARGNAME_TYPE_NAME = 'typeName';
     const ARGNAME_NON_NULLABLE = 'nonNullable';
     const ARGNAME_IS_ARRAY = 'isArray';

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -10,7 +10,7 @@ class SchemaDefinition
     const ARGNAME_NAME = 'name';
     const ARGNAME_NAMESPACED_NAME = 'namespacedName';
     const ARGNAME_ELEMENT_NAME = 'elementName';
-    const ARGNAME_TYPE = 'type';
+    const ARGNAME_TYPE_NAME = 'typeName';
     const ARGNAME_NON_NULLABLE = 'nonNullable';
     const ARGNAME_IS_ARRAY = 'isArray';
     const ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY = 'isNonNullableItemsInArray';

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -39,7 +39,7 @@ class SchemaHelpers
     {
         return array_filter(
             $fieldOrDirectiveArgsSchemaDefinition,
-            fn ($fieldOrDirectiveArgSchemaDefinition) => $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] == SchemaDefinition::TYPE_ENUM
+            fn ($fieldOrDirectiveArgSchemaDefinition) => $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] == SchemaDefinition::TYPE_ENUM
         );
     }
 

--- a/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaHelpers.php
@@ -39,7 +39,7 @@ class SchemaHelpers
     {
         return array_filter(
             $fieldOrDirectiveArgsSchemaDefinition,
-            fn ($fieldOrDirectiveArgSchemaDefinition) => $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] == SchemaDefinition::TYPE_ENUM
+            fn ($fieldOrDirectiveArgSchemaDefinition) => $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_RESOLVER] instanceof EnumTypeResolverInterface
         );
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -449,8 +449,8 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
                     } elseif (ComponentConfiguration::validateFieldTypeResponseWithSchemaDefinition()) {
                         $fieldSchemaDefinition = $objectTypeFieldResolver->getSchemaDefinitionForField($this, $fieldName, $fieldArgs);
                         // If may be array or not, then there's no validation to do
-                        $fieldType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
-                        $fieldMayBeArrayType = in_array($fieldType, [
+                        $fieldTypeName = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+                        $fieldMayBeArrayType = in_array($fieldTypeName, [
                             SchemaDefinition::TYPE_INPUT_OBJECT,
                             SchemaDefinition::TYPE_OBJECT,
                             SchemaDefinition::TYPE_MIXED,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -449,7 +449,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
                     } elseif (ComponentConfiguration::validateFieldTypeResponseWithSchemaDefinition()) {
                         $fieldSchemaDefinition = $objectTypeFieldResolver->getSchemaDefinitionForField($this, $fieldName, $fieldArgs);
                         // If may be array or not, then there's no validation to do
-                        $fieldType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+                        $fieldType = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
                         $fieldMayBeArrayType = in_array($fieldType, [
                             SchemaDefinition::TYPE_INPUT_OBJECT,
                             SchemaDefinition::TYPE_OBJECT,

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasTypeSchemaDefinitionReferenceTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/HasTypeSchemaDefinitionReferenceTrait.php
@@ -27,7 +27,7 @@ trait HasTypeSchemaDefinitionReferenceTrait
         // each of which initializes their Fields (we are here), which may reference
         // a different Type that doesn't exist yet, and can't be created here
         // or it creates an endless loop
-        $typeName = $this->schemaDefinition[SchemaDefinition::ARGNAME_TYPE];
+        $typeName = $this->schemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
         $this->type = $this->getTypeFromTypeName($typeName);
     }
     public function getTypeID(): string

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -421,8 +421,8 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     protected function introduceSDLNotationToFieldSchemaDefinition(array $fieldSchemaDefinitionPath): void
     {
         $fieldSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinition, $fieldSchemaDefinitionPath);
-        $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
-        $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
+        $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+        $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaHelpers::getTypeToOutputInSchema(
             $type,
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] ?? null,
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
@@ -440,8 +440,8 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
         if ($fieldOrDirectiveArgs = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? null) {
             foreach ($fieldOrDirectiveArgs as $fieldOrDirectiveArgName => $fieldOrDirectiveArgSchemaDefinition) {
                 // The type is set always
-                $type = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE];
-                $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
+                $type = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+                $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaHelpers::getTypeToOutputInSchema(
                     $type,
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null,
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
@@ -452,8 +452,8 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
                 // If it is an input object, it may have its own args to also convert
                 if ($type == SchemaDefinition::TYPE_INPUT_OBJECT) {
                     foreach (($fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? []) as $inputFieldArgName => $inputFieldArgDefinition) {
-                        $inputFieldType = $inputFieldArgDefinition[SchemaDefinition::ARGNAME_TYPE];
-                        $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_ARGS][$inputFieldArgName][SchemaDefinition::ARGNAME_TYPE] = SchemaHelpers::getTypeToOutputInSchema(
+                        $inputFieldType = $inputFieldArgDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+                        $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_ARGS][$inputFieldArgName][SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaHelpers::getTypeToOutputInSchema(
                             $inputFieldType,
                             $inputFieldArgDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null,
                             $inputFieldArgDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
@@ -516,7 +516,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
         $directiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ??= [];
         $directiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][] = [
             SchemaDefinition::ARGNAME_NAME => SchemaElements::DIRECTIVE_PARAM_NESTED_UNDER,
-            SchemaDefinition::ARGNAME_TYPE => GraphQLServerSchemaDefinition::TYPE_INT,
+            SchemaDefinition::ARGNAME_TYPE_NAME => GraphQLServerSchemaDefinition::TYPE_INT,
             SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Nest the directive under another one, indicated as a relative position from this one (a negative int)', 'graphql-server'),
         ];
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -421,9 +421,9 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     protected function introduceSDLNotationToFieldSchemaDefinition(array $fieldSchemaDefinitionPath): void
     {
         $fieldSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinition, $fieldSchemaDefinitionPath);
-        $type = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+        $typeName = $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
         $fieldSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaHelpers::getTypeToOutputInSchema(
-            $type,
+            $typeName,
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_NON_NULLABLE] ?? null,
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
             $fieldSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false,
@@ -440,9 +440,9 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
         if ($fieldOrDirectiveArgs = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? null) {
             foreach ($fieldOrDirectiveArgs as $fieldOrDirectiveArgName => $fieldOrDirectiveArgSchemaDefinition) {
                 // The type is set always
-                $type = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+                $typeName = $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
                 $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaHelpers::getTypeToOutputInSchema(
-                    $type,
+                    $typeName,
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null,
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false,
@@ -450,11 +450,11 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
                     $fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS] ?? false,
                 );
                 // If it is an input object, it may have its own args to also convert
-                if ($type == SchemaDefinition::TYPE_INPUT_OBJECT) {
+                if ($typeName === SchemaDefinition::TYPE_INPUT_OBJECT) {
                     foreach (($fieldOrDirectiveArgSchemaDefinition[SchemaDefinition::ARGNAME_ARGS] ?? []) as $inputFieldArgName => $inputFieldArgDefinition) {
-                        $inputFieldType = $inputFieldArgDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
+                        $inputFieldTypeName = $inputFieldArgDefinition[SchemaDefinition::ARGNAME_TYPE_NAME];
                         $fieldOrDirectiveSchemaDefinition[SchemaDefinition::ARGNAME_ARGS][$fieldOrDirectiveArgName][SchemaDefinition::ARGNAME_ARGS][$inputFieldArgName][SchemaDefinition::ARGNAME_TYPE_NAME] = SchemaHelpers::getTypeToOutputInSchema(
-                            $inputFieldType,
+                            $inputFieldTypeName,
                             $inputFieldArgDefinition[SchemaDefinition::ARGNAME_MANDATORY] ?? null,
                             $inputFieldArgDefinition[SchemaDefinition::ARGNAME_IS_ARRAY] ?? false,
                             $inputFieldArgDefinition[SchemaDefinition::ARGNAME_IS_NON_NULLABLE_ITEMS_IN_ARRAY] ?? false,

--- a/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
@@ -98,17 +98,17 @@ class PostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     //                 [
     //                     [
     //                         SchemaDefinition::ARGNAME_NAME => 'filterBy',
-    //                         SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_INPUT_OBJECT,
+    //                         SchemaDefinition::ARGNAME_TYPE_NAME => SchemaDefinition::TYPE_INPUT_OBJECT,
     //                         SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Filter the block results based on different properties', 'block-metadata'),
     //                         SchemaDefinition::ARGNAME_ARGS => [
     //                             [
     //                                 SchemaDefinition::ARGNAME_NAME => 'blockNameStartsWith',
-    //                                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
+    //                                 SchemaDefinition::ARGNAME_TYPE_NAME => SchemaDefinition::TYPE_STRING,
     //                                 SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Include only blocks with the given name', 'block-metadata'),
     //                             ],
     //                             [
     //                                 SchemaDefinition::ARGNAME_NAME => 'metaProperties',
-    //                                 SchemaDefinition::ARGNAME_TYPE => SchemaDefinition::TYPE_STRING,
+    //                                 SchemaDefinition::ARGNAME_TYPE_NAME => SchemaDefinition::TYPE_STRING,
     //                                 SchemaDefinition::ARGNAME_IS_ARRAY => true,
     //                                 SchemaDefinition::ARGNAME_DESCRIPTION => $this->translationAPI->__('Include only these block properties in the meta entry from the block', 'block-metadata'),
     //                             ]


### PR DESCRIPTION
Added entry `ARGNAME_TYPE_RESOLVER` in addition to `ARGNAME_TYPE` (now renamed to `ARGNAME_TYPE_NAME`)