### PR TITLE
Replace `autowire` with HookSet and `initialize`

### DIFF
--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -72,6 +72,9 @@ services:
     PoP\ComponentModel\FormInputs\:
         resource: '../src/FormInputs/*'
 
+    PoP\ComponentModel\Hooks\:
+        resource: '../src/Hooks/*'
+
     PoP\ComponentModel\ModuleFilters\:
         resource: '../src/ModuleFilters/*'
 

--- a/layers/Engine/packages/component-model/src/Cache/Cache.php
+++ b/layers/Engine/packages/component-model/src/Cache/Cache.php
@@ -61,6 +61,11 @@ class Cache implements PersistentCacheInterface, TransientCacheInterface
         $this->cacheItemPool->clear();
     }
 
+    public function commit(): void
+    {
+        $this->cacheItemPool->commit();
+    }
+
 
     /**
      * If the item is not cached, it will return `null`

--- a/layers/Engine/packages/component-model/src/Cache/CacheInterface.php
+++ b/layers/Engine/packages/component-model/src/Cache/CacheInterface.php
@@ -17,6 +17,10 @@ interface CacheInterface
      * Remove all entries in the cache
      */
     public function clear(): void;
+    /**
+     * Commit entries in the pool
+     */
+    public function commit(): void;
     public function getCache(string $id, string $type): mixed;
     public function getComponentModelCache(string $id, string $type): mixed;
 

--- a/layers/Engine/packages/component-model/src/Hooks/MutationResolutionManagerHookSet.php
+++ b/layers/Engine/packages/component-model/src/Hooks/MutationResolutionManagerHookSet.php
@@ -30,6 +30,9 @@ class MutationResolutionManagerHookSet extends AbstractHookSet
 
     public function clearResults(): void
     {
-        $this->getMutationResolutionManager()->clearResults();
+        // Only if the service has been initialized
+        if ($this->mutationResolutionManager !== null) {
+            $this->getMutationResolutionManager()->clearResults();
+        }
     }
 }

--- a/layers/Engine/packages/component-model/src/Hooks/MutationResolutionManagerHookSet.php
+++ b/layers/Engine/packages/component-model/src/Hooks/MutationResolutionManagerHookSet.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Hooks;
+
+use PoP\ComponentModel\MutationResolution\MutationResolutionManagerInterface;
+use PoP\Hooks\AbstractHookSet;
+
+class MutationResolutionManagerHookSet extends AbstractHookSet
+{
+    private ?MutationResolutionManagerInterface $mutationResolutionManager = null;
+
+    final public function setMutationResolutionManager(MutationResolutionManagerInterface $mutationResolutionManager): void
+    {
+        $this->mutationResolutionManager = $mutationResolutionManager;
+    }
+    final protected function getMutationResolutionManager(): MutationResolutionManagerInterface
+    {
+        return $this->mutationResolutionManager ??= $this->instanceManager->getInstance(MutationResolutionManagerInterface::class);
+    }
+
+    protected function init(): void
+    {
+        $this->getHooksAPI()->addAction(
+            'augmentVarsProperties',
+            [$this, 'clearResults']
+        );
+    }
+
+    public function clearResults(): void
+    {
+        $this->getMutationResolutionManager()->clearResults();
+    }
+}

--- a/layers/Engine/packages/component-model/src/MutationResolution/MutationResolutionManager.php
+++ b/layers/Engine/packages/component-model/src/MutationResolution/MutationResolutionManager.php
@@ -6,7 +6,6 @@ namespace PoP\ComponentModel\MutationResolution;
 
 use PoP\ComponentModel\MutationResolverBridges\ComponentMutationResolverBridgeInterface;
 use PoP\ComponentModel\Services\BasicServiceTrait;
