### PR TITLE
Improve nested error messages

### DIFF
--- a/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -190,10 +190,21 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
                 $item[Tokens::EXTENSIONS] ?? []
             )
         ) {
-            $entry['extensions'] = $extensions;
+            $entry['extensions'] = $this->reformatExtensions($extensions);
         }
         // }
         return $entry;
+    }
+
+    /**
+     * Enable to modify the shape of the extensions.
+     *
+     * @param array<string,mixed> $extensions
+     * @return array<string,mixed>
+     */
+    protected function reformatExtensions(array $extensions): array
+    {
+        return $extensions;
     }
 
     protected function getDBEntryExtensions(string $dbKey, int | string $id, array $item): array
@@ -233,7 +244,7 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
                 $item[Tokens::EXTENSIONS] ?? []
             )
         ) {
-            $entry['extensions'] = $extensions;
+            $entry['extensions'] = $this->reformatExtensions($extensions);
         }
         // }
         return $entry;
@@ -269,7 +280,7 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
                 $extensions
             )
         ) {
-            $entry['extensions'] = $extensions;
+            $entry['extensions'] = $this->reformatExtensions($extensions);
         };
         // }
         return $entry;

--- a/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/API/packages/api-graphql/src/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -204,6 +204,13 @@ class GraphQLDataStructureFormatter extends MirrorQueryDataStructureFormatter
      */
     protected function reformatExtensions(array $extensions): array
     {
+        // Recursive call for nested elements
+        foreach (($extensions[Tokens::NESTED] ?? []) as $index => $nested) {
+            if (!isset($nested[Tokens::EXTENSIONS])) {
+                continue;
+            }
+            $extensions[Tokens::NESTED][$index][Tokens::EXTENSIONS] = $this->reformatExtensions($nested[Tokens::EXTENSIONS]);
+        }
         return $extensions;
     }
 

