### PR TITLE
Add OneofQueryableObjectInputType

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractOneofQueryableInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractOneofQueryableInputObjectTypeResolver.php
@@ -12,7 +12,7 @@ use stdClass;
  *
  * @see https://github.com/graphql/graphql-spec/pull/825
  */
-abstract class AbstractOneofInputObjectTypeResolver extends AbstractInputObjectTypeResolver implements OneofInputObjectTypeResolverInterface
+abstract class AbstractOneofQueryableInputObjectTypeResolver extends AbstractQueryableInputObjectTypeResolver implements OneofInputObjectTypeResolverInterface
 {
     use OneofInputObjectTypeResolverTrait;
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\TypeResolvers\InputObjectType;
+
+/**
+ * Based on GraphQL's oneof InputObject Type
+ *
+ * @see https://github.com/graphql/graphql-spec/pull/825
+ */
+interface OneofInputObjectTypeResolverInterface extends InputObjectTypeResolverInterface
+{
+    
+}

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverInterface.php
@@ -11,5 +11,5 @@ namespace PoP\ComponentModel\TypeResolvers\InputObjectType;
  */
 interface OneofInputObjectTypeResolverInterface extends InputObjectTypeResolverInterface
 {
-    
+
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\TypeResolvers\InputObjectType;
+
+use PoP\ComponentModel\Error\Error;
+use PoP\Translation\TranslationAPIInterface;
+use stdClass;
+
+trait OneofInputObjectTypeResolverTrait
+{
+    abstract protected function getErrorCode(): string;
+    abstract protected function getTranslationAPI(): TranslationAPIInterface;
+    abstract public function getMaybeNamespacedTypeName(): string;
+    
+    /**
+     * Validate that there is exactly one input set
+     */
+    protected function validateOneofInputObjectValue(stdClass $inputValue): ?Error
+    {
+        $inputValueSize = count((array)$inputValue);
+        if ($inputValueSize !== 1) {
+            return new Error(
+                $this->getErrorCode(),
+                sprintf(
+                    $this->getTranslationAPI()->__('The oneof input object \'%s\' must receive exactly 1 input, but %s', 'component-model'),
+                    $this->getMaybeNamespacedTypeName(),
+                    $inputValueSize === 0 ?
+                        $this->getTranslationAPI()->__('no input was provided', 'component-model')
+                        : sprintf(
+                            $this->getTranslationAPI()->__('\'%s\' inputs were provided (\'%s\')', 'component-model'),
+                            $inputValueSize,
+                            implode(
+                                $this->getTranslationAPI()->__('\', \'', 'component-model'),
+                                array_keys((array)$inputValue)
+                            )
+                        )
+                )
+            );
+        }
+
+        return null;
+    }
+}

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php
@@ -13,7 +13,7 @@ trait OneofInputObjectTypeResolverTrait
     abstract protected function getErrorCode(): string;
     abstract protected function getTranslationAPI(): TranslationAPIInterface;
     abstract public function getMaybeNamespacedTypeName(): string;
-    
+
     /**
      * Validate that there is exactly one input set
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -413,7 +413,7 @@ Similar to custom scalars, custom enum types can be added to the GraphQL schema!
 
 ## Oneof Input Objects
 
-This is a feature currently under consideration to be included in the GraphQL spec: [graphql/graphql-spec#733](https://github.com/graphql/graphql-spec/pull/733), and already implemented for the GraphQL API for WordPress.
+This is a feature currently under consideration to be included in the GraphQL spec: [graphql/graphql-spec#733](https://github.com/graphql/graphql-spec/pull/825), and already implemented for the GraphQL API for WordPress.
 
 The Oneof Input Object introduces a form of polymorphism for inputs in GraphQL. It defines a list of named members each with an associated type (like the fields in Object types and Input Object types), where exactly one of those members must be provided as an input when resolving the query (or otherwise it returns a validation error).
 

--- a/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -81,8 +81,8 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
 
     public function getFieldArgTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): int
     {
-        return match ($fieldName) {
-            'customPost' => SchemaTypeModifiers::MANDATORY,
+        return match ([$fieldName => $fieldArgName]) {
+            ['customPost' => 'by'] => SchemaTypeModifiers::MANDATORY,
             default => parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
         };
     }

--- a/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -22,7 +22,7 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListObjectTypeFieldResolver
 {
     private ?RootCustomPostByInputObjectTypeResolver $rootCustomPostByInputObjectTypeResolver = null;
-    
+
     final public function setRootCustomPostByInputObjectTypeResolver(RootCustomPostByInputObjectTypeResolver $rootCustomPostByInputObjectTypeResolver): void
     {
         $this->rootCustomPostByInputObjectTypeResolver = $rootCustomPostByInputObjectTypeResolver;
@@ -31,7 +31,7 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
     {
         return $this->rootCustomPostByInputObjectTypeResolver ??= $this->instanceManager->getInstance(RootCustomPostByInputObjectTypeResolver::class);
     }
-    
+
     public function getObjectTypeResolverClassesToAttachTo(): array
     {
         return [

--- a/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -10,7 +10,7 @@ use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ObjectType\RootObjectTypeResolver;
 use PoPSchema\CustomPosts\ModuleProcessors\CommonCustomPostFilterInputContainerModuleProcessor;
 use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
-use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\RootCustomPostByInputObjectTypeResolver;
+use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\CustomPostByInputObjectTypeResolver;
 use PoPSchema\SchemaCommons\Constants\QueryOptions;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
@@ -21,15 +21,15 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
  */
 class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListObjectTypeFieldResolver
 {
-    private ?RootCustomPostByInputObjectTypeResolver $rootCustomPostByInputObjectTypeResolver = null;
+    private ?CustomPostByInputObjectTypeResolver $customPostByInputObjectTypeResolver = null;
 
-    final public function setRootCustomPostByInputObjectTypeResolver(RootCustomPostByInputObjectTypeResolver $rootCustomPostByInputObjectTypeResolver): void
+    final public function setCustomPostByInputObjectTypeResolver(CustomPostByInputObjectTypeResolver $customPostByInputObjectTypeResolver): void
     {
-        $this->rootCustomPostByInputObjectTypeResolver = $rootCustomPostByInputObjectTypeResolver;
+        $this->customPostByInputObjectTypeResolver = $customPostByInputObjectTypeResolver;
     }
-    final protected function getRootCustomPostByInputObjectTypeResolver(): RootCustomPostByInputObjectTypeResolver
+    final protected function getCustomPostByInputObjectTypeResolver(): CustomPostByInputObjectTypeResolver
     {
-        return $this->rootCustomPostByInputObjectTypeResolver ??= $this->instanceManager->getInstance(RootCustomPostByInputObjectTypeResolver::class);
+        return $this->customPostByInputObjectTypeResolver ??= $this->instanceManager->getInstance(CustomPostByInputObjectTypeResolver::class);
     }
 
     public function getObjectTypeResolverClassesToAttachTo(): array
@@ -72,7 +72,7 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
             'customPost' => array_merge(
                 $fieldArgNameTypeResolvers,
                 [
-                    'by' => $this->getRootCustomPostByInputObjectTypeResolver(),
+                    'by' => $this->getCustomPostByInputObjectTypeResolver(),
                 ]
             ),
             default => $fieldArgNameTypeResolvers,

--- a/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -52,7 +52,7 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
     public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
     {
         return match ($fieldName) {
-            'customPost' => $this->getTranslationAPI()->__('Custom post with a specific ID', 'customposts'),
+            'customPost' => $this->getTranslationAPI()->__('Query a custom post by different properties', 'customposts'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }

--- a/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ObjectType\RootObjectTypeResolver;
 use PoPSchema\CustomPosts\ModuleProcessors\CommonCustomPostFilterInputContainerModuleProcessor;
 use PoPSchema\CustomPosts\TypeHelpers\CustomPostUnionTypeHelpers;
+use PoPSchema\CustomPosts\TypeResolvers\InputObjectType\RootCustomPostByInputObjectTypeResolver;
 use PoPSchema\SchemaCommons\Constants\QueryOptions;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
 
@@ -19,6 +21,17 @@ use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
  */
 class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListObjectTypeFieldResolver
 {
+    private ?RootCustomPostByInputObjectTypeResolver $rootCustomPostByInputObjectTypeResolver = null;
+    
+    final public function setRootCustomPostByInputObjectTypeResolver(RootCustomPostByInputObjectTypeResolver $rootCustomPostByInputObjectTypeResolver): void
+    {
+        $this->rootCustomPostByInputObjectTypeResolver = $rootCustomPostByInputObjectTypeResolver;
+    }
+    final protected function getRootCustomPostByInputObjectTypeResolver(): RootCustomPostByInputObjectTypeResolver
+    {
+        return $this->rootCustomPostByInputObjectTypeResolver ??= $this->instanceManager->getInstance(RootCustomPostByInputObjectTypeResolver::class);
+    }
+    
     public function getObjectTypeResolverClassesToAttachTo(): array
     {
         return [
@@ -32,7 +45,6 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
             parent::getFieldNamesToResolve(),
             [
                 'customPost',
-                'customPostBySlug',
             ]
         );
     }
@@ -41,7 +53,6 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
     {
         return match ($fieldName) {
             'customPost' => $this->getTranslationAPI()->__('Custom post with a specific ID', 'customposts'),
-            'customPostBySlug' => $this->getTranslationAPI()->__('Custom post with a specific slug', 'customposts'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -49,9 +60,30 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
     public function getFieldFilterInputContainerModule(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?array
     {
         return match ($fieldName) {
-            'customPost' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_UNIONTYPE],
-            'customPostBySlug' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_SLUG_UNIONTYPE],
+            'customPost' => [CommonCustomPostFilterInputContainerModuleProcessor::class, CommonCustomPostFilterInputContainerModuleProcessor::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_UNIONTYPE],
             default => parent::getFieldFilterInputContainerModule($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldArgNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): array
+    {
+        $fieldArgNameTypeResolvers = parent::getFieldArgNameTypeResolvers($objectTypeResolver, $fieldName);
+        return match ($fieldName) {
+            'customPost' => array_merge(
+                $fieldArgNameTypeResolvers,
+                [
+                    'by' => $this->getRootCustomPostByInputObjectTypeResolver(),
+                ]
+            ),
+            default => $fieldArgNameTypeResolvers,
+        };
+    }
+
+    public function getFieldArgTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): int
+    {
+        return match ($fieldName) {
+            'customPost' => SchemaTypeModifiers::MANDATORY,
+            default => parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
         };
     }
 
@@ -72,7 +104,6 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
     ): mixed {
         switch ($fieldName) {
             case 'customPost':
-            case 'customPostBySlug':
                 $query = array_merge(
                     $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs),
                     $this->getQuery($objectTypeResolver, $object, $fieldName, $fieldArgs)
@@ -89,11 +120,8 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
     {
         return match ($fieldName) {
-            'customPost',
-            'customPostBySlug',
-                => CustomPostUnionTypeHelpers::getCustomPostUnionOrTargetObjectTypeResolver(),
-            default
-                => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+            'customPost' => CustomPostUnionTypeHelpers::getCustomPostUnionOrTargetObjectTypeResolver(),
+            default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
         };
     }
 }

--- a/layers/Schema/packages/customposts/src/ModuleProcessors/CommonCustomPostFilterInputContainerModuleProcessor.php
+++ b/layers/Schema/packages/customposts/src/ModuleProcessors/CommonCustomPostFilterInputContainerModuleProcessor.php
@@ -15,6 +15,7 @@ class CommonCustomPostFilterInputContainerModuleProcessor extends AbstractFilter
     public const HOOK_FILTER_INPUTS = __CLASS__ . ':filter-inputs';
 
     public const MODULE_FILTERINPUTCONTAINER_CUSTOMPOSTSTATUS = 'filterinputcontainer-custompoststatus';
+    public const MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_UNIONTYPE = 'filterinputcontainer-custompost-by-uniontype';
     public const MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS = 'filterinputcontainer-custompost-by-id-status';
     public const MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_UNIONTYPE = 'filterinputcontainer-custompost-by-id-uniontype';
     public const MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS_UNIONTYPE = 'filterinputcontainer-custompost-by-id-status-uniontype';
@@ -26,6 +27,7 @@ class CommonCustomPostFilterInputContainerModuleProcessor extends AbstractFilter
     {
         return array(
             [self::class, self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOSTSTATUS],
+            [self::class, self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_UNIONTYPE],
             [self::class, self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS],
             [self::class, self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_UNIONTYPE],
             [self::class, self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS_UNIONTYPE],
@@ -40,6 +42,9 @@ class CommonCustomPostFilterInputContainerModuleProcessor extends AbstractFilter
         return match ($module[1]) {
             self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOSTSTATUS => [
                 [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_CUSTOMPOSTSTATUS],
+            ],
+            self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_UNIONTYPE => [
+                [FilterInputModuleProcessor::class, FilterInputModuleProcessor::MODULE_FILTERINPUT_UNIONCUSTOMPOSTTYPES],
             ],
             self::MODULE_FILTERINPUTCONTAINER_CUSTOMPOST_BY_ID_STATUS => [
                 [CommonFilterInputModuleProcessor::class, CommonFilterInputModuleProcessor::MODULE_FILTERINPUT_ID],

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/AbstractRootCustomPostByInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/AbstractRootCustomPostByInputObjectTypeResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\CustomPosts\TypeResolvers\InputObjectType;
+
+use PoP\ComponentModel\TypeResolvers\InputObjectType\AbstractOneofQueryableInputObjectTypeResolver;
+use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
+use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
+use PoPSchema\SchemaCommons\FilterInputProcessors\FilterInputProcessor;
+
+abstract class AbstractRootCustomPostByInputObjectTypeResolver extends AbstractOneofQueryableInputObjectTypeResolver
+{
+    private ?IDScalarTypeResolver $idScalarTypeResolver = null;
+    private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+
+    final public function setIDScalarTypeResolver(IDScalarTypeResolver $idScalarTypeResolver): void
+    {
+        $this->idScalarTypeResolver = $idScalarTypeResolver;
+    }
+    final protected function getIDScalarTypeResolver(): IDScalarTypeResolver
+    {
+        return $this->idScalarTypeResolver ??= $this->instanceManager->getInstance(IDScalarTypeResolver::class);
+    }
+    final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
+    {
+        $this->stringScalarTypeResolver = $stringScalarTypeResolver;
+    }
+    final protected function getStringScalarTypeResolver(): StringScalarTypeResolver
+    {
+        return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->getTranslationAPI()->__('Oneof input to fetch a custom post', 'customposts');
+    }
+
+    public function getInputFieldNameTypeResolvers(): array
+    {
+        return [
+            'id' => $this->getIDScalarTypeResolver(),
+            'slug' => $this->getStringScalarTypeResolver(),
+        ];
+    }
+
+    public function getInputFieldDescription(string $inputFieldName): ?string
+    {
+        return match ($inputFieldName) {
+            'id' => $this->getTranslationAPI()->__('Query by custom post ID', 'customposts'),
+            'slug' => $this->getTranslationAPI()->__('Query by custom post slug', 'customposts'),
+            default => parent::getInputFieldDescription($inputFieldName),
+        };
+    }
+
+    public function getInputFieldFilterInput(string $inputFieldName): ?array
+    {
+        return match ($inputFieldName) {
+            'id' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_INCLUDE],
+            'slug' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_SLUG],
+            default => parent::getInputFieldFilterInput($inputFieldName),
+        };
+    }
+}

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostByInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/CustomPostByInputObjectTypeResolver.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPosts\TypeResolvers\InputObjectType;
 
-class RootCustomPostByInputObjectTypeResolver extends AbstractRootCustomPostByInputObjectTypeResolver
+class CustomPostByInputObjectTypeResolver extends AbstractRootCustomPostByInputObjectTypeResolver
 {
     public function getTypeName(): string
     {
-        return 'RootCustomPostByInput';
+        return 'CustomPostByInput';
     }
 }

--- a/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/RootCustomPostByInputObjectTypeResolver.php
+++ b/layers/Schema/packages/customposts/src/TypeResolvers/InputObjectType/RootCustomPostByInputObjectTypeResolver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\CustomPosts\TypeResolvers\InputObjectType;
+
+class RootCustomPostByInputObjectTypeResolver extends AbstractRootCustomPostByInputObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'RootCustomPostByInput';
+    }
+}


### PR DESCRIPTION
As to transform all the fields to fetch a single entity, from the many properties to use, such as `id` and `slug`.

This enables to merge all the several fields into only 1.

Before:

- `Root.customPost` <= by ID
- `Root.customPostBySlug`

Now:

- `Root.customPost(by: CustomPostByInput)`

With:

```graphql
type CustomPostByInput oneof {
  id: ID
  slug: String
}
```