### PR TITLE
Validate enums in `coerceValue`

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -23,7 +23,6 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\Services\BasicServiceTrait;
 use PoP\ComponentModel\State\ApplicationState;
-use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\FieldSymbols;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\PipelinePositions;
@@ -829,29 +828,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      */
     public function resolveDirectiveValidationDeprecationMessages(RelationalTypeResolverInterface $relationalTypeResolver, string $directiveName, array $directiveArgs): array
     {
-        /**
-         * Deprecations for the directive args of Enum Type
-         */
-        $consolidatedDirectiveArgNameTypeResolvers = $this->getConsolidatedDirectiveArgNameTypeResolvers($relationalTypeResolver);
-        /** @var array<string, EnumTypeResolverInterface> */
-        $enumConsolidatedDirectiveArgNameTypeResolvers = array_filter(
-            $consolidatedDirectiveArgNameTypeResolvers,
-            fn (InputTypeResolverInterface $inputTypeResolver) => $inputTypeResolver instanceof EnumTypeResolverInterface
-        );
-        $enumConsolidatedDirectiveArgNamesIsArrayOfArrays = $enumConsolidatedDirectiveArgNamesIsArray = [];
-        foreach (array_keys($enumConsolidatedDirectiveArgNameTypeResolvers) as $directiveArgName) {
-            $consolidatedDirectiveArgTypeModifiers = $this->getConsolidatedDirectiveArgTypeModifiers($relationalTypeResolver, $directiveArgName);
-            $enumConsolidatedDirectiveArgNamesIsArrayOfArrays[$directiveArgName]  = $consolidatedDirectiveArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
-            $enumConsolidatedDirectiveArgNamesIsArray[$directiveArgName]  = $consolidatedDirectiveArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY;
-        }
-        return $this->validateEnumFieldOrDirectiveArgumentDeprecations(
-            $enumConsolidatedDirectiveArgNameTypeResolvers,
-            $enumConsolidatedDirectiveArgNamesIsArrayOfArrays,
-            $enumConsolidatedDirectiveArgNamesIsArray,
-            $directiveName,
-            $directiveArgs,
-            ResolverTypes::DIRECTIVE
-        );
+        return [];
     }
 
     public function getDirectiveWarningDescription(RelationalTypeResolverInterface $relationalTypeResolver): ?string

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -338,7 +338,8 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             $directiveName,
             $directiveArgs,
             $nestedObjectErrors,
-            $nestedObjectWarnings
+            $nestedObjectWarnings,
+            $nestedObjectDeprecationMessages,
         ) = $this->getFieldQueryInterpreter()->extractDirectiveArgumentsForObject($this, $relationalTypeResolver, $object, $this->directive, $variables, $expressions);
 
         // Store the args, they may be used in `resolveDirective`
@@ -356,6 +357,12 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             $objectWarnings[$id] = array_merge(
                 $objectWarnings[$id] ?? [],
                 $fieldOutputKeyWarningMessages
+            );
+        }
+        foreach ($nestedObjectDeprecationMessages as $id => $fieldOutputKeyDeprecationMessages) {
+            $objectDeprecations[$id] = array_merge(
+                $objectDeprecations[$id] ?? [],
+                $fieldOutputKeyDeprecationMessages
             );
         }
 

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -30,7 +30,6 @@ use PoP\ComponentModel\TypeResolvers\PipelinePositions;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyDynamicScalarTypeResolver;
 use PoP\ComponentModel\Versioning\VersioningHelpers;
-use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\FieldQuery\QueryHelpers;
 use PoP\Root\Environment as RootEnvironment;
 