--- a/layers/Engine/packages/component-model/src/ErrorHandling/Error.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/Error.php
@@ -62,6 +62,19 @@ class Error
     }
 
     /**
+     * @param array<string, mixed> $data
+     */
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    public function addData(string $key, mixed $value): void
+    {
+        $this->data[$key] = $value;
+    }
+
+    /**
      * @return Error[]
      */
     public function getNestedErrors(): array

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorService.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorService.php
@@ -10,10 +10,9 @@ class ErrorService implements ErrorServiceInterface
 {
     /**
      * @param string[]|null $path
-     * @param string[]|null $argPath
      * @return array<string, mixed>
      */
-    public function getErrorOutput(Error $error, ?array $path = null, ?array $argPath = null): array
+    public function getErrorOutput(Error $error, ?array $path = null, ?string $argName = null): array
     {
         $errorOutput = [
             Tokens::MESSAGE => $error->getMessageOrCode(),
@@ -24,11 +23,14 @@ class ErrorService implements ErrorServiceInterface
         if ($data = $error->getData()) {
             $errorOutput[Tokens::EXTENSIONS] = $data;
         }
-        if ($argPath !== null) {
-            $errorOutput[Tokens::EXTENSIONS][Tokens::ARGUMENT_PATH] = $argPath;
+        if ($argName !== null) {
+            $errorOutput[Tokens::EXTENSIONS][Tokens::ARGUMENT_PATH] = array_merge(
+                [$argName],
+                $errorOutput[Tokens::EXTENSIONS][Tokens::ARGUMENT_PATH] ?? []
+            );
         }
         foreach ($error->getNestedErrors() as $nestedError) {
-            $errorOutput[Tokens::EXTENSIONS][Tokens::NESTED][] = $this->getErrorOutput($nestedError);
+            $errorOutput[Tokens::EXTENSIONS][Tokens::NESTED][] = $this->getErrorOutput($nestedError, null, $argName);
         }
         return $errorOutput;
     }

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorService.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorService.php
@@ -10,9 +10,10 @@ class ErrorService implements ErrorServiceInterface
 {
     /**
      * @param string[]|null $path
+     * @param string[]|null $argPath
      * @return array<string, mixed>
      */
-    public function getErrorOutput(Error $error, ?array $path = null): array
+    public function getErrorOutput(Error $error, ?array $path = null, ?array $argPath = null): array
     {
         $errorOutput = [
             Tokens::MESSAGE => $error->getMessageOrCode(),
@@ -22,6 +23,9 @@ class ErrorService implements ErrorServiceInterface
         }
         if ($data = $error->getData()) {
             $errorOutput[Tokens::EXTENSIONS] = $data;
+        }
+        if ($argPath !== null) {
+            $errorOutput[Tokens::EXTENSIONS][Tokens::ARGUMENT_PATH] = $argPath;
         }
         foreach ($error->getNestedErrors() as $nestedError) {
             $errorOutput[Tokens::EXTENSIONS][Tokens::NESTED][] = $this->getErrorOutput($nestedError);

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorServiceInterface.php
@@ -10,5 +10,5 @@ interface ErrorServiceInterface
      * @param string[]|null $path
      * @return array<string, mixed>
      */
-    public function getErrorOutput(Error $error, ?array $path = null, ?array $argPath = null): array;
+    public function getErrorOutput(Error $error, ?array $path = null, ?string $argName = null): array;
 }

--- a/layers/Engine/packages/component-model/src/ErrorHandling/ErrorServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/ErrorHandling/ErrorServiceInterface.php
@@ -10,5 +10,5 @@ interface ErrorServiceInterface
      * @param string[]|null $path
      * @return array<string, mixed>
      */
-    public function getErrorOutput(Error $error, ?array $path = null): array;
+    public function getErrorOutput(Error $error, ?array $path = null, ?array $argPath = null): array;
 }

--- a/layers/Engine/packages/component-model/src/Feedback/Tokens.php
+++ b/layers/Engine/packages/component-model/src/Feedback/Tokens.php
@@ -12,4 +12,5 @@ class Tokens
     const NESTED = 'nested';
     const EXTENSIONS = 'extensions';
     const ID_FIELDS = 'idFields';
+    const ARG_PATH = 'argPath';
 }

--- a/layers/Engine/packages/component-model/src/Feedback/Tokens.php
+++ b/layers/Engine/packages/component-model/src/Feedback/Tokens.php
@@ -12,5 +12,5 @@ class Tokens
     const NESTED = 'nested';
     const EXTENSIONS = 'extensions';
     const ID_FIELDS = 'idFields';
-    const ARG_PATH = 'argPath';
+    const ARGUMENT_PATH = 'argumentPath';
 }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -498,7 +498,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                     $errorMessage = sprintf(
                         $this->getTranslationAPI()->__('On %1$s \'%2$s\', argument with name \'%3$s\' has not been documented in the schema', 'pop-component-model'),
                         $resolverType == ResolverTypes::FIELD ? $this->getTranslationAPI()->__('field', 'component-model') : $this->getTranslationAPI()->__('directive', 'component-model'),
-                        $fieldOrDirective,
+                        $this->getFieldName($fieldOrDirective),
                         $fieldOrDirectiveArgName
                     );
                     if ($treatUndefinedFieldOrDirectiveArgsAsErrors) {

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -961,7 +961,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         $errorFieldOrDirective = $errorData[ErrorDataTokens::FIELD_NAME] ?? null;
                     }
                     $errorFieldOrDirective = $errorFieldOrDirective ?? $fieldOrDirectiveOutputKey;
-                    $objectErrors[(string)$id][] = $this->getErrorService()->getErrorOutput($error, [$errorFieldOrDirective], [$directiveArgName]);
+                    $objectErrors[(string)$id][] = $this->getErrorService()->getErrorOutput($error, [$errorFieldOrDirective], $directiveArgName);
                     $fieldOrDirectiveArgs[$directiveArgName] = null;
                     continue;
                 }
@@ -1476,7 +1476,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                     );
                 }
                 // Either treat it as an error or a warning
-                $schemaWarningOrError = $this->getErrorService()->getErrorOutput($directiveArgError, [$fieldDirective]);
+                $schemaWarningOrError = $this->getErrorService()->getErrorOutput($directiveArgError, [$fieldDirective], $failedCastingDirectiveArgName);
                 if ($treatTypeCoercingFailuresAsErrors) {
                     $schemaErrors[] = $schemaWarningOrError;
                 } else {
@@ -1576,7 +1576,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                     );
                 }
                 // Either treat it as an error or a warning
-                $schemaWarningOrError = $this->getErrorService()->getErrorOutput($fieldArgError, [$field]);
+                $schemaWarningOrError = $this->getErrorService()->getErrorOutput($fieldArgError, [$field], $failedCastingFieldArgName);
                 if ($treatTypeCoercingFailuresAsErrors) {
                     $schemaErrors[] = $schemaWarningOrError;
                 } else {

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -510,6 +510,9 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                                     $this->getTranslationAPI()->__('%s. The directive has been ignored', 'pop-component-model'),
                                     $errorMessage
                                 ),
+                                Tokens::EXTENSIONS => [
+                                    Tokens::ARGUMENT_PATH => [$fieldOrDirectiveArgName],
+                                ],
                         ];
                         continue;
                     } else {
@@ -519,6 +522,9 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                                 $this->getTranslationAPI()->__('%s, so it may have no effect (it has not been removed from the query, though)', 'pop-component-model'),
                                 $errorMessage
                             ),
