### PR TITLE
Remove array spread for functions inside match

### DIFF
--- a/layers/Schema/packages/categories/src/ModuleProcessors/CategoryFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/categories/src/ModuleProcessors/CategoryFilterInputContainerModuleProcessor.php
@@ -36,15 +36,16 @@ class CategoryFilterInputContainerModuleProcessor extends AbstractFilterInputCon
         $topLevelCategoryFilterInputModules = [
             [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_PARENT_ID],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_CATEGORIES => [
                 ...$categoryFilterInputModules,
                 ...$topLevelCategoryFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_CHILDCATEGORIES => [
                 ...$categoryFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_CATEGORYCOUNT => [
                 ...$categoryFilterInputModules,

--- a/layers/Schema/packages/comments/src/ModuleProcessors/CommentFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/comments/src/ModuleProcessors/CommentFilterInputContainerModuleProcessor.php
@@ -73,6 +73,7 @@ class CommentFilterInputContainerModuleProcessor extends AbstractFilterInputCont
         $adminCommentFilterInputModules = [
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_COMMENT_STATUS],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ((string)$module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_COMMENT_BY_ID_STATUS => [
                 [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],
@@ -81,17 +82,17 @@ class CommentFilterInputContainerModuleProcessor extends AbstractFilterInputCont
             self::MODULE_FILTERINPUTCONTAINER_RESPONSECOUNT => $responseFilterInputModules,
             self::MODULE_FILTERINPUTCONTAINER_RESPONSES => [
                 ...$responseFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_COMMENTCOUNT => $customPostCommentFilterInputModules,
             self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_COMMENTS => [
                 ...$customPostCommentFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_COMMENTCOUNT => $rootCommentFilterInputModules,
             self::MODULE_FILTERINPUTCONTAINER_COMMENTS => [
                 ...$rootCommentFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSECOUNT => [
                 ...$responseFilterInputModules,
@@ -99,7 +100,7 @@ class CommentFilterInputContainerModuleProcessor extends AbstractFilterInputCont
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSES => [
                 ...$responseFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
                 ...$adminCommentFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_ADMINCOMMENTCOUNT => [
@@ -108,7 +109,7 @@ class CommentFilterInputContainerModuleProcessor extends AbstractFilterInputCont
             ],
             self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_ADMINCOMMENTS => [
                 ...$customPostCommentFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
                 ...$adminCommentFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTCOUNT => [
@@ -117,7 +118,7 @@ class CommentFilterInputContainerModuleProcessor extends AbstractFilterInputCont
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTS => [
                 ...$rootCommentFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
                 ...$adminCommentFilterInputModules,
             ],
             default => [],

--- a/layers/Schema/packages/customposts/src/ModuleProcessors/CustomPostFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/customposts/src/ModuleProcessors/CustomPostFilterInputContainerModuleProcessor.php
@@ -48,26 +48,27 @@ class CustomPostFilterInputContainerModuleProcessor extends AbstractCustomPostFi
         $adminCustomPostFilterInputModules = [
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOSTSTATUS],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_UNIONCUSTOMPOSTLIST => [
                 ...$customPostFilterInputModules,
                 ...$unionCustomPostFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINUNIONCUSTOMPOSTLIST => [
                 ...$customPostFilterInputModules,
                 ...$unionCustomPostFilterInputModules,
                 ...$adminCustomPostFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOSTLISTLIST => [
                 ...$customPostFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINCUSTOMPOSTLISTLIST => [
                 ...$customPostFilterInputModules,
                 ...$adminCustomPostFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_UNIONCUSTOMPOSTCOUNT => [
                 ...$customPostFilterInputModules,

--- a/layers/Schema/packages/generic-customposts/src/ModuleProcessors/GenericCustomPostFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/generic-customposts/src/ModuleProcessors/GenericCustomPostFilterInputContainerModuleProcessor.php
@@ -40,15 +40,16 @@ class GenericCustomPostFilterInputContainerModuleProcessor extends AbstractCusto
         $adminGenericCustomPostFilterInputModules = [
             [CustomPostFilterInputModuleProcessor::class, CustomPostFilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOSTSTATUS],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_GENERICCUSTOMPOSTLIST=> [
                 ...$genericCustomPostFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINGENERICCUSTOMPOSTLIST => [
                     ...$genericCustomPostFilterInputModules,
                     ...$adminGenericCustomPostFilterInputModules,
-                    ...$this->getPaginationFilterInputModules(),
+                    ...$paginationFilterInputModules,
                 ],
             self::MODULE_FILTERINPUTCONTAINER_GENERICCUSTOMPOSTCOUNT => $genericCustomPostFilterInputModules,
             self::MODULE_FILTERINPUTCONTAINER_ADMINGENERICCUSTOMPOSTCOUNT => [

--- a/layers/Schema/packages/media/src/ModuleProcessors/MediaFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/media/src/ModuleProcessors/MediaFilterInputContainerModuleProcessor.php
@@ -32,10 +32,11 @@ class MediaFilterInputContainerModuleProcessor extends AbstractFilterInputContai
             [CommonFilterMultipleInputModuleProcessor::class, CommonFilterMultipleInputModuleProcessor::MODULE_FILTERINPUT_DATES],
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_MIME_TYPES],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_MEDIAITEMS => [
                 ...$mediaFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_MEDIAITEMCOUNT => [
                 ...$mediaFilterInputModules,

--- a/layers/Schema/packages/menus/src/ModuleProcessors/MenuFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/menus/src/ModuleProcessors/MenuFilterInputContainerModuleProcessor.php
@@ -29,10 +29,11 @@ class MenuFilterInputContainerModuleProcessor extends AbstractFilterInputContain
             [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH],
             [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SLUGS],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_MENUS => [
                 ...$menuFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_MENUCOUNT => $menuFilterInputModules,
             default => [],

--- a/layers/Schema/packages/posts/src/ModuleProcessors/AbstractPostFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/posts/src/ModuleProcessors/AbstractPostFilterInputContainerModuleProcessor.php
@@ -38,15 +38,16 @@ abstract class AbstractPostFilterInputContainerModuleProcessor extends AbstractC
         $statusFilterInputModules = [
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOSTSTATUS],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_POSTS => [
                 ...$postFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_POSTCOUNT => $postFilterInputModules,
             self::MODULE_FILTERINPUTCONTAINER_ADMINPOSTS => [
                 ...$postFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
                 ...$statusFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINPOSTCOUNT => [

--- a/layers/Schema/packages/tags/src/ModuleProcessors/TagFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/tags/src/ModuleProcessors/TagFilterInputContainerModuleProcessor.php
@@ -29,10 +29,11 @@ class TagFilterInputContainerModuleProcessor extends AbstractFilterInputContaine
             [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH],
             [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SLUGS],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_TAGS => [
                 ...$tagFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_TAGCOUNT => $tagFilterInputModules,
             default => [],

--- a/layers/Schema/packages/users/src/ModuleProcessors/UserFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/users/src/ModuleProcessors/UserFilterInputContainerModuleProcessor.php
@@ -35,15 +35,16 @@ class UserFilterInputContainerModuleProcessor extends AbstractFilterInputContain
         $adminUserFilterInputModules = [
             [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_EMAILS],
         ];
+        $paginationFilterInputModules = $this->getPaginationFilterInputModules();
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_USERS => [
                 ...$userFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_ADMINUSERS => [
                 ...$userFilterInputModules,
                 ...$adminUserFilterInputModules,
-                ...$this->getPaginationFilterInputModules(),
+                ...$paginationFilterInputModules,
             ],
             self::MODULE_FILTERINPUTCONTAINER_USERCOUNT => $userFilterInputModules,
             self::MODULE_FILTERINPUTCONTAINER_ADMINUSERCOUNT => [


### PR DESCRIPTION
Issue reported here: https://github.com/rectorphp/rector-src/pull/928#issuecomment-929877707.

Rector doesn't handle downgrading array spread operator for functions inside `match` gracefully, since the new variable is added outside the downgraded `switch`, so that the same function may be repeated multiple times:

```php
public function getFilterInputModules($module) : array
{
    $item0Unpacked = $this->getIDFilterInputModules();
    $responseFilterInputModules = \array_merge($item0Unpacked, [[CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_SEARCH], [CommonFilterMultipleInputModuleProcessor::class, CommonFilterMultipleInputModuleProcessor::MODULE_FILTERINPUT_DATES], [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_COMMENT_TYPES]]);
    $customPostCommentFilterInputModules = \array_merge(\is_array($responseFilterInputModules) ? $responseFilterInputModules : \iterator_to_array($responseFilterInputModules), [[CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_PARENT_ID], [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_PARENT_IDS], [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_EXCLUDE_PARENT_IDS]]);
    $rootCommentFilterInputModules = \array_merge(\is_array($customPostCommentFilterInputModules) ? $customPostCommentFilterInputModules : \iterator_to_array($customPostCommentFilterInputModules), [[FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOST_ID], [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOST_IDS], [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_EXCLUDE_CUSTOMPOST_IDS], [CustomPostFilterInputModuleProcessor::class, CustomPostFilterInputModuleProcessor::MODULE_FILTERINPUT_UNIONCUSTOMPOSTTYPES]]);
    $adminCommentFilterInputModules = [[FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_COMMENT_STATUS]];
    $item1Unpacked = $this->getPaginationFilterInputModules();
    $item2Unpacked = $this->getPaginationFilterInputModules();
    $item3Unpacked = $this->getPaginationFilterInputModules();
    $item4Unpacked = $this->getPaginationFilterInputModules();
    $item5Unpacked = $this->getPaginationFilterInputModules();
    $item6Unpacked = $this->getPaginationFilterInputModules();
    switch ((string) $module[1]) {
        case self::MODULE_FILTERINPUTCONTAINER_COMMENT_BY_ID_STATUS:
            return [[CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID], [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_COMMENT_STATUS]];
        case self::MODULE_FILTERINPUTCONTAINER_RESPONSECOUNT:
            return $responseFilterInputModules;
        case self::MODULE_FILTERINPUTCONTAINER_RESPONSES:
            return \array_merge(\is_array($responseFilterInputModules) ? $responseFilterInputModules : \iterator_to_array($responseFilterInputModules), $item1Unpacked);
        case self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_COMMENTCOUNT:
            return $customPostCommentFilterInputModules;
        case self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_COMMENTS:
            return \array_merge(\is_array($customPostCommentFilterInputModules) ? $customPostCommentFilterInputModules : \iterator_to_array($customPostCommentFilterInputModules), $item2Unpacked);
        case self::MODULE_FILTERINPUTCONTAINER_COMMENTCOUNT:
            return $rootCommentFilterInputModules;
        case self::MODULE_FILTERINPUTCONTAINER_COMMENTS:
            return \array_merge(\is_array($rootCommentFilterInputModules) ? $rootCommentFilterInputModules : \iterator_to_array($rootCommentFilterInputModules), $item3Unpacked);
        case self::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSECOUNT:
            return \array_merge(\is_array($responseFilterInputModules) ? $responseFilterInputModules : \iterator_to_array($responseFilterInputModules), $adminCommentFilterInputModules);
        case self::MODULE_FILTERINPUTCONTAINER_ADMINRESPONSES:
            return \array_merge(\is_array($responseFilterInputModules) ? $responseFilterInputModules : \iterator_to_array($responseFilterInputModules), $item4Unpacked, $adminCommentFilterInputModules);
        case self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_ADMINCOMMENTCOUNT:
            return \array_merge(\is_array($customPostCommentFilterInputModules) ? $customPostCommentFilterInputModules : \iterator_to_array($customPostCommentFilterInputModules), $adminCommentFilterInputModules);
        case self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_ADMINCOMMENTS:
            return \array_merge(\is_array($customPostCommentFilterInputModules) ? $customPostCommentFilterInputModules : \iterator_to_array($customPostCommentFilterInputModules), $item5Unpacked, $adminCommentFilterInputModules);
        case self::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTCOUNT:
            return \array_merge(\is_array($rootCommentFilterInputModules) ? $rootCommentFilterInputModules : \iterator_to_array($rootCommentFilterInputModules), $adminCommentFilterInputModules);
        case self::MODULE_FILTERINPUTCONTAINER_ADMINCOMMENTS:
            return \array_merge(\is_array($rootCommentFilterInputModules) ? $rootCommentFilterInputModules : \iterator_to_array($rootCommentFilterInputModules), $item6Unpacked, $adminCommentFilterInputModules);
        default:
            return [];
    }
}
```

To make this code nicer, this PR extracts calling `...$this->getPaginationFilterInputModules()`, like this:

```php
return match ($module[1]) {
    self::MODULE_FILTERINPUTCONTAINER_ADMINUSERS => [
        ...$userFilterInputModules,
        ...$adminUserFilterInputModules,
        ...$this->getPaginationFilterInputModules(),
    ],
}
```

into an external variable, like this:

```php
$paginationFilterInputModules = $this->getPaginationFilterInputModules();
return match ($module[1]) {
    self::MODULE_FILTERINPUTCONTAINER_ADMINUSERS => [
        ...$userFilterInputModules,
        ...$adminUserFilterInputModules,
        ...$paginationFilterInputModules,
    ],
}
```