### PR TITLE
Rename InputObject methods

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -33,19 +33,19 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         return $this->inputCoercingService ??= $this->instanceManager->getInstance(InputCoercingServiceInterface::class);
     }
 
-    public function getInputObjectFieldDescription(string $inputFieldName): ?string
+    public function getInputFieldDescription(string $inputFieldName): ?string
     {
         return null;
     }
-    public function getInputObjectFieldDeprecationMessage(string $inputFieldName): ?string
+    public function getInputFieldDeprecationMessage(string $inputFieldName): ?string
     {
         return null;
     }
-    public function getInputObjectFieldDefaultValue(string $inputFieldName): mixed
+    public function getInputFieldDefaultValue(string $inputFieldName): mixed
     {
         return null;
     }
-    public function getInputObjectFieldTypeModifiers(string $inputFieldName): int
+    public function getInputFieldTypeModifiers(string $inputFieldName): int
     {
         return SchemaTypeModifiers::NONE;
     }
@@ -67,13 +67,13 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
     final protected function coerceInputObjectValue(stdClass $inputValue): stdClass|Error
     {
         $coercedInputObjectValue = new stdClass();
-        $inputFieldNameTypeResolvers = $this->getInputObjectFieldNameTypeResolvers();
+        $inputFieldNameTypeResolvers = $this->getInputFieldNameTypeResolvers();
 
         /**
          * Inject all properties with default value
          */
         foreach ($inputFieldNameTypeResolvers as $inputFieldName => $inputTypeResolver) {
-            if (isset($inputValue->$inputFieldName) || ($inputFieldDefaultValue = $this->getInputObjectFieldDefaultValue($inputFieldName)) === null) {
+            if (isset($inputValue->$inputFieldName) || ($inputFieldDefaultValue = $this->getInputFieldDefaultValue($inputFieldName)) === null) {
                 continue;
             }
             $inputValue->$inputFieldName = $inputFieldDefaultValue;
@@ -113,7 +113,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                 continue;
             }
 
-            $inputFieldTypeModifiers = $this->getInputObjectFieldTypeModifiers($inputFieldName);
+            $inputFieldTypeModifiers = $this->getInputFieldTypeModifiers($inputFieldName);
             $inputFieldIsArrayType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
             $inputFieldIsNonNullArrayItemsType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY) === SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY;
             $inputFieldIsArrayOfArraysType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
@@ -190,7 +190,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             if (isset($inputValue->$inputFieldName)) {
                 continue;
             }
-            $inputFieldTypeModifiers = $this->getInputObjectFieldTypeModifiers($inputFieldName);
+            $inputFieldTypeModifiers = $this->getInputFieldTypeModifiers($inputFieldName);
             $inputFieldTypeModifiersIsMandatory = ($inputFieldTypeModifiers & SchemaTypeModifiers::MANDATORY) === SchemaTypeModifiers::MANDATORY;
             if (!$inputFieldTypeModifiersIsMandatory) {
                 continue;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -151,7 +151,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             }
 
             // Cast (or "coerce" in GraphQL terms) the value
-            $coercedInputPropertyValue = $this->getInputCoercingService()->coerceInputValue(
+            $coercedInputFieldValue = $this->getInputCoercingService()->coerceInputValue(
                 $inputTypeResolver,
                 $inputFieldValue,
                 $inputFieldIsArrayType,
@@ -159,12 +159,12 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             );
 
             // Check if the coercion produced errors
-            $maybeCoercedInputPropertyValueErrors = $this->getInputCoercingService()->extractErrorsFromCoercedInputValue(
-                $coercedInputPropertyValue,
+            $maybeCoercedInputFieldValueErrors = $this->getInputCoercingService()->extractErrorsFromCoercedInputValue(
+                $coercedInputFieldValue,
                 $inputFieldIsArrayType,
                 $inputFieldIsArrayOfArraysType,
             );
-            if ($maybeCoercedInputPropertyValueErrors !== []) {
+            if ($maybeCoercedInputFieldValueErrors !== []) {
                 $castingError = new Error(
                     $this->getErrorCode(),
                     sprintf(
@@ -173,14 +173,14 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                         $inputTypeResolver->getMaybeNamespacedTypeName()
                     ),
                     null,
-                    $maybeCoercedInputPropertyValueErrors
+                    $maybeCoercedInputFieldValueErrors
                 );
                 $errors[] = $castingError;
                 continue;
             }
 
             // The input field is valid, add to the resulting InputObject
-            $coercedInputObjectValue->$inputFieldName = $coercedInputPropertyValue;
+            $coercedInputObjectValue->$inputFieldName = $coercedInputFieldValue;
         }
 
         /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -66,7 +66,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
 
     final protected function coerceInputObjectValue(stdClass $inputValue): stdClass|Error
     {
-        $coercedInputObjectValue = new stdClass();
+        $coercedInputValue = new stdClass();
         $inputFieldNameTypeResolvers = $this->getInputFieldNameTypeResolvers();
 
         /**
@@ -109,7 +109,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
              * these values by types `String` and `[String]`.
              */
             if ($inputTypeResolver === $this->getDangerouslyDynamicScalarTypeResolver()) {
-                $coercedInputObjectValue->$inputFieldName = $this->getDangerouslyDynamicScalarTypeResolver()->coerceValue($inputFieldValue);
+                $coercedInputValue->$inputFieldName = $this->getDangerouslyDynamicScalarTypeResolver()->coerceValue($inputFieldValue);
                 continue;
             }
 
@@ -180,7 +180,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             }
 
             // The input field is valid, add to the resulting InputObject
-            $coercedInputObjectValue->$inputFieldName = $coercedInputFieldValue;
+            $coercedInputValue->$inputFieldName = $coercedInputFieldValue;
         }
 
         /**
@@ -218,6 +218,6 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         }
 
         // Add all missing properties which have a default value
-        return $coercedInputObjectValue;
+        return $coercedInputValue;
     }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -82,13 +82,13 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         /** @var Error[] */
         $errors = [];
         foreach ((array)$inputValue as $inputFieldName => $inputFieldValue) {
-            // Check that the property exists
+            // Check that the input field exists
             $inputTypeResolver = $inputFieldNameTypeResolvers[$inputFieldName] ?? null;
             if ($inputTypeResolver === null) {
                 $errors[] = new Error(
                     $this->getErrorCode(),
                     sprintf(
-                        $this->getTranslationAPI()->__('There is no property \'%s\' in input object \'%s\''),
+                        $this->getTranslationAPI()->__('There is no input field \'%s\' in input object \'%s\''),
                         $inputFieldName,
                         $this->getMaybeNamespacedTypeName()
                     )
@@ -114,10 +114,10 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             }
 
             $inputFieldTypeModifiers = $this->getInputObjectFieldTypeModifiers($inputFieldName);
-            $propertyIsArrayType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
-            $propertyIsNonNullArrayItemsType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY) === SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY;
-            $propertyIsArrayOfArraysType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
-            $propertyIsNonNullArrayOfArraysItemsType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS;
+            $inputFieldIsArrayType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
+            $inputFieldIsNonNullArrayItemsType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY) === SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY;
+            $inputFieldIsArrayOfArraysType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
+            $inputFieldIsNonNullArrayOfArraysItemsType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY_OF_ARRAYS;
 
             /**
              * Support passing a single value where a list is expected:
@@ -129,18 +129,18 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
              */
             $inputFieldValue = $this->getInputCoercingService()->maybeConvertInputValueFromSingleToList(
                 $inputFieldValue,
-                $propertyIsArrayType,
-                $propertyIsArrayOfArraysType,
+                $inputFieldIsArrayType,
+                $inputFieldIsArrayOfArraysType,
             );
 
             // Validate that the expected array/non-array input is provided
             $maybeErrorMessage = $this->getInputCoercingService()->validateInputArrayModifiers(
                 $inputFieldValue,
                 $inputFieldName,
-                $propertyIsArrayType,
-                $propertyIsNonNullArrayItemsType,
-                $propertyIsArrayOfArraysType,
-                $propertyIsNonNullArrayOfArraysItemsType,
+                $inputFieldIsArrayType,
+                $inputFieldIsNonNullArrayItemsType,
+                $inputFieldIsArrayOfArraysType,
+                $inputFieldIsNonNullArrayOfArraysItemsType,
             );
             if ($maybeErrorMessage !== null) {
                 $errors[] = new Error(
@@ -154,21 +154,21 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             $coercedInputPropertyValue = $this->getInputCoercingService()->coerceInputValue(
                 $inputTypeResolver,
                 $inputFieldValue,
-                $propertyIsArrayType,
-                $propertyIsArrayOfArraysType,
+                $inputFieldIsArrayType,
+                $inputFieldIsArrayOfArraysType,
             );
 
             // Check if the coercion produced errors
             $maybeCoercedInputPropertyValueErrors = $this->getInputCoercingService()->extractErrorsFromCoercedInputValue(
                 $coercedInputPropertyValue,
-                $propertyIsArrayType,
-                $propertyIsArrayOfArraysType,
+                $inputFieldIsArrayType,
+                $inputFieldIsArrayOfArraysType,
             );
             if ($maybeCoercedInputPropertyValueErrors !== []) {
                 $castingError = new Error(
                     $this->getErrorCode(),
                     sprintf(
-                        $this->getTranslationAPI()->__('Casting property \'%s\' of type \'%s\' produced errors', 'component-model'),
+                        $this->getTranslationAPI()->__('Casting input field \'%s\' of type \'%s\' produced errors', 'component-model'),
                         $inputFieldName,
                         $inputTypeResolver->getMaybeNamespacedTypeName()
                     ),
@@ -179,7 +179,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                 continue;
             }
 
-            // The property is valid, add to the resulting InputObject
+            // The input field is valid, add to the resulting InputObject
             $coercedInputObjectValue->$inputFieldName = $coercedInputPropertyValue;
         }
 
@@ -198,7 +198,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             $errors[] = new Error(
                 $this->getErrorCode(),
                 sprintf(
-                    $this->getTranslationAPI()->__('Mandatory property \'%s\' in input object \'%s\' has not been provided'),
+                    $this->getTranslationAPI()->__('Mandatory input field \'%s\' in input object \'%s\' has not been provided'),
                     $inputFieldName,
                     $this->getMaybeNamespacedTypeName()
                 )

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
@@ -21,8 +21,8 @@ interface InputObjectTypeResolverInterface extends InputTypeResolverInterface
      * @return array<string, InputTypeResolverInterface>
      */
     public function getInputObjectFieldNameTypeResolvers(): array;
-    public function getInputObjectFieldDescription(string $inputObjectFieldName): ?string;
-    public function getInputObjectFieldDeprecationMessage(string $inputObjectFieldName): ?string;
-    public function getInputObjectFieldDefaultValue(string $inputObjectFieldName): mixed;
-    public function getInputObjectFieldTypeModifiers(string $inputObjectFieldName): int;
+    public function getInputObjectFieldDescription(string $inputFieldName): ?string;
+    public function getInputObjectFieldDeprecationMessage(string $inputFieldName): ?string;
+    public function getInputObjectFieldDefaultValue(string $inputFieldName): mixed;
+    public function getInputObjectFieldTypeModifiers(string $inputFieldName): int;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
@@ -20,9 +20,9 @@ interface InputObjectTypeResolverInterface extends InputTypeResolverInterface
      *
      * @return array<string, InputTypeResolverInterface>
      */
-    public function getInputObjectFieldNameTypeResolvers(): array;
-    public function getInputObjectFieldDescription(string $inputFieldName): ?string;
-    public function getInputObjectFieldDeprecationMessage(string $inputFieldName): ?string;
-    public function getInputObjectFieldDefaultValue(string $inputFieldName): mixed;
-    public function getInputObjectFieldTypeModifiers(string $inputFieldName): int;
+    public function getInputFieldNameTypeResolvers(): array;
+    public function getInputFieldDescription(string $inputFieldName): ?string;
+    public function getInputFieldDeprecationMessage(string $inputFieldName): ?string;
+    public function getInputFieldDefaultValue(string $inputFieldName): mixed;
+    public function getInputFieldTypeModifiers(string $inputFieldName): int;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers\InputObjectType;
 
-use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
-use stdClass;
 
 /**
  * Based on GraphQL InputObject Type
@@ -16,7 +14,7 @@ use stdClass;
 interface InputObjectTypeResolverInterface extends InputTypeResolverInterface
 {
     /**
-     * Define InputObject fields
+     * Define input fields
      *
      * @return array<string, InputTypeResolverInterface>
      */

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/DateQueryInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/DateQueryInputObjectTypeResolver.php
@@ -28,7 +28,7 @@ class DateQueryInputObjectTypeResolver extends AbstractInputObjectTypeResolver
         return 'DateQuery';
     }
 
-    public function getInputObjectFieldNameTypeResolvers(): array
+    public function getInputFieldNameTypeResolvers(): array
     {
         return [
             'after' => $this->getDateScalarTypeResolver(),


### PR DESCRIPTION
Remove `Object` from the methods in `InputObjectTypeResolverInterface`. 

Eg: `getInputObjectFieldNameTypeResolvers` => `getInputFieldNameTypeResolvers`