### PR TITLE
Fix converting object to string in query

### DIFF
--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -23,6 +23,9 @@ services:
     PoP\ComponentModel\Engine\EngineInterface:
         class: \PoP\ComponentModel\Engine\Engine
 
+    PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface:
+        class: \PoP\ComponentModel\ObjectSerialization\ObjectSerializationManager
+
     PoP\ComponentModel\DirectivePipeline\DirectivePipelineServiceInterface:
         class: \PoP\ComponentModel\DirectivePipeline\DirectivePipelineService
 

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterObjectSerializerCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/RegisterObjectSerializerCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Container\CompilerPasses;
+
+use PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface;
+use PoP\ComponentModel\ObjectSerialization\ObjectSerializerInterface;
+use PoP\Root\Container\CompilerPasses\AbstractInjectServiceIntoRegistryCompilerPass;
+
+class RegisterObjectSerializerCompilerPass extends AbstractInjectServiceIntoRegistryCompilerPass
+{
+    protected function getRegistryServiceDefinition(): string
+    {
+        return ObjectSerializationManagerInterface::class;
+    }
+    protected function getServiceClass(): string
+    {
+        return ObjectSerializerInterface::class;
+    }
+    protected function getRegistryMethodCallName(): string
+    {
+        return 'addObjectSerializer';
+    }
+}

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorProvider.php
@@ -4,12 +4,24 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\ErrorHandling;
 
+use PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface;
 use PoP\ComponentModel\Services\BasicServiceTrait;
 use stdClass;
 
 class ErrorProvider implements ErrorProviderInterface
 {
     use BasicServiceTrait;
+
+    private ?ObjectSerializationManagerInterface $objectSerializationManager = null;
+
+    final public function setObjectSerializationManager(ObjectSerializationManagerInterface $objectSerializationManager): void
+    {
+        $this->objectSerializationManager = $objectSerializationManager;
+    }
+    final protected function getObjectSerializationManager(): ObjectSerializationManagerInterface
+    {
+        return $this->objectSerializationManager ??= $this->instanceManager->getInstance(ObjectSerializationManagerInterface::class);
+    }
 
     /**
      * @param array<string, mixed>|null $data
@@ -92,7 +104,7 @@ class ErrorProvider implements ErrorProviderInterface
         if ($value instanceof stdClass) {
             $valueAsString = json_encode($value);
         } elseif (is_object($value)) {
-            $valueAsString = $value->__serialize();
+            $valueAsString = $this->getObjectSerializationManager()->serialize($value);
         } else {
             $valueAsString = (string) $value;
         }

--- a/layers/Engine/packages/component-model/src/Facades/ObjectSerialization/ObjectSerializationManagerFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/ObjectSerialization/ObjectSerializationManagerFacade.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Facades\ObjectSerialization;
+
+use PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface;
+use PoP\Root\Container\ContainerBuilderFactory;
+
+class ObjectSerializationManagerFacade
+{
+    public static function getInstance(): ObjectSerializationManagerInterface
+    {
+        /**
+         * @var ObjectSerializationManagerInterface
+         */
+        $service = ContainerBuilderFactory::getInstance()->get(ObjectSerializationManagerInterface::class);
+        return $service;
+    }
+}

--- a/layers/Engine/packages/component-model/src/ObjectSerialization/AbstractObjectSerializer.php
+++ b/layers/Engine/packages/component-model/src/ObjectSerialization/AbstractObjectSerializer.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\ObjectSerialization;
+
+use PoP\ComponentModel\Services\BasicServiceTrait;
+
+abstract class AbstractObjectSerializer implements ObjectSerializerInterface
+{
+    use BasicServiceTrait;
+}