@@ -482,32 +481,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
 
         if ($this->canValidateFieldOrDirectiveArgumentsWithValuesForSchema($directiveArgs)) {
             /**
-             * Validate all enum values provided via args are valid
-             */
-            /** @var array<string, EnumTypeResolverInterface> */
-            $enumConsolidatedDirectiveArgNameTypeResolvers = array_filter(
-                $consolidatedDirectiveArgNameTypeResolvers,
-                fn (InputTypeResolverInterface $inputTypeResolver) => $inputTypeResolver instanceof EnumTypeResolverInterface
-            );
-            $enumConsolidatedDirectiveArgNamesIsArrayOfArrays = $enumConsolidatedDirectiveArgNamesIsArray = [];
-            foreach (array_keys($enumConsolidatedDirectiveArgNameTypeResolvers) as $directiveArgName) {
-                $consolidatedDirectiveArgTypeModifiers = $this->getConsolidatedDirectiveArgTypeModifiers($relationalTypeResolver, $directiveArgName);
-                $enumConsolidatedDirectiveArgNamesIsArrayOfArrays[$directiveArgName] = ($consolidatedDirectiveArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
-                $enumConsolidatedDirectiveArgNamesIsArray[$directiveArgName] = ($consolidatedDirectiveArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
-            }
-            [$maybeErrors] = $this->validateEnumFieldOrDirectiveArguments(
-                $enumConsolidatedDirectiveArgNameTypeResolvers,
-                $enumConsolidatedDirectiveArgNamesIsArrayOfArrays,
-                $enumConsolidatedDirectiveArgNamesIsArray,
-                $directiveName,
-                $directiveArgs,
-                ResolverTypes::DIRECTIVE
-            );
-            if ($maybeErrors) {
-                return $maybeErrors;
-            }
-
-            /**
              * Validate directive argument constraints
              */
             if (
@@ -849,8 +822,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      */
     public function resolveDirectiveValidationDeprecationMessages(RelationalTypeResolverInterface $relationalTypeResolver, string $directiveName, array $directiveArgs): array
     {
-        $directiveDeprecationMessages = [];
-
         /**
          * Deprecations for the directive args of Enum Type
          */
@@ -866,7 +837,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             $enumConsolidatedDirectiveArgNamesIsArrayOfArrays[$directiveArgName]  = $consolidatedDirectiveArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
             $enumConsolidatedDirectiveArgNamesIsArray[$directiveArgName]  = $consolidatedDirectiveArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY;
         }
-        [$maybeErrors, $maybeDeprecations] = $this->validateEnumFieldOrDirectiveArguments(
+        return $this->validateEnumFieldOrDirectiveArgumentDeprecations(
             $enumConsolidatedDirectiveArgNameTypeResolvers,
             $enumConsolidatedDirectiveArgNamesIsArrayOfArrays,
             $enumConsolidatedDirectiveArgNamesIsArray,
@@ -874,9 +845,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             $directiveArgs,
             ResolverTypes::DIRECTIVE
         );
-        $directiveDeprecationMessages = $maybeDeprecations;
-
-        return $directiveDeprecationMessages;
     }
 
     public function getDirectiveWarningDescription(RelationalTypeResolverInterface $relationalTypeResolver): ?string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -30,7 +30,6 @@ use PoP\ComponentModel\Schema\SchemaDefinitionServiceInterface;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
-use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
@@ -716,34 +715,6 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
                 $fieldDeprecationMessage
             );
         }
-
-        /**
-         * Deprecations for the field args of Enum Type
-         */
-        $consolidatedFieldArgNameTypeResolvers = $this->getConsolidatedFieldArgNameTypeResolvers($objectTypeResolver, $fieldName);
-        /** @var array<string, EnumTypeResolverInterface> */
-        $enumConsolidatedFieldArgNameTypeResolvers = array_filter(
-            $consolidatedFieldArgNameTypeResolvers,
-            fn (InputTypeResolverInterface $inputTypeResolver) => $inputTypeResolver instanceof EnumTypeResolverInterface
-        );
-        $enumConsolidatedFieldArgNamesIsArrayOfArrays = $enumConsolidatedFieldArgNamesIsArray = [];
-        foreach (array_keys($enumConsolidatedFieldArgNameTypeResolvers) as $fieldArgName) {
-            $consolidatedFieldArgTypeModifiers = $this->getConsolidatedFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName);
-            $enumConsolidatedFieldArgNamesIsArrayOfArrays[$fieldArgName]  = $consolidatedFieldArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
-            $enumConsolidatedFieldArgNamesIsArray[$fieldArgName]  = $consolidatedFieldArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY;
-        }
-        $maybeDeprecations = $this->validateEnumFieldOrDirectiveArgumentDeprecations(
-            $enumConsolidatedFieldArgNameTypeResolvers,
-            $enumConsolidatedFieldArgNamesIsArrayOfArrays,
-            $enumConsolidatedFieldArgNamesIsArray,
-            $fieldName,
-            $fieldArgs,
-            ResolverTypes::FIELD
-        );
-        $fieldDeprecationMessages = array_merge(
-            $fieldDeprecationMessages,
-            $maybeDeprecations
-        );
 
         return $fieldDeprecationMessages;
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -38,7 +38,6 @@ use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyDynamicScalarTypeResolver;
 use PoP\ComponentModel\Versioning\VersioningHelpers;
 use PoP\Engine\CMS\CMSServiceInterface;
-use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\LooseContracts\NameResolverInterface;
 use stdClass;
 
@@ -628,32 +627,6 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
 
         if ($this->canValidateFieldOrDirectiveArgumentsWithValuesForSchema($fieldArgs)) {
             /**
-             * Validate all enum values provided via args are valid
-             */
-            /** @var array<string, EnumTypeResolverInterface> */
-            $enumConsolidatedFieldArgNameTypeResolvers = array_filter(
-                $consolidatedFieldArgNameTypeResolvers,
-                fn (InputTypeResolverInterface $inputTypeResolver) => $inputTypeResolver instanceof EnumTypeResolverInterface
-            );
-            $enumConsolidatedFieldArgNamesIsArrayOfArrays = $enumConsolidatedFieldArgNamesIsArray = [];
-            foreach (array_keys($enumConsolidatedFieldArgNameTypeResolvers) as $fieldArgName) {
-                $consolidatedFieldArgTypeModifiers = $this->getConsolidatedFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName);
-                $enumConsolidatedFieldArgNamesIsArrayOfArrays[$fieldArgName] = ($consolidatedFieldArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
-                $enumConsolidatedFieldArgNamesIsArray[$fieldArgName] = ($consolidatedFieldArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
-            }
-            [$maybeErrors] = $this->validateEnumFieldOrDirectiveArguments(
-                $enumConsolidatedFieldArgNameTypeResolvers,
-                $enumConsolidatedFieldArgNamesIsArrayOfArrays,
-                $enumConsolidatedFieldArgNamesIsArray,
-                $fieldName,
-                $fieldArgs,
-                ResolverTypes::FIELD
-            );
-            if ($maybeErrors) {
-                return $maybeErrors;
-            }
-
-            /**
              * Validate field argument constraints
              */
             if (
@@ -759,7 +732,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
             $enumConsolidatedFieldArgNamesIsArrayOfArrays[$fieldArgName]  = $consolidatedFieldArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
             $enumConsolidatedFieldArgNamesIsArray[$fieldArgName]  = $consolidatedFieldArgTypeModifiers & SchemaTypeModifiers::IS_ARRAY;
         }
-        [$maybeErrors, $maybeDeprecations] = $this->validateEnumFieldOrDirectiveArguments(
+        $maybeDeprecations = $this->validateEnumFieldOrDirectiveArgumentDeprecations(
             $enumConsolidatedFieldArgNameTypeResolvers,
             $enumConsolidatedFieldArgNamesIsArrayOfArrays,
             $enumConsolidatedFieldArgNamesIsArray,

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Resolvers;
 
 use PoP\ComponentModel\ComponentConfiguration;
-use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
 use PoP\Translation\TranslationAPIInterface;
@@ -78,56 +77,6 @@ trait FieldOrDirectiveResolverTrait
     protected function canValidateFieldOrDirectiveArgumentsWithValuesForSchema(array $fieldOrDirectiveArgs): bool
     {
         return !FieldQueryUtils::isAnyFieldArgumentValueAFieldOrExpression($fieldOrDirectiveArgs);
-    }
-
-    /**
-     * @param array $enumDirectiveArgNameTypeResolvers array<string, EnumTypeResolverInterface>
-     * @param array $enumDirectiveArgNamesIsArrayOfArrays array<string, bool>
-     * @param array $enumDirectiveArgNamesIsArray array<string, bool>
-     * @return string[]
-     */
-    private function validateEnumFieldOrDirectiveArgumentDeprecations(
-        array $enumDirectiveArgNameTypeResolvers,
-        array $enumDirectiveArgNamesIsArrayOfArrays,
-        array $enumDirectiveArgNamesIsArray,
-        string $fieldOrDirectiveName,
-        array $fieldOrDirectiveArgs,
-        string $type
-    ): array {
-        $deprecations = [];
-        foreach (array_keys($enumDirectiveArgNameTypeResolvers) as $fieldOrDirectiveArgumentName) {
-            $fieldOrDirectiveArgumentValue = $fieldOrDirectiveArgs[$fieldOrDirectiveArgumentName] ?? null;
-            if ($fieldOrDirectiveArgumentValue === null) {
-                continue;
-            }
-            $enumTypeFieldOrDirectiveArgIsArrayOfArrays = $enumDirectiveArgNamesIsArrayOfArrays[$fieldOrDirectiveArgumentName];
-            $enumTypeFieldOrDirectiveArgIsArray = $enumDirectiveArgNamesIsArray[$fieldOrDirectiveArgumentName];
-            $fieldOrDirectiveArgumentEnumTypeResolver = $enumDirectiveArgNameTypeResolvers[$fieldOrDirectiveArgumentName];
-
-            /**
-             * Pass all the enum values to be validated, as a list.
-             * Possibilities:
-             *   1. Single item => [item]
-             *   2. Array => Array
-             *   3. Array of arrays => flatten into array
-             */
-            if ($enumTypeFieldOrDirectiveArgIsArrayOfArrays) {
-                $fieldOrDirectiveArgumentValueEnums = array_unique(GeneralUtils::arrayFlatten($fieldOrDirectiveArgumentValue));
-            } elseif ($enumTypeFieldOrDirectiveArgIsArray) {
-                $fieldOrDirectiveArgumentValueEnums = $fieldOrDirectiveArgumentValue;
-            } else {
-                $fieldOrDirectiveArgumentValueEnums = [$fieldOrDirectiveArgumentValue];
-            }
-            $this->doValidateEnumFieldOrDirectiveArgumentDeprecationsItem(
-                $deprecations,
-                $fieldOrDirectiveArgumentEnumTypeResolver,
-                $fieldOrDirectiveArgumentValueEnums,
-                $fieldOrDirectiveArgumentName,
-                $fieldOrDirectiveName,
-                $type,
-            );
-        }
-        return $deprecations;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -673,7 +673,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         }
         $fieldArgs = $this->validateExtractedFieldOrDirectiveArgumentsForSchema($objectTypeResolver, $field, $fieldArgs, $variables, $schemaErrors, $schemaWarnings, $schemaDeprecations);
         // Cast the values to their appropriate type. If casting fails, the value returns as null
-        $fieldArgs = $this->castAndValidateFieldArgumentsForSchema($objectTypeResolver, $field, $fieldArgs, $schemaErrors, $schemaWarnings);
+        $fieldArgs = $this->castAndValidateFieldArgumentsForSchema($objectTypeResolver, $field, $fieldArgs, $schemaErrors, $schemaWarnings, $schemaDeprecations);
 
         // If there's an error, those args will be removed. Then, re-create the fieldDirective to pass it to the function below
         if ($schemaErrors) {
@@ -751,7 +751,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         );
         $directiveArgs = $this->validateExtractedFieldOrDirectiveArgumentsForSchema($relationalTypeResolver, $fieldDirective, $directiveArgs, $variables, $schemaErrors, $schemaWarnings, $schemaDeprecations);
         // Cast the values to their appropriate type. If casting fails, the value returns as null
-        $directiveArgs = $this->castAndValidateDirectiveArgumentsForSchema($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $schemaErrors, $schemaWarnings, $disableDynamicFields);
+        $directiveArgs = $this->castAndValidateDirectiveArgumentsForSchema($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $schemaErrors, $schemaWarnings, $schemaDeprecations, $disableDynamicFields);
         // Enable the directiveResolver to add its own code validations
         $directiveArgs = $directiveResolver->validateDirectiveArgumentsForSchema($relationalTypeResolver, $directiveName, $directiveArgs, $schemaErrors, $schemaWarnings, $schemaDeprecations);
 
@@ -838,7 +838,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         ?array $variables,
         ?array $expressions
     ): array {
-        $objectErrors = $objectWarnings = [];
+        $objectErrors = $objectWarnings = $objectDeprecations = [];
         $validAndResolvedField = $field;
         $fieldName = $this->getFieldName($field);
         $extractedFieldArgs = $fieldArgs = $this->extractFieldArguments(
@@ -851,7 +851,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         $fieldArgs = $this->extractFieldOrDirectiveArgumentsForObject($objectTypeResolver, $object, $fieldArgs, $fieldOutputKey, $variables, $expressions, $objectErrors);
         // Cast the values to their appropriate type. If casting fails, the value returns as null
         $castingObjectErrors = $castingObjectWarnings = [];
-        $fieldArgs = $this->castAndValidateFieldArgumentsForObject($objectTypeResolver, $field, $fieldArgs, $castingObjectErrors, $castingObjectWarnings);
+        $fieldArgs = $this->castAndValidateFieldArgumentsForObject($objectTypeResolver, $field, $fieldArgs, $castingObjectErrors, $castingObjectWarnings, $objectDeprecations);
         if ($castingObjectErrors || $castingObjectWarnings) {
             $id = $objectTypeResolver->getID($object);
             if ($castingObjectErrors) {
@@ -886,7 +886,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         array $variables,
         array $expressions
     ): array {
-        $objectErrors = $objectWarnings = [];
+        $objectErrors = $objectWarnings = $objectDeprecations = [];
         $validAndResolvedDirective = $fieldDirective;
         $directiveName = $this->getFieldDirectiveName($fieldDirective);
         $extractedDirectiveArgs = $directiveArgs = $this->extractDirectiveArguments(
@@ -900,7 +900,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         $directiveArgs = $this->extractFieldOrDirectiveArgumentsForObject($relationalTypeResolver, $object, $directiveArgs, $directiveOutputKey, $variables, $expressions, $objectErrors);
         // Cast the values to their appropriate type. If casting fails, the value returns as null
         $castingObjectErrors = $castingObjectWarnings = [];
-        $directiveArgs = $this->castAndValidateDirectiveArgumentsForObject($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $castingObjectErrors, $castingObjectWarnings);
+        $directiveArgs = $this->castAndValidateDirectiveArgumentsForObject($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $castingObjectErrors, $castingObjectWarnings, $objectDeprecations);
         if ($castingObjectErrors || $castingObjectWarnings) {
             $id = $relationalTypeResolver->getID($object);
             if ($castingObjectErrors) {
@@ -975,6 +975,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         string $directive,
         array $directiveArgs,
         array &$failedCastingDirectiveArgErrors,
+        array &$castingDirectiveArgDeprecationMessages,
         bool $forSchema
     ): array {
         $directiveArgSchemaDefinition = $this->getDirectiveSchemaDefinitionArgs($directiveResolver, $relationalTypeResolver);
@@ -982,6 +983,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             $directiveArgs,
             $directiveArgSchemaDefinition,
             $failedCastingDirectiveArgErrors,
+            $castingDirectiveArgDeprecationMessages,
             $forSchema
         );
     }
@@ -995,6 +997,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         array $fieldArgs,
         array &$failedCastingFieldArgErrors,
         array &$schemaOrObjectErrors,
+        array &$castingFieldArgDeprecationMessages,
         bool $forSchema
     ): ?array {
         $fieldArgSchemaDefinition = $this->getFieldArgsSchemaDefinition($objectTypeResolver, $field);
@@ -1009,6 +1012,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             $fieldArgs,
             $fieldArgSchemaDefinition,
             $failedCastingFieldArgErrors,
+            $castingFieldArgDeprecationMessages,
             $forSchema
         );
     }
@@ -1020,6 +1024,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         array $fieldOrDirectiveArgs,
         array $fieldOrDirectiveArgSchemaDefinition,
         array &$failedCastingFieldOrDirectiveArgErrors,
+        array &$castingFieldOrDirectiveArgDeprecationMessages,
         bool $forSchema
     ): array {
         // Cast all argument values
@@ -1148,6 +1153,10 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                     $fieldOrDirectiveArgIsArrayType,
                     $fieldOrDirectiveArgIsArrayOfArraysType,
                 );
+                $castingFieldOrDirectiveArgDeprecationMessages = array_merge(
+                    $castingFieldOrDirectiveArgDeprecationMessages,
+                    $deprecationMessages
+                );
             }
 
             // No errors, assign the value
@@ -1159,35 +1168,47 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
     /**
      * @param array<string,Error> $failedCastingDirectiveArgErrors
      */
-    protected function castDirectiveArgumentsForSchema(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $fieldDirective, array $directiveArgs, array &$failedCastingDirectiveArgErrors, bool $disableDynamicFields = false): array
+    protected function castDirectiveArgumentsForSchema(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $fieldDirective, array $directiveArgs, array &$failedCastingDirectiveArgErrors, array &$castingDirectiveArgDeprecationMessages, bool $disableDynamicFields = false): array
     {
         // If the directive doesn't allow dynamic fields (Eg: <cacheControl(maxAge:id())>), then treat it as not for schema
         $forSchema = !$disableDynamicFields;
-        return $this->castDirectiveArguments($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $failedCastingDirectiveArgErrors, $forSchema);
+        return $this->castDirectiveArguments($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $failedCastingDirectiveArgErrors, $castingDirectiveArgDeprecationMessages, $forSchema);
     }
 
     /**
      * @param array<string,Error> $failedCastingFieldArgErrors
      */
-    protected function castFieldArgumentsForSchema(ObjectTypeResolverInterface $objectTypeResolver, string $field, array $fieldArgs, array &$failedCastingFieldArgErrors, array &$schemaErrors): ?array
-    {
-        return $this->castFieldArguments($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $schemaErrors, true);
+    protected function castFieldArgumentsForSchema(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        string $field,
+        array $fieldArgs,
+        array &$failedCastingFieldArgErrors,
+        array &$schemaErrors,
+        array &$castingFieldArgDeprecationMessages,
+    ): ?array {
+        return $this->castFieldArguments($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $schemaErrors, $castingFieldArgDeprecationMessages, true);
     }
 
     /**
      * @param array<string,Error> $failedCastingDirectiveArgErrors
      */
-    protected function castDirectiveArgumentsForObject(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $directive, array $directiveArgs, array &$failedCastingDirectiveArgErrors): array
+    protected function castDirectiveArgumentsForObject(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $directive, array $directiveArgs, array &$failedCastingDirectiveArgErrors, array &$castingDirectiveArgDeprecationMessages): array
     {
-        return $this->castDirectiveArguments($directiveResolver, $relationalTypeResolver, $directive, $directiveArgs, $failedCastingDirectiveArgErrors, false);
+        return $this->castDirectiveArguments($directiveResolver, $relationalTypeResolver, $directive, $directiveArgs, $failedCastingDirectiveArgErrors, $castingDirectiveArgDeprecationMessages, false);
     }
 
     /**
      * @param array<string,Error> $failedCastingFieldArgErrors
      */
-    protected function castFieldArgumentsForObject(ObjectTypeResolverInterface $objectTypeResolver, string $field, array $fieldArgs, array &$failedCastingFieldArgErrors, array &$objectErrors): ?array
-    {
-        return $this->castFieldArguments($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $objectErrors, false);
+    protected function castFieldArgumentsForObject(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        string $field,
+        array $fieldArgs,
+        array &$failedCastingFieldArgErrors,
+        array &$objectErrors,
+        array &$castingFieldArgDeprecationMessages,
+    ): ?array {
+        return $this->castFieldArguments($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $objectErrors, $castingFieldArgDeprecationMessages, false);
     }
 
     /**
@@ -1332,22 +1353,24 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         return $fieldArgNameDefaultValues;
     }
 
-    protected function castAndValidateDirectiveArgumentsForSchema(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $fieldDirective, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings, bool $disableDynamicFields = false): array
+    protected function castAndValidateDirectiveArgumentsForSchema(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $fieldDirective, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations, bool $disableDynamicFields = false): array
     {
         if ($directiveArgs) {
             $failedCastingDirectiveArgErrors = [];
-            $castedDirectiveArgs = $this->castDirectiveArgumentsForSchema($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $failedCastingDirectiveArgErrors, $disableDynamicFields);
-            return $this->validateAndFilterCastDirectiveArguments($directiveResolver, $relationalTypeResolver, $castedDirectiveArgs, $failedCastingDirectiveArgErrors, $fieldDirective, $directiveArgs, $schemaErrors, $schemaWarnings);
+            $castingDirectiveArgDeprecationMessages = [];
+            $castedDirectiveArgs = $this->castDirectiveArgumentsForSchema($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $failedCastingDirectiveArgErrors, $castingDirectiveArgDeprecationMessages, $disableDynamicFields);
+            return $this->validateAndFilterCastDirectiveArguments($directiveResolver, $relationalTypeResolver, $castedDirectiveArgs, $failedCastingDirectiveArgErrors, $castingDirectiveArgDeprecationMessages, $fieldDirective, $directiveArgs, $schemaErrors, $schemaWarnings, $schemaDeprecations);
         }
         return $directiveArgs;
     }
 
-    protected function castAndValidateFieldArgumentsForSchema(ObjectTypeResolverInterface $objectTypeResolver, string $field, array $fieldArgs, array &$schemaErrors, array &$schemaWarnings): ?array
+    protected function castAndValidateFieldArgumentsForSchema(ObjectTypeResolverInterface $objectTypeResolver, string $field, array $fieldArgs, array &$schemaErrors, array &$schemaWarnings, array &$schemaDeprecations): ?array
     {
         if ($fieldArgs) {
             $failedCastingFieldArgErrors = [];
             $castingSchemaErrors = [];
-            $castedFieldArgs = $this->castFieldArgumentsForSchema($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $castingSchemaErrors);
+            $castingFieldArgDeprecationMessages = [];
+            $castedFieldArgs = $this->castFieldArgumentsForSchema($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $castingSchemaErrors, $castingFieldArgDeprecationMessages);
             if ($castingSchemaErrors) {
                 $schemaErrors = array_merge(
                     $schemaErrors,
@@ -1355,23 +1378,25 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                 );
                 return null;
             }
-            return $this->validateAndFilterCastFieldArguments($objectTypeResolver, $castedFieldArgs, $failedCastingFieldArgErrors, $field, $fieldArgs, $schemaErrors, $schemaWarnings);
+            return $this->validateAndFilterCastFieldArguments($objectTypeResolver, $castedFieldArgs, $failedCastingFieldArgErrors, $castingFieldArgDeprecationMessages, $field, $fieldArgs, $schemaErrors, $schemaWarnings, $schemaDeprecations);
         }
         return $fieldArgs;
     }
 
-    protected function castAndValidateDirectiveArgumentsForObject(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $fieldDirective, array $directiveArgs, array &$objectErrors, array &$objectWarnings): ?array
+    protected function castAndValidateDirectiveArgumentsForObject(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, string $fieldDirective, array $directiveArgs, array &$objectErrors, array &$objectWarnings, array &$objectDeprecations): ?array
     {
         $failedCastingDirectiveArgErrors = [];
-        $castedDirectiveArgs = $this->castDirectiveArgumentsForObject($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $failedCastingDirectiveArgErrors);
-        return $this->validateAndFilterCastDirectiveArguments($directiveResolver, $relationalTypeResolver, $castedDirectiveArgs, $failedCastingDirectiveArgErrors, $fieldDirective, $directiveArgs, $objectErrors, $objectWarnings);
+        $castingDirectiveArgDeprecationMessages = [];
+        $castedDirectiveArgs = $this->castDirectiveArgumentsForObject($directiveResolver, $relationalTypeResolver, $fieldDirective, $directiveArgs, $failedCastingDirectiveArgErrors, $castingDirectiveArgDeprecationMessages);
+        return $this->validateAndFilterCastDirectiveArguments($directiveResolver, $relationalTypeResolver, $castedDirectiveArgs, $failedCastingDirectiveArgErrors, $castingDirectiveArgDeprecationMessages, $fieldDirective, $directiveArgs, $objectErrors, $objectWarnings, $objectDeprecations);
     }
 
-    protected function castAndValidateFieldArgumentsForObject(ObjectTypeResolverInterface $objectTypeResolver, string $field, array $fieldArgs, array &$objectErrors, array &$objectWarnings): ?array
+    protected function castAndValidateFieldArgumentsForObject(ObjectTypeResolverInterface $objectTypeResolver, string $field, array $fieldArgs, array &$objectErrors, array &$objectWarnings, array &$objectDeprecations): ?array
     {
         $failedCastingFieldArgErrors = [];
         $castingObjectErrors = [];
-        $castedFieldArgs = $this->castFieldArgumentsForObject($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $castingObjectErrors);
+        $castingFieldArgDeprecationMessages = [];
+        $castedFieldArgs = $this->castFieldArgumentsForObject($objectTypeResolver, $field, $fieldArgs, $failedCastingFieldArgErrors, $castingObjectErrors, $castingFieldArgDeprecationMessages);
         if ($castingObjectErrors) {
             $objectErrors = array_merge(
                 $objectErrors,
@@ -1379,14 +1404,29 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             );
             return null;
         }
-        return $this->validateAndFilterCastFieldArguments($objectTypeResolver, $castedFieldArgs, $failedCastingFieldArgErrors, $field, $fieldArgs, $objectErrors, $objectWarnings);
+        return $this->validateAndFilterCastFieldArguments($objectTypeResolver, $castedFieldArgs, $failedCastingFieldArgErrors, $castingFieldArgDeprecationMessages, $field, $fieldArgs, $objectErrors, $objectWarnings, $objectDeprecations);
     }
 
     /**
      * @param array<string,Error> $failedCastingDirectiveArgErrors
      */
-    protected function validateAndFilterCastDirectiveArguments(DirectiveResolverInterface $directiveResolver, RelationalTypeResolverInterface $relationalTypeResolver, array $castedDirectiveArgs, array &$failedCastingDirectiveArgErrors, string $fieldDirective, array $directiveArgs, array &$schemaErrors, array &$schemaWarnings): array
-    {
+    protected function validateAndFilterCastDirectiveArguments(
+        DirectiveResolverInterface $directiveResolver,
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        array $castedDirectiveArgs,
+        array &$failedCastingDirectiveArgErrors,
+        array &$castingDirectiveArgDeprecationMessages,
+        string $fieldDirective,
+        array $directiveArgs,
+        array &$schemaErrors,
+        array &$schemaWarnings,
+        array &$schemaDeprecations,
+    ): array {
+        // Add the deprecations
+        foreach ($castingDirectiveArgDeprecationMessages as $castingDirectiveArgDeprecationMessage) {
+            $schemaDeprecations[] = $this->getErrorService()->getErrorOutput($castingDirectiveArgDeprecationMessage, [$fieldDirective]);
+        }
+
         // If any casting can't be done, show an error
         if ($failedCastingDirectiveArgErrors) {
             $directiveName = $this->getFieldDirectiveName($fieldDirective);
@@ -1464,11 +1504,21 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         ObjectTypeResolverInterface $objectTypeResolver,
         array $castedFieldArgs,
         array &$failedCastingFieldArgErrors,
+        array &$castingFieldArgDeprecationMessages,
         string $field,
         array $fieldArgs,
         array &$schemaErrors,
-        array &$schemaWarnings
+        array &$schemaWarnings,
+        array &$schemaDeprecations,
     ): array {
+        // Add the deprecations
+        foreach ($castingFieldArgDeprecationMessages as $castingFieldArgDeprecationMessage) {
+            $schemaDeprecations[] = [
+                Tokens::PATH => [$field],
+                Tokens::MESSAGE => $castingFieldArgDeprecationMessage,
+            ];
+        }
+
         // If any casting can't be done, show an error
         if ($failedCastingFieldArgErrors) {
             $fieldName = $this->getFieldName($field);

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1424,7 +1424,10 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
     ): array {
         // Add the deprecations
         foreach ($castingDirectiveArgDeprecationMessages as $castingDirectiveArgDeprecationMessage) {
-            $schemaDeprecations[] = $this->getErrorService()->getErrorOutput($castingDirectiveArgDeprecationMessage, [$fieldDirective]);
+            $schemaDeprecations[] = [
+                Tokens::PATH => [$fieldDirective],
+                Tokens::MESSAGE => $castingDirectiveArgDeprecationMessage,
+            ];
         }
 
         // If any casting can't be done, show an error

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -16,6 +16,7 @@ use PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface;
 use PoP\ComponentModel\Resolvers\ResolverTypes;
 use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\AbstractRelationalTypeResolver;
+use PoP\ComponentModel\TypeResolvers\DeprecatableInputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
@@ -1137,6 +1138,16 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                 $failedCastingFieldOrDirectiveArgErrors[$argName] = $castingError;
                 unset($fieldOrDirectiveArgs[$argName]);
                 continue;
+            }
+
+            // Obtain the deprecations
+            if ($fieldOrDirectiveArgTypeResolver instanceof DeprecatableInputTypeResolverInterface) {
+                $deprecationMessages = $this->getInputCoercingService()->getInputValueDeprecationMessages(
+                    $fieldOrDirectiveArgTypeResolver,
+                    $argValue,
+                    $fieldOrDirectiveArgIsArrayType,
+                    $fieldOrDirectiveArgIsArrayOfArraysType,
+                );
             }
 
             // No errors, assign the value

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -182,7 +182,6 @@ class InputCoercingService implements InputCoercingServiceInterface
         bool $inputIsArrayType,
         bool $inputIsArrayOfArraysType
     ): array {
-        // Cast (or "coerce" in GraphQL terms) the value
         if ($inputIsArrayOfArraysType) {
             return GeneralUtils::arrayFlatten(array_filter(
                 $inputValue ?? [],

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -233,11 +233,10 @@ class InputCoercingService implements InputCoercingServiceInterface
                     if ($arrayOfArraysArgValueElem === null) {
                         continue;
                     }
-                    $deprecationMessage = $deprecatableInputTypeResolver->getInputValueDeprecationMessage($arrayOfArraysArgValueElem);
-                    if (empty($deprecationMessage)) {
-                        continue;
-                    }
-                    $inputValueDeprecations[] = $deprecationMessage;
+                    $inputValueDeprecations = array_merge(
+                        $inputValueDeprecations,
+                        $deprecatableInputTypeResolver->getInputValueDeprecationMessages($arrayOfArraysArgValueElem)
+                    );
                 }
             }
         } elseif ($inputIsArrayType) {
@@ -246,17 +245,14 @@ class InputCoercingService implements InputCoercingServiceInterface
                 if ($arrayArgValueElem === null) {
                     continue;
                 }
-                $deprecationMessage = $deprecatableInputTypeResolver->getInputValueDeprecationMessage($arrayArgValueElem);
-                if (empty($deprecationMessage)) {
-                    continue;
-                }
-                $inputValueDeprecations[] = $deprecationMessage;
+                $inputValueDeprecations = array_merge(
+                    $inputValueDeprecations,
+                    $deprecatableInputTypeResolver->getInputValueDeprecationMessages($arrayArgValueElem)
+                );
             }
         } else {
             // Execute against the single value
-            if ($deprecationMessage = $deprecatableInputTypeResolver->getInputValueDeprecationMessage($inputValue)) {
-                $inputValueDeprecations[] = $deprecationMessage;
-            }
+            $inputValueDeprecations = $deprecatableInputTypeResolver->getInputValueDeprecationMessages($inputValue);
         }
         return array_unique($inputValueDeprecations);
     }

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -149,9 +149,12 @@ class InputCoercingService implements InputCoercingServiceInterface
         bool $inputIsArrayType,
         bool $inputIsArrayOfArraysType
     ): mixed {
+        if ($inputValue === null) {
+            return null;
+        }
         if ($inputIsArrayOfArraysType) {
             // If the value is an array of arrays, then cast each subelement to the item type
-            return $inputValue === null ? null : array_map(
+            return array_map(
                 // If it contains a null value, return it as is
                 fn (?array $arrayArgValueElem) => $arrayArgValueElem === null ? null : array_map(
                     fn (mixed $arrayOfArraysArgValueElem) => $arrayOfArraysArgValueElem === null ? null : $inputTypeResolver->coerceValue($arrayOfArraysArgValueElem),
@@ -162,13 +165,13 @@ class InputCoercingService implements InputCoercingServiceInterface
         }
         if ($inputIsArrayType) {
             // If the value is an array, then cast each element to the item type
-            return $inputValue === null ? null : array_map(
+            return array_map(
                 fn (mixed $arrayArgValueElem) => $arrayArgValueElem === null ? null : $inputTypeResolver->coerceValue($arrayArgValueElem),
                 $inputValue
             );
         }
         // Otherwise, simply cast the given value directly
-        return $inputValue === null ? null : $inputTypeResolver->coerceValue($inputValue);
+        return $inputTypeResolver->coerceValue($inputValue);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -149,7 +149,6 @@ class InputCoercingService implements InputCoercingServiceInterface
         bool $inputIsArrayType,
         bool $inputIsArrayOfArraysType
     ): mixed {
-        // Cast (or "coerce" in GraphQL terms) the value
         if ($inputIsArrayOfArraysType) {
             // If the value is an array of arrays, then cast each subelement to the item type
             return $inputValue === null ? null : array_map(

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingServiceInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Schema;
 
 use PoP\ComponentModel\ErrorHandling\Error;
+use PoP\ComponentModel\TypeResolvers\DeprecatableInputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 
 interface InputCoercingServiceInterface
@@ -59,6 +60,18 @@ interface InputCoercingServiceInterface
      * @return Error[] Errors from coercing the input value
      */
     public function extractErrorsFromCoercedInputValue(
+        mixed $inputValue,
+        bool $inputIsArrayType,
+        bool $inputIsArrayOfArraysType
+    ): array;
+
+    /**
+     * If applicable, get the deprecation messages for the input value
+     *
+     * @return string[]
+     */
+    public function getInputValueDeprecationMessages(
+        DeprecatableInputTypeResolverInterface $inputTypeResolver,
         mixed $inputValue,
         bool $inputIsArrayType,
         bool $inputIsArrayOfArraysType

--- a/layers/Engine/packages/component-model/src/TypeResolvers/DeprecatableInputTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/DeprecatableInputTypeResolverInterface.php
@@ -18,7 +18,7 @@ interface DeprecatableInputTypeResolverInterface extends InputTypeResolverInterf
      * obtain the deprecation messages for an input value.
      *
      * @param string|int|float|bool|stdClass $inputValue the (custom) scalar in any format: itself (eg: an object) or its representation (eg: as a string)
-     * @return string|null The deprecation message
+     * @return string[] The deprecation messages
      */
-    public function getInputValueDeprecationMessage(string|int|float|bool|stdClass $inputValue): ?string;
+    public function getInputValueDeprecationMessages(string|int|float|bool|stdClass $inputValue): array;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/DeprecatableInputTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/DeprecatableInputTypeResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\TypeResolvers;
+
+use stdClass;
+
+/**
+ * Input types which can be deprecated:
+ *
+ * - EnumType
+ */
+interface DeprecatableInputTypeResolverInterface extends InputTypeResolverInterface
+{
+    /**
+     * For input types that can be deprecated (i.e. EnumType),
+     * obtain the deprecation messages for an input value.
+     *
+     * @param string|int|float|bool|stdClass $inputValue the (custom) scalar in any format: itself (eg: an object) or its representation (eg: as a string)
+     * @return string|null The deprecation message
+     */
+    public function getInputValueDeprecationMessage(string|int|float|bool|stdClass $inputValue): ?string;
+}

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -67,7 +67,13 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
     final public function getInputValueDeprecationMessages(string|int|float|bool|stdClass $inputValue): array
     {
         if ($deprecationMessage = $this->getConsolidatedEnumValueDeprecationMessage($inputValue)) {
-            return [$deprecationMessage];
+            return [
+                sprintf(
+                    $this->getTranslationAPI()->__('Enum value \'%s\' is deprecated: %s', 'component-model'),
+                    $inputValue,
+                    $deprecationMessage
+                ),
+            ];
         }
         return [];
     }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -49,7 +49,7 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
             );
             return $this->getError(
                 sprintf(
-                    $this->getTranslationAPI()->__('Value \'%1$s\' for enum type \'%2$s\' is not allowed (the only allowed values are: \'%3$s\')', 'component-model'),
+                    $this->getTranslationAPI()->__('Value \'%1$s\' for enum type \'%2$s\' is not valid (the only valid values are: \'%3$s\')', 'component-model'),
                     $inputValue,
                     $this->getMaybeNamespacedTypeName(),
                     implode($this->getTranslationAPI()->__('\', \''), $nonDeprecatedEnumValues)

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers\EnumType;
 
-use PoP\ComponentModel\ErrorHandling\Error;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use stdClass;
 
@@ -57,6 +56,17 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
             );
         }
         return $inputValue;
+    }
+
+    /**
+     * Obtain the deprecation messages for an input value.
+     *
+     * @param string|int|float|bool|stdClass $inputValue the (custom) scalar in any format: itself (eg: an object) or its representation (eg: as a string)
+     * @return string|null The deprecation message
+     */
+    final public function getInputValueDeprecationMessage(string|int|float|bool|stdClass $inputValue): ?string
+    {
+        return $this->getConsolidatedEnumValueDeprecationMessage($inputValue);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -62,11 +62,14 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
      * Obtain the deprecation messages for an input value.
      *
      * @param string|int|float|bool|stdClass $inputValue the (custom) scalar in any format: itself (eg: an object) or its representation (eg: as a string)
-     * @return string|null The deprecation message
+     * @return string[] The deprecation messages
      */
-    final public function getInputValueDeprecationMessage(string|int|float|bool|stdClass $inputValue): ?string
+    final public function getInputValueDeprecationMessages(string|int|float|bool|stdClass $inputValue): array
     {
-        return $this->getConsolidatedEnumValueDeprecationMessage($inputValue);
+        if ($deprecationMessage = $this->getConsolidatedEnumValueDeprecationMessage($inputValue)) {
+            return [$deprecationMessage];
+        }
+        return [];
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -41,6 +41,21 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
      */
     final public function coerceValue(string|int|float|bool|stdClass $inputValue): string|int|float|bool|object
     {
+        $enumValues = $this->getConsolidatedEnumValues();
+        if (!in_array($inputValue, $enumValues)) {
+            $nonDeprecatedEnumValues = array_filter(
+                $enumValues,
+                fn (string $enumValue) => empty($this->getConsolidatedEnumValueDeprecationMessage($enumValue))
+            );
+            return $this->getError(
+                sprintf(
+                    $this->getTranslationAPI()->__('Value \'%1$s\' for enum type \'%2$s\' is not allowed (the only allowed values are: \'%3$s\')', 'component-model'),
+                    $inputValue,
+                    $this->getMaybeNamespacedTypeName(),
+                    implode($this->getTranslationAPI()->__('\', \''), $nonDeprecatedEnumValues)
+                )
+            );
+        }
         return $inputValue;
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/EnumTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/EnumTypeResolverInterface.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\TypeResolvers\EnumType;
 
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
-use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\DeprecatableInputTypeResolverInterface;
 
-interface EnumTypeResolverInterface extends ConcreteTypeResolverInterface, InputTypeResolverInterface
+interface EnumTypeResolverInterface extends ConcreteTypeResolverInterface, DeprecatableInputTypeResolverInterface
 {
     /**
      * The values in the enum

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -264,16 +264,6 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                 continue;
             }
 
-            // Obtain the deprecations
-            if ($inputFieldTypeResolver instanceof DeprecatableInputTypeResolverInterface) {
-                $deprecationMessages = $this->getInputCoercingService()->getInputValueDeprecationMessages(
-                    $inputFieldTypeResolver,
-                    $inputFieldValue,
-                    $inputFieldIsArrayType,
-                    $inputFieldIsArrayOfArraysType,
-                );
-            }
-
             // The input field is valid, add to the resulting InputObject
             $coercedInputValue->$inputFieldName = $coercedInputFieldValue;
         }
@@ -314,6 +304,53 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
 
         // Add all missing properties which have a default value
         return $coercedInputValue;
+    }
+
+    /**
+     * Obtain the deprecation messages for an input value.
+     *
+     * @param string|int|float|bool|stdClass $inputValue the (custom) scalar in any format: itself (eg: an object) or its representation (eg: as a string)
+     * @return string[] The deprecation messages
+     */
+    final public function getInputValueDeprecationMessages(string|int|float|bool|stdClass $inputValue): array
+    {
+        $inputValueDeprecationMessages = [];
+        $inputFieldNameTypeResolvers = $this->getConsolidatedInputFieldNameTypeResolvers();
+
+        foreach ((array)$inputValue as $inputFieldName => $inputFieldValue) {
+            // Check that the input field exists
+            $inputFieldTypeResolver = $inputFieldNameTypeResolvers[$inputFieldName] ?? null;
+            if ($inputFieldTypeResolver === null) {
+                $errors[] = new Error(
+                    $this->getErrorCode(),
+                    sprintf(
+                        $this->getTranslationAPI()->__('There is no input field \'%s\' in input object \'%s\''),
+                        $inputFieldName,
+                        $this->getMaybeNamespacedTypeName()
+                    )
+                );
+                continue;
+            }
+
+            // Obtain the deprecations
+            if ($inputFieldTypeResolver instanceof DeprecatableInputTypeResolverInterface) {
+                $inputFieldTypeModifiers = $this->getConsolidatedInputFieldTypeModifiers($inputFieldName);
+                $inputFieldIsArrayType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
+                $inputFieldIsArrayOfArraysType = ($inputFieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
+
+                $deprecationMessages = $this->getInputCoercingService()->getInputValueDeprecationMessages(
+                    $inputFieldTypeResolver,
+                    $inputFieldValue,
+                    $inputFieldIsArrayType,
+                    $inputFieldIsArrayOfArraysType,
+                );
+                $inputValueDeprecationMessages = array_merge(
+                    $inputValueDeprecationMessages,
+                    $deprecationMessages
+                );
+            }
+        }
+        return array_unique($inputValueDeprecationMessages);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -11,6 +11,7 @@ use PoP\ComponentModel\Resolvers\TypeSchemaDefinitionResolverTrait;
 use PoP\ComponentModel\Schema\InputCoercingServiceInterface;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
+use PoP\ComponentModel\TypeResolvers\DeprecatableInputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyDynamicScalarTypeResolver;
 use stdClass;
@@ -261,6 +262,16 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                 );
                 $errors[] = $castingError;
                 continue;
+            }
+
+            // Obtain the deprecations
+            if ($inputFieldTypeResolver instanceof DeprecatableInputTypeResolverInterface) {
+                $deprecationMessages = $this->getInputCoercingService()->getInputValueDeprecationMessages(
+                    $inputFieldTypeResolver,
+                    $inputFieldValue,
+                    $inputFieldIsArrayType,
+                    $inputFieldIsArrayOfArraysType,
+                );
             }
 
             // The input field is valid, add to the resulting InputObject

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/InputObjectTypeResolverInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeResolvers\InputObjectType;
 
+use PoP\ComponentModel\TypeResolvers\DeprecatableInputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use stdClass;
 
@@ -12,7 +13,7 @@ use stdClass;
  *
  * @see https://spec.graphql.org/draft/#sec-Input-Objects
  */
-interface InputObjectTypeResolverInterface extends InputTypeResolverInterface
+interface InputObjectTypeResolverInterface extends DeprecatableInputTypeResolverInterface
 {
     /**
      * Define input fields

--- a/layers/WPSchema/packages/customposts/src/TypeResolvers/EnumType/QueryRelationEnumTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/TypeResolvers/EnumType/QueryRelationEnumTypeResolver.php
@@ -43,4 +43,13 @@ class QueryRelationEnumTypeResolver extends AbstractEnumTypeResolver
             default => parent::getEnumValueDescription($enumValue),
         };
     }
+
+    public function getEnumValueDeprecationMessage(string $enumValue): ?string
+    {
+        return match ($enumValue) {
+            QueryRelations::AND => $this->getTranslationAPI()->__('`AND` relation', 'schema-commons'),
+            QueryRelations::OR => $this->getTranslationAPI()->__('`OR` relation', 'schema-commons'),
+            default => parent::getEnumValueDescription($enumValue),
+        };
+    }
 }

--- a/layers/WPSchema/packages/customposts/src/TypeResolvers/EnumType/QueryRelationEnumTypeResolver.php
+++ b/layers/WPSchema/packages/customposts/src/TypeResolvers/EnumType/QueryRelationEnumTypeResolver.php
@@ -43,13 +43,4 @@ class QueryRelationEnumTypeResolver extends AbstractEnumTypeResolver
             default => parent::getEnumValueDescription($enumValue),
         };
     }
-
-    public function getEnumValueDeprecationMessage(string $enumValue): ?string
-    {
-        return match ($enumValue) {
-            QueryRelations::AND => $this->getTranslationAPI()->__('`AND` relation', 'schema-commons'),
-            QueryRelations::OR => $this->getTranslationAPI()->__('`OR` relation', 'schema-commons'),
-            default => parent::getEnumValueDescription($enumValue),
-        };
-    }
 }


### PR DESCRIPTION
Same for deprecations.

Created new interface `DeprecatableInputTypeResolverInterface` for all TypeResolvers that can be deprecated:

- EnumTypeResolver
- InputObjectTypeResolver <= because it can contain an input field of EnumType