### PR TITLE
Override CustomPostDateQueryInput in WPSchema

### DIFF
--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -700,7 +700,6 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
             $fieldArgTypeResolver = $fieldArgNameTypeResolvers[$fieldArgName];
             if (
                 $fieldArgTypeResolver instanceof InputObjectTypeResolverInterface
-                && $fieldArgValue instanceof stdClass
             ) {
                 $errors = array_merge(
                     $errors,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractQueryableInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractQueryableInputObjectTypeResolver.php
@@ -48,10 +48,24 @@ abstract class AbstractQueryableInputObjectTypeResolver extends AbstractInputObj
     }
 
     /**
+     * The base behavior can only be applied when the value is an stdClass.
+     * If it is an array, or array of arrays, then apply this logic recursively.
+     *
      * @param array<string, mixed> $query
+     * @param stdClass|stdClass[]|array<stdClass[]> $inputValue
      */
-    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass $inputValue): void
+    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass|array $inputValue): void
     {
+        // Here $inputValue is an array, or array of arrays
+        if (is_array($inputValue)) {
+            foreach ($inputValue as $index => $inputValueElem) {
+                $queryElem = [];
+                $this->integrateInputValueToFilteringQueryArgs($queryElem, $inputValueElem);
+                $query[$index] = $queryElem;
+            }
+            return;
+        }
+        // Here $inputValue is an stdClass
         foreach ((array)$inputValue as $inputFieldName => $inputFieldValue) {
             $this->integrateInputFieldValueToFilteringQueryArgs($inputFieldName, $query, $inputFieldValue);
         }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/QueryableInputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/QueryableInputObjectTypeResolverInterface.php
@@ -24,6 +24,7 @@ interface QueryableInputObjectTypeResolverInterface extends InputObjectTypeResol
      * Apply the FilterInputs to produce the filtering query
      *
      * @param array<string, mixed> $query
+     * @param stdClass|stdClass[]|array<stdClass[]> $inputValue
      */
-    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass $inputValue): void;
+    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass|array $inputValue): void;
 }

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -49,9 +49,15 @@ class CustomPostDateQueryInputObjectTypeResolver extends AbstractQueryableInputO
      * @see https://developer.wordpress.org/reference/classes/wp_query/#date-parameters
      *
      * @param array<string, mixed> $query
+     * @param stdClass|stdClass[]|array<stdClass[]> $inputValue
      */
-    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass $inputValue): void
+    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass|array $inputValue): void
     {
+        if (is_array($inputValue)) {
+            parent::integrateInputValueToFilteringQueryArgs($query, $inputValue);
+            return;
+        }
+        
         if (isset($inputValue->before)) {
             $query['date-to'] = $this->getDateScalarTypeResolver()->serialize($inputValue->before);
         }

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -57,7 +57,7 @@ class CustomPostDateQueryInputObjectTypeResolver extends AbstractQueryableInputO
             parent::integrateInputValueToFilteringQueryArgs($query, $inputValue);
             return;
         }
-        
+
         if (isset($inputValue->before)) {
             $query['date-to'] = $this->getDateScalarTypeResolver()->serialize($inputValue->before);
         }

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoPSchema\CustomPosts\TypeResolvers\InputObjectType;
 
 use PoP\ComponentModel\TypeResolvers\InputObjectType\AbstractQueryableInputObjectTypeResolver;
-use PoPSchema\SchemaCommons\FilterInputProcessors\FilterInputProcessor;
 use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\DateScalarTypeResolver;
 
 class CustomPostDateQueryInputObjectTypeResolver extends AbstractQueryableInputObjectTypeResolver

--- a/layers/WPSchema/packages/customposts/config/Overrides/schema-services.yaml
+++ b/layers/WPSchema/packages/customposts/config/Overrides/schema-services.yaml
@@ -5,3 +5,6 @@ services:
 
     PoPSchema\CustomPosts\TypeResolvers\EnumType\CustomPostOrderByEnumTypeResolver:
         class: PoPWPSchema\CustomPosts\Overrides\TypeResolvers\EnumType\CustomPostOrderByEnumTypeResolver