--- a/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializationManager.php
+++ b/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializationManager.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\ObjectSerialization;
+
+class ObjectSerializationManager implements ObjectSerializationManagerInterface
+{
+    /**
+     * @var array<string, ObjectSerializerInterface>
+     */
+    public array $objectSerializers = [];
+
+    final public function addObjectSerializer(ObjectSerializerInterface $objectSerializer): void
+    {
+        $this->objectSerializers[$objectSerializer->getObjectClassToSerialize()] = $objectSerializer;
+    }
+
+    public function serialize(object $object): string
+    {
+        // Find the Serialize that serializes this object
+        $objectSerializer = null;
+        /** @var string|false */
+        $classToSerialize = $object::class;
+        while ($objectSerializer === null && $classToSerialize !== false) {
+            $objectSerializer = $this->objectSerializers[$classToSerialize] ?? null;
+            $classToSerialize = \get_parent_class($classToSerialize);
+        }
+        if ($objectSerializer !== null) {
+            return $objectSerializer->serialize($object);
+        }
+        
+        /**
+         * No Serializer found. Then call the '__serialize' method of the object,
+         * expecting it to implement it. If it doesn't, it will throw an exception,
+         * so the developer will be made aware to create the corresponding Serializer
+         * for that object class
+         */
+        return $object->__serialize();
+    }
+}

--- a/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializationManager.php
+++ b/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializationManager.php
@@ -29,7 +29,7 @@ class ObjectSerializationManager implements ObjectSerializationManagerInterface
         if ($objectSerializer !== null) {
             return $objectSerializer->serialize($object);
         }
-        
+
         /**
          * No Serializer found. Then call the '__serialize' method of the object,
          * expecting it to implement it. If it doesn't, it will throw an exception,

--- a/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializationManagerInterface.php
+++ b/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializationManagerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\ObjectSerialization;
+
+interface ObjectSerializationManagerInterface
+{
+    public function addObjectSerializer(ObjectSerializerInterface $objectSerializer): void;
+    public function serialize(object $object): string;
+}

--- a/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializerInterface.php
+++ b/layers/Engine/packages/component-model/src/ObjectSerialization/ObjectSerializerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\ObjectSerialization;
+
+interface ObjectSerializerInterface
+{
+    public function getObjectClassToSerialize(): string;
+    public function serialize(object $object): string;
+}

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -12,6 +12,7 @@ use PoP\ComponentModel\ErrorHandling\ErrorDataTokens;
 use PoP\ComponentModel\ErrorHandling\ErrorServiceInterface;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\Misc\GeneralUtils;
+use PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface;
 use PoP\ComponentModel\Resolvers\ResolverTypes;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\AbstractRelationalTypeResolver;
@@ -94,6 +95,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
     private ?DangerouslyDynamicScalarTypeResolver $dangerouslyDynamicScalarTypeResolver = null;
     private ?ErrorServiceInterface $errorService = null;
     private ?InputCoercingServiceInterface $inputCoercingService = null;
+    private ?ObjectSerializationManagerInterface $objectSerializationManager = null;
 
     final public function setDangerouslyDynamicScalarTypeResolver(DangerouslyDynamicScalarTypeResolver $dangerouslyDynamicScalarTypeResolver): void
     {
@@ -118,6 +120,14 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
     final protected function getInputCoercingService(): InputCoercingServiceInterface
     {
         return $this->inputCoercingService ??= $this->instanceManager->getInstance(InputCoercingServiceInterface::class);
+    }
+    final public function setObjectSerializationManager(ObjectSerializationManagerInterface $objectSerializationManager): void
+    {
+        $this->objectSerializationManager = $objectSerializationManager;
+    }
+    final protected function getObjectSerializationManager(): ObjectSerializationManagerInterface
+    {
+        return $this->objectSerializationManager ??= $this->instanceManager->getInstance(ObjectSerializationManagerInterface::class);
     }
 
     /**
@@ -1827,5 +1837,10 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             return $this->getFieldName($field);
         }
         return parent::getNoAliasFieldOutputKey($field);
+    }
+
+    protected function serializeObject(object $object): string
+    {
+        return $this->getObjectSerializationManager()->serialize($object);
     }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/AbstractScalarTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/AbstractScalarTypeResolver.php
@@ -5,11 +5,23 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\TypeResolvers\ScalarType;
 
 use PoP\ComponentModel\ErrorHandling\Error;
+use PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use stdClass;
 
 abstract class AbstractScalarTypeResolver extends AbstractTypeResolver implements ScalarTypeResolverInterface
 {
+    private ?ObjectSerializationManagerInterface $objectSerializationManager = null;
+    
+    final public function setObjectSerializationManager(ObjectSerializationManagerInterface $objectSerializationManager): void
+    {
+        $this->objectSerializationManager = $objectSerializationManager;
+    }
+    final protected function getObjectSerializationManager(): ObjectSerializationManagerInterface
+    {
+        return $this->objectSerializationManager ??= $this->instanceManager->getInstance(ObjectSerializationManagerInterface::class);
+    }
+
     public function getSpecifiedByURL(): ?string
     {
         return null;
@@ -38,7 +50,7 @@ abstract class AbstractScalarTypeResolver extends AbstractTypeResolver implement
         }
         // Convert object to string
         if (is_object($scalarValue)) {
-            return $scalarValue->__serialize();
+            return $this->getObjectSerializationManager()->serialize($scalarValue);
         }
         // Return as is
         return $scalarValue;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/AbstractScalarTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/AbstractScalarTypeResolver.php
@@ -12,7 +12,7 @@ use stdClass;
 abstract class AbstractScalarTypeResolver extends AbstractTypeResolver implements ScalarTypeResolverInterface
 {
     private ?ObjectSerializationManagerInterface $objectSerializationManager = null;
-    
+
     final public function setObjectSerializationManager(ObjectSerializationManagerInterface $objectSerializationManager): void
     {
         $this->objectSerializationManager = $objectSerializationManager;

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -781,6 +781,13 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
             } elseif ($fieldArgValue instanceof stdClass) {
                 // Convert from array to its representation of object in a string
                 $fieldArgValue = $this->getObjectAsStringForQuery($fieldArgValue);
+            } elseif (is_object($fieldArgValue)) {
+                /**
+                 * This function accepts objects because it is called
+                 * after calling `coerceValue`, so a string like `2020-01-01`
+                 * will be transformed to a `Date` object
+                 */
+                $fieldArgValue = $this->wrapStringInQuotes($fieldArgValue->__serialize());
             } elseif (is_string($fieldArgValue)) {
                 // If it doesn't have them yet, wrap the string between quotes for if there's a special symbol
                 // inside of it (eg: it if has a ",", it will split the element there when decoding again
@@ -901,6 +908,13 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                     // inside of it (eg: it if has a ",", it will split the element there when decoding again
                     // from string to array in `getField`)
                     $value = $this->maybeWrapStringInQuotes($value);
+                } elseif (is_object($value)) {
+                    /**
+                     * This function accepts objects because it is called
+                     * after calling `coerceValue`, so a string like `2020-01-01`
+                     * will be transformed to a `Date` object
+                     */
+                    $value = $this->wrapStringInQuotes($value->__serialize());
                 }
                 $elems[] = $key . QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEOBJECT_KEYVALUEDELIMITER . $value;
             }

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -226,41 +226,6 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
         return $field;
     }
 