+                            Tokens::EXTENSIONS => [
+                                Tokens::ARGUMENT_PATH => [$fieldOrDirectiveArgName],
+                            ],
                         ];
                     }
                 }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -961,7 +961,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
                         $errorFieldOrDirective = $errorData[ErrorDataTokens::FIELD_NAME] ?? null;
                     }
                     $errorFieldOrDirective = $errorFieldOrDirective ?? $fieldOrDirectiveOutputKey;
-                    $objectErrors[(string)$id][] = $this->getErrorService()->getErrorOutput($error, [$errorFieldOrDirective]);
+                    $objectErrors[(string)$id][] = $this->getErrorService()->getErrorOutput($error, [$errorFieldOrDirective], [$directiveArgName]);
                     $fieldOrDirectiveArgs[$directiveArgName] = null;
                     continue;
                 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -249,16 +249,28 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                 $inputFieldIsArrayOfArraysType,
             );
             if ($maybeCoercedInputFieldValueErrors !== []) {
-                $castingError = new Error(
-                    $this->getErrorCode(),
-                    sprintf(
-                        $this->getTranslationAPI()->__('Casting input field \'%s\' of type \'%s\' produced errors', 'component-model'),
-                        $inputFieldName,
-                        $inputFieldTypeResolver->getMaybeNamespacedTypeName()
-                    ),
-                    null,
-                    $maybeCoercedInputFieldValueErrors
-                );
+                $castingError = count($maybeCoercedInputFieldValueErrors) === 1 ?
+                    new Error(
+                        $maybeCoercedInputFieldValueErrors[0]->getCode(),
+                        sprintf(
+                            '%s: %s',
+                            // $this->getMaybeNamespacedTypeName(),
+                            $inputFieldName,
+                            $maybeCoercedInputFieldValueErrors[0]->getMessage()
+                        ),
+                        $maybeCoercedInputFieldValueErrors[0]->getData(),
+                        $maybeCoercedInputFieldValueErrors[0]->getNestedErrors()
+                    )
+                    : new Error(
+                        $this->getErrorCode(),
+                        sprintf(
+                            $this->getTranslationAPI()->__('Casting input field \'%s\' of type \'%s\' produced errors', 'component-model'),
+                            $inputFieldName,
+                            $inputFieldTypeResolver->getMaybeNamespacedTypeName()
+                        ),
+                        null,
+                        $maybeCoercedInputFieldValueErrors
+                    );
                 $errors[] = $castingError;
                 continue;
             }
@@ -292,13 +304,25 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
 
         // If there was any error, return it
         if ($errors) {
-            return $this->getError(
-                sprintf(
-                    $this->getTranslationAPI()->__('Casting input object of type \'%s\' produced errors', 'component-model'),
-                    $this->getMaybeNamespacedTypeName()
-                ),
-                $errors
-            );
+            return count($errors) === 1 ?
+                $errors[0]    
+                // new Error(
+                //     $errors[0]->getCode(),
+                //     sprintf(
+                //         '(in \'%s\') %s',
+                //         $this->getMaybeNamespacedTypeName(),
+                //         $errors[0]->getMessage()
+                //     ),
+                //     $errors[0]->getData(),
+                //     $errors[0]->getNestedErrors()
+                // )
+                : $this->getError(
+                    sprintf(
+                        $this->getTranslationAPI()->__('Casting input object of type \'%s\' produced errors', 'component-model'),
+                        $this->getMaybeNamespacedTypeName()
+                    ),
+                    $errors
+                );
         }
 
         // Add all missing properties which have a default value

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -316,7 +316,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         // If there was any error, return it
         if ($errors) {
             return count($errors) === 1 ?
-                $errors[0]    
+                $errors[0]
                 : $this->getError(
                     sprintf(
                         $this->getTranslationAPI()->__('Casting input object of type \'%s\' produced errors', 'component-model'),

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -178,7 +178,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                         $this->getMaybeNamespacedTypeName()
                     ),
                     [
-                        Tokens::ARG_PATH => [$inputFieldName],
+                        Tokens::ARGUMENT_PATH => [$inputFieldName],
                     ]
                 );
                 continue;
@@ -235,7 +235,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                     $this->getErrorCode(),
                     $maybeErrorMessage,
                     [
-                        Tokens::ARG_PATH => [$inputFieldName],
+                        Tokens::ARGUMENT_PATH => [$inputFieldName],
                     ]
                 );
                 continue;
