### PR TITLE
Renamed interface Elemental to Node

### DIFF
--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProviderInterface.php
@@ -47,7 +47,7 @@ interface ErrorProviderInterface
         string | int $objectID,
         string $fieldName,
         array $fieldArgs,
-    ): Error ;
+    ): Error;
     /**
      * @param string[] $schemaErrors
      */

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/NodeInterfaceTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/NodeInterfaceTypeFieldResolver.php
@@ -6,7 +6,7 @@ namespace PoP\ComponentModel\FieldResolvers\InterfaceType;
 
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
-use PoP\ComponentModel\TypeResolvers\InterfaceType\ElementalInterfaceTypeResolver;
+use PoP\ComponentModel\TypeResolvers\InterfaceType\NodeInterfaceTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -26,7 +26,7 @@ class NodeInterfaceTypeFieldResolver extends AbstractInterfaceTypeFieldResolver
     public function getInterfaceTypeResolverClassesToAttachTo(): array
     {
         return [
-            ElementalInterfaceTypeResolver::class,
+            NodeInterfaceTypeResolver::class,
         ];
     }
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/NodeInterfaceTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/NodeInterfaceTypeFieldResolver.php
@@ -10,7 +10,7 @@ use PoP\ComponentModel\TypeResolvers\InterfaceType\ElementalInterfaceTypeResolve
 use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
 use Symfony\Contracts\Service\Attribute\Required;
 