-    /**
-     * Replace the fieldArgs in the field
-     *
-     * @param array<string, mixed> $fieldArgs
-     */
-    protected function replaceFieldArgs(string $field, array $fieldArgs): string
-    {
-        // Return a new field, replacing its fieldArgs (if any) with the provided ones
-        // Used when validating a field and removing the fieldArgs that threw a warning
-        list(
-            $fieldArgsOpeningSymbolPos,
-            $fieldArgsClosingSymbolPos
-        ) = QueryHelpers::listFieldArgsSymbolPositions($field);
-
-        // If it currently has fieldArgs, append the fieldArgs after the fieldName
-        if ($fieldArgsOpeningSymbolPos !== false && $fieldArgsClosingSymbolPos !== false) {
-            $fieldName = $this->getFieldName($field);
-            return substr(
-                $field,
-                0,
-                $fieldArgsOpeningSymbolPos
-            ) .
-            $this->getFieldArgsAsString($fieldArgs) .
-            substr(
-                $field,
-                $fieldArgsClosingSymbolPos + strlen(QuerySyntax::SYMBOL_FIELDDIRECTIVE_CLOSING)
-            );
-        }
-
-        // Otherwise there are none. Then add the fieldArgs between the fieldName and whatever may come after
-        // (alias, directives, or nothing)
-        $fieldName = $this->getFieldName($field);
-        return $fieldName . $this->getFieldArgsAsString($fieldArgs) . substr($field, strlen($fieldName));
-    }
-
     public function isFieldArgumentValueAField(mixed $fieldArgValue): bool
     {
         // If the result fieldArgValue is a string (i.e. not numeric), and it has brackets (...),

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -767,6 +767,10 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
             QuerySyntax::SYMBOL_FIELDARGS_CLOSING;
     }
 