-use Symfony\Contracts\Service\Attribute\Required;
 
 class MutationResolutionManager implements MutationResolutionManagerInterface
 {
@@ -16,15 +15,6 @@ class MutationResolutionManager implements MutationResolutionManagerInterface
      * @var array<string, mixed>
      */
     private array $results = [];
-
-    #[Required]
-    final public function autowireInitializeMutationResolutionManager(): void
-    {
-        $this->getHooksAPI()->addAction(
-            'augmentVarsProperties',
-            [$this, 'clearResults']
-        );
-    }
 
     public function clearResults(): void
     {

--- a/layers/Engine/packages/engine/src/Cache/Cache.php
+++ b/layers/Engine/packages/engine/src/Cache/Cache.php
@@ -6,31 +6,9 @@ namespace PoP\Engine\Cache;
 
 use PoP\ComponentModel\Cache\Cache as UpstreamCache;
 use Psr\Cache\CacheItemInterface;
-use Symfony\Contracts\Service\Attribute\Required;
 
 class Cache extends UpstreamCache
 {
-    #[Required]
-    final public function autowireInitializeCache(): void
-    {
-        // When a plugin is activated/deactivated, ANY plugin, delete the corresponding cached files
-        // This is particularly important for the MEMORY, since we can't set by constants to not use it
-        $this->getHooksAPI()->addAction(
-            'popcms:componentInstalledOrUninstalled',
-            function (): void {
-                $this->clear();
-            }
-        );
-
-        // Save all deferred cacheItems
-        $this->getHooksAPI()->addAction(
-            'popcms:shutdown',
-            function (): void {
-                $this->commit();
-            }
-        );
-    }
-
     /**
      * Override to save as deferred, on hook "popcms:shutdown"
      */

--- a/layers/Engine/packages/engine/src/Cache/Cache.php
+++ b/layers/Engine/packages/engine/src/Cache/Cache.php
@@ -18,7 +18,7 @@ class Cache extends UpstreamCache
         $this->getHooksAPI()->addAction(
             'popcms:componentInstalledOrUninstalled',
             function (): void {
-                $this->cacheItemPool->clear();
+                $this->clear();
             }
         );
 
@@ -26,7 +26,7 @@ class Cache extends UpstreamCache
         $this->getHooksAPI()->addAction(
             'popcms:shutdown',
             function (): void {
-                $this->cacheItemPool->commit();
+                $this->commit();
             }
         );
     }

--- a/layers/Engine/packages/engine/src/Hooks/CacheHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/CacheHookSet.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Engine\Hooks;
+
+use PoP\ComponentModel\Cache\PersistentCacheInterface;
+use PoP\ComponentModel\Cache\TransientCacheInterface;
+use PoP\Hooks\AbstractHookSet;
+
+class CacheHookSet extends AbstractHookSet
+{
+    private ?PersistentCacheInterface $persistentCache = null;
+    private ?TransientCacheInterface $transientCache = null;
+
+    final public function setPersistentCache(PersistentCacheInterface $persistentCache): void
+    {
+        $this->persistentCache = $persistentCache;
+    }
+    final protected function getPersistentCache(): PersistentCacheInterface
+    {
+        return $this->persistentCache ??= $this->instanceManager->getInstance(PersistentCacheInterface::class);
+    }
+    final public function setTransientCache(TransientCacheInterface $transientCache): void
+    {
+        $this->transientCache = $transientCache;
+    }
+    final protected function getTransientCache(): TransientCacheInterface
+    {
+        return $this->transientCache ??= $this->instanceManager->getInstance(TransientCacheInterface::class);
+    }
+
+    protected function init(): void
+    {
+        // When a plugin is activated/deactivated, ANY plugin, delete the corresponding cached files
+        // This is particularly important for the MEMORY, since we can't set by constants to not use it
+        $this->getHooksAPI()->addAction(
+            'popcms:componentInstalledOrUninstalled',
+            [$this, 'clear']
+        );
+
+        // Save all deferred cacheItems
+        $this->getHooksAPI()->addAction(
+            'popcms:shutdown',
+            [$this, 'commit']
+        );
+    }
+
+    public function clear(): void
+    {
+        // Only if the services have been initialized
+        if ($this->persistentCache !== null) {
+            $this->getPersistentCache()->clear();
+        }
+        if ($this->transientCache !== null) {
+            $this->getTransientCache()->clear();
+        }
+    }
+
+    public function commit(): void
+    {
+        // Only if the services have been initialized
+        if ($this->persistentCache !== null) {
+            $this->getPersistentCache()->commit();
+        }
+        if ($this->transientCache !== null) {
+            $this->getTransientCache()->commit();
+        }
+    }
+}

--- a/layers/Engine/packages/root/src/Services/AbstractAutomaticallyInstantiatedService.php
+++ b/layers/Engine/packages/root/src/Services/AbstractAutomaticallyInstantiatedService.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\Root\Services;
 
-use PoP\Root\Component\ApplicationEvents;
-
 /**
  * A service which must always be instantiated,
  * so it's done automatically by the application.
@@ -14,14 +12,5 @@ use PoP\Root\Component\ApplicationEvents;
 abstract class AbstractAutomaticallyInstantiatedService implements AutomaticallyInstantiatedServiceInterface
 {
     use ServiceTrait;
-
-    public function initialize(): void
-    {
-        // By default, do nothing
-    }
-
-    public function getInstantiationEvent(): string
-    {
-        return ApplicationEvents::BEFORE_BOOT;
-    }
+    use AutomaticallyInstantiatedServiceTrait;
 }

--- a/layers/Engine/packages/root/src/Services/AbstractAutomaticallyInstantiatedService.php
+++ b/layers/Engine/packages/root/src/Services/AbstractAutomaticallyInstantiatedService.php
@@ -11,6 +11,5 @@ namespace PoP\Root\Services;
  */
 abstract class AbstractAutomaticallyInstantiatedService implements AutomaticallyInstantiatedServiceInterface
 {
-    use ServiceTrait;
     use AutomaticallyInstantiatedServiceTrait;
 }

--- a/layers/Engine/packages/root/src/Services/AutomaticallyInstantiatedServiceTrait.php
+++ b/layers/Engine/packages/root/src/Services/AutomaticallyInstantiatedServiceTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\Root\Services;
+
+use PoP\Root\Component\ApplicationEvents;
+
+/**
+ * A service which must always be instantiated,
+ * so it's done automatically by the application.
+ * Eg: hooks.
+ */
+trait AutomaticallyInstantiatedServiceTrait
+{
+    public function initialize(): void
+    {
+        // By default, do nothing
+    }
+
+    public function getInstantiationEvent(): string
+    {
+        return ApplicationEvents::BEFORE_BOOT;
+    }
+}

--- a/layers/Engine/packages/root/src/Services/AutomaticallyInstantiatedServiceTrait.php
+++ b/layers/Engine/packages/root/src/Services/AutomaticallyInstantiatedServiceTrait.php
@@ -13,6 +13,8 @@ use PoP\Root\Component\ApplicationEvents;
  */
 trait AutomaticallyInstantiatedServiceTrait
 {
+    use ServiceTrait;
+
     public function initialize(): void
     {
         // By default, do nothing

--- a/layers/Wassup/packages/gravityforms-mutations/src/MutationResolverBridges/GravityFormsAddEntryToFormMutationResolverBridge.php
+++ b/layers/Wassup/packages/gravityforms-mutations/src/MutationResolverBridges/GravityFormsAddEntryToFormMutationResolverBridge.php
@@ -8,13 +8,16 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
 use PoP\ComponentModel\QueryInputOutputHandlers\ResponseConstants;
 use PoP\ComponentModel\State\ApplicationState;
+use PoP\Root\Services\AutomaticallyInstantiatedServiceInterface;
+use PoP\Root\Services\AutomaticallyInstantiatedServiceTrait;
 use PoPSchema\Users\TypeAPIs\UserTypeAPIInterface;
 use PoPSitesWassup\FormMutations\MutationResolverBridges\AbstractFormComponentMutationResolverBridge;
 use PoPSitesWassup\GravityFormsMutations\MutationResolvers\GravityFormsAddEntryToFormMutationResolver;
-use Symfony\Contracts\Service\Attribute\Required;
 
-class GravityFormsAddEntryToFormMutationResolverBridge extends AbstractFormComponentMutationResolverBridge
+class GravityFormsAddEntryToFormMutationResolverBridge extends AbstractFormComponentMutationResolverBridge implements AutomaticallyInstantiatedServiceInterface
 {
+    use AutomaticallyInstantiatedServiceTrait;
+
     public const HOOK_FORM_FIELDNAMES = __CLASS__ . ':form-fieldnames';
 
     private ?UserTypeAPIInterface $userTypeAPI = null;
@@ -37,8 +40,7 @@ class GravityFormsAddEntryToFormMutationResolverBridge extends AbstractFormCompo
         return $this->gravityFormsAddEntryToFormMutationResolver ??= $this->instanceManager->getInstance(GravityFormsAddEntryToFormMutationResolver::class);
     }
 
-    #[Required]
-    final public function autowireInitializeGravityFormsAddEntryToFormMutationResolverBridge()
+    final public function initialize(): void
     {
         // Execute before $hooksAPI->addAction('wp',  array('RGForms', 'maybe_process_form'), 9);
         if ('POST' === $_SERVER['REQUEST_METHOD']) {


### PR DESCRIPTION
The HooksAPI is used to initialize services in `autowire` functions, such as:

```php
#[Required]
final public function autowireInitializeMutationResolutionManager(): void
{
    $this->getHooksAPI()->addAction(
        'augmentVarsProperties',
        [$this, 'clearResults']
    );
}
```

But doing so would trigger an error:

```
2021-11-08T06:29:39.623035972Z [Mon Nov 08 06:29:39.622771 2021] [php:error] [pid 1820] [client 172.19.0.2:54250] PHP Fatal error:  Uncaught Error: Typed property PoP\\ComponentModel\\Cache\\Cache::$instanceManager must not be accessed before initialization in /app/wordpress/Engine/packages/component-model/src/Services/BasicServiceTrait.php:24
Stack trace:
#0 /app/wordpress/Engine/packages/engine/src/Cache/Cache.php(18): PoP\\ComponentModel\\Cache\\Cache->getHooksAPI()
#1 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php(1615): PoP\\Engine\\Cache\\Cache->autowireInitializeCache()
#2 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php(1113): Symfony\\Component\\DependencyInjection\\ContainerBuilder->callMethod(Object(PoP\\Engine\\Cache\\Cache), Array, Array)
#3 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php(597): Symfony\\Component\\DependencyInjection\\ContainerBuilder->createService(Object(Symfony\\Component\\DependencyInjection\\Definition), Array, true, 'PoP\\\\ComponentMo...')
#4 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php(542): Symfony\\Component\\DependencyInjection\\ContainerBuilder->doGet('PoP\\\\ComponentMo...', 1)
#5 /app/wordpress/Engine/packages/root/src/Instances/InstanceManager.php(14): Symfony\\Component\\DependencyInjection\\ContainerBuilder->get('PoP\\\\ComponentMo...')
#6 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(131): PoP\\Root\\Instances\\InstanceManager->getInstance('PoP\\\\ComponentMo...')
#7 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(404): PoP\\ComponentModel\\Engine\\Engine->getPersistentCache()
#8 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(446): PoP\\ComponentModel\\Engine\\Engine->getModelPropsModuletree(Array)
#9 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(336): PoP\\ComponentModel\\Engine\\Engine->processAndGenerateData()
#10 /app/wordpress/Engine/packages/engine/src/Engine/Engine.php(57): PoP\\ComponentModel\\Engine\\Engine->generateData()
#11 /app/wordpress/Engine/packages/engine/src/Engine/Engine.php(63): PoP\\Engine\\Engine\\Engine->generateData()
#12 /app/wordpress/Engine/packages/engine-wp/templates/Output.php(5): PoP\\Engine\\Engine\\Engine->outputResponse()
#13 /app/wordpress/wp-content/plugins/graphql-api/src/ConditionalOnContext/Admin/Services/EndpointResolvers/AdminEndpointResolver.php(188): include('/app/wordpress/...')
#14 /app/wordpress/wp-includes/class-wp-hook.php(303): GraphQLAPI\\GraphQLAPI\\ConditionalOnContext\\Admin\\Services\\EndpointResolvers\\AdminEndpointResolver->GraphQLAPI\\GraphQLAPI\\ConditionalOnContext\\Admin\\Services\\EndpointResolvers\\{closure}('')
#15 /app/wordpress/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
#16 /app/wordpress/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#17 /app/wordpress/wp-admin/admin.php(175): do_action('admin_init')
#18 /app/wordpress/wp-admin/edit.php(10): require_once('/app/wordpress/...')
#19 {main}
  thrown in /app/wordpress/Engine/packages/component-model/src/Services/BasicServiceTrait.php on line 24, referer: https://graphql-api-pro.lndo.site/wp-admin/post.php?post=18&action=edit
```

The reason is that `$this->getHooksAPI()` would read `$this->instanceManager`, but in the service container dump, the `autowire` function to initialize the `$instanceManager` would be generated in the inverse order:

```php
protected function getPersistentCacheInterfaceService()
{
    $this->services['PoP\\ComponentModel\\Cache\\PersistentCacheInterface'] = $instance = new \PoP\Engine\Cache\Cache(($this->services['persistent_cache_item_pool'] ?? $this->getPersistentCacheItemPoolService()));

    $instance->autowireInitializeCache();
    $instance->setInstanceManager(($this->services['PoP\\Root\\Instances\\InstanceManagerInterface'] ?? ($this->services['PoP\\Root\\Instances\\InstanceManagerInterface'] = new \PoP\Root\Instances\InstanceManager())));

    return $instance;
}
```

There are 2 solutions, implemented for different services:

1. Move the `autowire` logic to external HookSet services, which are already initialized always
2. Implement `AutomaticallyInstantiatedServiceInterface` and use its `initialize` method (instead of using an `autowire` function)