### PR TITLE
Complete migrating filters to InputObject

### DIFF
--- a/layers/Schema/packages/post-categories/src/SchemaHooks/InputObjectTypeHookSet.php
+++ b/layers/Schema/packages/post-categories/src/SchemaHooks/InputObjectTypeHookSet.php
@@ -10,6 +10,7 @@ use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInte
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
 use PoP\Hooks\AbstractHookSet;
+use PoPSchema\Categories\FilterInputProcessors\FilterInputProcessor;
 use PoPSchema\Posts\TypeResolvers\InputObjectType\AbstractPostsFilterInputObjectTypeResolver;
 
 class InputObjectTypeHookSet extends AbstractHookSet
@@ -42,6 +43,12 @@ class InputObjectTypeHookSet extends AbstractHookSet
         $this->getHooksAPI()->addFilter(
             HookNames::INPUT_FIELD_TYPE_MODIFIERS,
             [$this, 'getInputFieldTypeModifiers'],
+            10,
+            3
+        );
+        $this->getHooksAPI()->addFilter(
+            HookNames::INPUT_FIELD_FILTER_INPUT,
+            [$this, 'getInputFieldFilterInput'],
             10,
             3
         );
@@ -92,6 +99,20 @@ class InputObjectTypeHookSet extends AbstractHookSet
                 => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
             default
                 => $inputFieldTypeModifiers,
+        };
+    }
+
+    public function getInputFieldFilterInput(
+        ?array $inputFieldFilterInput,
+        InputObjectTypeResolverInterface $inputObjectTypeResolver,
+        string $inputFieldName,
+    ): ?array {
+        if (!($inputObjectTypeResolver instanceof AbstractPostsFilterInputObjectTypeResolver)) {
+            return $inputFieldFilterInput;
+        }
+        return match ($inputFieldName) {
+            'categoryIDs' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_CATEGORY_IDS],
+            default => $inputFieldFilterInput,
         };
     }
 }

--- a/layers/Schema/packages/post-tags/src/SchemaHooks/InputObjectTypeHookSet.php
+++ b/layers/Schema/packages/post-tags/src/SchemaHooks/InputObjectTypeHookSet.php
@@ -12,6 +12,7 @@ use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\Hooks\AbstractHookSet;
 use PoPSchema\Posts\TypeResolvers\InputObjectType\AbstractPostsFilterInputObjectTypeResolver;
+use PoPSchema\Tags\FilterInputProcessors\FilterInputProcessor;
 
 class InputObjectTypeHookSet extends AbstractHookSet
 {
@@ -52,6 +53,12 @@ class InputObjectTypeHookSet extends AbstractHookSet
         $this->getHooksAPI()->addFilter(
             HookNames::INPUT_FIELD_TYPE_MODIFIERS,
             [$this, 'getInputFieldTypeModifiers'],
+            10,
+            3
+        );
+        $this->getHooksAPI()->addFilter(
+            HookNames::INPUT_FIELD_FILTER_INPUT,
+            [$this, 'getInputFieldFilterInput'],
             10,
             3
         );
@@ -105,6 +112,21 @@ class InputObjectTypeHookSet extends AbstractHookSet
                 => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
             default
                 => $inputFieldTypeModifiers,
+        };
+    }
+
+    public function getInputFieldFilterInput(
+        ?array $inputFieldFilterInput,
+        InputObjectTypeResolverInterface $inputObjectTypeResolver,
+        string $inputFieldName,
+    ): ?array {
+        if (!($inputObjectTypeResolver instanceof AbstractPostsFilterInputObjectTypeResolver)) {
+            return $inputFieldFilterInput;
+        }
+        return match ($inputFieldName) {
+            'tagIDs' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_TAG_IDS],
+            'tagSlugs' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_TAG_SLUGS],
+            default => $inputFieldFilterInput,
         };
     }
 }

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/SchemaHooks/InputObjectTypeHookSet.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/CustomPosts/SchemaHooks/InputObjectTypeHookSet.php
@@ -12,6 +12,7 @@ use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\Hooks\AbstractHookSet;
 use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\AbstractCustomPostsFilterInputObjectTypeResolver;
+use PoPSchema\Users\ConditionalOnComponent\CustomPosts\FilterInputProcessors\FilterInputProcessor;
 
 class InputObjectTypeHookSet extends AbstractHookSet
 {
@@ -52,6 +53,12 @@ class InputObjectTypeHookSet extends AbstractHookSet
         $this->getHooksAPI()->addFilter(
             HookNames::INPUT_FIELD_TYPE_MODIFIERS,
             [$this, 'getInputFieldTypeModifiers'],
+            10,
+            3
+        );
+        $this->getHooksAPI()->addFilter(
+            HookNames::INPUT_FIELD_FILTER_INPUT,
+            [$this, 'getInputFieldFilterInput'],
             10,
             3
         );
@@ -112,6 +119,22 @@ class InputObjectTypeHookSet extends AbstractHookSet
                 => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
             default
                 => $inputFieldTypeModifiers,
+        };
+    }
+
+    public function getInputFieldFilterInput(
+        ?array $inputFieldFilterInput,
+        InputObjectTypeResolverInterface $inputObjectTypeResolver,
+        string $inputFieldName,
+    ): ?array {
+        if (!($inputObjectTypeResolver instanceof AbstractCustomPostsFilterInputObjectTypeResolver)) {
+            return $inputFieldFilterInput;
+        }
+        return match ($inputFieldName) {
+            'authorIDs' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_AUTHOR_IDS],
+            'authorSlug' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_AUTHOR_SLUG],
+            'excludeAuthorIDs' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_EXCLUDE_AUTHOR_IDS],
+            default => $inputFieldFilterInput,
         };
     }
 }


### PR DESCRIPTION
Completed filters for `Root.posts`:

- `authorIDs`
- `authorSlug`
- `excludeAuthorIDs`
- `tagSlugs`
- `tagIDs`
- `categoryIDs`