+    /**
+     * This is the base implementation. Override function whenever
+     * the object does not contain `__serialize`
+     */
     protected function serializeObject(object $object): string
     {
         return $object->__serialize();

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -787,7 +787,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                  * after calling `coerceValue`, so a string like `2020-01-01`
                  * will be transformed to a `Date` object
                  */
-                $fieldArgValue = $this->wrapStringInQuotes($fieldArgValue->__serialize());
+                $fieldArgValue = $this->wrapStringInQuotes($this->serializeObject($fieldArgValue));
             } elseif (is_string($fieldArgValue)) {
                 // If it doesn't have them yet, wrap the string between quotes for if there's a special symbol
                 // inside of it (eg: it if has a ",", it will split the element there when decoding again
@@ -800,6 +800,11 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
             QuerySyntax::SYMBOL_FIELDARGS_OPENING .
             implode(QuerySyntax::SYMBOL_FIELDARGS_ARGSEPARATOR, $elems) .
             QuerySyntax::SYMBOL_FIELDARGS_CLOSING;
+    }
+
+    protected function serializeObject(object $object): string
+    {
+        return $object->__serialize();
     }
 
     /**
@@ -914,7 +919,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                      * after calling `coerceValue`, so a string like `2020-01-01`
                      * will be transformed to a `Date` object
                      */
-                    $value = $this->wrapStringInQuotes($value->__serialize());
+                    $value = $this->wrapStringInQuotes($this->serializeObject($value));
                 }
                 $elems[] = $key . QuerySyntax::SYMBOL_FIELDARGS_ARGVALUEOBJECT_KEYVALUEDELIMITER . $value;
             }

--- a/layers/Schema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Comments\FieldResolvers\ObjectType;
 
+use DateTime;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\FilterInput\FilterInputHelper;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -361,10 +362,10 @@ class CommentObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRes
                 return $this->getCommentTypeAPI()->getCommentParent($comment);
 
             case 'date':
-                return $this->getDateFormatter()->format(
+                return new DateTime($this->getDateFormatter()->format(
                     $fieldArgs['format'],
                     $this->getCommentTypeAPI()->getCommentDate($comment, $fieldArgs['gmt'])
-                );
+                ));
         }
 
         $query = array_merge(

--- a/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\FieldResolvers\ObjectType;
 
+use DateTime;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\Formatters\DateFormatterInterface;
@@ -113,16 +114,16 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
                 return $fieldArgs['status'] == $customPostTypeAPI->getStatus($customPost);
 
             case 'date':
-                return $this->getDateFormatter()->format(
+                return new DateTime($this->getDateFormatter()->format(
                     $fieldArgs['format'],
                     $customPostTypeAPI->getPublishedDate($customPost, $fieldArgs['gmt'])
-                );
+                ));
 
             case 'modified':
-                return $this->getDateFormatter()->format(
+                return new DateTime($this->getDateFormatter()->format(
                     $fieldArgs['format'],
                     $customPostTypeAPI->getModifiedDate($customPost, $fieldArgs['gmt'])
-                );
+                ));
 
             case 'title':
                 return $customPostTypeAPI->getTitle($customPost);

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -54,10 +54,10 @@ class CustomPostDateQueryInputObjectTypeResolver extends AbstractQueryableInputO
     public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass $inputValue): void
     {
         if (isset($inputValue->before)) {
-            $query['date-to'] = $this->dateScalarTypeResolver->serialize($inputValue->before);
+            $query['date-to'] = $this->getDateScalarTypeResolver()->serialize($inputValue->before);
         }
         if (isset($inputValue->after)) {
-            $query['date-from'] = $this->dateScalarTypeResolver->serialize($inputValue->after);
+            $query['date-from'] = $this->getDateScalarTypeResolver()->serialize($inputValue->after);
         }
     }
 }

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -7,6 +7,7 @@ namespace PoPSchema\CustomPosts\TypeResolvers\InputObjectType;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\AbstractQueryableInputObjectTypeResolver;
 use PoPSchema\SchemaCommons\FilterInputProcessors\FilterInputProcessor;
 use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\DateScalarTypeResolver;
