### PR TITLE
Return object with `coerceValue`

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -39,7 +39,7 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
      *
      * This function simply returns the same value always.
      */
-    final public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    final public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         return $inputValue;
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -134,7 +134,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         return $this->consolidatedInputFieldTypeModifiersCache[$inputFieldName];
     }
 
-    final public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    final public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if (!($inputValue instanceof stdClass)) {
             return $this->getError(

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputTypeResolverInterface.php
@@ -28,7 +28,7 @@ interface InputTypeResolverInterface extends TypeResolverInterface
      * with a descriptive error message.
      *
      * @param string|int|float|bool|stdClass $inputValue the (custom) scalar in any format: itself (eg: an object) or its representation (eg: as a string)
-     * @return string|int|float|bool|stdClass|Error the coerced (custom) scalar, or an instance of Error if it can't be done
+     * @return string|int|float|bool|object the coerced (custom) scalar, or an instance of Error if it can't be done
      *
      * @see https://spec.graphql.org/draft/#sec-Input-Values
      */

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputTypeResolverInterface.php
@@ -32,5 +32,5 @@ interface InputTypeResolverInterface extends TypeResolverInterface
      *
      * @see https://spec.graphql.org/draft/#sec-Input-Values
      */
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error;
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/DangerouslyDynamicScalarTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/DangerouslyDynamicScalarTypeResolver.php
@@ -29,7 +29,7 @@ class DangerouslyDynamicScalarTypeResolver extends AbstractScalarTypeResolver
     /**
      * This method will never be called for DangerouslyDynamicScalar
      */
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         return $inputValue;
     }

--- a/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/AnyBuiltInScalarScalarTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/AnyBuiltInScalarScalarTypeResolver.php
@@ -23,7 +23,7 @@ class AnyBuiltInScalarScalarTypeResolver extends AbstractScalarTypeResolver
     /**
      * Accept anything and everything, other than arrays and objects
      */
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsNotStdClass($inputValue)) {
             return $error;

--- a/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/BooleanScalarTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/BooleanScalarTypeResolver.php
@@ -21,7 +21,7 @@ class BooleanScalarTypeResolver extends AbstractScalarTypeResolver
         return 'Boolean';
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsNotStdClass($inputValue)) {
             return $error;

--- a/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/FloatScalarTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/FloatScalarTypeResolver.php
@@ -26,7 +26,7 @@ class FloatScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('The Float scalar type represents float numbers.', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsNotStdClass($inputValue)) {
             return $error;

--- a/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/IDScalarTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/IDScalarTypeResolver.php
@@ -36,7 +36,7 @@ class IDScalarTypeResolver extends AbstractScalarTypeResolver
      *
      * @see https://spec.graphql.org/draft/#sec-ID.Input-Coercion
      */
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsNotStdClass($inputValue)) {
             return $error;

--- a/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/IntScalarTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/IntScalarTypeResolver.php
@@ -26,7 +26,7 @@ class IntScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('The Int scalar type represents non-fractional signed whole numeric values.', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsNotStdClass($inputValue)) {
             return $error;

--- a/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/StringScalarTypeResolver.php
+++ b/layers/Engine/packages/engine/src/TypeResolvers/ScalarType/StringScalarTypeResolver.php
@@ -25,7 +25,7 @@ class StringScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('The String scalar type represents textual data, represented as UTF-8 character sequences.', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsNotStdClass($inputValue)) {
             return $error;

--- a/layers/Engine/packages/function-fields/src/TypeResolvers/ScalarType/ArrayKeyScalarTypeResolver.php
+++ b/layers/Engine/packages/function-fields/src/TypeResolvers/ScalarType/ArrayKeyScalarTypeResolver.php
@@ -25,7 +25,7 @@ class ArrayKeyScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('Associative and non-associative array keys, which can be either a String or an Int.', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsNotStdClass($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
@@ -53,6 +53,6 @@ class DateScalarTypeResolver extends AbstractScalarTypeResolver
                 )
             );
         }
-        return $inputValue;
+        return $dt;
     }
 }

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
@@ -31,7 +31,7 @@ class DateScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('Date scalar. It follows the ISO 8601 specification, with format "Y-m-d" (representing "<YYYY>-<MM>-<DD>")', 'schema-commons');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
@@ -58,6 +58,6 @@ class DateTimeScalarTypeResolver extends AbstractScalarTypeResolver
                 )
             );
         }
-        return $inputValue;
+        return $dt;
     }
 }

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
@@ -36,7 +36,7 @@ class DateTimeScalarTypeResolver extends AbstractScalarTypeResolver
         );
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DomainScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DomainScalarTypeResolver.php
@@ -25,7 +25,7 @@ class DomainScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('Domain scalar, such as https://mysite.com or http://www.mysite.org', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/EmailScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/EmailScalarTypeResolver.php
@@ -30,7 +30,7 @@ class EmailScalarTypeResolver extends AbstractScalarTypeResolver
         return 'https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1';
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/IPScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/IPScalarTypeResolver.php
@@ -25,7 +25,7 @@ class IPScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('IP scalar, including both IPv4 (such as 192.168.0.1) and IPv6 (such as 2001:0db8:85a3:08d3:1319:8a2e:0370:7334)', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/IPv4ScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/IPv4ScalarTypeResolver.php
@@ -30,7 +30,7 @@ class IPv4ScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('IPv4 scalar, such as 192.168.0.1', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/IPv6ScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/IPv6ScalarTypeResolver.php
@@ -30,7 +30,7 @@ class IPv6ScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('IPv6 scalar, such as 2001:0db8:85a3:08d3:1319:8a2e:0370:7334', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/JSONObjectScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/JSONObjectScalarTypeResolver.php
@@ -31,7 +31,7 @@ class JSONObjectScalarTypeResolver extends AbstractScalarTypeResolver
         return 'https://datatracker.ietf.org/doc/html/rfc7159';
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if (!($inputValue instanceof stdClass)) {
             return $this->getError(

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/MACAddressScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/MACAddressScalarTypeResolver.php
@@ -25,7 +25,7 @@ class MACAddressScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('MAC (media access control) address scalar, such as 00:1A:C2:7B:00:47', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/PhoneNumberScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/PhoneNumberScalarTypeResolver.php
@@ -30,7 +30,7 @@ class PhoneNumberScalarTypeResolver extends AbstractScalarTypeResolver
         return 'https://datatracker.ietf.org/doc/html/rfc3966#section-5.1';
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/RegexScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/RegexScalarTypeResolver.php
@@ -25,7 +25,7 @@ class RegexScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('Regex scalar, such as /([a-zA-Z_][0-9a-zA-Z_]*)/', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/URLScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/URLScalarTypeResolver.php
@@ -25,7 +25,7 @@ class URLScalarTypeResolver extends AbstractScalarTypeResolver
         return $this->getTranslationAPI()->__('URL scalar, such as https://mysite.com/my-fabulous-page', 'component-model');
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/UUIDScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/UUIDScalarTypeResolver.php
@@ -30,7 +30,7 @@ class UUIDScalarTypeResolver extends AbstractScalarTypeResolver
         return 'https://datatracker.ietf.org/doc/html/rfc4122';
     }
 
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|stdClass|Error
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
         if ($error = $this->validateIsString($inputValue)) {
             return $error;


### PR DESCRIPTION
Fixed `DateScalarResolver` and `DateTimeScalarResolver` to return a `Date` in `coerceValue`, not a `String`.

For that, changed also the signature of `coerceValue`, to return `object`, instead of `stdClass|Error` (which are included in `object`)