### PR TITLE
Rename "name" to "search" when filtering users

### DIFF
--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -160,9 +160,12 @@ class UserTypeAPI extends AbstractUserTypeAPI
             $query['login'] = $query['username'];
             unset($query['username']);
         }
-        // Attach "*" before/after the search term to support searching partial strings
-        // But not when searching emails!
+        /**
+         * Watch out: "search" and "emails" can't be set at the same time,
+         * because they both use the same "search" field in the query.
+         */
         if (isset($query['search']) && !($query['emails'] ?? null)) {
+            // Search: Attach "*" before/after the term, to support searching partial strings
             $query['search'] = sprintf(
                 '*%s*',
                 $query['search']

--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -123,6 +123,8 @@ class UserTypeAPI extends AbstractUserTypeAPI
      * 4. Remove hook
      *
      * @param mixed[] $query
+     *
+     * @see https://developer.wordpress.org/reference/classes/wp_user_query/#search-parameters
      */
     protected function filterByEmails(array &$query): bool
     {
@@ -130,6 +132,7 @@ class UserTypeAPI extends AbstractUserTypeAPI
             $emails = $query['emails'];
             // This works for either 1 or many emails
             $query['search'] = implode(',', $emails);
+            $query['search_columns'] = ['user_email'];
             // But if there's more than 1 email, we must modify the SQL query with a hook
             if (count($emails) > 1) {
                 return true;

--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -161,7 +161,8 @@ class UserTypeAPI extends AbstractUserTypeAPI
             unset($query['username']);
         }
         // Attach "*" before/after the search term to support searching partial strings
-        if (isset($query['search'])) {
+        // But not when searching emails!
+        if (isset($query['search']) && !($query['emails'] ?? null)) {
             $query['search'] = sprintf(
                 '*%s*',
                 $query['search']

--- a/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/Schema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -157,6 +157,13 @@ class UserTypeAPI extends AbstractUserTypeAPI
             $query['login'] = $query['username'];
             unset($query['username']);
         }
+        // Attach "*" before/after the search term to support searching partial strings
+        if (isset($query['search'])) {
+            $query['search'] = sprintf(
+                '*%s*',
+                $query['search']
+            );
+        }
         if (isset($query['include']) && is_array($query['include'])) {
             // It can be an array or a string
             $query['include'] = implode(',', $query['include']);

--- a/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/AbstractUsersFilterInputObjectTypeResolver.php
+++ b/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/AbstractUsersFilterInputObjectTypeResolver.php
@@ -4,31 +4,24 @@ declare(strict_types=1);
 
 namespace PoPSchema\Users\TypeResolvers\InputObjectType;
 
-use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoPSchema\SchemaCommons\TypeResolvers\InputObjectType\AbstractObjectsFilterInputObjectTypeResolver;
-use PoPSchema\SchemaCommons\FilterInputProcessors\FilterInputProcessor as SchemaCommonsFilterInputProcessor;
-use PoPSchema\Users\ComponentConfiguration;
-use PoPSchema\Users\FilterInputProcessors\FilterInputProcessor;
 
 abstract class AbstractUsersFilterInputObjectTypeResolver extends AbstractObjectsFilterInputObjectTypeResolver
 {
+    private ?UserSearchByInputObjectTypeResolver $userSearchByInputObjectTypeResolver = null;
+
+    final public function setUserSearchByInputObjectTypeResolver(UserSearchByInputObjectTypeResolver $userSearchByInputObjectTypeResolver): void
+    {
+        $this->userSearchByInputObjectTypeResolver = $userSearchByInputObjectTypeResolver;
+    }
+    final protected function getUserSearchByInputObjectTypeResolver(): UserSearchByInputObjectTypeResolver
+    {
+        return $this->userSearchByInputObjectTypeResolver ??= $this->instanceManager->getInstance(UserSearchByInputObjectTypeResolver::class);
+    }
+
     public function getTypeDescription(): ?string
     {
         return $this->getTranslationAPI()->__('Input to filter users', 'users');
-    }
-
-    public function getAdminInputFieldNames(): array
-    {
-        $adminInputFieldNames = parent::getAdminInputFieldNames();
-        if ($this->treatUserEmailAsAdminData()) {
-            $adminInputFieldNames[] = 'emails';
-        }
-        return $adminInputFieldNames;
-    }
-
-    protected function treatUserEmailAsAdminData(): bool
-    {
-        return ComponentConfiguration::treatUserEmailAsAdminData();
     }
 
     public function getInputFieldNameTypeResolvers(): array
@@ -36,8 +29,7 @@ abstract class AbstractUsersFilterInputObjectTypeResolver extends AbstractObject
         return array_merge(
             parent::getInputFieldNameTypeResolvers(),
             [
-                'search' => $this->getStringScalarTypeResolver(),
-                'emails' => $this->getStringScalarTypeResolver(),
+                'searchBy' => $this->getUserSearchByInputObjectTypeResolver(),
             ]
         );
     }
@@ -45,26 +37,8 @@ abstract class AbstractUsersFilterInputObjectTypeResolver extends AbstractObject
     public function getInputFieldDescription(string $inputFieldName): ?string
     {
         return match ($inputFieldName) {
-            'search' => $this->getTranslationAPI()->__('Search for custom posts containing the given string', 'customposts'),
-            'emails' => $this->getTranslationAPI()->__('Custom post emails', 'customposts'),
+            'searchBy' => $this->getTranslationAPI()->__('Search for users', 'users'),
             default => parent::getInputFieldDescription($inputFieldName),
-        };
-    }
-
-    public function getInputFieldTypeModifiers(string $inputFieldName): int
-    {
-        return match ($inputFieldName) {
-            'emails' => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
-            default => parent::getInputFieldTypeModifiers($inputFieldName)
-        };
-    }
-
-    public function getInputFieldFilterInput(string $inputFieldName): ?array
-    {
-        return match ($inputFieldName) {
-            'search' => [SchemaCommonsFilterInputProcessor::class, SchemaCommonsFilterInputProcessor::FILTERINPUT_SEARCH],
-            'emails' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_EMAIL_OR_EMAILS],
-            default => parent::getInputFieldFilterInput($inputFieldName),
         };
     }
 }

--- a/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/AbstractUsersFilterInputObjectTypeResolver.php
+++ b/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/AbstractUsersFilterInputObjectTypeResolver.php
@@ -6,6 +6,7 @@ namespace PoPSchema\Users\TypeResolvers\InputObjectType;
 
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoPSchema\SchemaCommons\TypeResolvers\InputObjectType\AbstractObjectsFilterInputObjectTypeResolver;
+use PoPSchema\SchemaCommons\FilterInputProcessors\FilterInputProcessor as SchemaCommonsFilterInputProcessor;
 use PoPSchema\Users\ComponentConfiguration;
 use PoPSchema\Users\FilterInputProcessors\FilterInputProcessor;
 
@@ -35,7 +36,7 @@ abstract class AbstractUsersFilterInputObjectTypeResolver extends AbstractObject
         return array_merge(
             parent::getInputFieldNameTypeResolvers(),
             [
-                'name' => $this->getStringScalarTypeResolver(),
+                'search' => $this->getStringScalarTypeResolver(),
                 'emails' => $this->getStringScalarTypeResolver(),
             ]
         );
@@ -44,7 +45,7 @@ abstract class AbstractUsersFilterInputObjectTypeResolver extends AbstractObject
     public function getInputFieldDescription(string $inputFieldName): ?string
     {
         return match ($inputFieldName) {
-            'name' => $this->getTranslationAPI()->__('Search for custom posts containing the given string', 'customposts'),
+            'search' => $this->getTranslationAPI()->__('Search for custom posts containing the given string', 'customposts'),
             'emails' => $this->getTranslationAPI()->__('Custom post emails', 'customposts'),
             default => parent::getInputFieldDescription($inputFieldName),
         };
@@ -61,7 +62,7 @@ abstract class AbstractUsersFilterInputObjectTypeResolver extends AbstractObject
     public function getInputFieldFilterInput(string $inputFieldName): ?array
     {
         return match ($inputFieldName) {
-            'name' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_NAME],
+            'search' => [SchemaCommonsFilterInputProcessor::class, SchemaCommonsFilterInputProcessor::FILTERINPUT_SEARCH],
             'emails' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_EMAIL_OR_EMAILS],
             default => parent::getInputFieldFilterInput($inputFieldName),
         };

--- a/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/UserSearchByInputObjectTypeResolver.php
+++ b/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/UserSearchByInputObjectTypeResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\Users\TypeResolvers\InputObjectType;
+
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\InputObjectType\AbstractOneofQueryableInputObjectTypeResolver;
+use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
+use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
+use PoPSchema\SchemaCommons\FilterInputProcessors\FilterInputProcessor as SchemaCommonsFilterInputProcessor;
+use PoPSchema\Users\ComponentConfiguration;
+use PoPSchema\Users\FilterInputProcessors\FilterInputProcessor;
+
+class UserSearchByInputObjectTypeResolver extends AbstractOneofQueryableInputObjectTypeResolver
+{
+    private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+
+    final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
+    {
+        $this->stringScalarTypeResolver = $stringScalarTypeResolver;
+    }
+    final protected function getStringScalarTypeResolver(): StringScalarTypeResolver
+    {
+        return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
+    }
+
+    public function getTypeName(): string
+    {
+        return 'UserSearchByInput';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->getTranslationAPI()->__('Oneof input to specify the property and data to search users', 'users');
+    }
+
+    public function getInputFieldNameTypeResolvers(): array
+    {
+        return [
+            'name' => $this->getStringScalarTypeResolver(),
+            'emails' => $this->getStringScalarTypeResolver(),
+        ];
+    }
+
+    public function getAdminInputFieldNames(): array
+    {
+        $adminInputFieldNames = parent::getAdminInputFieldNames();
+        if (ComponentConfiguration::treatUserEmailAsAdminData()) {
+            $adminInputFieldNames[] = 'emails';
+        }
+        return $adminInputFieldNames;
+    }
+
+    public function getInputFieldDescription(string $inputFieldName): ?string
+    {
+        return match ($inputFieldName) {
+            'name' => $this->getTranslationAPI()->__('Search by name', 'users'),
+            'emails' => $this->getTranslationAPI()->__('Search by email(s)', 'users'),
+            default => parent::getInputFieldDescription($inputFieldName),
+        };
+    }
+
+    public function getInputFieldTypeModifiers(string $inputFieldName): int
+    {
+        return match ($inputFieldName) {
+            'emails' => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
+            default => parent::getInputFieldTypeModifiers($inputFieldName)
+        };
+    }
+
+    public function getInputFieldFilterInput(string $inputFieldName): ?array
+    {
+        return match ($inputFieldName) {
+            'name' => [SchemaCommonsFilterInputProcessor::class, SchemaCommonsFilterInputProcessor::FILTERINPUT_SEARCH],
+            'emails' => [FilterInputProcessor::class, FilterInputProcessor::FILTERINPUT_EMAIL_OR_EMAILS],
+            default => parent::getInputFieldFilterInput($inputFieldName),
+        };
+    }
+}

--- a/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/UserSearchByInputObjectTypeResolver.php
+++ b/layers/Schema/packages/users/src/TypeResolvers/InputObjectType/UserSearchByInputObjectTypeResolver.php
@@ -6,7 +6,6 @@ namespace PoPSchema\Users\TypeResolvers\InputObjectType;
 
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\AbstractOneofQueryableInputObjectTypeResolver;
-use PoP\Engine\TypeResolvers\ScalarType\IDScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoPSchema\SchemaCommons\FilterInputProcessors\FilterInputProcessor as SchemaCommonsFilterInputProcessor;
 use PoPSchema\Users\ComponentConfiguration;


### PR DESCRIPTION
Also, "search" and "emails" can't be set at the same time, so added both of them under oneof input `UserSearchByInput`