+use stdClass;
 
 class CustomPostDateQueryInputObjectTypeResolver extends AbstractQueryableInputObjectTypeResolver
 {
@@ -43,12 +44,20 @@ class CustomPostDateQueryInputObjectTypeResolver extends AbstractQueryableInputO
         };
     }
 
-    protected function getFilteringQueryArgNameToCopyInputFieldValue(string $inputFieldName): ?string
+    /**
+     * Integrate parameters into the "date_query" WP_Query arg
+     *
+     * @see https://developer.wordpress.org/reference/classes/wp_query/#date-parameters
+     *
+     * @param array<string, mixed> $query
+     */
+    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass $inputValue): void
     {
-        return match ($inputFieldName) {
-            'after' => 'date-from',
-            'before' => 'date-to',
-            default => parent::getFilteringQueryArgNameToCopyInputFieldValue($inputFieldName),
-        };
+        if (isset($inputValue->before)) {
+            $query['date-to'] = $this->dateScalarTypeResolver->serialize($inputValue->before);
+        }
+        if (isset($inputValue->after)) {
+            $query['date-from'] = $this->dateScalarTypeResolver->serialize($inputValue->after);
+        }
     }
 }

--- a/layers/Schema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Media\FieldResolvers\ObjectType;
 
+use DateTime;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -226,15 +227,15 @@ class MediaObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResol
             case 'description':
                 return $this->getMediaTypeAPI()->getDescription($media);
             case 'date':
-                return $this->getDateFormatter()->format(
+                return new DateTime($this->getDateFormatter()->format(
                     $fieldArgs['format'],
                     $this->getMediaTypeAPI()->getDate($media, $fieldArgs['gmt'])
-                );
+                ));
             case 'modified':
-                return $this->getDateFormatter()->format(
+                return new DateTime($this->getDateFormatter()->format(
                     $fieldArgs['format'],
                     $this->getMediaTypeAPI()->getModified($media, $fieldArgs['gmt'])
-                );
+                ));
             case 'mimeType':
                 return $this->getMediaTypeAPI()->getMimeType($media);
         }

--- a/layers/Schema/packages/schema-commons/config/services.yaml
+++ b/layers/Schema/packages/schema-commons/config/services.yaml
@@ -15,3 +15,6 @@ services:
 
     PoPSchema\SchemaCommons\FormInputs\:
         resource: '../src/FormInputs/*'
+
+    PoPSchema\SchemaCommons\ObjectSerializers\:
+        resource: '../src/ObjectSerializers/*'

--- a/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
+++ b/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoP\ComponentModel\ObjectSerialization;
+namespace PoPSchema\SchemaCommons\ObjectSerialization;
 
 use DateTime;
 use DateTimeInterface;

--- a/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
+++ b/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\ObjectSerialization;
+
+use DateTime;
+use DateTimeInterface;
+use PoP\ComponentModel\ObjectSerialization\AbstractObjectSerializer;
+
+class DateTimeObjectSerializer extends AbstractObjectSerializer
+{
+    public function getObjectClassToSerialize(): string
+    {
+        return DateTime::class;
+    }
+    public function serialize(object $object): string
+    {
+        /** @var $object DateTime */
+        return $object->format(DateTimeInterface::ATOM);
+    }
+}