@@ -276,7 +276,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                         $inputFieldTypeResolver->getMaybeNamespacedTypeName()
                     ),
                     [
-                        Tokens::ARG_PATH => [$inputFieldName],
+                        Tokens::ARGUMENT_PATH => [$inputFieldName],
                     ],
                     $maybeCoercedInputFieldValueErrors
                 );
@@ -307,7 +307,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                     $this->getMaybeNamespacedTypeName()
                 ),
                 [
-                    Tokens::ARG_PATH => [$inputFieldName],
+                    Tokens::ARGUMENT_PATH => [$inputFieldName],
                 ]
             );
             continue;
@@ -346,9 +346,9 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
     protected function prependArgPathToError(Error &$error, array $argPath): void
     {
         $errorData = $error->getData();
-        $error->addData(Tokens::ARG_PATH, array_merge(
+        $error->addData(Tokens::ARGUMENT_PATH, array_merge(
             $argPath,
-            $errorData[Tokens::ARG_PATH] ?? []
+            $errorData[Tokens::ARGUMENT_PATH] ?? []
         ));
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -176,7 +176,10 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                         $this->getTranslationAPI()->__('There is no input field \'%s\' in input object \'%s\''),
                         $inputFieldName,
                         $this->getMaybeNamespacedTypeName()
-                    )
+                    ),
+                    [
+                        Tokens::ARG_PATH => [$inputFieldName],
+                    ]
                 );
                 continue;
             }
@@ -230,7 +233,10 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             if ($maybeErrorMessage !== null) {
                 $errors[] = new Error(
                     $this->getErrorCode(),
-                    $maybeErrorMessage
+                    $maybeErrorMessage,
+                    [
+                        Tokens::ARG_PATH => [$inputFieldName],
+                    ]
                 );
                 continue;
             }
@@ -299,7 +305,10 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                     $this->getTranslationAPI()->__('Mandatory input field \'%s\' in input object \'%s\' has not been provided'),
                     $inputFieldName,
                     $this->getMaybeNamespacedTypeName()
