### PR TITLE
Return error if option name or meta key does not exist

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -161,6 +161,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - Admin fields
 - Validate constraints for field and directive arguments
 - Added options "default limit" and "max limit" for Posts and Pages
+- Return an error if the option name or the meta key does not exist, or is not exposed in the schema
 - Performance improvement: Avoid regenerating the container when the schema is modified
 - Clicking on "Save Changes" on the Settings page will always regenerate the schema
 - Prettyprint GraphQL queries in the module docs

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -871,19 +871,23 @@ Returns:
 {
   "errors": [
     {
-      "message": "There is no option with name 'nonExistentOption'",
+      "message": "There is no meta with key 'nothingHere'",
       "extensions": {
-        "type": "Root",
-        "id": "root",
-        "field": "option(name:\"nonExistentOption\")"
+        "type": "Post",
+        "id": 1,
+        "field": "metaValue(key:\"nothingHere\")"
       }
     }
   ],
   "data": {
-    "option": null
+    "post": {
+      "id": 1,
+      "metaValue": null
+    }
   }
 }
 ```
+
 ## Performance improvement: Avoid regenerating the container when the schema is modified
 
 The explanation below is a bit technical, but the TL;DR is: the plugin is now faster when saving CPTs (Schema Configuration, ACLs, and CCLs).

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -811,6 +811,79 @@ Now, they have their own:
 
 <a href="../../images/releases/v09/posts-settings-new-options.png" target="_blank">![Default and max limit options for posts in the Settings page](../../images/releases/v09/posts-settings-new-options.png)</a>
 
+## Return an error if the option name or the meta key does not exist, or is not exposed in the schema
+
+When executing field `Root.option`, if the option name does not exist, or is not exposed in the schema (it must be added to the allowlist in the Settings), the query now returns an error.
+
+For instance, executing this query:
+
+```graphql
+{
+  option(name:"nonExistentOption")
+}
+```
+
+Returns:
+
+```json
+{
+  "errors": [
+    {
+      "message": "There is no option with name 'nonExistentOption'",
+      "extensions": {
+        "type": "Root",
+        "id": "root",
+        "field": "option(name:\"nonExistentOption\")"
+      }
+    }
+  ],
+  "data": {
+    "option": null
+  }
+}
+```
+
+The same behavior happens for the meta fields, when querying for a meta key that does not exist, or has not been exposed in the schema (via the corresponding Settings page for that entity):
+
+- `CustomPost.metaValue`
+- `CustomPost.metaValues`
+- `User.metaValue`
+- `User.metaValues`
+- `Comment.metaValue`
+- `Comment.metaValues`
+- `Taxonomy.metaValue`
+- `Taxonomy.metaValues`
+
+For instance, executing this query:
+
+```graphql
+{
+  post(by: { id: 1 }) {
+    id
+    metaValue(key: "nothingHere")
+  }
+}
+```
+
+Returns:
+
+```json
+{
+  "errors": [
+    {
+      "message": "There is no option with name 'nonExistentOption'",
+      "extensions": {
+        "type": "Root",
+        "id": "root",
+        "field": "option(name:\"nonExistentOption\")"
+      }
+    }
+  ],
+  "data": {
+    "option": null
+  }
+}
+```
 ## Performance improvement: Avoid regenerating the container when the schema is modified
 
 The explanation below is a bit technical, but the TL;DR is: the plugin is now faster when saving CPTs (Schema Configuration, ACLs, and CCLs).

--- a/layers/Schema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
@@ -12,8 +12,10 @@ class CommentMetaTypeAPI extends AbstractCommentMetaTypeAPI
      * If the key is non-existent, return `null`.
      * Otherwise, return the value.
      */
-    public function doGetCommentMeta(string | int $commentID, string $key, bool $single = false): mixed
+    protected function doGetCommentMeta(string | int $commentID, string $key, bool $single = false): mixed
     {
+        // This function does not differentiate between a stored empty value,
+        // and a non-existing key! So if empty, treat it as non-existant and return null
         $value = \get_comment_meta($commentID, $key, $single);
         if (($single && $value === '') || (!$single && $value === [])) {
             return null;

--- a/layers/Schema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
@@ -15,7 +15,7 @@ class CommentMetaTypeAPI extends AbstractCommentMetaTypeAPI
     public function doGetCommentMeta(string | int $commentID, string $key, bool $single = false): mixed
     {
         $value = \get_comment_meta($commentID, $key, $single);
-        if ($value === '') {
+        if (($single && $value === '') || (!$single && $value === [])) {
             return null;
         }
         return $value;

--- a/layers/Schema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
@@ -8,8 +8,16 @@ use PoPSchema\CommentMeta\TypeAPIs\AbstractCommentMetaTypeAPI;
 
 class CommentMetaTypeAPI extends AbstractCommentMetaTypeAPI
 {
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     public function doGetCommentMeta(string | int $commentID, string $key, bool $single = false): mixed
     {
-        return \get_comment_meta($commentID, $key, $single);
+        $value = \get_comment_meta($commentID, $key, $single);
+        if ($value === '') {
+            return null;
+        }
+        return $value;
     }
 }

--- a/layers/Schema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -82,8 +82,7 @@ class CommentObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                         $fieldName === 'metaValue'
                     );
                 } catch (InvalidArgumentException $e) {
-                    // If the meta key does not exist, or is not in the allowlist,
-                    // it will throw an exception
+                    // If the meta key is not in the allowlist, it will throw an exception
                     return new Error(
                         'meta-key-not-exists',
                         $e->getMessage()

--- a/layers/Schema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\CommentMeta\FieldResolvers\ObjectType;
 
+use InvalidArgumentException;
+use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPSchema\CommentMeta\TypeAPIs\CommentMetaTypeAPIInterface;
@@ -73,11 +75,21 @@ class CommentObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         switch ($fieldName) {
             case 'metaValue':
             case 'metaValues':
-                return $this->getCommentMetaTypeAPI()->getCommentMeta(
-                    $objectTypeResolver->getID($comment),
-                    $fieldArgs['key'],
-                    $fieldName === 'metaValue'
-                );
+                try {
+                    $value = $this->getCommentMetaTypeAPI()->getCommentMeta(
+                        $objectTypeResolver->getID($comment),
+                        $fieldArgs['key'],
+                        $fieldName === 'metaValue'
+                    );
+                } catch (InvalidArgumentException $e) {
+                    // If the meta key does not exist, or is not in the allowlist,
+                    // it will throw an exception
+                    return new Error(
+                        'meta-key-not-exists',
+                        $e->getMessage()
+                    );
+                }
+                return $value;
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
@@ -11,7 +11,9 @@ use PoPSchema\Meta\TypeAPIs\AbstractMetaTypeAPI;
 abstract class AbstractCommentMetaTypeAPI extends AbstractMetaTypeAPI implements CommentMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */
@@ -27,5 +29,9 @@ abstract class AbstractCommentMetaTypeAPI extends AbstractMetaTypeAPI implements
         return $this->doGetCommentMeta($commentID, $key, $single);
     }
 
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     abstract protected function doGetCommentMeta(string | int $commentID, string $key, bool $single = false): mixed;
 }

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
@@ -4,25 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\CommentMeta\TypeAPIs;
 
-use PoP\ComponentModel\Services\BasicServiceTrait;
+use InvalidArgumentException;
 use PoPSchema\CommentMeta\ComponentConfiguration;
-use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface;
+use PoPSchema\Meta\TypeAPIs\AbstractMetaTypeAPI;
 
-abstract class AbstractCommentMetaTypeAPI implements CommentMetaTypeAPIInterface
+abstract class AbstractCommentMetaTypeAPI extends AbstractMetaTypeAPI implements CommentMetaTypeAPIInterface
 {
-    use BasicServiceTrait;
-
-    private ?AllowOrDenySettingsServiceInterface $allowOrDenySettingsService = null;
-
-    final public function setAllowOrDenySettingsService(AllowOrDenySettingsServiceInterface $allowOrDenySettingsService): void
-    {
-        $this->allowOrDenySettingsService = $allowOrDenySettingsService;
-    }
-    final protected function getAllowOrDenySettingsService(): AllowOrDenySettingsServiceInterface
-    {
-        return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
-    }
-
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     final public function getCommentMeta(string | int $commentID, string $key, bool $single = false): mixed
     {
         /**
@@ -31,9 +23,7 @@ abstract class AbstractCommentMetaTypeAPI implements CommentMetaTypeAPIInterface
          */
         $entries = ComponentConfiguration::getCommentMetaEntries();
         $behavior = ComponentConfiguration::getCommentMetaBehavior();
-        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($key, $entries, $behavior)) {
-            return null;
-        }
+        $this->assertIsEntryAllowed($entries, $behavior, $key);
         return $this->doGetCommentMeta($commentID, $key, $single);
     }
 

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
@@ -9,7 +9,9 @@ use InvalidArgumentException;
 interface CommentMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace PoPSchema\CommentMeta\TypeAPIs;
 
+use InvalidArgumentException;
+
 interface CommentMetaTypeAPIInterface
 {
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     public function getCommentMeta(string | int $commentID, string $key, bool $single = false): mixed;
 }

--- a/layers/Schema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
@@ -15,7 +15,7 @@ class CustomPostMetaTypeAPI extends AbstractCustomPostMetaTypeAPI
     protected function doGetCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed
     {
         $value = \get_post_meta($customPostID, $key, $single);
-        if ($value === '') {
+        if (($single && $value === '') || (!$single && $value === [])) {
             return null;
         }
         return $value;

--- a/layers/Schema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
@@ -14,6 +14,8 @@ class CustomPostMetaTypeAPI extends AbstractCustomPostMetaTypeAPI
      */
     protected function doGetCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed
     {
+        // This function does not differentiate between a stored empty value,
+        // and a non-existing key! So if empty, treat it as non-existant and return null
         $value = \get_post_meta($customPostID, $key, $single);
         if (($single && $value === '') || (!$single && $value === [])) {
             return null;

--- a/layers/Schema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
@@ -8,8 +8,16 @@ use PoPSchema\CustomPostMeta\TypeAPIs\AbstractCustomPostMetaTypeAPI;
 
 class CustomPostMetaTypeAPI extends AbstractCustomPostMetaTypeAPI
 {
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     protected function doGetCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed
     {
-        return \get_post_meta($customPostID, $key, $single);
+        $value = \get_post_meta($customPostID, $key, $single);
+        if ($value === '') {
+            return null;
+        }
+        return $value;
     }
 }

--- a/layers/Schema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -82,8 +82,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                         $fieldName === 'metaValue'
                     );
                 } catch (InvalidArgumentException $e) {
-                    // If the meta key does not exist, or is not in the allowlist,
-                    // it will throw an exception
+                    // If the meta key is not in the allowlist, it will throw an exception
                     return new Error(
                         'meta-key-not-exists',
                         $e->getMessage()

--- a/layers/Schema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMeta\FieldResolvers\ObjectType;
 
+use InvalidArgumentException;
+use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPSchema\CustomPostMeta\TypeAPIs\CustomPostMetaTypeAPIInterface;
@@ -73,11 +75,21 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         switch ($fieldName) {
             case 'metaValue':
             case 'metaValues':
-                return $this->getCustomPostMetaTypeAPI()->getCustomPostMeta(
-                    $objectTypeResolver->getID($customPost),
-                    $fieldArgs['key'],
-                    $fieldName === 'metaValue'
-                );
+                try {
+                    $value = $this->getCustomPostMetaTypeAPI()->getCustomPostMeta(
+                        $objectTypeResolver->getID($customPost),
+                        $fieldArgs['key'],
+                        $fieldName === 'metaValue'
+                    );
+                } catch (InvalidArgumentException $e) {
+                    // If the meta key does not exist, or is not in the allowlist,
+                    // it will throw an exception
+                    return new Error(
+                        'meta-key-not-exists',
+                        $e->getMessage()
+                    );
+                }
+                return $value;
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
@@ -4,25 +4,17 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMeta\TypeAPIs;
 
-use PoP\ComponentModel\Services\BasicServiceTrait;
+use InvalidArgumentException;
+use PoPSchema\Meta\TypeAPIs\AbstractMetaTypeAPI;
 use PoPSchema\CustomPostMeta\ComponentConfiguration;
-use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface;
 
-abstract class AbstractCustomPostMetaTypeAPI implements CustomPostMetaTypeAPIInterface
+abstract class AbstractCustomPostMetaTypeAPI extends AbstractMetaTypeAPI implements CustomPostMetaTypeAPIInterface
 {
-    use BasicServiceTrait;
-
-    private ?AllowOrDenySettingsServiceInterface $allowOrDenySettingsService = null;
-
-    final public function setAllowOrDenySettingsService(AllowOrDenySettingsServiceInterface $allowOrDenySettingsService): void
-    {
-        $this->allowOrDenySettingsService = $allowOrDenySettingsService;
-    }
-    final protected function getAllowOrDenySettingsService(): AllowOrDenySettingsServiceInterface
-    {
-        return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
-    }
-
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     final public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed
     {
         /**
@@ -31,9 +23,7 @@ abstract class AbstractCustomPostMetaTypeAPI implements CustomPostMetaTypeAPIInt
          */
         $entries = ComponentConfiguration::getCustomPostMetaEntries();
         $behavior = ComponentConfiguration::getCustomPostMetaBehavior();
-        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($key, $entries, $behavior)) {
-            return null;
-        }
+        $this->assertIsEntryAllowed($entries, $behavior, $key);
         return $this->doGetCustomPostMeta($customPostID, $key, $single);
     }
 

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
@@ -11,21 +11,23 @@ use PoPSchema\CustomPostMeta\ComponentConfiguration;
 abstract class AbstractCustomPostMetaTypeAPI extends AbstractMetaTypeAPI implements CustomPostMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */
     final public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed
     {
-        /**
-         * Check if the allow/denylist validation fails
-         * Compare for full match or regex
-         */
         $entries = ComponentConfiguration::getCustomPostMetaEntries();
         $behavior = ComponentConfiguration::getCustomPostMetaBehavior();
         $this->assertIsEntryAllowed($entries, $behavior, $key);
         return $this->doGetCustomPostMeta($customPostID, $key, $single);
     }
 
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     abstract protected function doGetCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed;
 }

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace PoPSchema\CustomPostMeta\TypeAPIs;
 
+use InvalidArgumentException;
+
 interface CustomPostMetaTypeAPIInterface
 {
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed;
 }

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
@@ -9,7 +9,9 @@ use InvalidArgumentException;
 interface CustomPostMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */

--- a/layers/Schema/packages/meta/src/FieldResolvers/InterfaceType/WithMetaInterfaceTypeFieldResolver.php
+++ b/layers/Schema/packages/meta/src/FieldResolvers/InterfaceType/WithMetaInterfaceTypeFieldResolver.php
@@ -94,8 +94,8 @@ class WithMetaInterfaceTypeFieldResolver extends AbstractInterfaceTypeFieldResol
     public function getFieldDescription(string $fieldName): ?string
     {
         return match ($fieldName) {
-            'metaValue' => $this->getTranslationAPI()->__('Single meta value', 'custompostmeta'),
-            'metaValues' => $this->getTranslationAPI()->__('List of meta values', 'custompostmeta'),
+            'metaValue' => $this->getTranslationAPI()->__('Single meta value. Meta value response: if the key is not allowed via the settings, it returns an error; if the key is non-existent, or the value is empty, it returns `null`; otherwise, it returns the meta value', 'custompostmeta'),
+            'metaValues' => $this->getTranslationAPI()->__('List of meta values. Meta value response: if the key is not allowed via the settings, it returns an error; if the key is non-existent, or the value is empty, it returns `null`; otherwise, it returns the meta value', 'custompostmeta'),
             default => parent::getFieldDescription($fieldName),
         };
     }

--- a/layers/Schema/packages/meta/src/FieldResolvers/InterfaceType/WithMetaInterfaceTypeFieldResolver.php
+++ b/layers/Schema/packages/meta/src/FieldResolvers/InterfaceType/WithMetaInterfaceTypeFieldResolver.php
@@ -94,8 +94,8 @@ class WithMetaInterfaceTypeFieldResolver extends AbstractInterfaceTypeFieldResol
     public function getFieldDescription(string $fieldName): ?string
     {
         return match ($fieldName) {
-            'metaValue' => $this->getTranslationAPI()->__('Single meta value. Meta value response: if the key is not allowed via the settings, it returns an error; if the key is non-existent, or the value is empty, it returns `null`; otherwise, it returns the meta value', 'custompostmeta'),
-            'metaValues' => $this->getTranslationAPI()->__('List of meta values. Meta value response: if the key is not allowed via the settings, it returns an error; if the key is non-existent, or the value is empty, it returns `null`; otherwise, it returns the meta value', 'custompostmeta'),
+            'metaValue' => $this->getTranslationAPI()->__('Single meta value. If the key is not allowed, it returns an error; if the key is non-existent, or the value is empty, it returns `null`; otherwise, it returns the meta value.', 'custompostmeta'),
+            'metaValues' => $this->getTranslationAPI()->__('List of meta values. If the key is not allowed, it returns an error; if the key is non-existent, or the value is empty, it returns `null`; otherwise, it returns the meta value.', 'custompostmeta'),
             default => parent::getFieldDescription($fieldName),
         };
     }

--- a/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
@@ -24,7 +24,9 @@ abstract class AbstractMetaTypeAPI
     }
 
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */

--- a/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\Meta\TypeAPIs;
+
+use InvalidArgumentException;
+use PoP\ComponentModel\Services\BasicServiceTrait;
+use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface;
+
+abstract class AbstractMetaTypeAPI
+{
+    use BasicServiceTrait;
+
+    private ?AllowOrDenySettingsServiceInterface $allowOrDenySettingsService = null;
+
+    final public function setAllowOrDenySettingsService(AllowOrDenySettingsServiceInterface $allowOrDenySettingsService): void
+    {
+        $this->allowOrDenySettingsService = $allowOrDenySettingsService;
+    }
+    final protected function getAllowOrDenySettingsService(): AllowOrDenySettingsServiceInterface
+    {
+        return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
+    }
+
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
+    final protected function assertIsEntryAllowed(array $entries, string $behavior, string $key): bool|InvalidArgumentException
+    {
+        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($key, $entries, $behavior)) {
+            return throw new InvalidArgumentException(
+                sprintf(
+                    $this->getTranslationAPI()->__('There is no meta with key \'%s\'', 'commentmeta'),
+                    $key
+                )
+            );
+        }
+        return true;
+    }
+}

--- a/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -119,11 +119,11 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     ): mixed {
         switch ($fieldName) {
             case 'option':
-                $name = $fieldArgs['name'];
                 try {
-                    $value = $this->getSettingsTypeAPI()->getOption($name);
+                    $value = $this->getSettingsTypeAPI()->getOption($fieldArgs['name']);
                 } catch (InvalidArgumentException $e) {
-                    // If the option does not exist, it will throw an exception
+                    // If the option does not exist, or is not in the allowlist,
+                    // it will throw an exception
                     return new Error(
                         'option-name-not-exists',
                         $e->getMessage()

--- a/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace PoPSchema\Settings\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
-use PoP\Engine\TypeResolvers\ScalarType\AnyBuiltInScalarScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ObjectType\RootObjectTypeResolver;
+use PoP\Engine\TypeResolvers\ScalarType\AnyBuiltInScalarScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoPSchema\Settings\TypeAPIs\SettingsTypeAPIInterface;
 
@@ -121,7 +122,13 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 if ($value = $this->getSettingsTypeAPI()->getOption($name)) {
                     return $value;
                 }
-                return null;
+                return new Error(
+                    'option-name-not-exists',
+                    sprintf(
+                        $this->getTranslationAPI()->__('There is no option with name \'%s\'', 'settings'),
+                        $name
+                    )
+                );
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -122,8 +122,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 try {
                     $value = $this->getSettingsTypeAPI()->getOption($fieldArgs['name']);
                 } catch (InvalidArgumentException $e) {
-                    // If the option does not exist, or is not in the allowlist,
-                    // it will throw an exception
+                    // If the option is not in the allowlist, it will throw an exception
                     return new Error(
                         'option-name-not-exists',
                         $e->getMessage()

--- a/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Settings\FieldResolvers\ObjectType;
 
+use InvalidArgumentException;
 use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -119,16 +120,16 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         switch ($fieldName) {
             case 'option':
                 $name = $fieldArgs['name'];
-                if ($value = $this->getSettingsTypeAPI()->getOption($name)) {
-                    return $value;
+                try {
+                    $value = $this->getSettingsTypeAPI()->getOption($name);
+                } catch (InvalidArgumentException $e) {
+                    // If the option does not exist, it will throw an exception
+                    return new Error(
+                        'option-name-not-exists',
+                        $e->getMessage()
+                    );
                 }
-                return new Error(
-                    'option-name-not-exists',
-                    sprintf(
-                        $this->getTranslationAPI()->__('There is no option with name \'%s\'', 'settings'),
-                        $name
-                    )
-                );
+                return $value;
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Settings\TypeAPIs;
 
+use InvalidArgumentException;
 use PoP\ComponentModel\Services\BasicServiceTrait;
 use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface;
 use PoPSchema\Settings\ComponentConfiguration;
@@ -23,6 +24,9 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
         return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
     }
 
+    /**
+     * @throws InvalidArgumentException When the option does not exist, or is not in the allowlist
+     */
     final public function getOption(string $name): mixed
     {
         /**
@@ -32,7 +36,12 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
         $settingsEntries = ComponentConfiguration::getSettingsEntries();
         $settingsBehavior = ComponentConfiguration::getSettingsBehavior();
         if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($name, $settingsEntries, $settingsBehavior)) {
-            return null;
+            return throw new InvalidArgumentException(
+                sprintf(
+                    $this->getTranslationAPI()->__('There is no option with name \'%s\'', 'settings'),
+                    $name
+                )
+            );
         }
         return $this->doGetOption($name);
     }

--- a/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -33,9 +33,20 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
          * Check if the allow/denylist validation fails
          * Compare for full match or regex
          */
-        $settingsEntries = ComponentConfiguration::getSettingsEntries();
-        $settingsBehavior = ComponentConfiguration::getSettingsBehavior();
-        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($name, $settingsEntries, $settingsBehavior)) {
+        $entries = ComponentConfiguration::getSettingsEntries();
+        $behavior = ComponentConfiguration::getSettingsBehavior();
+        $this->assertIsEntryAllowed($entries, $behavior, $name);
+        return $this->doGetOption($name);
+    }
+
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
+    final protected function assertIsEntryAllowed(array $entries, string $behavior, string $name): bool|InvalidArgumentException
+    {
+        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($name, $entries, $behavior)) {
             return throw new InvalidArgumentException(
                 sprintf(
                     $this->getTranslationAPI()->__('There is no option with name \'%s\'', 'settings'),
@@ -43,7 +54,7 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
                 )
             );
         }
-        return $this->doGetOption($name);
+        return true;
     }
 
     abstract protected function doGetOption(string $name): mixed;

--- a/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -40,7 +40,9 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
     }
 
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */
@@ -57,5 +59,9 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
         return true;
     }
 
+    /**
+     * If the name is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     abstract protected function doGetOption(string $name): mixed;
 }

--- a/layers/Schema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace PoPSchema\Settings\TypeAPIs;
 
+use InvalidArgumentException;
+
 interface SettingsTypeAPIInterface
 {
+    /**
+     * @throws InvalidArgumentException When the option does not exist, or is not in the allowlist
+     */
     public function getOption(string $name): mixed;
 }

--- a/layers/Schema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
@@ -12,8 +12,10 @@ class TaxonomyMetaTypeAPI extends AbstractTaxonomyMetaTypeAPI
      * If the key is non-existent, return `null`.
      * Otherwise, return the value.
      */
-    public function doGetTaxonomyMeta(string | int $termID, string $key, bool $single = false): mixed
+    protected function doGetTaxonomyMeta(string | int $termID, string $key, bool $single = false): mixed
     {
+        // This function does not differentiate between a stored empty value,
+        // and a non-existing key! So if empty, treat it as non-existant and return null
         $value = \get_term_meta($termID, $key, $single);
         if (($single && $value === '') || (!$single && $value === [])) {
             return null;

--- a/layers/Schema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
@@ -15,7 +15,7 @@ class TaxonomyMetaTypeAPI extends AbstractTaxonomyMetaTypeAPI
     public function doGetTaxonomyMeta(string | int $termID, string $key, bool $single = false): mixed
     {
         $value = \get_term_meta($termID, $key, $single);
-        if ($value === '') {
+        if (($single && $value === '') || (!$single && $value === [])) {
             return null;
         }
         return $value;

--- a/layers/Schema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
@@ -8,8 +8,16 @@ use PoPSchema\TaxonomyMeta\TypeAPIs\AbstractTaxonomyMetaTypeAPI;
 
 class TaxonomyMetaTypeAPI extends AbstractTaxonomyMetaTypeAPI
 {
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     public function doGetTaxonomyMeta(string | int $termID, string $key, bool $single = false): mixed
     {
-        return \get_term_meta($termID, $key, $single);
+        $value = \get_term_meta($termID, $key, $single);
+        if ($value === '') {
+            return null;
+        }
+        return $value;
     }
 }

--- a/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\TaxonomyMeta\FieldResolvers\ObjectType;
 
+use InvalidArgumentException;
+use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPSchema\Meta\FieldResolvers\InterfaceType\WithMetaInterfaceTypeFieldResolver;
@@ -73,11 +75,21 @@ class TaxonomyObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         switch ($fieldName) {
             case 'metaValue':
             case 'metaValues':
-                return $this->getTaxonomyMetaTypeAPI()->getTaxonomyTermMeta(
-                    $objectTypeResolver->getID($taxonomy),
-                    $fieldArgs['key'],
-                    $fieldName === 'metaValue'
-                );
+                try {
+                    $value = $this->getTaxonomyMetaTypeAPI()->getTaxonomyTermMeta(
+                        $objectTypeResolver->getID($taxonomy),
+                        $fieldArgs['key'],
+                        $fieldName === 'metaValue'
+                    );
+                } catch (InvalidArgumentException $e) {
+                    // If the meta key does not exist, or is not in the allowlist,
+                    // it will throw an exception
+                    return new Error(
+                        'meta-key-not-exists',
+                        $e->getMessage()
+                    );
+                }
+                return $value;
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
@@ -82,8 +82,7 @@ class TaxonomyObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                         $fieldName === 'metaValue'
                     );
                 } catch (InvalidArgumentException $e) {
-                    // If the meta key does not exist, or is not in the allowlist,
-                    // it will throw an exception
+                    // If the meta key is not in the allowlist, it will throw an exception
                     return new Error(
                         'meta-key-not-exists',
                         $e->getMessage()

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
@@ -4,36 +4,22 @@ declare(strict_types=1);
 
 namespace PoPSchema\TaxonomyMeta\TypeAPIs;
 
-use PoP\ComponentModel\Services\BasicServiceTrait;
-use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface;
+use InvalidArgumentException;
+use PoPSchema\Meta\TypeAPIs\AbstractMetaTypeAPI;
 use PoPSchema\TaxonomyMeta\ComponentConfiguration;
 
-abstract class AbstractTaxonomyMetaTypeAPI implements TaxonomyMetaTypeAPIInterface
+abstract class AbstractTaxonomyMetaTypeAPI extends AbstractMetaTypeAPI implements TaxonomyMetaTypeAPIInterface
 {
-    use BasicServiceTrait;
-
-    private ?AllowOrDenySettingsServiceInterface $allowOrDenySettingsService = null;
-
-    final public function setAllowOrDenySettingsService(AllowOrDenySettingsServiceInterface $allowOrDenySettingsService): void
-    {
-        $this->allowOrDenySettingsService = $allowOrDenySettingsService;
-    }
-    final protected function getAllowOrDenySettingsService(): AllowOrDenySettingsServiceInterface
-    {
-        return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
-    }
-
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     final public function getTaxonomyTermMeta(string | int $termID, string $key, bool $single = false): mixed
     {
-        /**
-         * Check if the allow/denylist validation fails
-         * Compare for full match or regex
-         */
         $entries = ComponentConfiguration::getTaxonomyMetaEntries();
         $behavior = ComponentConfiguration::getTaxonomyMetaBehavior();
-        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($key, $entries, $behavior)) {
-            return null;
-        }
+        $this->assertIsEntryAllowed($entries, $behavior, $key);
         return $this->doGetTaxonomyMeta($termID, $key, $single);
     }
 

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
@@ -11,7 +11,9 @@ use PoPSchema\TaxonomyMeta\ComponentConfiguration;
 abstract class AbstractTaxonomyMetaTypeAPI extends AbstractMetaTypeAPI implements TaxonomyMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */
@@ -23,5 +25,9 @@ abstract class AbstractTaxonomyMetaTypeAPI extends AbstractMetaTypeAPI implement
         return $this->doGetTaxonomyMeta($termID, $key, $single);
     }
 
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     abstract protected function doGetTaxonomyMeta(string | int $termID, string $key, bool $single = false): mixed;
 }

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
@@ -9,7 +9,9 @@ use InvalidArgumentException;
 interface TaxonomyMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace PoPSchema\TaxonomyMeta\TypeAPIs;
 
+use InvalidArgumentException;
+
 interface TaxonomyMetaTypeAPIInterface
 {
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     public function getTaxonomyTermMeta(string | int $termID, string $key, bool $single = false): mixed;
 }

--- a/layers/Schema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
@@ -18,7 +18,7 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
     public function doGetUserMeta(string | int $userID, string $key, bool $single = false): mixed
     {
         $value = \get_user_meta($userID, $key, $single);
-        if ($value === '') {
+        if (($single && $value === '') || (!$single && $value === [])) {
             return null;
         }
         return $value;

--- a/layers/Schema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
@@ -11,8 +11,16 @@ use PoPSchema\UserMeta\TypeAPIs\AbstractUserMetaTypeAPI;
  */
 class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
 {
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     public function doGetUserMeta(string | int $userID, string $key, bool $single = false): mixed
     {
-        return \get_user_meta($userID, $key, $single);
+        $value = \get_user_meta($userID, $key, $single);
+        if ($value === '') {
+            return null;
+        }
+        return $value;
     }
 }

--- a/layers/Schema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
@@ -15,8 +15,10 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
      * If the key is non-existent, return `null`.
      * Otherwise, return the value.
      */
-    public function doGetUserMeta(string | int $userID, string $key, bool $single = false): mixed
+    protected function doGetUserMeta(string | int $userID, string $key, bool $single = false): mixed
     {
+        // This function does not differentiate between a stored empty value,
+        // and a non-existing key! So if empty, treat it as non-existant and return null
         $value = \get_user_meta($userID, $key, $single);
         if (($single && $value === '') || (!$single && $value === [])) {
             return null;

--- a/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -82,8 +82,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                         $fieldName === 'metaValue'
                     );
                 } catch (InvalidArgumentException $e) {
-                    // If the meta key does not exist, or is not in the allowlist,
-                    // it will throw an exception
+                    // If the meta key is not in the allowlist, it will throw an exception
                     return new Error(
                         'meta-key-not-exists',
                         $e->getMessage()

--- a/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserMeta\FieldResolvers\ObjectType;
 
+use InvalidArgumentException;
+use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPSchema\Meta\FieldResolvers\InterfaceType\WithMetaInterfaceTypeFieldResolver;
@@ -73,11 +75,21 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         switch ($fieldName) {
             case 'metaValue':
             case 'metaValues':
-                return $this->getUserMetaTypeAPI()->getUserMeta(
-                    $objectTypeResolver->getID($user),
-                    $fieldArgs['key'],
-                    $fieldName === 'metaValue'
-                );
+                try {
+                    $value = $this->getUserMetaTypeAPI()->getUserMeta(
+                        $objectTypeResolver->getID($user),
+                        $fieldArgs['key'],
+                        $fieldName === 'metaValue'
+                    );
+                } catch (InvalidArgumentException $e) {
+                    // If the meta key does not exist, or is not in the allowlist,
+                    // it will throw an exception
+                    return new Error(
+                        'meta-key-not-exists',
+                        $e->getMessage()
+                    );
+                }
+                return $value;
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
@@ -4,36 +4,22 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserMeta\TypeAPIs;
 
-use PoP\ComponentModel\Services\BasicServiceTrait;
-use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface;
+use InvalidArgumentException;
+use PoPSchema\Meta\TypeAPIs\AbstractMetaTypeAPI;
 use PoPSchema\UserMeta\ComponentConfiguration;
 
-abstract class AbstractUserMetaTypeAPI implements UserMetaTypeAPIInterface
+abstract class AbstractUserMetaTypeAPI extends AbstractMetaTypeAPI implements UserMetaTypeAPIInterface
 {
-    use BasicServiceTrait;
-
-    private ?AllowOrDenySettingsServiceInterface $allowOrDenySettingsService = null;
-
-    final public function setAllowOrDenySettingsService(AllowOrDenySettingsServiceInterface $allowOrDenySettingsService): void
-    {
-        $this->allowOrDenySettingsService = $allowOrDenySettingsService;
-    }
-    final protected function getAllowOrDenySettingsService(): AllowOrDenySettingsServiceInterface
-    {
-        return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
-    }
-
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     final public function getUserMeta(string | int $userID, string $key, bool $single = false): mixed
     {
-        /**
-         * Check if the allow/denylist validation fails
-         * Compare for full match or regex
-         */
         $entries = ComponentConfiguration::getUserMetaEntries();
         $behavior = ComponentConfiguration::getUserMetaBehavior();
-        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($key, $entries, $behavior)) {
-            return null;
-        }
+        $this->assertIsEntryAllowed($entries, $behavior, $key);
         return $this->doGetUserMeta($userID, $key, $single);
     }
 

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
@@ -11,7 +11,9 @@ use PoPSchema\UserMeta\ComponentConfiguration;
 abstract class AbstractUserMetaTypeAPI extends AbstractMetaTypeAPI implements UserMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */
@@ -23,5 +25,9 @@ abstract class AbstractUserMetaTypeAPI extends AbstractMetaTypeAPI implements Us
         return $this->doGetUserMeta($userID, $key, $single);
     }
 
+    /**
+     * If the key is non-existent, return `null`.
+     * Otherwise, return the value.
+     */
     abstract protected function doGetUserMeta(string | int $userID, string $key, bool $single = false): mixed;
 }

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
@@ -9,7 +9,9 @@ use InvalidArgumentException;
 interface UserMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserMeta\TypeAPIs;
 
+use InvalidArgumentException;
+
 interface UserMetaTypeAPIInterface
 {
+    /**
+     * If the allow/denylist validation fails, throw an exception
+     *
+     * @throws InvalidArgumentException
+     */
     public function getUserMeta(string | int $userID, string $key, bool $single = false): mixed;
 }


### PR DESCRIPTION
When executing field `Root.option`, if the option name does not exist, or is not exposed in the schema (it must be added to the allowlist in the Settings), the query now returns an error.

For instance, executing this query:

```graphql
{
  option(name:"nonExistentOption")
}
```

Returns:

```json
{
  "errors": [
    {
      "message": "There is no option with name 'nonExistentOption'",
      "extensions": {
        "type": "Root",
        "id": "root",
        "field": "option(name:\"nonExistentOption\")"
      }
    }
  ],
  "data": {
    "option": null
  }
}
```

The same behavior happens for the meta fields, when querying for a meta key that does not exist, or has not been exposed in the schema (via the corresponding Settings page for that entity):

- `CustomPost.metaValue`
- `CustomPost.metaValues`
- `User.metaValue`
- `User.metaValues`
- `Comment.metaValue`
- `Comment.metaValues`
- `Taxonomy.metaValue`
- `Taxonomy.metaValues`

For instance, executing this query:

```graphql
{
  post(by: { id: 1 }) {
    id
    metaValue(key: "nothingHere")
  }
}
```

Returns:

```json
{
  "errors": [
    {
      "message": "There is no meta with key 'nothingHere'",
      "extensions": {
        "type": "Post",
        "id": 1,
        "field": "metaValue(key:\"nothingHere\")"
      }
    }
  ],
  "data": {
    "post": {
      "id": 1,
      "metaValue": null
    }
  }
}
```