### PR TITLE
Added "isAdminElement" property to schema introspection

### DIFF
--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/EnumTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/EnumTypeSchemaDefinitionProvider.php
@@ -38,18 +38,22 @@ class EnumTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvi
     {
         $enums = [];
         $enumValues = $this->enumTypeResolver->getConsolidatedEnumValues();
+        $adminEnumValues = $this->enumTypeResolver->getConsolidatedAdminEnumValues();
         foreach ($enumValues as $enumValue) {
-            $enum = [
+            $enumValueSchemaDefinition = [
                 SchemaDefinition::VALUE => $enumValue,
             ];
             if ($description = $this->enumTypeResolver->getConsolidatedEnumValueDescription($enumValue)) {
-                $enum[SchemaDefinition::DESCRIPTION] = $description;
+                $enumValueSchemaDefinition[SchemaDefinition::DESCRIPTION] = $description;
             }
             if ($deprecationMessage = $this->enumTypeResolver->getConsolidatedEnumValueDeprecationMessage($enumValue)) {
-                $enum[SchemaDefinition::DEPRECATED] = true;
-                $enum[SchemaDefinition::DEPRECATION_MESSAGE] = $deprecationMessage;
+                $enumValueSchemaDefinition[SchemaDefinition::DEPRECATED] = true;
+                $enumValueSchemaDefinition[SchemaDefinition::DEPRECATION_MESSAGE] = $deprecationMessage;
             }
-            $enums[$enumValue] = $enum;
+            if (in_array($enumValue, $adminEnumValues)) {
+                $enumValueSchemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+            }
+            $enums[$enumValue] = $enumValueSchemaDefinition;
         }
         $schemaDefinition[SchemaDefinition::ITEMS] = $enums;
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/AbstractInterfaceTypeFieldResolver.php
@@ -463,6 +463,9 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
             $this->getFieldTypeModifiers($fieldName),
             $this->getConsolidatedFieldDeprecationMessage($fieldName),
         );
+        if (in_array($fieldName, $this->getAdminFieldNames())) {
+            $schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+        }
 
         if ($args = $this->getFieldArgsSchemaDefinition($fieldName)) {
             $schemaDefinition[SchemaDefinition::ARGS] = $args;
@@ -525,6 +528,7 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
         $schemaFieldArgs = [];
         $skipExposingDangerouslyDynamicScalarTypeInSchema = ComponentConfiguration::skipExposingDangerouslyDynamicScalarTypeInSchema();
         $consolidatedFieldArgNameTypeResolvers = $this->getConsolidatedFieldArgNameTypeResolvers($fieldName);
+        $adminFieldArgNames = $this->getConsolidatedAdminFieldArgNames($fieldName);
         foreach ($consolidatedFieldArgNameTypeResolvers as $fieldArgName => $fieldArgInputTypeResolver) {
             /**
              * `DangerouslyDynamic` is a special scalar type which is not coerced or validated.
@@ -550,6 +554,9 @@ abstract class AbstractInterfaceTypeFieldResolver extends AbstractFieldResolver 
                 $this->getConsolidatedFieldArgDefaultValue($fieldName, $fieldArgName),
                 $this->getConsolidatedFieldArgTypeModifiers($fieldName, $fieldArgName),
             );
+            if (in_array($fieldArgName, $adminFieldArgNames)) {
+                $schemaFieldArgs[$fieldArgName][SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+            }
         }
         $this->schemaFieldArgsCache[$cacheKey] = $schemaFieldArgs;
         return $this->schemaFieldArgsCache[$cacheKey];

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -523,6 +523,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
             return $this->schemaFieldArgsCache[$cacheKey];
         }
         $schemaFieldArgs = [];
+        $adminFieldArgNames = $this->getConsolidatedAdminFieldArgNames($objectTypeResolver, $fieldName);
         $consolidatedFieldArgNameTypeResolvers = $this->getConsolidatedFieldArgNameTypeResolvers($objectTypeResolver, $fieldName);
         foreach ($consolidatedFieldArgNameTypeResolvers as $fieldArgName => $fieldArgInputTypeResolver) {
             $fieldArgDescription =
@@ -535,6 +536,9 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
                 $this->getConsolidatedFieldArgDefaultValue($objectTypeResolver, $fieldName, $fieldArgName),
                 $this->getConsolidatedFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
             );
+            if (in_array($fieldArgName, $adminFieldArgNames)) {
+                $schemaFieldArgs[$fieldArgName][SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+            }
         }
         $this->schemaFieldArgsCache[$cacheKey] = $schemaFieldArgs;
         return $this->schemaFieldArgsCache[$cacheKey];
@@ -860,6 +864,9 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         }
         if ($this->getFieldMutationResolver($objectTypeResolver, $fieldName) !== null) {
             $schemaDefinition[SchemaDefinition::FIELD_IS_MUTATION] = true;
+        }
+        if (in_array($fieldName, $this->getAdminFieldNames())) {
+            $schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
         }
 
         if ($extensions = $this->getFieldSchemaDefinitionExtensions($objectTypeResolver, $fieldName, $fieldArgs)) {

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -37,6 +37,7 @@ class SchemaDefinition
     public const POSSIBLE_TYPES = 'possibleTypes';
     public const DIRECTIVES = 'directives';
     public const GLOBAL_DIRECTIVES = 'globalDirectives';
+    public const IS_ADMIN_ELEMENT = 'isAdminElement';
     public const FIELD_IS_MUTATION = 'isMutation';
     public const DIRECTIVE_KIND = 'directiveKind';
     public const DIRECTIVE_PIPELINE_POSITION = 'pipelinePosition';

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\Resolvers\TypeSchemaDefinitionResolverTrait;
 use PoP\ComponentModel\Schema\InputCoercingServiceInterface;
+use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use PoP\ComponentModel\TypeResolvers\DeprecatableInputTypeResolverInterface;
@@ -473,6 +474,9 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             $this->getConsolidatedInputFieldDefaultValue($inputFieldName),
             $this->getConsolidatedInputFieldTypeModifiers($inputFieldName),
         );
+        if (in_array($inputFieldName, $this->getConsolidatedAdminInputFieldNames())) {
+            $inputFieldSchemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+        }
 
         $this->schemaDefinitionForInputFieldCache[$inputFieldName] = $inputFieldSchemaDefinition;
         return $this->schemaDefinitionForInputFieldCache[$inputFieldName];

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
@@ -12,11 +12,13 @@ use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\JSONObjectScalarTypeResolver;
 
 class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+    private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
 
     final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
     {
@@ -34,6 +36,14 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
     }
+    final public function setJSONObjectScalarTypeResolver(JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver): void
+    {
+        $this->jsonObjectScalarTypeResolver = $jsonObjectScalarTypeResolver;
+    }
+    final protected function getJSONObjectScalarTypeResolver(): JSONObjectScalarTypeResolver
+    {
+        return $this->jsonObjectScalarTypeResolver ??= $this->instanceManager->getInstance(JSONObjectScalarTypeResolver::class);
+    }
 
     public function getObjectTypeResolverClassesToAttachTo(): array
     {
@@ -49,6 +59,7 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'description',
             'isDeprecated',
             'deprecationReason',
+            'extensions',
         ];
     }
 
@@ -59,6 +70,7 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'description' => $this->getStringScalarTypeResolver(),
             'isDeprecated' => $this->getBooleanScalarTypeResolver(),
             'deprecationReason' => $this->getStringScalarTypeResolver(),
+            'extensions' => $this->getJSONObjectScalarTypeResolver(),
             default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
         };
     }
@@ -67,7 +79,8 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return match ($fieldName) {
             'name',
-            'isDeprecated'
+            'isDeprecated',
+            'extensions'
                 => SchemaTypeModifiers::NON_NULLABLE,
             default
                 => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
@@ -81,6 +94,7 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'description' => $this->getTranslationAPI()->__('Enum value\'s description as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-FAJbLACyBIC1BHnjL)', 'graphql-server'),
             'isDeprecated' => $this->getTranslationAPI()->__('Is the enum value deprecated?', 'graphql-server'),
             'deprecationReason' => $this->getTranslationAPI()->__('Why was the enum value deprecated?', 'graphql-server'),
+            'extensions' => $this->getTranslationAPI()->__('Custom metadata added to the enum value (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -111,6 +125,8 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $enumValue->isDeprecated();
             case 'deprecationReason':
                 return $enumValue->getDeprecatedReason();
+            case 'extensions':
+                return (object) $enumValue->getExtensions();
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractNamedType.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractNamedType.php
@@ -30,6 +30,7 @@ abstract class AbstractNamedType extends AbstractSchemaDefinitionReferenceObject
 
     public function getExtensions(): array
     {
-        return [];
+        $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
+        return $extensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumValue.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumValue.php
@@ -28,4 +28,12 @@ class EnumValue extends AbstractSchemaDefinitionReferenceObject
     {
         return $this->schemaDefinition[SchemaDefinition::DEPRECATION_MESSAGE] ?? null;
     }
+    public function getExtensions(): array
+    {
+        $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
+        if ($this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] ?? null) {
+            $extensions[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+        }
+        return $extensions;
+    }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Field.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Field.php
@@ -42,6 +42,9 @@ class Field extends AbstractSchemaDefinitionReferenceObject
         if ($this->schemaDefinition[SchemaDefinition::FIELD_IS_MUTATION] ?? null) {
             $extensions[SchemaDefinition::FIELD_IS_MUTATION] = true;
         }
+        if ($this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] ?? null) {
+            $extensions[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+        }
         return $extensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
@@ -38,7 +38,7 @@ class InputValue extends AbstractSchemaDefinitionReferenceObject
         }
         return null;
     }
-    
+
     public function getExtensions(): array
     {
         $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
@@ -44,6 +44,7 @@ class InputValue extends AbstractSchemaDefinitionReferenceObject
         $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
         if ($this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] ?? null) {
             $extensions[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-        }return $extensions;
+        }
+        return $extensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
@@ -42,6 +42,8 @@ class InputValue extends AbstractSchemaDefinitionReferenceObject
     public function getExtensions(): array
     {
         $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
-        return $extensions;
+        if ($this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] ?? null) {
+            $extensions[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
+        }return $extensions;
     }
 }


### PR DESCRIPTION
Property `isAdminElement` was added under `extensions` when doing introspection, for:

- fields
- input values
- input fields
- enum values

Can use this query:

```graphql
query GetIntrospectionExtensions {
  __schema {
    types {
      name
      extensions
      fields(includeDeprecated: true) {
        name
        extensions
        args {
          name
          extensions
        }
      }
      inputFields {
        name
        extensions
      }
      enumValues(includeDeprecated: true) {
        name
        extensions
      }
    }
  }
}
```