### PR TITLE
Validate constraints in InputObject

### DIFF
--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -31,6 +31,7 @@ use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -39,6 +40,7 @@ use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Engine\CMS\CMSServiceInterface;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\LooseContracts\NameResolverInterface;
+use stdClass;
 
 abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver implements ObjectTypeFieldResolverInterface
 {
@@ -690,20 +692,29 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         array $fieldArgs
     ): array {
         $errors = [];
+        $fieldArgNameTypeResolvers = $this->getConsolidatedFieldArgNameTypeResolvers($objectTypeResolver, $fieldName);
         foreach ($fieldArgs as $fieldArgName => $fieldArgValue) {
-            if (
-                $maybeErrors = $this->validateFieldArgValue(
+            /**
+             * If the field is an InputObject, let it perform validations on its input fields
+             */
+            $fieldArgTypeResolver = $fieldArgNameTypeResolvers[$fieldArgName];
+            if ($fieldArgTypeResolver instanceof InputObjectTypeResolverInterface
+                && $fieldArgValue instanceof stdClass
+            ) {
+                $errors = array_merge(
+                    $errors,
+                    $fieldArgTypeResolver->validateInputValue($fieldArgValue)
+                );  
+            }
+            $errors = array_merge(
+                $errors,
+                $this->validateFieldArgValue(
                     $objectTypeResolver,
                     $fieldName,
                     $fieldArgName,
                     $fieldArgValue
                 )
-            ) {
-                $errors = array_merge(
-                    $errors,
-                    $maybeErrors
-                );
-            }
+            );
         }
         return $errors;
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -698,13 +698,14 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
              * If the field is an InputObject, let it perform validations on its input fields
              */
             $fieldArgTypeResolver = $fieldArgNameTypeResolvers[$fieldArgName];
-            if ($fieldArgTypeResolver instanceof InputObjectTypeResolverInterface
+            if (
+                $fieldArgTypeResolver instanceof InputObjectTypeResolverInterface
                 && $fieldArgValue instanceof stdClass
             ) {
                 $errors = array_merge(
                     $errors,
                     $fieldArgTypeResolver->validateInputValue($fieldArgValue)
-                );  
+                );
             }
             $errors = array_merge(
                 $errors,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -370,4 +370,13 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         $this->schemaDefinitionForInputFieldCache[$inputFieldName] = $inputFieldSchemaDefinition;
         return $this->schemaDefinitionForInputFieldCache[$inputFieldName];
     }
+    /**
+     * Validate constraints on the input field's value
+     *
+     * @return string[] Error messages
+     */
+    public function validateInputFieldValue(string $inputFieldName, mixed $inputFieldValue): array
+    {
+        return [];
+    }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -382,7 +382,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             $errors = array_merge(
                 $errors,
                 $this->validateInputFieldValue($inputFieldName, $inputFieldValue)
-            );            
+            );
         }
         return $errors;
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -375,6 +375,22 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
      *
      * @return string[] Error messages
      */
+    public function validateInputValue(stdClass $inputValue): array
+    {
+        $errors = [];
+        foreach ((array)$inputValue as $inputFieldName => $inputFieldValue) {
+            $errors = array_merge(
+                $errors,
+                $this->validateInputFieldValue($inputFieldName, $inputFieldValue)
+            );            
+        }
+        return $errors;
+    }
+    /**
+     * Validate constraints on the input field's value
+     *
+     * @return string[] Error messages
+     */
     public function validateInputFieldValue(string $inputFieldName, mixed $inputFieldValue): array
     {
         return [];

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -375,7 +375,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
      *
      * @return string[] Error messages
      */
-    public function validateInputValue(stdClass $inputValue): array
+    final public function validateInputValue(stdClass $inputValue): array
     {
         $errors = [];
         foreach ((array)$inputValue as $inputFieldName => $inputFieldValue) {
@@ -391,7 +391,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
      *
      * @return string[] Error messages
      */
-    public function validateInputFieldValue(string $inputFieldName, mixed $inputFieldValue): array
+    protected function validateInputFieldValue(string $inputFieldName, mixed $inputFieldValue): array
     {
         return [];
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\TypeResolvers\InputObjectType;
 
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
+use stdClass;
 
 /**
  * Based on GraphQL InputObject Type
@@ -41,9 +42,9 @@ interface InputObjectTypeResolverInterface extends InputTypeResolverInterface
     public function skipExposingInputFieldInSchema(string $inputFieldName): bool;
     public function getInputFieldSchemaDefinition(string $inputFieldName): array;
     /**
-     * Validate constraints on the input field's value
+     * Validate constraints on the input's value
      *
      * @return string[] Error messages
      */
-    public function validateInputFieldValue(string $inputFieldName, mixed $inputFieldValue): array;
+    public function validateInputValue(stdClass $inputValue): array;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
@@ -40,4 +40,10 @@ interface InputObjectTypeResolverInterface extends InputTypeResolverInterface
      */
     public function skipExposingInputFieldInSchema(string $inputFieldName): bool;
     public function getInputFieldSchemaDefinition(string $inputFieldName): array;
+    /**
+     * Validate constraints on the input field's value
+     *
+     * @return string[] Error messages
+     */
+    public function validateInputFieldValue(string $inputFieldName, mixed $inputFieldValue): array;
 }


### PR DESCRIPTION
Added methods to `AbstractInputObjectTypeResolver`:

- `validateInputValue` <= final
- `validateInputFieldValue` <= to override

For instance, this code will validate the length of the value for an input field:

```php
/**
 * Validate constraints on the input field's value
 *
 * @return string[] Error messages
 */
protected function validateInputFieldValue(string $inputFieldName, mixed $inputFieldValue): array
{
    $errors = parent::validateInputFieldValue($inputFieldName, $inputFieldValue);
    if ($inputFieldName === 'before' && strlen($inputFieldValue) < 66) {
        $errors[] = $this->getTranslationAPI()->__('Input field before requires strings of at least 66 chars long');
    }
    return $errors;
}
```