--- a/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
+++ b/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoPSchema\SchemaCommons\ObjectSerialization;
+namespace PoPSchema\SchemaCommons\ObjectSerializers;
 
 use DateTime;
 use DateTimeInterface;

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
+
+use DateTime;
+use DateTimeInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\AbstractScalarTypeResolver;
+use stdClass;
+
+/**
+ * GraphQL Custom Scalar
+ *
+ * @see https://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars
+ */
+abstract class AbstractDateTimeScalarTypeResolver extends AbstractScalarTypeResolver
+{
+    public function getTypeDescription(): ?string
+    {
+        return sprintf(
+            $this->getTranslationAPI()->__('%s scalar. It follows the ISO 8601 specification, with format "%s")', 'schema-commons'),
+            $this->getTypeName(),
+            $this->getDateTimeFormat()
+        );
+    }
+
+    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
+    {
+        if ($error = $this->validateIsString($inputValue)) {
+            return $error;
+        }
+
+        /**
+         * Validate the format
+         *
+         * @see https://stackoverflow.com/a/13194398
+         */
+        $format = $this->getDateTimeFormat();
+        $dt = DateTime::createFromFormat($format, $inputValue);
+        if ($dt === false || array_sum($dt::getLastErrors())) {
+            return $this->getError(
+                sprintf(
+                    $this->getTranslationAPI()->__('Type \'%s\' must be provided with format \'%s\'', 'component-model'),
+                    $this->getMaybeNamespacedTypeName(),
+                    $format
+                )
+            );
+        }
+        return $dt;
+    }
+
+    abstract protected function getDateTimeFormat(): string;
+
+    public function serialize(string|int|float|bool|object $scalarValue): string|int|float|bool|array
+    {
+        /** @var DateTimeInterface $scalarValue */
+        return $scalarValue->format($this->getDateTimeFormat());
+    }
+}

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
@@ -74,6 +74,10 @@ abstract class AbstractDateTimeScalarTypeResolver extends AbstractScalarTypeReso
         ];
     }
 
+    /**
+     * Because DateTimeObjectSerializer also uses the same format 'Y-m-d\TH:i:sP',
+     * override this function to provide the specific format for each case
+     */
     public function serialize(string|int|float|bool|object $scalarValue): string|int|float|bool|array
     {
         /** @var DateTimeInterface $scalarValue */

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
@@ -53,7 +53,7 @@ abstract class AbstractDateTimeScalarTypeResolver extends AbstractScalarTypeReso
     }
 
     abstract protected function getDateTimeFormat(): string;
-    
+
     /**
      * Allow to define more than one input format, so that
      * Date can be represented as either:

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
 
+use DateTimeInterface;
+
 class DateScalarTypeResolver extends AbstractDateTimeScalarTypeResolver
 {
     public function getTypeName(): string
@@ -14,5 +16,15 @@ class DateScalarTypeResolver extends AbstractDateTimeScalarTypeResolver
     protected function getDateTimeFormat(): string
     {
         return 'Y-m-d';
+    }
+
+    protected function getDateTimeInputFormats(): array
+    {
+        return array_merge(
+            parent::getDateTimeInputFormats(),
+            [
+                DateTimeInterface::ATOM,
+            ]
+        );
     }
 }

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
@@ -4,55 +4,15 @@ declare(strict_types=1);
 
 namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
 
-use DateTime;
-use PoP\ComponentModel\ErrorHandling\Error;
-use PoP\ComponentModel\TypeResolvers\ScalarType\AbstractScalarTypeResolver;
-use stdClass;
-
-/**
- * GraphQL Custom Scalar
- *
- * @see https://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars
- */
-class DateScalarTypeResolver extends AbstractScalarTypeResolver
+class DateScalarTypeResolver extends AbstractDateTimeScalarTypeResolver
 {
     public function getTypeName(): string
     {
         return 'Date';
     }
 
-    public function getSpecifiedByURL(): ?string
+    protected function getDateTimeFormat(): string
     {
-        return 'https://datatracker.ietf.org/doc/html/rfc3339#section-5.6';
-    }
-
-    public function getTypeDescription(): ?string
-    {
-        return $this->getTranslationAPI()->__('Date scalar. It follows the ISO 8601 specification, with format "Y-m-d" (representing "<YYYY>-<MM>-<DD>")', 'schema-commons');
-    }
-
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
-    {
-        if ($error = $this->validateIsString($inputValue)) {
-            return $error;
-        }
-
-        /**
-         * Validate that the format is 'Y-m-d'
-         *
-         * @see https://stackoverflow.com/a/13194398
-         */
-        $format = 'Y-m-d';
-        $dt = DateTime::createFromFormat($format, $inputValue);
-        if ($dt === false || array_sum($dt::getLastErrors())) {
-            return $this->getError(
-                sprintf(
-                    $this->getTranslationAPI()->__('Type \'%s\' must be provided with format \'%s\'', 'component-model'),
-                    $this->getMaybeNamespacedTypeName(),
-                    $format
-                )
-            );
-        }
-        return $dt;
+        return 'Y-m-d';
     }
 }

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
@@ -4,60 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
 