+
+    PoPSchema\CustomPosts\TypeResolvers\InputObjectType\CustomPostDateQueryInputObjectTypeResolver:
+        class: PoPWPSchema\CustomPosts\Overrides\TypeResolvers\InputObjectType\CustomPostDateQueryInputObjectTypeResolver

--- a/layers/WPSchema/packages/customposts/config/schema-services.yaml
+++ b/layers/WPSchema/packages/customposts/config/schema-services.yaml
@@ -6,5 +6,8 @@ services:
     PoPWPSchema\CustomPosts\FieldResolvers\:
         resource: '../src/FieldResolvers/*'
 
+    PoPWPSchema\CustomPosts\TypeResolvers\:
+        resource: '../src/TypeResolvers/*'
+
     PoPWPSchema\CustomPosts\SchemaHooks\:
         resource: '../src/SchemaHooks/*'

--- a/layers/WPSchema/packages/customposts/config/schema-services.yaml
+++ b/layers/WPSchema/packages/customposts/config/schema-services.yaml
@@ -5,3 +5,6 @@ services:
 
     PoPWPSchema\CustomPosts\FieldResolvers\:
         resource: '../src/FieldResolvers/*'
+
+    PoPWPSchema\CustomPosts\SchemaHooks\:
+        resource: '../src/SchemaHooks/*'

--- a/layers/WPSchema/packages/customposts/src/Constants/QueryRelations.php
+++ b/layers/WPSchema/packages/customposts/src/Constants/QueryRelations.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CustomPosts\Constants;
+
+class QueryRelations
+{
+    public const OR = 'OR';
+    public const AND = 'AND';
+}