-                )
+                ),
+                [
+                    Tokens::ARG_PATH => [$inputFieldName],
+                ]
             );
             continue;
         }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -317,16 +317,6 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         if ($errors) {
             return count($errors) === 1 ?
                 $errors[0]    
-                // new Error(
-                //     $errors[0]->getCode(),
-                //     sprintf(
-                //         '(in \'%s\') %s',
-                //         $this->getMaybeNamespacedTypeName(),
-                //         $errors[0]->getMessage()
-                //     ),
-                //     $errors[0]->getData(),
-                //     $errors[0]->getNestedErrors()
-                // )
                 : $this->getError(
                     sprintf(
                         $this->getTranslationAPI()->__('Casting input object of type \'%s\' produced errors', 'component-model'),

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -34,7 +34,13 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
     }
 
     /**
-     * Change properties for GraphQL
+     * Change properties for GraphQL.
+     *
+     * Rename the fields to the most appropriate name:
+     * 
+     *   - field
+     *   - directive
+     *   - fields <= baseline
      */
     protected function addFieldOrDirectiveEntryToExtensions(array &$extensions, array $item): void
     {
@@ -61,6 +67,25 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
         // Many fields
         $extensions['fields'] = $fields;
     }
+    /**
+     * Enable to modify the shape of the extensions.
+     *
+     * @param array<string,mixed> $extensions
+     * @return array<string,mixed>
+     */
+    protected function reformatExtensions(array $extensions): array
+    {
+        $extensions = parent::reformatExtensions($extensions);
+        $vars = ApplicationState::getVars();
+        if ($vars['standard-graphql']) {
+            // Convert the argumentPath from array to string
+            if (!empty($extensions[Tokens::ARGUMENT_PATH])) {
+                $extensions[Tokens::ARGUMENT_PATH] = implode('.', $extensions[Tokens::ARGUMENT_PATH]);
+            }    
+        }
+        return $extensions;
+    }
+
     /**
      * Change properties for GraphQL
      */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -68,7 +68,14 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
         $extensions['fields'] = $fields;
     }
     /**
-     * Enable to modify the shape of the extensions.
+     * Convert the argumentPath from array to string.
+     * 
+     * The field or directive argument name is appended ":", and input fields
+     * are separated with ".":
+     * 
+     *   ['filter'] => 'filter:'
+     *   ['filter', 'dateQuery'] => 'filter:dateQuery
+     *   ['filter', 'dateQuery', 'relation'] => 'filter:dateQuery.relation
      *
      * @param array<string,mixed> $extensions
      * @return array<string,mixed>
@@ -78,9 +85,14 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
         $extensions = parent::reformatExtensions($extensions);
         $vars = ApplicationState::getVars();
         if ($vars['standard-graphql']) {
-            // Convert the argumentPath from array to string
             if (!empty($extensions[Tokens::ARGUMENT_PATH])) {
-                $extensions[Tokens::ARGUMENT_PATH] = implode('.', $extensions[Tokens::ARGUMENT_PATH]);
+                // The first element is the field or directive argument name
+                $fieldOrDirectiveName = array_shift($extensions[Tokens::ARGUMENT_PATH]);
+                $extensions[Tokens::ARGUMENT_PATH] = sprintf(
+                    '%s:%s',
+                    $fieldOrDirectiveName,
+                    implode('.', $extensions[Tokens::ARGUMENT_PATH])
+                );
             }    
         }
         return $extensions;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/DataStructureFormatters/GraphQLDataStructureFormatter.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Overrides/DataStructureFormatters/GraphQLDataStructureFormatter.php
@@ -37,7 +37,7 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
      * Change properties for GraphQL.
      *
      * Rename the fields to the most appropriate name:
-     * 
+     *
      *   - field
      *   - directive
      *   - fields <= baseline
@@ -69,10 +69,10 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
     }
     /**
      * Convert the argumentPath from array to string.
-     * 
+     *
      * The field or directive argument name is appended ":", and input fields
      * are separated with ".":
-     * 
+     *
      *   ['filter'] => 'filter:'
      *   ['filter', 'dateQuery'] => 'filter:dateQuery
      *   ['filter', 'dateQuery', 'relation'] => 'filter:dateQuery.relation
@@ -93,7 +93,7 @@ class GraphQLDataStructureFormatter extends UpstreamGraphQLDataStructureFormatte
                     $fieldOrDirectiveName,
                     implode('.', $extensions[Tokens::ARGUMENT_PATH])
                 );
-            }    
+            }
         }
         return $extensions;
     }


### PR DESCRIPTION
Instead of printing error messages as nested, if there's only 1 nested error, then directly bubble it up.

To not lose the context, added entry `extensions.argumentPath` on the error entry.

argumentPath format: The field or directive argument name is appended `:`, and input fields are separated with `.`:

```
  ['filter'] => 'filter:'
  ['filter', 'dateQuery'] => 'filter:dateQuery
  ['filter', 'dateQuery', 'relation'] => 'filter:dateQuery.relation
```

So this query (which has a single error):

```graphql
{
  posts (
    filter:{
      dateQuery:
      [
        {
          before:"2022-01-03",
          after:"2020-01-01",
          relation:"@"
        },
        {
          before:"2019-01-02",
          after:"2018-11-02",
        }
      ]
    }
  ) {
    id
    title
    date
  }
}
```

...shows this error:

```json
{
  "errors": [
    {
      "message": "Value '@' for enum type 'QueryRelationEnum' is not valid (the only valid values are: 'AND', 'OR')",
      "extensions": {
        "type": "QueryRoot",
        "field": "posts(filter:{dateQuery:[0:{before:\"2022-01-03\",after:\"2020-01-01\",relation:\"@\"},1:{before:\"2019-01-02\",after:\"2018-11-02\"}]})",
        "argumentPath": "filter:dateQuery.relation"
      }
    }
  ],
  "data": {
    "posts": null
  }
}
```

And this query (which has more than 1 nested error):

```graphql
{
  posts (
    filter:{
      notExists:333
      dateQuery:
      [
        {
          before:"2022-01-03",
          after:"2020-01-01",
          relation:"@"
        },
        {
          before:"2019-01-02",
          after:"2018-11-02",
        }
      ]
    }
  ) {
    id
    title
    date
  }
}
```

...has this response:

```json
{
  "errors": [
    {
      "message": "Casting input object of type 'RootPostsFilterInput' produced errors",
      "extensions": {
        "type": "QueryRoot",
        "field": "posts(filter:{notExists:333,dateQuery:[0:{before:\"2022-01-03\",after:\"2020-01-01\",relation:\"@\"},1:{before:\"2019-01-02\",after:\"2018-11-02\"}]})",
        "argumentPath": "filter:",
        "nested": [
          {
            "message": "There is no input field 'notExists' in input object 'RootPostsFilterInput'",
            "extensions": {
              "argumentPath": "filter:notExists"
            }
          },
          {
            "message": "Value '@' for enum type 'QueryRelationEnum' is not valid (the only valid values are: 'AND', 'OR')",
            "extensions": {
              "argumentPath": "filter:dateQuery.relation"
            }
          }
        ]
      }
    }
  ],
  "data": {
    "posts": null
  }
}
```