-use DateTime;
 use DateTimeInterface;
-use PoP\ComponentModel\ErrorHandling\Error;
-use PoP\ComponentModel\TypeResolvers\ScalarType\AbstractScalarTypeResolver;
-use stdClass;
 
-/**
- * GraphQL Custom Scalar
- *
- * @see https://spec.graphql.org/draft/#sec-Scalars.Custom-Scalars
- */
-class DateTimeScalarTypeResolver extends AbstractScalarTypeResolver
+class DateTimeScalarTypeResolver extends AbstractDateTimeScalarTypeResolver
 {
     public function getTypeName(): string
     {
         return 'DateTime';
     }
 
-    public function getSpecifiedByURL(): ?string
+    protected function getDateTimeFormat(): string
     {
-        return 'https://datatracker.ietf.org/doc/html/rfc3339#section-5.6';
-    }
-
-    public function getTypeDescription(): ?string
-    {
-        $format = DateTimeInterface::ATOM;
-        return sprintf(
-            $this->getTranslationAPI()->__('DateTime scalar. It follows the ISO 8601 specification, with format "%s")', 'schema-commons'),
-            $format
-        );
-    }
-
-    public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
-    {
-        if ($error = $this->validateIsString($inputValue)) {
-            return $error;
-        }
-
-        /**
-         * Validate the format
-         *
-         * @see https://stackoverflow.com/a/13194398
-         */
-        $format = DateTimeInterface::ATOM;
-        $dt = DateTime::createFromFormat($format, $inputValue);
-        if ($dt === false || array_sum($dt::getLastErrors())) {
-            return $this->getError(
-                sprintf(
-                    $this->getTranslationAPI()->__('Type \'%s\' must be provided with format \'%s\'', 'component-model'),
-                    $this->getMaybeNamespacedTypeName(),
-                    $format
-                )
-            );
-        }
-        return $dt;
+        return DateTimeInterface::ATOM;
     }
 }


### PR DESCRIPTION
Fixed bug:

