### PR TITLE
Removed `SchemaDefinition::RELATIONAL`

### DIFF
--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -683,10 +683,6 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
             SchemaDefinition::TYPE_NAME => $type,
         ];
 
-        if ($fieldTypeResolver instanceof RelationalTypeResolverInterface) {
-            $schemaDefinition[SchemaDefinition::RELATIONAL] = true;
-        }
-
         // Check it args can be queried without their name
         if ($this->enableOrderedSchemaFieldArgs($objectTypeResolver, $fieldName)) {
             $schemaDefinition[SchemaDefinition::ENABLE_ORDERED_ARGS] = true;

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -31,7 +31,6 @@ class SchemaDefinition
     const ENABLE_ORDERED_ARGS = 'enableOrderedArgs';
     const RESULTS_IMPLEMENT_INTERFACE = 'resultsImplementInterface';
     const INTERFACES = 'interfaces';
-    const RELATIONAL = 'relational';
     const FIELDS = 'fields';
     const CONNECTIONS = 'connections';
     const GLOBAL_CONNECTIONS = 'globalConnections';

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -637,7 +637,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
             $fieldSchemaDefinition[SchemaDefinition::REFERENCED_TYPE] = $typeNames[0];
         }
         $isGlobal = $objectTypeFieldResolver->isGlobal($this, $fieldName);
-        $isConnection = isset($fieldSchemaDefinition[SchemaDefinition::RELATIONAL]) && $fieldSchemaDefinition[SchemaDefinition::RELATIONAL];
+        $isConnection = $fieldSchemaDefinition[SchemaDefinition::TYPE_RESOLVER] instanceof RelationalTypeResolverInterface;
         if ($isGlobal) {
             // If it is relational, it is a global connection
             if ($isConnection) {
@@ -654,10 +654,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
             $entry = $isConnection ?
                 SchemaDefinition::CONNECTIONS :
                 SchemaDefinition::FIELDS;
-        }
-        // Can remove attribute "relational"
-        if ($isConnection) {
-            unset($fieldSchemaDefinition[SchemaDefinition::RELATIONAL]);
         }
         $typeSchemaKey = $this->schemaDefinitionService->getTypeSchemaKey($this);
         $this->schemaDefinition[$typeSchemaKey][$entry][$fieldName] = $fieldSchemaDefinition;


### PR DESCRIPTION
Since providing the typeResolver, we can directly check:

```php
$isConnection = $fieldSchemaDefinition[SchemaDefinition::TYPE_RESOLVER] instanceof RelationalTypeResolverInterface;
```