--- a/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -89,6 +89,10 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
      */
     public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass|array $inputValue): void
     {
+        /**
+         * Collect all the "date_query" results, and then arrange them properly
+         * as an array, with the "relation" as the first element (if defined)
+         */
         if (is_array($inputValue)) {
             $innerQueries = [];
             parent::integrateInputValueToFilteringQueryArgs($innerQueries, $inputValue);
@@ -97,21 +101,27 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
             if (isset($innerQueries[0]['date_query']['relation'])) {
                 $query['date_query']['relation'] = $innerQueries[0]['date_query']['relation'];
             }
+            // Re-create an array with all the subelements
             foreach ($innerQueries as $innerQuery) {
                 $query['date_query'][] = $innerQuery['date_query'];
             }
             return;
         }
 
+        /**
+         * Here it's a single stdClass. Create the config for a single "date_query"
+         */
         $dateQuery = [];
 
+        // These elements must be serialized, from Date to String
         if (isset($inputValue->before)) {
             $dateQuery['before'] = $this->getDateScalarTypeResolver()->serialize($inputValue->before);
         }
         if (isset($inputValue->after)) {
             $dateQuery['after'] = $this->getDateScalarTypeResolver()->serialize($inputValue->after);
         }
-        
+
+        // These elements can copy directly
         $properties = [
             'year',
             'month',
@@ -126,11 +136,13 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
             'relation',
         ];
         foreach ($properties as $property) {
-            if (isset($inputValue->$property)) {
-                $dateQuery[$property] = $inputValue->$property;
+            if (!isset($inputValue->$property)) {
+                continue;
             }
+            $dateQuery[$property] = $inputValue->$property;
         }
 
+        // Assign under "date_query"
         if ($dateQuery !== []) {
             $query['date_query'] = $dateQuery;
         }

--- a/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace PoPWPSchema\CustomPosts\Overrides\TypeResolvers\InputObjectType;
 
 use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+use PoP\Engine\TypeResolvers\ScalarType\IntScalarTypeResolver;
 use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\CustomPostDateQueryInputObjectTypeResolver as UpstreamCustomPostDateQueryInputObjectTypeResolver;
 use stdClass;
 
 class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQueryInputObjectTypeResolver
 {
     private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+    private ?IntScalarTypeResolver $intScalarTypeResolver = null;
 
     final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
     {
@@ -20,6 +22,14 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
     {
         return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
     }
+    final public function setIntScalarTypeResolver(IntScalarTypeResolver $intScalarTypeResolver): void
+    {
+        $this->intScalarTypeResolver = $intScalarTypeResolver;
+    }
+    final protected function getIntScalarTypeResolver(): IntScalarTypeResolver
+    {
+        return $this->intScalarTypeResolver ??= $this->instanceManager->getInstance(IntScalarTypeResolver::class);
+    }
 
     public function getInputFieldNameTypeResolvers(): array
     {
@@ -27,6 +37,13 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
             parent::getInputFieldNameTypeResolvers(),
             [
                 'inclusive' => $this->getBooleanScalarTypeResolver(),
+                'year' => $this->getIntScalarTypeResolver(),
+                'month' => $this->getIntScalarTypeResolver(),
+                'week' => $this->getIntScalarTypeResolver(),
+                'day' => $this->getIntScalarTypeResolver(),
+                'hour' => $this->getIntScalarTypeResolver(),
+                'minute' => $this->getIntScalarTypeResolver(),
+                'second' => $this->getIntScalarTypeResolver(),
             ]
         );
     }
@@ -35,6 +52,13 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
     {
         return match ($inputFieldName) {
             'inclusive' => $this->getTranslationAPI()->__('For after/before, whether exact value should be matched or not', 'customposts'),
+            'year' => $this->getTranslationAPI()->__('4 digit year (e.g. 2011)', 'customposts'),
+            'month' => $this->getTranslationAPI()->__('Month number (from 1 to 12)', 'customposts'),
+            'week' => $this->getTranslationAPI()->__('Week of the year (from 0 to 53)', 'customposts'),
+            'day' => $this->getTranslationAPI()->__('Day of the month (from 1 to 31)', 'customposts'),
+            'hour' => $this->getTranslationAPI()->__('Hour (from 0 to 23)', 'customposts'),
+            'minute' => $this->getTranslationAPI()->__('Minute (from 0 to 59)', 'customposts'),
+            'second' => $this->getTranslationAPI()->__('Second (0 to 59)', 'customposts'),
             default => parent::getInputFieldDescription($inputFieldName),
         };
     }
@@ -56,8 +80,20 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
         if (isset($inputValue->after)) {
             $dateQuery['after'] = $this->getDateScalarTypeResolver()->serialize($inputValue->after);
         }
-        if (isset($inputValue->inclusive)) {
-            $dateQuery['inclusive'] = $inputValue->inclusive;
+        $properties = [
+            'year',
+            'month',
+            'week',
+            'day',
+            'hour',
+            'minute',
+            'second',
+            'inclusive',
+        ];
+        foreach ($properties as $property) {
+            if (isset($inputValue->$property)) {
+                $dateQuery[$property] = $inputValue->$property;
+            }
         }
 
         if ($dateQuery !== []) {

--- a/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CustomPosts\Overrides\TypeResolvers\InputObjectType;
+
+use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\CustomPostDateQueryInputObjectTypeResolver as UpstreamCustomPostDateQueryInputObjectTypeResolver;
+use stdClass;
+
+class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQueryInputObjectTypeResolver
+{
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+
+    final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
+    {
+        $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+    }
+
+    public function getInputFieldNameTypeResolvers(): array
+    {
+        return array_merge(
+            parent::getInputFieldNameTypeResolvers(),
+            [
+                'inclusive' => $this->getBooleanScalarTypeResolver(),
+            ]
+        );
+    }
+
+    public function getInputFieldDescription(string $inputFieldName): ?string
+    {
+        return match ($inputFieldName) {
+            'inclusive' => $this->getTranslationAPI()->__('For after/before, whether exact value should be matched or not', 'customposts'),
+            default => parent::getInputFieldDescription($inputFieldName),
+        };
+    }
+
+    /**
+     * Integrate parameters into the "date_query" WP_Query arg
+     *
+     * @see https://developer.wordpress.org/reference/classes/wp_query/#date-parameters
+     *
+     * @param array<string, mixed> $query
+     */
+    public function integrateInputValueToFilteringQueryArgs(array &$query, stdClass $inputValue): void
+    {
+        $dateQuery = [];
+
+        if (isset($inputValue->before)) {
+            $dateQuery['before'] = $inputValue->before;
+        }
+        if (isset($inputValue->after)) {
+            $dateQuery['after'] = $inputValue->after;
+        }
+        if (isset($inputValue->inclusive)) {
+            $dateQuery['inclusive'] = $inputValue->inclusive;
+        }
+
+        if ($dateQuery !== []) {
+            $query['date_query'] = $dateQuery;
+        }
+    }
+}

--- a/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -74,7 +74,7 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
             'second' => $this->getTranslationAPI()->__('Second (0 to 59)', 'customposts'),
             'compare' => $this->getTranslationAPI()->__('Determines and validates what comparison operator to use', 'customposts'),
             'column' => $this->getTranslationAPI()->__('Posts column to query against. Default: ‘post_date’)', 'customposts'),
-            'relation' => $this->getTranslationAPI()->__('OR or AND, how the sub-arrays should be compared. Default: AND', 'customposts'),
+            'relation' => $this->getTranslationAPI()->__('OR or AND, how the sub-arrays should be compared. Default: AND. Only the value from the first sub-array will be used', 'customposts'),
             default => parent::getInputFieldDescription($inputFieldName),
         };
     }

--- a/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -51,10 +51,10 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
         $dateQuery = [];
 
         if (isset($inputValue->before)) {
-            $dateQuery['before'] = $inputValue->before;
+            $dateQuery['before'] = $this->getDateScalarTypeResolver()->serialize($inputValue->before);
         }
         if (isset($inputValue->after)) {
-            $dateQuery['after'] = $inputValue->after;
+            $dateQuery['after'] = $this->getDateScalarTypeResolver()->serialize($inputValue->after);
         }
         if (isset($inputValue->inclusive)) {
             $dateQuery['inclusive'] = $inputValue->inclusive;

--- a/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/Overrides/TypeResolvers/InputObjectType/CustomPostDateQueryInputObjectTypeResolver.php
@@ -8,6 +8,7 @@ use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\IntScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\CustomPostDateQueryInputObjectTypeResolver as UpstreamCustomPostDateQueryInputObjectTypeResolver;
+use PoPWPSchema\CustomPosts\TypeResolvers\EnumType\QueryRelationEnumTypeResolver;
 use stdClass;
 
 class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQueryInputObjectTypeResolver
@@ -15,6 +16,7 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
     private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
     private ?IntScalarTypeResolver $intScalarTypeResolver = null;
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+    private ?QueryRelationEnumTypeResolver $queryRelationEnumTypeResolver = null;
 
     final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
     {
@@ -40,6 +42,14 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
     {
         return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
     }
+    final public function setQueryRelationEnumTypeResolver(QueryRelationEnumTypeResolver $queryRelationEnumTypeResolver): void
+    {
+        $this->queryRelationEnumTypeResolver = $queryRelationEnumTypeResolver;
+    }
+    final protected function getQueryRelationEnumTypeResolver(): QueryRelationEnumTypeResolver
+    {
+        return $this->queryRelationEnumTypeResolver ??= $this->instanceManager->getInstance(QueryRelationEnumTypeResolver::class);
+    }
 
     public function getInputFieldNameTypeResolvers(): array
     {
@@ -56,7 +66,7 @@ class CustomPostDateQueryInputObjectTypeResolver extends UpstreamCustomPostDateQ
                 'second' => $this->getIntScalarTypeResolver(),
                 'compare' => $this->getStringScalarTypeResolver(),
                 'column' => $this->getStringScalarTypeResolver(),
-                'relation' => $this->getStringScalarTypeResolver(),
+                'relation' => $this->getQueryRelationEnumTypeResolver(),
             ]
         );
     }

--- a/layers/WPSchema/packages/customposts/src/SchemaHooks/InputObjectTypeHookSet.php
+++ b/layers/WPSchema/packages/customposts/src/SchemaHooks/InputObjectTypeHookSet.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CustomPosts\SchemaHooks;
+
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\InputObjectType\HookNames;
+use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
+use PoP\Hooks\AbstractHookSet;
+use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\AbstractCustomPostsFilterInputObjectTypeResolver;
+
+class InputObjectTypeHookSet extends AbstractHookSet
+{
+    protected function init(): void
+    {
+        $this->getHooksAPI()->addFilter(
+            HookNames::INPUT_FIELD_TYPE_MODIFIERS,
+            [$this, 'getInputFieldTypeModifiers'],
+            10,
+            3
+        );
+    }
+
+    /**
+     * Transform "dateQuery" from a single value to an array of them
+     */
+    public function getInputFieldTypeModifiers(
+        int $inputFieldTypeModifiers,
+        InputObjectTypeResolverInterface $inputObjectTypeResolver,
+        string $inputFieldName
+    ): int {
+        if (!($inputObjectTypeResolver instanceof AbstractCustomPostsFilterInputObjectTypeResolver)) {
+            return $inputFieldTypeModifiers;
+        }
+        return match ($inputFieldName) {
+            'dateQuery' => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
+            default => $inputFieldTypeModifiers,
+        };
+    }
+}

--- a/layers/WPSchema/packages/customposts/src/TypeResolvers/EnumType/QueryRelationEnumTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/TypeResolvers/EnumType/QueryRelationEnumTypeResolver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CustomPosts\TypeResolvers\EnumType;
+
+use PoP\ComponentModel\TypeResolvers\EnumType\AbstractEnumTypeResolver;
+use PoPWPSchema\CustomPosts\Constants\QueryRelations;
+
+/**
+ * Query "relation" arg, as explained here:
+ *
+ * @see https://developer.wordpress.org/reference/classes/wp_query/#custom-field-post-meta-parameters
+ */
+class QueryRelationEnumTypeResolver extends AbstractEnumTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'QueryRelation';
+    }
+
+    public function getTypeDescription(): string
+    {
+        return $this->getTranslationAPI()->__('The logical relationship between array values in query args (for meta query, date parameters, and others) when there is more than one', 'customposts');
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getEnumValues(): array
+    {
+        return [
+            QueryRelations::AND,
+            QueryRelations::OR,
+        ];
+    }
+
+    public function getEnumValueDescription(string $enumValue): ?string
+    {
+        return match ($enumValue) {
+            QueryRelations::AND => $this->getTranslationAPI()->__('`AND` relation', 'schema-commons'),
+            QueryRelations::OR => $this->getTranslationAPI()->__('`OR` relation', 'schema-commons'),
+            default => parent::getEnumValueDescription($enumValue),
+        };
+    }
+}


### PR DESCRIPTION
Override class `CustomPostDateQueryInputObjectTypeResolver` in WPSchema, to implement all WordPress-specific properties:

- year (int) – 4 digit year (e.g. 2011).
- month (int) – Month number (from 1 to 12).
- week (int) – Week of the year (from 0 to 53).
- day (int) – Day of the month (from 1 to 31).
- hour (int) – Hour (from 0 to 23).
- minute (int) – Minute (from 0 to 59).
- second (int) – Second (0 to 59).
- inclusive (boolean) – For after/before, whether exact value should be matched or not’.
- compare (string) – See WP_Date_Query::get_compare().
- column (string) – Posts column to query against. Default: ‘post_date’.
- relation (string) – OR or AND, how the sub-arrays should be compared. Default: AND.

Documentation: https://developer.wordpress.org/reference/classes/wp_query/#date-parameters