### PR TITLE
If query validation fails, do not execute query

### DIFF
--- a/layers/API/packages/api/src/Hooks/VarsHookSet.php
+++ b/layers/API/packages/api/src/Hooks/VarsHookSet.php
@@ -73,6 +73,9 @@ class VarsHookSet extends AbstractHookSet
 
             // Enable mutations?
             $vars['are-mutations-enabled'] = ComponentConfiguration::enableMutations();
+
+            // Entry to indicate if the query has errors (eg: some GraphQL variable not submitted)
+            $vars['does-api-query-have-errors'] = false;
         }
     }
 

--- a/layers/API/packages/api/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
+++ b/layers/API/packages/api/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
@@ -30,7 +30,7 @@ class RootRelationalFieldDataloadModuleProcessor extends AbstractRelationalField
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_ROOT:

--- a/layers/API/packages/api/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
+++ b/layers/API/packages/api/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\API\ModuleProcessors;
 
+use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\Engine\ObjectModels\Root;
 use PoP\Engine\Schema\SchemaDefinitionServiceInterface;
@@ -32,6 +33,10 @@ class RootRelationalFieldDataloadModuleProcessor extends AbstractRelationalField
 
     public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
+        $vars = ApplicationState::getVars();
+        if ($vars['does-api-query-have-errors']) {
+            return null;
+        }
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_ROOT:
                 return Root::ID;

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -1127,12 +1127,14 @@ class Engine implements EngineInterface
                     // ------------------------------------------
                     // Execute and get the ids and the meta
                     $dbObjectIDOrIDs = $processor->getObjectIDOrIDs($module, $module_props, $data_properties);
-                    // If the type is union, we must add the type to each object
-                    if ($dbObjectIDOrIDs !== null) {
-                        $typeDBObjectIDOrIDs = $isUnionTypeResolver ?
-                            $relationalTypeResolver->getQualifiedDBObjectIDOrIDs($dbObjectIDOrIDs)
-                            : $dbObjectIDOrIDs;
+                    // To simplify the logic, deal with arrays only
+                    if ($dbObjectIDOrIDs === null) {
+                        $dbObjectIDOrIDs = [];
                     }
+                    // If the type is union, we must add the type to each object
+                    $typeDBObjectIDOrIDs = $isUnionTypeResolver ?
+                        $relationalTypeResolver->getQualifiedDBObjectIDOrIDs($dbObjectIDOrIDs)
+                        : $dbObjectIDOrIDs;
 
                     $objectIDs = is_array($dbObjectIDOrIDs) ? $dbObjectIDOrIDs : array($dbObjectIDOrIDs);
                     $typeDBObjectIDs = is_array($typeDBObjectIDOrIDs) ? $typeDBObjectIDOrIDs : array($typeDBObjectIDOrIDs);

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/AbstractModuleProcessor.php
@@ -688,7 +688,7 @@ abstract class AbstractModuleProcessor implements ModuleProcessorInterface
         return DataSources::MUTABLEONREQUEST;
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         return array();
     }

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/ModuleProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/ModuleProcessorInterface.php
@@ -36,7 +36,7 @@ interface ModuleProcessorInterface
     public function getImmutableDatasetsettings(array $module, array &$props): array;
     public function getDatasetDatabaseKeys(array $module, array &$props): array;
     public function getDatasource(array $module, array &$props): string;
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array;
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null;
     public function getRelationalTypeResolver(array $module): ?RelationalTypeResolverInterface;
     public function getComponentMutationResolverBridge(array $module): ?ComponentMutationResolverBridgeInterface;
     public function prepareDataPropertiesAfterMutationExecution(array $module, array &$props, array &$data_properties): void;

--- a/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
+++ b/layers/Engine/packages/component-model/src/ModuleProcessors/QueryDataModuleProcessorTrait.php
@@ -79,7 +79,7 @@ trait QueryDataModuleProcessorTrait
         return $ret;
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         // Prepare the Query to get data from the DB
         $datasource = $data_properties[DataloadingConstants::DATASOURCE] ?? null;

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
@@ -693,6 +693,8 @@ class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
             }
         }
 
