### PR TITLE
Rename functions to "QualifiedEntries"

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -67,7 +67,7 @@ final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver 
 
         // Check for errors first, warnings and deprecations then
         $success = true;
-        if ($schemaValidationErrors = $objectTypeResolver->resolveFieldValidationErrorDescriptions($field, $variables)) {
+        if ($schemaValidationErrors = $objectTypeResolver->resolveFieldValidationErrorQualifiedEntries($field, $variables)) {
             $schemaErrors = array_merge(
                 $schemaErrors,
                 $schemaValidationErrors

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -74,7 +74,7 @@ final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver 
             );
             $success = false;
         }
-        if ($schemaValidationWarnings = $objectTypeResolver->resolveFieldValidationWarningDescriptions($field, $variables)) {
+        if ($schemaValidationWarnings = $objectTypeResolver->resolveFieldValidationWarningQualifiedEntries($field, $variables)) {
             $schemaWarnings = array_merge(
                 $schemaWarnings,
                 $schemaValidationWarnings

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -80,7 +80,7 @@ final class ValidateDirectiveResolver extends AbstractValidateDirectiveResolver 
                 $schemaValidationWarnings
             );
         }
-        if ($schemaValidationDeprecations = $objectTypeResolver->resolveFieldDeprecationDescriptions($field, $variables)) {
+        if ($schemaValidationDeprecations = $objectTypeResolver->resolveFieldDeprecationQualifiedEntries($field, $variables)) {
             $schemaDeprecations = array_merge(
                 $schemaDeprecations,
                 $schemaValidationDeprecations

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -736,7 +736,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                     $fieldOrDirectiveArgs[$argName] = null;
                 }
                 // Find warnings and deprecations
-                if ($maybeWarnings = $this->resolveFieldArgumentValueWarningsForSchema($objectTypeResolver, $argValue, $variables)) {
+                if ($maybeWarnings = $this->resolveFieldArgumentValueWarningQualifiedEntriesForSchema($objectTypeResolver, $argValue, $variables)) {
                     foreach ($maybeWarnings as $schemaWarning) {
                         array_unshift($schemaWarning[Tokens::PATH], $fieldOrDirective);
                         $schemaWarnings[] = $schemaWarning;
@@ -1777,18 +1777,18 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         return [];
     }
 
-    protected function resolveFieldArgumentValueWarningsForSchema(ObjectTypeResolverInterface $objectTypeResolver, mixed $fieldArgValue, ?array $variables): array
+    protected function resolveFieldArgumentValueWarningQualifiedEntriesForSchema(ObjectTypeResolverInterface $objectTypeResolver, mixed $fieldArgValue, ?array $variables): array
     {
         // If it is an array, apply this function on all elements
         if (is_array($fieldArgValue)) {
             return GeneralUtils::arrayFlatten(array_filter(array_map(function ($fieldArgValueElem) use ($objectTypeResolver, $variables) {
-                return $this->resolveFieldArgumentValueWarningsForSchema($objectTypeResolver, $fieldArgValueElem, $variables);
+                return $this->resolveFieldArgumentValueWarningQualifiedEntriesForSchema($objectTypeResolver, $fieldArgValueElem, $variables);
             }, $fieldArgValue)));
         }
 
         // If the result fieldArgValue is a field, then validate it and resolve it
         if ($this->isFieldArgumentValueAField($fieldArgValue)) {
-            return $objectTypeResolver->resolveFieldValidationWarningDescriptions($fieldArgValue, $variables);
+            return $objectTypeResolver->resolveFieldValidationWarningQualifiedEntries($fieldArgValue, $variables);
         }
 
         return [];

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -742,7 +742,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         $schemaWarnings[] = $schemaWarning;
                     }
                 }
-                if ($maybeDeprecations = $this->resolveFieldArgumentValueDeprecationsForSchema($objectTypeResolver, $argValue, $variables)) {
+                if ($maybeDeprecations = $this->resolveFieldArgumentValueDeprecationQualifiedEntriesForSchema($objectTypeResolver, $argValue, $variables)) {
                     foreach ($maybeDeprecations as $schemaDeprecation) {
                         array_unshift($schemaDeprecation[Tokens::PATH], $fieldOrDirective);
                         $schemaDeprecations[] = $schemaDeprecation;
@@ -1794,18 +1794,18 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         return [];
     }
 
-    protected function resolveFieldArgumentValueDeprecationsForSchema(ObjectTypeResolverInterface $objectTypeResolver, mixed $fieldArgValue, ?array $variables): array
+    protected function resolveFieldArgumentValueDeprecationQualifiedEntriesForSchema(ObjectTypeResolverInterface $objectTypeResolver, mixed $fieldArgValue, ?array $variables): array
     {
         // If it is an array, apply this function on all elements
         if (is_array($fieldArgValue)) {
             return GeneralUtils::arrayFlatten(array_filter(array_map(function ($fieldArgValueElem) use ($objectTypeResolver, $variables) {
-                return $this->resolveFieldArgumentValueDeprecationsForSchema($objectTypeResolver, $fieldArgValueElem, $variables);
+                return $this->resolveFieldArgumentValueDeprecationQualifiedEntriesForSchema($objectTypeResolver, $fieldArgValueElem, $variables);
             }, $fieldArgValue)));
         }
 
         // If the result fieldArgValue is a field, then validate it and resolve it
         if ($this->isFieldArgumentValueAField($fieldArgValue)) {
-            return $objectTypeResolver->resolveFieldDeprecationDescriptions($fieldArgValue, $variables);
+            return $objectTypeResolver->resolveFieldDeprecationQualifiedEntries($fieldArgValue, $variables);
         }
 
         return [];

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -726,7 +726,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         if ($fieldOrDirectiveArgs) {
             foreach ($fieldOrDirectiveArgs as $argName => $argValue) {
                 // Validate it
-                if ($maybeErrors = $this->resolveFieldArgumentValueErrorDescriptionsForSchema($objectTypeResolver, $argValue, $variables)) {
+                if ($maybeErrors = $this->resolveFieldArgumentValueErrorQualifiedEntriesForSchema($objectTypeResolver, $argValue, $variables)) {
                     foreach ($maybeErrors as $schemaError) {
                         array_unshift($schemaError[Tokens::PATH], $fieldOrDirective);
                         $this->prependPathOnNestedErrors($schemaError, $fieldOrDirective);
@@ -1746,12 +1746,12 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         return $fieldArgValue;
     }
 
-    protected function resolveFieldArgumentValueErrorDescriptionsForSchema(ObjectTypeResolverInterface $objectTypeResolver, mixed $fieldArgValue, ?array $variables): array
+    protected function resolveFieldArgumentValueErrorQualifiedEntriesForSchema(ObjectTypeResolverInterface $objectTypeResolver, mixed $fieldArgValue, ?array $variables): array
     {
         // If it is an array, apply this function on all elements
         if (is_array($fieldArgValue)) {
             return GeneralUtils::arrayFlatten(array_filter(array_map(function ($fieldArgValueElem) use ($objectTypeResolver, $variables) {
-                return $this->resolveFieldArgumentValueErrorDescriptionsForSchema($objectTypeResolver, $fieldArgValueElem, $variables);
+                return $this->resolveFieldArgumentValueErrorQualifiedEntriesForSchema($objectTypeResolver, $fieldArgValueElem, $variables);
             }, $fieldArgValue)));
         }
 
@@ -1771,7 +1771,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             }
 
             // If it reached here, it's a field! Validate it, or show an error
-            return $objectTypeResolver->resolveFieldValidationErrorDescriptions($fieldArgValue, $variables);
+            return $objectTypeResolver->resolveFieldValidationErrorQualifiedEntries($fieldArgValue, $variables);
         }
 
         return [];

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -182,7 +182,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
         ];
     }
 
-    final public function resolveFieldValidationWarningDescriptions(string $field, array &$variables = null): array
+    final public function resolveFieldValidationWarningQualifiedEntries(string $field, array &$variables = null): array
     {
         // Get the value from a fieldResolver, from the first one that resolves it
         if ($objectTypeFieldResolvers = $this->getObjectTypeFieldResolversForField($field)) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -207,7 +207,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
         return [];
     }
 
-    final public function resolveFieldDeprecationDescriptions(string $field, array &$variables = null): array
+    final public function resolveFieldDeprecationQualifiedEntries(string $field, array &$variables = null): array
     {
         // Get the value from a fieldResolver, from the first one that resolves it
         if ($objectTypeFieldResolvers = $this->getObjectTypeFieldResolversForField($field)) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -122,7 +122,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
         return null;
     }
 
-    final public function resolveFieldValidationErrorDescriptions(string $field, array &$variables = null): array
+    final public function resolveFieldValidationErrorQualifiedEntries(string $field, array &$variables = null): array
     {
         // Get the value from a fieldResolver, from the first one that resolves it
         list(

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
@@ -15,7 +15,7 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface
     public function hasObjectTypeFieldResolversForField(string $field): bool;
     public function resolveFieldValidationErrorQualifiedEntries(string $field, array &$variables = null): array;
     public function resolveFieldValidationWarningQualifiedEntries(string $field, array &$variables = null): array;
-    public function resolveFieldDeprecationDescriptions(string $field, array &$variables = null): array;
+    public function resolveFieldDeprecationQualifiedEntries(string $field, array &$variables = null): array;
     public function getFieldTypeResolver(string $field): ?ConcreteTypeResolverInterface;
     public function getFieldMutationResolver(string $field): ?MutationResolverInterface;
     public function isFieldAMutation(string $field): ?bool;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
@@ -14,7 +14,7 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface
     public function getFieldSchemaDefinition(string $field): ?array;
     public function hasObjectTypeFieldResolversForField(string $field): bool;
     public function resolveFieldValidationErrorQualifiedEntries(string $field, array &$variables = null): array;
-    public function resolveFieldValidationWarningDescriptions(string $field, array &$variables = null): array;
+    public function resolveFieldValidationWarningQualifiedEntries(string $field, array &$variables = null): array;
     public function resolveFieldDeprecationDescriptions(string $field, array &$variables = null): array;
     public function getFieldTypeResolver(string $field): ?ConcreteTypeResolverInterface;
     public function getFieldMutationResolver(string $field): ?MutationResolverInterface;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
@@ -13,7 +13,7 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface
     public function validateFieldArgumentsForSchema(string $field, array $fieldArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): array;
     public function getFieldSchemaDefinition(string $field): ?array;
     public function hasObjectTypeFieldResolversForField(string $field): bool;
-    public function resolveFieldValidationErrorDescriptions(string $field, array &$variables = null): array;
+    public function resolveFieldValidationErrorQualifiedEntries(string $field, array &$variables = null): array;
     public function resolveFieldValidationWarningDescriptions(string $field, array &$variables = null): array;
     public function resolveFieldDeprecationDescriptions(string $field, array &$variables = null): array;
     public function getFieldTypeResolver(string $field): ?ConcreteTypeResolverInterface;


### PR DESCRIPTION
Functions in ObjectTypeResolver which contain values of type:

```php
$schemaErrors[] = [
    Tokens::PATH => [$field],
    Tokens::MESSAGE => $error,
];
```

must be different from those returning the error/warning/deprecation message, as a string.

So they've been renamed, to including `"QualifiedEntries"`:

- `resolveFieldValidationErrorQualifiedEntries`
- `resolveFieldValidationWarningQualifiedEntries`
- `resolveFieldDeprecationQualifiedEntries`

