### PR TITLE
Removed `::getConfigurationEntries` from traits since it is abstract function

### DIFF
--- a/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForDirectivesInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForDirectivesInPrivateSchemaHookSet.php
@@ -16,7 +16,6 @@ abstract class AbstractConfigurableAccessControlForDirectivesInPrivateSchemaHook
         // However, there is a bug about, still unresolved by PHP 7.2: https://bugs.php.net/bug.php?id=63911
         // It was resolved by PHP 7.3.9, though, but handle to add compatibility up to PHP 7.1
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getEntries insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
-        AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getConfigurationEntries insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getRequiredEntryValue insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolvers insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolverClasses insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForDirectivesInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForDirectivesInPrivateSchemaHookSet.php
@@ -19,6 +19,7 @@ abstract class AbstractConfigurableAccessControlForDirectivesInPrivateSchemaHook
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getRequiredEntryValue insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolvers insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolverClasses insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
+        AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::autowireConfigurableMandatoryDirectivesForDirectivesTrait insteadof ConfigurableMandatoryDirectivesForDirectivesTrait;
     }
 
     protected function enabled(): bool

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet.php
@@ -20,7 +20,6 @@ abstract class AbstractConfigurableAccessControlForFieldsInPrivateSchemaHookSet 
         // However, there is a bug about, still unresolved by PHP 7.2: https://bugs.php.net/bug.php?id=63911
         // It was resolved by PHP 7.3.9, though, but handle to add compatibility up to PHP 7.1
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntries insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
-        AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getConfigurationEntries insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getFieldNames insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntriesByTypeAndInterfaces insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
     }