+        // If some variable hasn't been submitted, it will throw an Exception
+        // Let it bubble up
         $request = new Request($parsedData, $variables);
 
         // If the validation fails, it will throw an exception

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertorInterface.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertorInterface.php
@@ -7,8 +7,9 @@ namespace GraphQLByPoP\GraphQLQuery\Schema;
 interface GraphQLQueryConvertorInterface
 {
     /**
-     * Convert the GraphQL Query to PoP query in its requested form
-     * @return array 2 items: [operationType, fieldQuery]
+     * Convert the GraphQL Query to PoP query in its requested form.
+     *
+     * @return array 2 items: [operationType or null (if the query has errors), fieldQuery]
      */
     public function convertFromGraphQLToFieldQuery(
         string $graphQLQuery,

--- a/layers/GraphQLByPoP/packages/graphql-request/src/Hooks/VarsHookSet.php
+++ b/layers/GraphQLByPoP/packages/graphql-request/src/Hooks/VarsHookSet.php
@@ -201,7 +201,7 @@ class VarsHookSet extends AbstractHookSet
         // Set the operation type and, based on it, if mutations are supported
         $vars['graphql-operation-type'] = $operationType;
         $vars['are-mutations-enabled'] = $operationType === OperationTypes::MUTATION;
-        
+
         // If there was an error when parsing the query, the operationType will be null,
         // then there's no need to execute the query
         if ($operationType === null) {

--- a/layers/GraphQLByPoP/packages/graphql-request/src/Hooks/VarsHookSet.php
+++ b/layers/GraphQLByPoP/packages/graphql-request/src/Hooks/VarsHookSet.php
@@ -198,10 +198,15 @@ class VarsHookSet extends AbstractHookSet
             ComponentConfiguration::enableMultipleQueryExecution(),
             $operationName
         );
-
         // Set the operation type and, based on it, if mutations are supported
         $vars['graphql-operation-type'] = $operationType;
-        $vars['are-mutations-enabled'] = $operationType == OperationTypes::MUTATION;
+        $vars['are-mutations-enabled'] = $operationType === OperationTypes::MUTATION;
+        
+        // If there was an error when parsing the query, the operationType will be null,
+        // then there's no need to execute the query
+        if ($operationType === null) {
+            $vars['does-api-query-have-errors'] = true;
+        }
 
         // Set the query in $vars
         ApplicationStateUtils::maybeConvertQueryAndAddToVars($vars, $fieldQuery);

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
@@ -8,6 +8,7 @@ use GraphQLByPoP\GraphQLServer\ObjectModels\MutationRoot;
 use GraphQLByPoP\GraphQLServer\ObjectModels\QueryRoot;
 use GraphQLByPoP\GraphQLServer\Schema\GraphQLSchemaDefinitionServiceInterface;
 use PoP\API\ModuleProcessors\AbstractRelationalFieldDataloadModuleProcessor;
+use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 
 class RootRelationalFieldDataloadModuleProcessor extends AbstractRelationalFieldDataloadModuleProcessor
@@ -36,6 +37,10 @@ class RootRelationalFieldDataloadModuleProcessor extends AbstractRelationalField
 
     public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
+        $vars = ApplicationState::getVars();
+        if ($vars['does-api-query-have-errors']) {
+            return null;
+        }
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_QUERYROOT:
                 return QueryRoot::ID;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ModuleProcessors/RootRelationalFieldDataloadModuleProcessor.php
@@ -34,7 +34,7 @@ class RootRelationalFieldDataloadModuleProcessor extends AbstractRelationalField
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_QUERYROOT:

--- a/layers/Schema/packages/categories/src/ConditionalOnComponent/API/ModuleProcessors/AbstractFieldDataloadModuleProcessor.php
+++ b/layers/Schema/packages/categories/src/ConditionalOnComponent/API/ModuleProcessors/AbstractFieldDataloadModuleProcessor.php
@@ -38,7 +38,7 @@ abstract class AbstractFieldDataloadModuleProcessor extends AbstractRelationalFi
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_CATEGORY:

--- a/layers/Schema/packages/customposts/src/ConditionalOnComponent/API/ModuleProcessors/CustomPostRelationalFieldDataloadModuleProcessor.php
+++ b/layers/Schema/packages/customposts/src/ConditionalOnComponent/API/ModuleProcessors/CustomPostRelationalFieldDataloadModuleProcessor.php
@@ -61,7 +61,7 @@ class CustomPostRelationalFieldDataloadModuleProcessor extends AbstractRelationa
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_SINGLECUSTOMPOST:

--- a/layers/Schema/packages/pages/src/ModuleProcessors/FieldDataloadModuleProcessor.php
+++ b/layers/Schema/packages/pages/src/ModuleProcessors/FieldDataloadModuleProcessor.php
@@ -33,7 +33,7 @@ class FieldDataloadModuleProcessor extends AbstractRelationalFieldDataloadModule
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_PAGE:

--- a/layers/Schema/packages/posts/src/ConditionalOnComponent/API/ModuleProcessors/FieldDataloadModuleProcessor.php
+++ b/layers/Schema/packages/posts/src/ConditionalOnComponent/API/ModuleProcessors/FieldDataloadModuleProcessor.php
@@ -53,7 +53,7 @@ class FieldDataloadModuleProcessor extends AbstractRelationalFieldDataloadModule
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_SINGLEPOST:

--- a/layers/Schema/packages/queriedobject/src/ModuleProcessors/QueriedDBObjectModuleProcessorTrait.php
+++ b/layers/Schema/packages/queriedobject/src/ModuleProcessors/QueriedDBObjectModuleProcessorTrait.php
@@ -8,9 +8,9 @@ use PoP\ComponentModel\State\ApplicationState;
 
 trait QueriedDBObjectModuleProcessorTrait
 {
-    protected function getQueriedDBObjectID(array $module, array &$props, &$data_properties)
+    protected function getQueriedDBObjectID(array $module, array &$props, &$data_properties): string | int | array | null
     {
         $vars = ApplicationState::getVars();
-        return $vars['routing-state']['queried-object-id'];
+        return $vars['routing-state']['queried-object-id'] ?? null;
     }
 }

--- a/layers/Schema/packages/tags/src/ConditionalOnComponent/API/ModuleProcessors/AbstractFieldDataloadModuleProcessor.php
+++ b/layers/Schema/packages/tags/src/ConditionalOnComponent/API/ModuleProcessors/AbstractFieldDataloadModuleProcessor.php
@@ -49,7 +49,7 @@ abstract class AbstractFieldDataloadModuleProcessor extends AbstractRelationalFi
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_TAG:

--- a/layers/Schema/packages/users/src/ConditionalOnComponent/API/ModuleProcessors/FieldDataloadModuleProcessor.php
+++ b/layers/Schema/packages/users/src/ConditionalOnComponent/API/ModuleProcessors/FieldDataloadModuleProcessor.php
@@ -53,7 +53,7 @@ class FieldDataloadModuleProcessor extends AbstractRelationalFieldDataloadModule
         );
     }
 
-    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array
+    public function getObjectIDOrIDs(array $module, array &$props, &$data_properties): string | int | array | null
     {
         switch ($module[1]) {
             case self::MODULE_DATALOAD_RELATIONALFIELDS_SINGLEUSER:


### PR DESCRIPTION
If parsing the GraphQL query already has errors, then there's no need to execute the query.

In particular, executing this query without passing the `slug` variable:

```graphql
query CategoryBySlug($slug: String!) {
  category: postCategory(by: {slug: $slug}) {
    databaseId: id
    description
    id
    name
    slug
  }
}
```

...was producing this response:

```json
{
  "errors": [
    {
      "message": "Variable slug hasn't been submitted",
      "location": {
        "line": 2,
        "column": 37
      }
    },
    {
      "message": "There is no field 'id' on type 'Root'",
      "extensions": {
        "type": "Root",
        "field": "id"
      }
    }
  ]
}
```

With this PR, it is producing this response instead:

```json
{
  "errors": [
    {
      "message": "Variable slug hasn't been submitted",
      "location": {
        "line": 2,
        "column": 37
      }
    }
  ]
}
```