```
2021-11-12T06:26:57.620473958Z [Fri Nov 12 06:26:57.620249 2021] [php:error] [pid 211] [client 172.19.0.2:50042] PHP Fatal error:  Uncaught Error: Object of class DateTime could not be converted to string in /app/wordpress/Engine/packages/field-query/src/FieldQueryInterpreter.php:905
Stack trace:
#0 /app/wordpress/Engine/packages/field-query/src/FieldQueryInterpreter.php(894): PoP\\FieldQuery\\FieldQueryInterpreter->getObjectAsStringForQuery(Object(stdClass))
#1 /app/wordpress/Engine/packages/field-query/src/FieldQueryInterpreter.php(783): PoP\\FieldQuery\\FieldQueryInterpreter->getObjectAsStringForQuery(Object(stdClass))
#2 /app/wordpress/Engine/packages/field-query/src/FieldQueryInterpreter.php(251): PoP\\FieldQuery\\FieldQueryInterpreter->getFieldArgsAsString(Array)
#3 /app/wordpress/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php(674): PoP\\FieldQuery\\FieldQueryInterpreter->replaceFieldArgs('posts(sort:{ord...', Array)
#4 /app/wordpress/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php(307): PoP\\ComponentModel\\Schema\\FieldQueryInterpreter->extractFieldArgumentsForSchema(Object(GraphQLByPoP\\GraphQLServer\\TypeResolvers\\ObjectType\\QueryRootObjectTypeResolver), 'posts(sort:{ord...')
#5 /app/wordpress/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php(300): PoP\\ComponentModel\\TypeResolvers\\ObjectType\\AbstractObjectTypeResolver->doDissectFieldForSchema('posts(sort:{ord...')
#6 /app/wordpress/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php(250): PoP\\ComponentModel\\TypeResolvers\\ObjectType\\AbstractObjectTypeResolver->dissectFieldForSchema('posts(sort:{ord...')
#7 /app/wordpress/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php(69): PoP\\ComponentModel\\TypeResolvers\\ObjectType\\AbstractObjectTypeResolver->getFieldTypeResolver('posts(sort:{ord...')
#8 /app/wordpress/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php(260): PoP\\ComponentModel\\HelperServices\\DataloadHelperService->getTypeResolverFromSubcomponentDataField(Object(GraphQLByPoP\\GraphQLServer\\TypeResolvers\\ObjectType\\QueryRootObjectTypeResolver), 'posts(sort:{ord...')
#9 /app/wordpress/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php(175): PoP\\ComponentModel\\ModuleProcessors\\AbstractModuleProcessor->initModelProps(Array, Array)
#10 /app/wordpress/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php(218): PoP\\ComponentModel\\ModuleProcessors\\AbstractModuleProcessor->executeInitPropsModuletree(Array, Array, Array, 'initModelPropsM...', Array, Array, Array, Array)
#11 /app/wordpress/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php(210): PoP\\ComponentModel\\ModuleProcessors\\AbstractModuleProcessor->initModelPropsModuletree(Array, Array, Array, Array)
#12 /app/wordpress/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php(218): PoP\\ComponentModel\\ModuleProcessors\\AbstractModuleProcessor->executeInitPropsModuletree(Array, Array, Array, 'initModelPropsM...', Array, Array, Array, Array)
#13 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(409): PoP\\ComponentModel\\ModuleProcessors\\AbstractModuleProcessor->initModelPropsModuletree(Array, Array, Array, Array)
#14 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(445): PoP\\ComponentModel\\Engine\\Engine->getModelPropsModuletree(Array)
#15 /app/wordpress/Engine/packages/component-model/src/Engine/Engine.php(335): PoP\\ComponentModel\\Engine\\Engine->processAndGenerateData()
#16 /app/wordpress/Engine/packages/engine/src/Engine/Engine.php(56): PoP\\ComponentModel\\Engine\\Engine->generateData()
#17 /app/wordpress/Engine/packages/engine/src/Engine/Engine.php(62): PoP\\Engine\\Engine\\Engine->generateData()
#18 /app/wordpress/Engine/packages/engine-wp/templates/Output.php(5): PoP\\Engine\\Engine\\Engine->outputResponse()
#19 /app/wordpress/wp-content/plugins/graphql-api/src/ConditionalOnContext/Admin/Services/EndpointResolvers/AdminEndpointResolver.php(188): include('/app/wordpress/...')
#20 /app/wordpress/wp-includes/class-wp-hook.php(303): GraphQLAPI\\GraphQLAPI\\ConditionalOnContext\\Admin\\Services\\EndpointResolvers\\AdminEndpointResolver->GraphQLAPI\\GraphQLAPI\\ConditionalOnContext\\Admin\\Services\\EndpointResolvers\\{closure}('')
#21 /app/wordpress/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
#22 /app/wordpress/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#23 /app/wordpress/wp-admin/admin.php(175): do_action('admin_init')
#24 /app/wordpress/wp-admin/edit.php(10): require_once('/app/wordpress/...')
#25 {main}
  thrown in /app/wordpress/Engine/packages/field-query/src/FieldQueryInterpreter.php on line 905, referer: http://graphql-api-pro.lndo.site/wp-admin/admin.php?page=graphql_api&query=%7B%0A%20%20posts(%0A%20%20%20%20sort%3A%7B%0A%20%20%20%20%20%20order%3AASC%0A%20%20%20%20%20%20%23%20by%3AAUTHOR%0A%20%20%20%20%7D%2C%0A%20%20%20%20filter%3A%7B%0A%20%20%20%20%20%20search%3A%22Hel%22%0A%20%20%20%20%20%20dateQuery%3A%7B%0A%20%20%20%20%20%20%20%20before%3A%222022-01-02%22%2C%0A%20%20%20%20%20%20%20%20after%3A%222018-11-01%22%2C%0A%20%20%20%20%20%20%20%20%23%20inclusive%3Afalse%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20id%0A%20%20%20%20title%0A%20%20%20%20date%0A%20%20%20%20commentCount%0A%20%20%20%20author%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20name%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D
```