--- a/layers/Engine/packages/access-control/src/RelationalTypeResolverDecorators/ConfigurableAccessControlForDirectivesRelationalTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/access-control/src/RelationalTypeResolverDecorators/ConfigurableAccessControlForDirectivesRelationalTypeResolverDecoratorTrait.php
@@ -19,6 +19,7 @@ trait ConfigurableAccessControlForDirectivesRelationalTypeResolverDecoratorTrait
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getRequiredEntryValue insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolvers insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolverClasses insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
+        AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::autowireConfigurableMandatoryDirectivesForDirectivesTrait insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
     }
 
     /**

--- a/layers/Engine/packages/access-control/src/RelationalTypeResolverDecorators/ConfigurableAccessControlForDirectivesRelationalTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/access-control/src/RelationalTypeResolverDecorators/ConfigurableAccessControlForDirectivesRelationalTypeResolverDecoratorTrait.php
@@ -16,7 +16,6 @@ trait ConfigurableAccessControlForDirectivesRelationalTypeResolverDecoratorTrait
         // However, there is a bug about, still unresolved by PHP 7.2: https://bugs.php.net/bug.php?id=63911
         // It was resolved by PHP 7.3.9, though, but handle to add compatibility up to PHP 7.1
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getEntries insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
-        AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getConfigurationEntries insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getRequiredEntryValue insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolvers insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForDirectivesTrait::getDirectiveResolverClasses insteadof ConfigurableMandatoryDirectivesForDirectivesRelationalTypeResolverDecoratorTrait;

--- a/layers/Engine/packages/access-control/src/RelationalTypeResolverDecorators/ConfigurableAccessControlForFieldsRelationalTypeResolverDecoratorTrait.php
+++ b/layers/Engine/packages/access-control/src/RelationalTypeResolverDecorators/ConfigurableAccessControlForFieldsRelationalTypeResolverDecoratorTrait.php
@@ -15,7 +15,6 @@ trait ConfigurableAccessControlForFieldsRelationalTypeResolverDecoratorTrait
         // The conflict resolutions below should not be needed, because the functions are not repeated, but it is defined just once in the same source trait
         // However, there is a bug about, still unresolved by PHP 7.2: https://bugs.php.net/bug.php?id=63911
         // It was resolved by PHP 7.3.9, though, but handle to add compatibility up to PHP 7.1
-        AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getConfigurationEntries insteadof ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntries insteadof ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getFieldNames insteadof ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntriesByTypeAndInterfaces insteadof ConfigurableMandatoryDirectivesForFieldsRelationalTypeResolverDecoratorTrait;

--- a/layers/Engine/packages/component-model/src/Cache/Cache.php
+++ b/layers/Engine/packages/component-model/src/Cache/Cache.php
@@ -10,7 +10,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
-class Cache implements PersistentCacheInterface, TransientCacheInterface, CacheInterface
+class Cache implements PersistentCacheInterface, TransientCacheInterface
 {
     use ReplaceCurrentExecutionDataWithPlaceholdersTrait;
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -32,7 +32,6 @@ use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
-use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
@@ -42,9 +41,10 @@ use Symfony\Contracts\Service\Attribute\Required;
 abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver implements ObjectTypeFieldResolverInterface, ObjectTypeFieldSchemaDefinitionResolverInterface
 {
     use AttachableExtensionTrait;
-    use FieldOrDirectiveResolverTrait;
     use WithVersionConstraintFieldOrDirectiveResolverTrait;
-    use EnumTypeSchemaDefinitionResolverTrait;
+    use FieldOrDirectiveResolverTrait, EnumTypeSchemaDefinitionResolverTrait {
+        EnumTypeSchemaDefinitionResolverTrait::doAddSchemaDefinitionEnumValuesForField insteadof FieldOrDirectiveResolverTrait;
+    }
 
     /**
      * @var array<string, array>

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -782,9 +782,8 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
                 $interfaceTypeResolver->getAllInterfaceTypeFieldResolvers(),
                 $implementedInterfaceTypeFieldResolvers,
                 /**
-                 * Don't use arrow function here, or there are 3 chained rules for Rector to downgrade!
-                 * This is not handled currently, so `object` would not be removed, failing for PHP 7.1.
-                 * Also, vars `$a` and `$b` are wrongly added as `use($a, $b)` to the first `fn`,
+                 * Don't use arrow function here, or there's an issue when downgrading to PHP 7.1:
+                 * vars `$a` and `$b` are wrongly added as `use($a, $b)` to the first `fn`,
                  * as if they were present in the original function scope, which they are not
                  */
                 function (object $a, object $b) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -781,7 +781,15 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
             fn (InterfaceTypeResolverInterface $interfaceTypeResolver) => array_udiff(
                 $interfaceTypeResolver->getAllInterfaceTypeFieldResolvers(),
                 $implementedInterfaceTypeFieldResolvers,
-                fn (object $a, object $b) => get_class($a) <=> get_class($b)
+                /**
+                 * Don't use arrow function here, or there are 3 chained rules for Rector to downgrade!
+                 * This is not handled currently, so `object` would not be removed, failing for PHP 7.1.
+                 * Also, vars `$a` and `$b` are wrongly added as `use($a, $b)` to the first `fn`,
+                 * as if they were present in the original function scope, which they are not
+                 */
+                function (object $a, object $b) {
+                    return get_class($a) <=> get_class($b);
+                }
             ) === [],
         );
     }

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet.php
@@ -23,7 +23,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveCapabilityPrivateSchemaHookSet 
         // The conflict resolutions below should not be needed, because the functions are not repeated, but it is defined just once in the same source trait
         // However, there is a bug about, still unresolved by PHP 7.2: https://bugs.php.net/bug.php?id=63911
         // It was resolved by PHP 7.3.9, though, but handle to add compatibility up to PHP 7.1
-        AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getConfigurationEntries insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntries insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getFieldNames insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntriesByTypeAndInterfaces insteadof ConfigurableMandatoryDirectivesForFieldsTrait;

--- a/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
+++ b/layers/Schema/packages/user-roles-access-control/src/Hooks/MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet.php
@@ -23,7 +23,6 @@ class MaybeDisableFieldsIfLoggedInUserDoesNotHaveRolePrivateSchemaHookSet extend
         // The conflict resolutions below should not be needed, because the functions are not repeated, but it is defined just once in the same source trait
         // However, there is a bug about, still unresolved by PHP 7.2: https://bugs.php.net/bug.php?id=63911
         // It was resolved by PHP 7.3.9, though, but handle to add compatibility up to PHP 7.1
-        AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getConfigurationEntries insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntries insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getFieldNames insteadof ConfigurableMandatoryDirectivesForFieldsTrait;
         AccessControlConfigurableMandatoryDirectivesForFieldsTrait::getEntriesByTypeAndInterfaces insteadof ConfigurableMandatoryDirectivesForFieldsTrait;


### PR DESCRIPTION
Also fixed other traits, and code that wouldn't compile in PHP 7.1