-class ElementalInterfaceTypeFieldResolver extends AbstractInterfaceTypeFieldResolver
+class NodeInterfaceTypeFieldResolver extends AbstractInterfaceTypeFieldResolver
 {
     private ?IDScalarTypeResolver $idScalarTypeResolver = null;
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ElementalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ElementalObjectTypeFieldResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
-use PoP\ComponentModel\FieldResolvers\InterfaceType\ElementalInterfaceTypeFieldResolver;
+use PoP\ComponentModel\FieldResolvers\InterfaceType\NodeInterfaceTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\AbstractObjectTypeResolver;
@@ -13,15 +13,15 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 class ElementalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
-    private ?ElementalInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver = null;
+    private ?NodeInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver = null;
 
-    final public function setElementalInterfaceTypeFieldResolver(ElementalInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver): void
+    final public function setElementalInterfaceTypeFieldResolver(NodeInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver): void
     {
         $this->elementalInterfaceTypeFieldResolver = $elementalInterfaceTypeFieldResolver;
     }
-    final protected function getElementalInterfaceTypeFieldResolver(): ElementalInterfaceTypeFieldResolver
+    final protected function getElementalInterfaceTypeFieldResolver(): NodeInterfaceTypeFieldResolver
     {
-        return $this->elementalInterfaceTypeFieldResolver ??= $this->instanceManager->getInstance(ElementalInterfaceTypeFieldResolver::class);
+        return $this->elementalInterfaceTypeFieldResolver ??= $this->instanceManager->getInstance(NodeInterfaceTypeFieldResolver::class);
     }
 
     public function getObjectTypeResolverClassesToAttachTo(): array

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\TypeResolvers\ObjectType\AbstractObjectTypeResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
-class ElementalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+class NodeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?NodeInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver = null;
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
@@ -13,15 +13,15 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 class NodeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
-    private ?NodeInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver = null;
+    private ?NodeInterfaceTypeFieldResolver $nodeInterfaceTypeFieldResolver = null;
 
-    final public function setElementalInterfaceTypeFieldResolver(NodeInterfaceTypeFieldResolver $elementalInterfaceTypeFieldResolver): void
+    final public function setNodeInterfaceTypeFieldResolver(NodeInterfaceTypeFieldResolver $nodeInterfaceTypeFieldResolver): void
     {
-        $this->elementalInterfaceTypeFieldResolver = $elementalInterfaceTypeFieldResolver;
+        $this->nodeInterfaceTypeFieldResolver = $nodeInterfaceTypeFieldResolver;
     }
-    final protected function getElementalInterfaceTypeFieldResolver(): NodeInterfaceTypeFieldResolver
+    final protected function getNodeInterfaceTypeFieldResolver(): NodeInterfaceTypeFieldResolver
     {
-        return $this->elementalInterfaceTypeFieldResolver ??= $this->instanceManager->getInstance(NodeInterfaceTypeFieldResolver::class);
+        return $this->nodeInterfaceTypeFieldResolver ??= $this->instanceManager->getInstance(NodeInterfaceTypeFieldResolver::class);
     }
 
     public function getObjectTypeResolverClassesToAttachTo(): array
@@ -34,7 +34,7 @@ class NodeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     public function getImplementedInterfaceTypeFieldResolvers(): array
     {
         return [
-            $this->getElementalInterfaceTypeFieldResolver(),
+            $this->getNodeInterfaceTypeFieldResolver(),
         ];
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/NodeInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/NodeInterfaceTypeResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers\InterfaceType;
 
-class ElementalInterfaceTypeResolver extends AbstractInterfaceTypeResolver
+class NodeInterfaceTypeResolver extends AbstractInterfaceTypeResolver
 {
     public function getTypeName(): string
     {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/NodeInterfaceTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InterfaceType/NodeInterfaceTypeResolver.php
@@ -8,7 +8,7 @@ class NodeInterfaceTypeResolver extends AbstractInterfaceTypeResolver
 {
     public function getTypeName(): string
     {
-        return 'Elemental';
+        return 'Node';
     }
 
     public function getTypeDescription(): ?string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -168,7 +168,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Breaking changes
 
 - Renamed module "Schema for the Admin" to "Schema Admin Fields"
-- Renamed `AnyScalar` to `AnyBuiltInScalar`
+- Renamed scalar type `AnyScalar` to `AnyBuiltInScalar`
+- Renamed interface type `Elemental` to `Node`
 - Renamed all the "admin" fields: instead of prepending them with "unrestricted", now they are appended "ForAdmin"
 - The Access Control and Cache Control configuration lists will be broken: all fields for all non-root types broken will appear under "(Undefined entries)". These lists must be recreated
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -597,7 +597,7 @@ The GraphQL queries in the module documentation are now prettyprinted:
 
 ## Breaking changes
 
-### Renamed the "Schema Admin Fields"
+### Renamed module "Schema Admin Fields"
 
 Renamed module "Schema for the Admin" to "Schema Admin Fields". If this module had been disabled, it must be disabled again.
 
@@ -605,9 +605,13 @@ In addition, its block for the Schema Configuration also got renamed, so you mus
 
 <a href="../../images/releases/v09/schema-config-reset-the-template.png" target="_blank">![Click on "Reset the template" on all Schema Configurations](../../images/releases/v09/schema-config-reset-the-template.png)</a>
 
-### Renamed `AnyScalar` to `AnyBuiltInScalar`
+### Renamed scalar type `AnyScalar` to `AnyBuiltInScalar`
 
 Because custom scalar `AnyScalar` only represents the 5 built-in GraphQL scalar types (`String`, `Int`, `Boolean`, `Float`, and `ID`), it was renamed to `AnyBuiltInScalar` to better convey this information.
+
+### Renamed interface type `Elemental` to `Node`
+
+The `Elemental` interface contains field `id: ID!`. It has been renamed to `Node` to follow the convention by most GraphQL implementations (for instance, by [GitHub's GraphQL API](https://docs.github.com/en/graphql/reference/interfaces#node)).
 
 ### Renamed the Admin fields
 


### PR DESCRIPTION
The `Elemental` interface contains field `id: ID!`. It has been renamed to `Node` to follow the convention by most GraphQL implementations (for instance, by [GitHub's GraphQL API](https://docs.github.com/en/graphql/reference/interfaces#node)).