### PR TITLE
Convert "extensions" field to ObjectType

### DIFF
--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\API\ObjectModels\SchemaDefinition;
+
+use PoP\API\Schema\SchemaDefinition;
+
+abstract class AbstractNamedTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
+{
+    public function getSchemaDefinition(): array
+    {
+        $schemaDefinition = parent::getSchemaDefinition();
+        $schemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getNamedTypeExtensions();
+        return $schemaDefinition;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNamedTypeExtensions(): array
+    {
+        return [
+            SchemaDefinition::NAMESPACED_NAME => $this->typeResolver->getNamespacedTypeName(),
+            SchemaDefinition::ELEMENT_NAME => $this->typeResolver->getTypeName(),
+        ];
+    }
+}

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractTypeSchemaDefinitionProvider.php
@@ -33,12 +33,22 @@ abstract class AbstractTypeSchemaDefinitionProvider extends AbstractSchemaDefini
     {
         $schemaDefinition = [
             SchemaDefinition::NAME => $this->typeResolver->getMaybeNamespacedTypeName(),
-            SchemaDefinition::NAMESPACED_NAME => $this->typeResolver->getNamespacedTypeName(),
-            SchemaDefinition::ELEMENT_NAME => $this->typeResolver->getTypeName(),
         ];
         if ($description = $this->typeResolver->getTypeDescription()) {
             $schemaDefinition[SchemaDefinition::DESCRIPTION] = $description;
         }
+        $schemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getNamedTypeExtensions();
         return $schemaDefinition;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNamedTypeExtensions(): array
+    {
+        return [
+            SchemaDefinition::NAMESPACED_NAME => $this->typeResolver->getNamespacedTypeName(),
+            SchemaDefinition::ELEMENT_NAME => $this->typeResolver->getTypeName(),
+        ];
     }
 }

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/EnumTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/EnumTypeSchemaDefinitionProvider.php
@@ -8,7 +8,7 @@ use PoP\API\Schema\TypeKinds;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
 
-class EnumTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
+class EnumTypeSchemaDefinitionProvider extends AbstractNamedTypeSchemaDefinitionProvider
 {
     public function __construct(
         protected EnumTypeResolverInterface $enumTypeResolver,

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/EnumTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/EnumTypeSchemaDefinitionProvider.php
@@ -36,25 +36,6 @@ class EnumTypeSchemaDefinitionProvider extends AbstractNamedTypeSchemaDefinition
      */
     final protected function addEnumSchemaDefinition(array &$schemaDefinition): void
     {
-        $enums = [];
-        $enumValues = $this->enumTypeResolver->getConsolidatedEnumValues();
-        $adminEnumValues = $this->enumTypeResolver->getConsolidatedAdminEnumValues();
-        foreach ($enumValues as $enumValue) {
-            $enumValueSchemaDefinition = [
-                SchemaDefinition::VALUE => $enumValue,
-            ];
-            if ($description = $this->enumTypeResolver->getConsolidatedEnumValueDescription($enumValue)) {
-                $enumValueSchemaDefinition[SchemaDefinition::DESCRIPTION] = $description;
-            }
-            if ($deprecationMessage = $this->enumTypeResolver->getConsolidatedEnumValueDeprecationMessage($enumValue)) {
-                $enumValueSchemaDefinition[SchemaDefinition::DEPRECATED] = true;
-                $enumValueSchemaDefinition[SchemaDefinition::DEPRECATION_MESSAGE] = $deprecationMessage;
-            }
-            if (in_array($enumValue, $adminEnumValues)) {
-                $enumValueSchemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-            }
-            $enums[$enumValue] = $enumValueSchemaDefinition;
-        }
-        $schemaDefinition[SchemaDefinition::ITEMS] = $enums;
+        $schemaDefinition[SchemaDefinition::ITEMS] = $this->enumTypeResolver->getEnumSchemaDefinition();
     }
 }

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/InputObjectTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/InputObjectTypeSchemaDefinitionProvider.php
@@ -9,7 +9,7 @@ use PoP\API\Schema\SchemaDefinitionHelpers;
 use PoP\API\Schema\TypeKinds;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
 
-class InputObjectTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
+class InputObjectTypeSchemaDefinitionProvider extends AbstractNamedTypeSchemaDefinitionProvider
 {
     public function __construct(
         protected InputObjectTypeResolverInterface $inputObjectTypeResolver,

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/InterfaceTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/InterfaceTypeSchemaDefinitionProvider.php
@@ -9,7 +9,7 @@ use PoP\API\Schema\SchemaDefinitionHelpers;
 use PoP\API\Schema\TypeKinds;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 
-class InterfaceTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
+class InterfaceTypeSchemaDefinitionProvider extends AbstractNamedTypeSchemaDefinitionProvider
 {
     public function __construct(
         protected InterfaceTypeResolverInterface $interfaceTypeResolver,

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/ObjectTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/ObjectTypeSchemaDefinitionProvider.php
@@ -13,7 +13,7 @@ use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterfac
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyDynamicScalarTypeResolver;
 
-class ObjectTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
+class ObjectTypeSchemaDefinitionProvider extends AbstractNamedTypeSchemaDefinitionProvider
 {
     /**
      * @var InterfaceTypeResolverInterface[] List of the implemented interfaces, to add this Type to the InterfaceType's POSSIBLE_TYPES

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/ScalarTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/ScalarTypeSchemaDefinitionProvider.php
@@ -8,7 +8,7 @@ use PoP\API\Schema\SchemaDefinition;
 use PoP\API\Schema\TypeKinds;
 use PoP\ComponentModel\TypeResolvers\ScalarType\ScalarTypeResolverInterface;
 
-class ScalarTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
+class ScalarTypeSchemaDefinitionProvider extends AbstractNamedTypeSchemaDefinitionProvider
 {
     public function __construct(
         protected ScalarTypeResolverInterface $scalarTypeResolver,

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/UnionTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/UnionTypeSchemaDefinitionProvider.php
@@ -10,7 +10,7 @@ use PoP\API\Schema\TypeKinds;
 use PoP\ComponentModel\ComponentConfiguration;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
 
-class UnionTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
+class UnionTypeSchemaDefinitionProvider extends AbstractNamedTypeSchemaDefinitionProvider
 {
     public function __construct(
         protected UnionTypeResolverInterface $unionTypeResolver,

--- a/layers/API/packages/api/src/Schema/SchemaDefinitionService.php
+++ b/layers/API/packages/api/src/Schema/SchemaDefinitionService.php
@@ -20,6 +20,7 @@ use PoP\API\PersistedQueries\PersistedFragmentManagerInterface;
 use PoP\API\PersistedQueries\PersistedQueryManagerInterface;
 use PoP\ComponentModel\Cache\PersistentCacheInterface;
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
+use PoP\ComponentModel\State\ApplicationState;
 use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
@@ -152,12 +153,14 @@ class SchemaDefinitionService extends UpstreamSchemaDefinitionService implements
                 }
             }
 
-
             // Add the Fragment Catalogue
             $schemaDefinition[SchemaDefinition::PERSISTED_FRAGMENTS] = $this->getPersistedFragmentManager()->getPersistedFragmentsForSchema();
 
             // Add the Query Catalogue
             $schemaDefinition[SchemaDefinition::PERSISTED_QUERIES] = $this->getPersistedQueryManager()->getPersistedQueriesForSchema();
+
+            // Schema extensions
+            $schemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getSchemaExtensions();
 
             // Sort the elements in the schema alphabetically
             if (ComponentConfiguration::sortFullSchemaAlphabetically()) {
@@ -171,6 +174,17 @@ class SchemaDefinitionService extends UpstreamSchemaDefinitionService implements
         }
 
         return $schemaDefinition;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getSchemaExtensions(): array
+    {
+        $vars = ApplicationState::getVars();
+        return [
+            SchemaDefinition::SCHEMA_IS_NAMESPACED => $vars['namespace-types-and-interfaces'],
+        ];
     }
 
     public function sortFullSchemaAlphabetically(array &$schemaDefinition): void

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1284,6 +1284,8 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     public function getDirectiveExtensionsSchemaDefinition(RelationalTypeResolverInterface $relationalTypeResolver): array
     {
         return [
+            // @todo Implement "admin" directive, if needed
+            SchemaDefinition::IS_ADMIN_ELEMENT => false,
             SchemaDefinition::DIRECTIVE_PIPELINE_POSITION => $this->getPipelinePosition(),
             SchemaDefinition::DIRECTIVE_NEEDS_DATA_TO_EXECUTE => $this->needsIDsDataFieldsToExecute(),            
         ];

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1287,7 +1287,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             // @todo Implement "admin" directive, if needed
             SchemaDefinition::IS_ADMIN_ELEMENT => false,
             SchemaDefinition::DIRECTIVE_PIPELINE_POSITION => $this->getPipelinePosition(),
-            SchemaDefinition::DIRECTIVE_NEEDS_DATA_TO_EXECUTE => $this->needsIDsDataFieldsToExecute(),            
+            SchemaDefinition::DIRECTIVE_NEEDS_DATA_TO_EXECUTE => $this->needsIDsDataFieldsToExecute(),
         ];
     }
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1235,26 +1235,25 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             if ($args = $this->getDirectiveArgsSchemaDefinition($relationalTypeResolver)) {
                 $schemaDefinition[SchemaDefinition::ARGS] = $args;
             }
-            if ($extensions = $this->getDirectiveSchemaDefinitionExtensions($relationalTypeResolver)) {
-                $schemaDefinition[SchemaDefinition::EXTENSIONS] = $extensions;
-            }
-            /**
-             * Please notice: the version always comes from the directiveResolver, and not from the schemaDefinitionResolver
-             * That is because it is the implementer the one who knows what version it is, and not the one defining the interface
-             * If the interface changes, the implementer will need to change, so the version will be upgraded
-             * But it could also be that the contract doesn't change, but the implementation changes
-             * it's really not their responsibility
-             */
-            if (Environment::enableSemanticVersionConstraints() && $this->hasDirectiveVersion($relationalTypeResolver)) {
-                $schemaDefinition[SchemaDefinition::VERSION] = $this->getDirectiveVersion($relationalTypeResolver);
-            }
+            $schemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getDirectiveExtensionsSchemaDefinition($relationalTypeResolver);
             $this->schemaDefinitionForDirectiveCache[$key] = $schemaDefinition;
         }
         return $this->schemaDefinitionForDirectiveCache[$key];
     }
 
-    public function getDirectiveSchemaDefinitionExtensions(RelationalTypeResolverInterface $relationalTypeResolver): array
+    public function getDirectiveExtensionsSchemaDefinition(RelationalTypeResolverInterface $relationalTypeResolver): array
     {
-        return [];
+        $extensionsSchemaDefinition = [];
+        /**
+         * Please notice: the version always comes from the directiveResolver, and not from the schemaDefinitionResolver
+         * That is because it is the implementer the one who knows what version it is, and not the one defining the interface
+         * If the interface changes, the implementer will need to change, so the version will be upgraded
+         * But it could also be that the contract doesn't change, but the implementation changes
+         * it's really not their responsibility
+         */
+        if (Environment::enableSemanticVersionConstraints() && $this->hasDirectiveVersion($relationalTypeResolver)) {
+            $extensionsSchemaDefinition[SchemaDefinition::VERSION] = $this->getDirectiveVersion($relationalTypeResolver);
+        }
+        return $extensionsSchemaDefinition;
     }
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/HookNames.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/HookNames.php
@@ -10,4 +10,5 @@ class HookNames
     public const DIRECTIVE_ARG_DESCRIPTION = __CLASS__ . ':directive-arg-description';
     public const DIRECTIVE_ARG_DEFAULT_VALUE = __CLASS__ . ':directive-arg-default-value';
     public const DIRECTIVE_ARG_TYPE_MODIFIERS = __CLASS__ . ':directive-arg-type-modifiers';
+    public const DIRECTIVE_ARG_EXTENSIONS = __CLASS__ . ':directive-arg-extensions';
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/HookNames.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/HookNames.php
@@ -8,6 +8,7 @@ class HookNames
 {
     public const INTERFACE_TYPE_FIELD_DESCRIPTION = __CLASS__ . ':interface-type-field-description';
     public const INTERFACE_TYPE_FIELD_DEPRECATION_MESSAGE = __CLASS__ . ':interface-type-field-deprecation-message';
+    public const INTERFACE_TYPE_FIELD_EXTENSIONS = __CLASS__ . ':interface-type-field-extensions';
 
     public const INTERFACE_TYPE_FIELD_ARG_NAME_TYPE_RESOLVERS = __CLASS__ . ':interface-type-field-arg-name-type-resolvers';
     public const INTERFACE_TYPE_ADMIN_FIELD_ARG_NAMES = __CLASS__ . ':interface-type-admin-field-arg-names';

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/HookNames.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/HookNames.php
@@ -15,4 +15,5 @@ class HookNames
     public const INTERFACE_TYPE_FIELD_ARG_DESCRIPTION = __CLASS__ . ':interface-type-field-arg-description';
     public const INTERFACE_TYPE_FIELD_ARG_DEFAULT_VALUE = __CLASS__ . ':interface-type-field-arg-default-value';
     public const INTERFACE_TYPE_FIELD_ARG_TYPE_MODIFIERS = __CLASS__ . ':interface-type-field-arg-type-modifiers';
+    public const INTERFACE_TYPE_FIELD_ARG_EXTENSIONS = __CLASS__ . ':interface-type-field-arg-extensions';
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/InterfaceTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/InterfaceTypeFieldResolverInterface.php
@@ -31,5 +31,12 @@ interface InterfaceTypeFieldResolverInterface extends FieldResolverInterface, In
      */
     public function getPartiallyImplementedInterfaceTypeResolvers(): array;
     public function skipExposingFieldInSchema(string $fieldName): bool;
+    /**
+     * @return array<string, mixed>
+     */
     public function getFieldSchemaDefinition(string $fieldName): array;
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFieldExtensionsSchemaDefinition(string $fieldName): array;
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/InterfaceTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/InterfaceTypeFieldResolverInterface.php
@@ -35,8 +35,4 @@ interface InterfaceTypeFieldResolverInterface extends FieldResolverInterface, In
      * @return array<string, mixed>
      */
     public function getFieldSchemaDefinition(string $fieldName): array;
-    /**
-     * @return array<string, mixed>
-     */
-    public function getFieldExtensionsSchemaDefinition(string $fieldName): array;
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/InterfaceTypeFieldSchemaDefinitionResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/InterfaceTypeFieldSchemaDefinitionResolverInterface.php
@@ -36,6 +36,7 @@ interface InterfaceTypeFieldSchemaDefinitionResolverInterface
     public function getConsolidatedFieldArgDescription(string $fieldName, string $fieldArgName): ?string;
     public function getConsolidatedFieldArgDefaultValue(string $fieldName, string $fieldArgName): mixed;
     public function getConsolidatedFieldArgTypeModifiers(string $fieldName, string $fieldArgName): int;
+    public function isFieldAMutation(string $fieldName): bool;
     /**
      * Validate the constraints for a field argument
      *

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -74,6 +74,8 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
     protected array $consolidatedFieldArgTypeModifiersCache = [];
     /** @var array<string, array<string, mixed>> */
     protected array $schemaFieldArgsCache = [];
+    /** @var array<string, array<string, mixed>> */
+    protected array $schemaFieldArgExtensionsCache = [];
     /**
      * @var array<string, ObjectTypeFieldSchemaDefinitionResolverInterface>
      */
@@ -523,7 +525,6 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
             return $this->schemaFieldArgsCache[$cacheKey];
         }
         $schemaFieldArgs = [];
-        $adminFieldArgNames = $this->getConsolidatedAdminFieldArgNames($objectTypeResolver, $fieldName);
         $consolidatedFieldArgNameTypeResolvers = $this->getConsolidatedFieldArgNameTypeResolvers($objectTypeResolver, $fieldName);
         foreach ($consolidatedFieldArgNameTypeResolvers as $fieldArgName => $fieldArgInputTypeResolver) {
             $fieldArgDescription =
@@ -536,12 +537,40 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
                 $this->getConsolidatedFieldArgDefaultValue($objectTypeResolver, $fieldName, $fieldArgName),
                 $this->getConsolidatedFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
             );
-            if (in_array($fieldArgName, $adminFieldArgNames)) {
-                $schemaFieldArgs[$fieldArgName][SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-            }
+            $schemaFieldArgs[$fieldArgName][SchemaDefinition::EXTENSIONS] = $this->getConsolidatedFieldArgExtensionsSchemaDefinition($objectTypeResolver, $fieldName, $fieldArgName);
         }
         $this->schemaFieldArgsCache[$cacheKey] = $schemaFieldArgs;
         return $this->schemaFieldArgsCache[$cacheKey];
+    }
+
+    protected function getFieldArgExtensionsSchemaDefinition(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): array
+    {
+        $adminFieldArgNames = $this->getConsolidatedAdminFieldArgNames($objectTypeResolver, $fieldName);
+        return [
+            SchemaDefinition::IS_ADMIN_ELEMENT => in_array($fieldArgName, $adminFieldArgNames),
+        ];
+    }
+
+    /**
+     * Consolidation of the schema field arguments. Call this function to read the data
+     * instead of the individual functions, since it applies hooks to override/extend.
+     */
+    final protected function getConsolidatedFieldArgExtensionsSchemaDefinition(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): array
+    {
+        // Cache the result
+        $cacheKey = $objectTypeResolver::class . '.' . $fieldName . '(' . $fieldArgName . ':)';
+        if (array_key_exists($cacheKey, $this->schemaFieldArgExtensionsCache)) {
+            return $this->schemaFieldArgExtensionsCache[$cacheKey];
+        }
+        $this->schemaFieldArgExtensionsCache[$cacheKey] = $this->getHooksAPI()->applyFilters(
+            HookNames::OBJECT_TYPE_FIELD_ARG_EXTENSIONS,
+            $this->getFieldArgExtensionsSchemaDefinition($objectTypeResolver, $fieldName, $fieldArgName),
+            $this,
+            $objectTypeResolver,
+            $fieldName,
+            $fieldArgName,
+        );
+        return $this->schemaFieldArgExtensionsCache[$cacheKey];
     }
 
     public function getFieldDeprecationMessage(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
@@ -862,23 +891,24 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         if (Environment::enableSemanticVersionConstraints() && $this->hasFieldVersion($objectTypeResolver, $fieldName)) {
             $schemaDefinition[SchemaDefinition::VERSION] = $this->getFieldVersion($objectTypeResolver, $fieldName);
         }
-        if ($this->getFieldMutationResolver($objectTypeResolver, $fieldName) !== null) {
-            $schemaDefinition[SchemaDefinition::FIELD_IS_MUTATION] = true;
-        }
-        if (in_array($fieldName, $this->getAdminFieldNames())) {
-            $schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-        }
 
-        if ($extensions = $this->getFieldSchemaDefinitionExtensions($objectTypeResolver, $fieldName, $fieldArgs)) {
-            $schemaDefinition[SchemaDefinition::EXTENSIONS] = $extensions;
-        }
+        $schemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getFieldExtensionsSchemaDefinition($objectTypeResolver, $fieldName, $fieldArgs);
 
         return $schemaDefinition;
     }
 
-    public function getFieldSchemaDefinitionExtensions(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, array $fieldArgs): array
+    /**
+     * Watch out: The same extensions must be present for both
+     * the ObjectType and the InterfaceType!
+     *
+     * @return array<string, mixed>
+     */
+    public function getFieldExtensionsSchemaDefinition(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, array $fieldArgs): array
     {
-        return [];
+        return [
+            SchemaDefinition::FIELD_IS_MUTATION => $this->getFieldMutationResolver($objectTypeResolver, $fieldName) !== null,
+            SchemaDefinition::IS_ADMIN_ELEMENT => in_array($fieldName, $this->getAdminFieldNames()),
+        ];
     }
 
     protected function getInterfaceSchemaDefinitionResolverAdapterClass(): string

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/HookNames.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/HookNames.php
@@ -8,6 +8,7 @@ class HookNames
 {
     public const OBJECT_TYPE_FIELD_DESCRIPTION = __CLASS__ . ':object-type-field-description';
     public const OBJECT_TYPE_FIELD_DEPRECATION_MESSAGE = __CLASS__ . ':object-type-field-deprecation-message';
+    public const OBJECT_TYPE_FIELD_EXTENSIONS = __CLASS__ . ':object-type-field-extensions';
 
     public const OBJECT_TYPE_FIELD_ARG_NAME_TYPE_RESOLVERS = __CLASS__ . ':object-type-field-arg-name-type-resolvers';
     public const OBJECT_TYPE_ADMIN_FIELD_ARG_NAMES = __CLASS__ . ':object-type-admin-field-arg-names';

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/HookNames.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/HookNames.php
@@ -14,6 +14,7 @@ class HookNames
     public const OBJECT_TYPE_FIELD_ARG_DESCRIPTION = __CLASS__ . ':object-type-field-arg-description';
     public const OBJECT_TYPE_FIELD_ARG_DEFAULT_VALUE = __CLASS__ . ':object-type-field-arg-default-value';
     public const OBJECT_TYPE_FIELD_ARG_TYPE_MODIFIERS = __CLASS__ . ':object-type-field-arg-type-modifiers';
+    public const OBJECT_TYPE_FIELD_ARG_EXTENSIONS = __CLASS__ . ':object-type-field-arg-extensions';
 
     public const OBJECT_TYPE_MUTATION_FIELD_ARGS = __CLASS__ . ':object-type-mutation-field-args';
     public const OBJECT_TYPE_MUTATION_FIELD_ARGS_FOR_OBJECT = __CLASS__ . ':object-type-mutation-field-args-for-object';

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
@@ -31,8 +31,14 @@ interface ObjectTypeFieldResolverInterface extends FieldResolverInterface, Objec
      */
     public function skipExposingFieldInSchema(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): bool;
     public function skipExposingFieldArgInSchema(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): bool;
+    /**
+     * @return array<string, mixed>
+     */
     public function getFieldSchemaDefinition(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, array $fieldArgs): array;
-    public function getFieldSchemaDefinitionExtensions(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, array $fieldArgs): array;
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFieldExtensionsSchemaDefinition(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, array $fieldArgs): array;
     public function getFieldVersion(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string;
     public function hasFieldVersion(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): bool;
     public function getFieldVersionInputTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?InputTypeResolverInterface;

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
@@ -35,10 +35,6 @@ interface ObjectTypeFieldResolverInterface extends FieldResolverInterface, Objec
      * @return array<string, mixed>
      */
     public function getFieldSchemaDefinition(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, array $fieldArgs): array;
-    /**
-     * @return array<string, mixed>
-     */
-    public function getFieldExtensionsSchemaDefinition(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, array $fieldArgs): array;
     public function getFieldVersion(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string;
     public function hasFieldVersion(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): bool;
     public function getFieldVersionInputTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?InputTypeResolverInterface;

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -46,4 +46,5 @@ class SchemaDefinition
     public const DIRECTIVE_NEEDS_DATA_TO_EXECUTE = 'needsDataToExecute';
     public const DIRECTIVE_LIMITED_TO_FIELDS = 'limitedToFields';
     public const DIRECTIVE_EXPRESSIONS = 'expressions';
+    public const SCHEMA_IS_NAMESPACED = 'isSchemaNamespaced';
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\TypeResolvers\EnumType;
 
 use PoP\ComponentModel\ComponentConfiguration;
+use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\TypeResolvers\AbstractTypeResolver;
 use stdClass;
 
@@ -18,6 +19,12 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
     protected array $consolidatedEnumValueDescriptionCache = [];
     /** @var array<string, string|null> */
     protected array $consolidatedEnumValueDeprecationMessageCache = [];
+    /** @var array<string, array<string,mixed>> */
+    protected array $consolidatedEnumValueExtensionsCache = [];
+    /** @var array<string,array<string,mixed>>|null */
+    protected ?array $schemaDefinitionForEnumCache = null;
+    /** @var array<string, array<string,mixed>> */
+    protected array $schemaDefinitionForEnumValueCache = [];
 
     /**
      * The "admin" values in the enum
@@ -172,5 +179,76 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
             $this,
             $enumValue,
         );
+    }
+
+
+    /**
+     * Get the "schema" properties as for the enum
+     */
+    final public function getEnumSchemaDefinition(): array
+    {
+        // Cache the result
+        if ($this->schemaDefinitionForEnumCache !== null) {
+            return $this->schemaDefinitionForEnumCache;
+        }
+
+        $enumSchemaDefinition = [];
+        $enumValues = $this->getConsolidatedEnumValues();
+        foreach ($enumValues as $enumValue) {
+            $enumSchemaDefinition[$enumValue] = $this->getEnumValueSchemaDefinition($enumValue);
+        }
+        $this->schemaDefinitionForEnumCache = $enumSchemaDefinition;
+        return $this->schemaDefinitionForEnumCache;
+    }
+
+    /**
+     * Get the "schema" properties as for the enumValue
+     */
+    final public function getEnumValueSchemaDefinition(string $enumValue): array
+    {
+        // Cache the result
+        if (isset($this->schemaDefinitionForEnumValueCache[$enumValue])) {
+            return $this->schemaDefinitionForEnumValueCache[$enumValue];
+        }
+
+        $enumValueSchemaDefinition = [
+            SchemaDefinition::VALUE => $enumValue,
+        ];
+        if ($description = $this->getConsolidatedEnumValueDescription($enumValue)) {
+            $enumValueSchemaDefinition[SchemaDefinition::DESCRIPTION] = $description;
+        }
+        if ($deprecationMessage = $this->getConsolidatedEnumValueDeprecationMessage($enumValue)) {
+            $enumValueSchemaDefinition[SchemaDefinition::DEPRECATED] = true;
+            $enumValueSchemaDefinition[SchemaDefinition::DEPRECATION_MESSAGE] = $deprecationMessage;
+        }
+        $enumValueSchemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getConsolidatedEnumValueExtensionsSchemaDefinition($enumValue);
+
+        $this->schemaDefinitionForEnumValueCache[$enumValue] = $enumValueSchemaDefinition;;
+        return $this->schemaDefinitionForEnumValueCache[$enumValue];
+    }
+
+    protected function getEnumValueExtensionsSchemaDefinition(string $enumValue): array
+    {
+        return [
+            SchemaDefinition::IS_ADMIN_ELEMENT => in_array($enumValue, $this->getConsolidatedAdminEnumValues()),
+        ];
+    }
+
+    /**
+     * Consolidation of the schema inputs. Call this function to read the data
+     * instead of the individual functions, since it applies hooks to override/extend.
+     */
+    final public function getConsolidatedEnumValueExtensionsSchemaDefinition(string $enumValue): array
+    {
+        if (array_key_exists($enumValue, $this->consolidatedEnumValueExtensionsCache)) {
+            return $this->consolidatedEnumValueExtensionsCache[$enumValue];
+        }
+        $this->consolidatedEnumValueExtensionsCache[$enumValue] = $this->getHooksAPI()->applyFilters(
+            HookNames::ENUM_VALUE_EXTENSIONS,
+            $this->getEnumValueExtensionsSchemaDefinition($enumValue),
+            $this,
+            $enumValue,
+        );
+        return $this->consolidatedEnumValueExtensionsCache[$enumValue];
     }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -223,7 +223,8 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
         }
         $enumValueSchemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getConsolidatedEnumValueExtensionsSchemaDefinition($enumValue);
 
-        $this->schemaDefinitionForEnumValueCache[$enumValue] = $enumValueSchemaDefinition;;
+        $this->schemaDefinitionForEnumValueCache[$enumValue] = $enumValueSchemaDefinition;
+        ;
         return $this->schemaDefinitionForEnumValueCache[$enumValue];
     }
 

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/EnumTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/EnumTypeResolverInterface.php
@@ -43,4 +43,12 @@ interface EnumTypeResolverInterface extends ConcreteTypeResolverInterface, Depre
     public function getConsolidatedAdminEnumValues(): array;
     public function getConsolidatedEnumValueDescription(string $enumValue): ?string;
     public function getConsolidatedEnumValueDeprecationMessage(string $enumValue): ?string;
+    /**
+     * @return array<string,mixed>
+     */
+    public function getEnumValueSchemaDefinition(string $enumValue): array;
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    public function getEnumSchemaDefinition(): array;
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/HookNames.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/HookNames.php
@@ -10,4 +10,5 @@ class HookNames
     public const ADMIN_ENUM_VALUES = __CLASS__ . ':admin-enum-values';
     public const ENUM_VALUE_DESCRIPTION = __CLASS__ . ':enum-value-description';
     public const ENUM_VALUE_DEPRECATION_MESSAGE = __CLASS__ . ':enum-value-deprecation-message';
+    public const ENUM_VALUE_EXTENSIONS = __CLASS__ . ':enum-value-extensions';
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -31,6 +31,8 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
     private array $consolidatedInputFieldDefaultValueCache = [];
     /** @var array<string, int> */
     private array $consolidatedInputFieldTypeModifiersCache = [];
+    /** @var array<string, array<string,mixed>> */
+    private array $consolidatedInputFieldExtensionsCache = [];
     /** @var string[]|null */
     private ?array $consolidatedAdminInputFieldNames = null;
 
@@ -474,12 +476,36 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
             $this->getConsolidatedInputFieldDefaultValue($inputFieldName),
             $this->getConsolidatedInputFieldTypeModifiers($inputFieldName),
         );
-        if (in_array($inputFieldName, $this->getConsolidatedAdminInputFieldNames())) {
-            $inputFieldSchemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-        }
+        $inputFieldSchemaDefinition[SchemaDefinition::EXTENSIONS] = $this->getConsolidatedInputFieldExtensionsSchemaDefinition($inputFieldName);
 
         $this->schemaDefinitionForInputFieldCache[$inputFieldName] = $inputFieldSchemaDefinition;
         return $this->schemaDefinitionForInputFieldCache[$inputFieldName];
+    }
+
+    protected function getInputFieldExtensionsSchemaDefinition(string $inputFieldName): array
+    {
+        return [
+            SchemaDefinition::IS_ADMIN_ELEMENT => in_array($inputFieldName, $this->getConsolidatedAdminInputFieldNames()),
+        ];
+    }
+
+
+    /**
+     * Consolidation of the schema inputs. Call this function to read the data
+     * instead of the individual functions, since it applies hooks to override/extend.
+     */
+    final public function getConsolidatedInputFieldExtensionsSchemaDefinition(string $inputFieldName): array
+    {
+        if (array_key_exists($inputFieldName, $this->consolidatedInputFieldExtensionsCache)) {
+            return $this->consolidatedInputFieldExtensionsCache[$inputFieldName];
+        }
+        $this->consolidatedInputFieldExtensionsCache[$inputFieldName] = $this->getHooksAPI()->applyFilters(
+            HookNames::INPUT_FIELD_EXTENSIONS,
+            $this->getInputFieldExtensionsSchemaDefinition($inputFieldName),
+            $this,
+            $inputFieldName,
+        );
+        return $this->consolidatedInputFieldExtensionsCache[$inputFieldName];
     }
     /**
      * Validate constraints on the input field's value

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -489,7 +489,6 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
         ];
     }
 
-
     /**
      * Consolidation of the schema inputs. Call this function to read the data
      * instead of the individual functions, since it applies hooks to override/extend.

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/HookNames.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/HookNames.php
@@ -10,6 +10,7 @@ class HookNames
     public const INPUT_FIELD_DESCRIPTION = __CLASS__ . ':input-field-description';
     public const INPUT_FIELD_DEFAULT_VALUE = __CLASS__ . ':input-field-default-value';
     public const INPUT_FIELD_TYPE_MODIFIERS = __CLASS__ . ':input-field-type-modifiers';
+    public const INPUT_FIELD_EXTENSIONS = __CLASS__ . ':input-field-extensions';
     public const INPUT_FIELD_FILTER_INPUT = __CLASS__ . ':input-field-filter-input';
     public const ADMIN_INPUT_FIELD_NAMES = __CLASS__ . ':admin-input-field-names';
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -164,7 +164,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Added options "default limit" and "max limit" for Posts and Pages
 - Return an error if access is not allowed for the option name or meta key
 - Query `extensions` in the schema introspection
-  - Added custom metadata `isAdminElement`
+  - Implemented extension `isAdminElement`
 - Performance improvement: Avoid regenerating the container when the schema is modified
 - Clicking on "Save Changes" on the Settings page will always regenerate the schema
 - Prettyprint GraphQL queries in the module docs

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-expose-admin-data.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/schema-expose-admin-data.md
@@ -8,7 +8,7 @@ For instance, to access post data, we have field `Root.posts`, which by default 
 
 ## List of admin elements
 
-By default, the following elements are treated as private data:
+The elements below (among others) are, by default, treated as private data:
 
 **User:**
 
@@ -27,36 +27,43 @@ By default, the following elements are treated as private data:
 
 ## Inspecting the "admin" elements via schema introspection
 
-The `isAdminElement` property is added to field `extensions`, when doing schema introspection. To find out which are the "admin" elements from the schema, execute this query:
+The `isAdminElement` property is added to field `extensions` when doing schema introspection. To find out which are the "admin" elements from the schema, execute this query:
 
 ```graphql
-query GetIntrospectionExtensions {
+query ViewAdminElements {
   __schema {
     types {
       name
-      extensions
-      fields(includeDeprecated: true) {
+      fields {
         name
-        extensions
+        extensions {
+          isAdminElement
+        }
         args {
           name
-          extensions
+          extensions {
+            isAdminElement
+          }
         }
       }
       inputFields {
         name
-        extensions
+        extensions {
+          isAdminElement
+        }
       }
-      enumValues(includeDeprecated: true) {
+      enumValues {
         name
-        extensions
+        extensions {
+          isAdminElement
+        }
       }
     }
   }
 }
 ```
 
-And then search for entries `isAdminElement: true` in the results.
+And then search for entries with `"isAdminElement": true` in the results.
 
 ## Overriding the default configuration
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -911,73 +911,110 @@ Returns:
 
 Custom metadata attached to schema elements can now be queried via field `extensions`. This is a feature [requested for the GraphQL spec](https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306), but not yet approved. This GraphQL server already implements it, though, since it is very useful.
 
-The schema elements which can be added custom metadata via extensions are the following:
-
-- Types (for all named types: Object, Interface, Union, Scalar, Enum and InputObject)
-- Directives
-- Fields
-- Input values (field/directive arguments, and input fields)
-- Enum values
-
-The introspection elements of the schema have been upgraded with the new field:
+All introspection elements of the schema have been upgraded with the new field, each of them returning an object of a corresponding "`Extensions`" type, which exposes the custom properties for that element.
 
 ```graphql
+extend type __Schema {
+  extensions: SchemaExtensions!
+}
+
+type SchemaExtensions {
+  # Is the schema being namespaced?
+  isNamespaced: Boolean!
+}
+
 extend type __Type {
   # Non-null for named types, null for wrapping types (Non-Null and List)
-  extensions: JSONObject
+  extensions: NamedTypeExtensions
+}
+
+type NamedTypeExtensions {
+  # The type name
+  elementName: String!
+
+  # The "namespaced" type name
+  namespacedName: String!
 }
 
 extend type __Directive {
-  extensions: JSONObject!
+  extensions: DirectiveExtensions!
+}
+
+type DirectiveExtensions {
+  # If no objects are returned in the field (eg: because they failed validation), does the directive still need to be executed?
+  needsDataToExecute: Boolean!
 }
 
 extend type __Field {
-  extensions: JSONObject!
+  extensions: FieldExtensions!
+}
+
+type FieldExtensions {
+  # Useful for nested mutations
+  isMutation: Boolean!
+
+  # `true` => Only exposed when "Expose admin elements" is enabled
+  isAdminElement: Boolean!
 }
 
 extend type __InputValue {
-  extensions: JSONObject!
+  extensions: InputValueExtensions!
+}
+
+type InputValueExtensions {
+  isAdminElement: Boolean!
 }
 
 extend type __EnumValue {
-  extensions: JSONObject!
+  extensions: EnumValueExtensions!
+}
+
+type EnumValueExtensions {
+  isAdminElement: Boolean!
 }
 ```
 
-### Added custom metadata `isAdminElement`
+### Implemented extension `isAdminElement`
 
-A first implementation of the `extensions` field is the addition of property `isAdminElement`, to identify which are the "admin" elements from the schema (which can be accessed only when "Expose admin elements" is enabled in the Schema Configuration).
+Several `extensions` fields expose property `isAdminElement`, to identify which are the "admin" elements from the schema (i.e. elements which can only be accessed when "Expose admin elements" is enabled in the Schema Configuration).
 
-To do so, execute this query:
+To retrieve this data, execute this query:
 
 ```graphql
-query GetIntrospectionExtensions {
+query ViewAdminElements {
   __schema {
     types {
       name
-      extensions
-      fields(includeDeprecated: true) {
+      fields {
         name
-        extensions
+        extensions {
+          isAdminElement
+        }
         args {
           name
-          extensions
+          extensions {
+            isAdminElement
+          }
         }
       }
       inputFields {
         name
-        extensions
+        extensions {
+          isAdminElement
+        }
       }
-      enumValues(includeDeprecated: true) {
+      enumValues {
         name
-        extensions
+        extensions {
+          isAdminElement
+        }
       }
     }
   }
 }
 ```
 
-And then search for entries `isAdminElement: true` in the results.
+And then search for entries with `"isAdminElement": true` in the results.
 
 ## Performance improvement: Avoid regenerating the container when the schema is modified
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -922,24 +922,24 @@ The schema elements which can be added custom metadata via extensions are the fo
 The introspection elements of the schema have been upgraded with the new field:
 
 ```graphql
-type __Type {
+extend type __Type {
   # Non-null for named types, null for wrapping types (Non-Null and List)
   extensions: JSONObject
 }
 
-type __Directive {
+extend type __Directive {
   extensions: JSONObject!
 }
 
-type __Field {
+extend type __Field {
   extensions: JSONObject!
 }
 
-type __InputValue {
+extend type __InputValue {
   extensions: JSONObject!
 }
 
-type __EnumValue {
+extend type __EnumValue {
   extensions: JSONObject!
 }
 ```

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -914,18 +914,13 @@ Custom metadata attached to schema elements can now be queried via field `extens
 All introspection elements of the schema have been upgraded with the new field, each of them returning an object of a corresponding "`Extensions`" type, which exposes the custom properties for that element.
 
 ```graphql
-extend type __Schema {
-  extensions: SchemaExtensions!
-}
-
 type SchemaExtensions {
   # Is the schema being namespaced?
   isNamespaced: Boolean!
 }
 
-extend type __Type {
-  # Non-null for named types, null for wrapping types (Non-Null and List)
-  extensions: NamedTypeExtensions
+extend type __Schema {
+  extensions: SchemaExtensions!
 }
 
 type NamedTypeExtensions {
@@ -936,8 +931,9 @@ type NamedTypeExtensions {
   namespacedName: String!
 }
 
-extend type __Directive {
-  extensions: DirectiveExtensions!
+extend type __Type {
+  # Non-null for named types, null for wrapping types (Non-Null and List)
+  extensions: NamedTypeExtensions
 }
 
 type DirectiveExtensions {
@@ -945,8 +941,8 @@ type DirectiveExtensions {
   needsDataToExecute: Boolean!
 }
 
-extend type __Field {
-  extensions: FieldExtensions!
+extend type __Directive {
+  extensions: DirectiveExtensions!
 }
 
 type FieldExtensions {
@@ -957,20 +953,24 @@ type FieldExtensions {
   isAdminElement: Boolean!
 }
 
-extend type __InputValue {
-  extensions: InputValueExtensions!
+extend type __Field {
+  extensions: FieldExtensions!
 }
 
 type InputValueExtensions {
   isAdminElement: Boolean!
 }
 
-extend type __EnumValue {
-  extensions: EnumValueExtensions!
+extend type __InputValue {
+  extensions: InputValueExtensions!
 }
 
 type EnumValueExtensions {
   isAdminElement: Boolean!
+}
+
+extend type __EnumValue {
+  extensions: EnumValueExtensions!
 }
 ```
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\DirectiveExtensions;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveExtensionsObjectTypeResolver;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
+
+class DirectiveExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+
+    final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
+    {
+        $this->stringScalarTypeResolver = $stringScalarTypeResolver;
+    }
+    final protected function getStringScalarTypeResolver(): StringScalarTypeResolver
+    {
+        return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
+    }
+
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            DirectiveExtensionsObjectTypeResolver::class,
+        ];
+    }
+
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'version',
+        ];
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'version' => $this->getTranslationAPI()->__('The version of the directive, if any', 'graphql-server'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
+     * @param array<string, mixed>|null $variables
+     * @param array<string, mixed>|null $expressions
+     * @param array<string, mixed> $options
+     */
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        string $fieldName,
+        array $fieldArgs,
+        ?array $variables = null,
+        ?array $expressions = null,
+        array $options = []
+    ): mixed {
+        /** @var DirectiveExtensions */
+        $directiveExtensions = $object;
+        return match ($fieldName) {
+            'version' => $directiveExtensions->getVersion(),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            'version' => $this->getStringScalarTypeResolver(),
+            default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
@@ -6,6 +6,7 @@ namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
 use GraphQLByPoP\GraphQLServer\ObjectModels\Directive;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumType\DirectiveLocationEnumTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -14,7 +15,6 @@ use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
-use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\JSONObjectScalarTypeResolver;
 
 class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
@@ -22,7 +22,7 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
     private ?InputValueObjectTypeResolver $inputValueObjectTypeResolver = null;
     private ?DirectiveLocationEnumTypeResolver $directiveLocationEnumTypeResolver = null;
-    private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
+    private ?DirectiveExtensionsObjectTypeResolver $directiveExtensionsObjectTypeResolver = null;
 
     final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
     {
@@ -56,13 +56,13 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return $this->directiveLocationEnumTypeResolver ??= $this->instanceManager->getInstance(DirectiveLocationEnumTypeResolver::class);
     }
-    final public function setJSONObjectScalarTypeResolver(JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver): void
+    final public function setDirectiveExtensionsObjectTypeResolver(DirectiveExtensionsObjectTypeResolver $directiveExtensionsObjectTypeResolver): void
     {
-        $this->jsonObjectScalarTypeResolver = $jsonObjectScalarTypeResolver;
+        $this->directiveExtensionsObjectTypeResolver = $directiveExtensionsObjectTypeResolver;
     }
-    final protected function getJSONObjectScalarTypeResolver(): JSONObjectScalarTypeResolver
+    final protected function getDirectiveExtensionsObjectTypeResolver(): DirectiveExtensionsObjectTypeResolver
     {
-        return $this->jsonObjectScalarTypeResolver ??= $this->instanceManager->getInstance(JSONObjectScalarTypeResolver::class);
+        return $this->directiveExtensionsObjectTypeResolver ??= $this->instanceManager->getInstance(DirectiveExtensionsObjectTypeResolver::class);
     }
 
     public function getObjectTypeResolverClassesToAttachTo(): array
@@ -92,7 +92,7 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'isRepeatable' => $this->getBooleanScalarTypeResolver(),
             'args' => $this->getInputValueObjectTypeResolver(),
             'locations' => $this->getDirectiveLocationEnumTypeResolver(),
-            'extensions' => $this->getJSONObjectScalarTypeResolver(),
+            'extensions' => $this->getDirectiveExtensionsObjectTypeResolver(),
             default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
         };
     }
@@ -120,7 +120,7 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'args' => $this->getTranslationAPI()->__('Directive\'s arguments', 'graphql-server'),
             'locations' => $this->getTranslationAPI()->__('The locations where the directive may be placed', 'graphql-server'),
             'isRepeatable' => $this->getTranslationAPI()->__('Can the directive be executed more than once in the same field?', 'graphql-server'),
-            'extensions' => $this->getTranslationAPI()->__('Custom metadata added to the directive (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
+            'extensions' => $this->getTranslationAPI()->__('Extensions (custom metadata) added to the directive (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -154,7 +154,7 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             case 'isRepeatable':
                 return $directive->isRepeatable();
             case 'extensions':
-                return (object) $directive->getExtensions();
+                return $directive->getExtensions()->getID();
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\EnumValueExtensions;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\EnumValueExtensionsObjectTypeResolver;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+
+class EnumValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+
+    final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
+    {
+        $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+    }
+
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            EnumValueExtensionsObjectTypeResolver::class,
+        ];
+    }
+
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'isAdminElement',
+        ];
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'isAdminElement' => $this->getTranslationAPI()->__('Is this element considered an \'admin\' element in the schema? (If so, it is only exposed in the schema when \'Expose admin elements\' is enabled)', 'graphql-server'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        return match ($fieldName) {
+            'isAdminElement' => SchemaTypeModifiers::NON_NULLABLE,
+            default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
+     * @param array<string, mixed>|null $variables
+     * @param array<string, mixed>|null $expressions
+     * @param array<string, mixed> $options
+     */
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        string $fieldName,
+        array $fieldArgs,
+        ?array $variables = null,
+        ?array $expressions = null,
+        array $options = []
+    ): mixed {
+        /** @var EnumValueExtensions */
+        $enumValueExtensions = $object;
+        return match ($fieldName) {
+            'isAdminElement' => $enumValueExtensions->isAdminElement(),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            'isAdminElement' => $this->getBooleanScalarTypeResolver(),
+            default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
@@ -92,7 +92,7 @@ class DirectiveSchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         /** @var Directive */
         $directive = $object;
         return match ($fieldName) {
-            'kind' => ($directive->getExtensions())[SchemaDefinition::DIRECTIVE_KIND],
+            'kind' => $directive->getKind(),
             default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
         };
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\FieldExtensions;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\FieldExtensionsObjectTypeResolver;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+
+class FieldExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+
+    final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
+    {
+        $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+    }
+
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            FieldExtensionsObjectTypeResolver::class,
+        ];
+    }
+
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'isMutation',
+            'isAdminElement',
+        ];
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'isMutation' => $this->getTranslationAPI()->__('Is this a mutation field? Particularly required when doing \'nested mutations\' (where mutation fields can be present on any type, not only on `MutationRoot`)', 'graphql-server'),
+            'isAdminElement' => $this->getTranslationAPI()->__('Is this element considered an \'admin\' element in the schema? (If so, it is only exposed in the schema when \'Expose admin elements\' is enabled)', 'graphql-server'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        return match ($fieldName) {
+            'isMutation',
+            'isAdminElement'
+                => SchemaTypeModifiers::NON_NULLABLE,
+            default
+                => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
+     * @param array<string, mixed>|null $variables
+     * @param array<string, mixed>|null $expressions
+     * @param array<string, mixed> $options
+     */
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        string $fieldName,
+        array $fieldArgs,
+        ?array $variables = null,
+        ?array $expressions = null,
+        array $options = []
+    ): mixed {
+        /** @var FieldExtensions */
+        $fieldExtensions = $object;
+        return match ($fieldName) {
+            'isMutation' => $fieldExtensions->isMutation(),
+            'isAdminElement' => $fieldExtensions->isAdminElement(),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            'isMutation',
+            'isAdminElement'
+                => $this->getBooleanScalarTypeResolver(),
+            default
+                => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
 use GraphQLByPoP\GraphQLServer\ObjectModels\Field;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\FieldExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\FieldObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\TypeObjectTypeResolver;
@@ -14,13 +15,12 @@ use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
-use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\JSONObjectScalarTypeResolver;
 
 class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
-    private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
+    private ?FieldExtensionsObjectTypeResolver $fieldExtensionsObjectTypeResolver = null;
     private ?InputValueObjectTypeResolver $inputValueObjectTypeResolver = null;
     private ?TypeObjectTypeResolver $typeObjectTypeResolver = null;
 
@@ -40,13 +40,13 @@ class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
     }
-    final public function setJSONObjectScalarTypeResolver(JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver): void
+    final public function setFieldExtensionsObjectTypeResolver(FieldExtensionsObjectTypeResolver $fieldExtensionsObjectTypeResolver): void
     {
-        $this->jsonObjectScalarTypeResolver = $jsonObjectScalarTypeResolver;
+        $this->fieldExtensionsObjectTypeResolver = $fieldExtensionsObjectTypeResolver;
     }
-    final protected function getJSONObjectScalarTypeResolver(): JSONObjectScalarTypeResolver
+    final protected function getFieldExtensionsObjectTypeResolver(): FieldExtensionsObjectTypeResolver
     {
-        return $this->jsonObjectScalarTypeResolver ??= $this->instanceManager->getInstance(JSONObjectScalarTypeResolver::class);
+        return $this->fieldExtensionsObjectTypeResolver ??= $this->instanceManager->getInstance(FieldExtensionsObjectTypeResolver::class);
     }
     final public function setInputValueObjectTypeResolver(InputValueObjectTypeResolver $inputValueObjectTypeResolver): void
     {
@@ -92,7 +92,7 @@ class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'description' => $this->getStringScalarTypeResolver(),
             'isDeprecated' => $this->getBooleanScalarTypeResolver(),
             'deprecationReason' => $this->getStringScalarTypeResolver(),
-            'extensions' => $this->getJSONObjectScalarTypeResolver(),
+            'extensions' => $this->getFieldExtensionsObjectTypeResolver(),
             'args' => $this->getInputValueObjectTypeResolver(),
             'type' => $this->getTypeObjectTypeResolver(),
             default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
@@ -123,7 +123,7 @@ class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'type' => $this->getTranslationAPI()->__('Type to which the field belongs', 'graphql-server'),
             'isDeprecated' => $this->getTranslationAPI()->__('Is the field deprecated?', 'graphql-server'),
             'deprecationReason' => $this->getTranslationAPI()->__('Why was the field deprecated?', 'graphql-server'),
-            'extensions' => $this->getTranslationAPI()->__('Custom metadata added to the field (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
+            'extensions' => $this->getTranslationAPI()->__('Extensions (custom metadata) added to the field (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -159,7 +159,7 @@ class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             case 'deprecationReason':
                 return $field->getDeprecationMessage();
             case 'extensions':
-                return (object) $field->getExtensions();
+                return $field->getExtensions()->getID();
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\InputValueExtensions;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueExtensionsObjectTypeResolver;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+
+class InputValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+
+    final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
+    {
+        $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+    }
+
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            InputValueExtensionsObjectTypeResolver::class,
+        ];
+    }
+
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'isAdminElement',
+        ];
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'isAdminElement' => $this->getTranslationAPI()->__('Is this element considered an \'admin\' element in the schema? (If so, it is only exposed in the schema when \'Expose admin elements\' is enabled)', 'graphql-server'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        return match ($fieldName) {
+            'isAdminElement' => SchemaTypeModifiers::NON_NULLABLE,
+            default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
+     * @param array<string, mixed>|null $variables
+     * @param array<string, mixed>|null $expressions
+     * @param array<string, mixed> $options
+     */
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        string $fieldName,
+        array $fieldArgs,
+        ?array $variables = null,
+        ?array $expressions = null,
+        array $options = []
+    ): mixed {
+        /** @var InputValueExtensions */
+        $inputValueExtensions = $object;
+        return match ($fieldName) {
+            'isAdminElement' => $inputValueExtensions->isAdminElement(),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            'isAdminElement' => $this->getBooleanScalarTypeResolver(),
+            default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
 use GraphQLByPoP\GraphQLServer\ObjectModels\InputValue;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\TypeObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -12,13 +13,12 @@ use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
-use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\JSONObjectScalarTypeResolver;
 
 class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
     private ?TypeObjectTypeResolver $typeObjectTypeResolver = null;
-    private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
+    private ?InputValueExtensionsObjectTypeResolver $inputValueExtensionsObjectTypeResolver = null;
 
     final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
     {
@@ -36,13 +36,13 @@ class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return $this->typeObjectTypeResolver ??= $this->instanceManager->getInstance(TypeObjectTypeResolver::class);
     }
-    final public function setJSONObjectScalarTypeResolver(JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver): void
+    final public function setInputValueExtensionsObjectTypeResolver(InputValueExtensionsObjectTypeResolver $inputValueExtensionsObjectTypeResolver): void
     {
-        $this->jsonObjectScalarTypeResolver = $jsonObjectScalarTypeResolver;
+        $this->inputValueExtensionsObjectTypeResolver = $inputValueExtensionsObjectTypeResolver;
     }
-    final protected function getJSONObjectScalarTypeResolver(): JSONObjectScalarTypeResolver
+    final protected function getInputValueExtensionsObjectTypeResolver(): InputValueExtensionsObjectTypeResolver
     {
-        return $this->jsonObjectScalarTypeResolver ??= $this->instanceManager->getInstance(JSONObjectScalarTypeResolver::class);
+        return $this->inputValueExtensionsObjectTypeResolver ??= $this->instanceManager->getInstance(InputValueExtensionsObjectTypeResolver::class);
     }
 
     public function getObjectTypeResolverClassesToAttachTo(): array
@@ -70,7 +70,7 @@ class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'description' => $this->getStringScalarTypeResolver(),
             'defaultValue' => $this->getStringScalarTypeResolver(),
             'type' => $this->getTypeObjectTypeResolver(),
-            'extensions' => $this->getJSONObjectScalarTypeResolver(),
+            'extensions' => $this->getInputValueExtensionsObjectTypeResolver(),
             default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
         };
     }
@@ -94,7 +94,7 @@ class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'description' => $this->getTranslationAPI()->__('Input value\'s description', 'graphql-server'),
             'type' => $this->getTranslationAPI()->__('Type of the input value', 'graphql-server'),
             'defaultValue' => $this->getTranslationAPI()->__('Default value of the input value', 'graphql-server'),
-            'extensions' => $this->getTranslationAPI()->__('Custom metadata added to the input (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
+            'extensions' => $this->getTranslationAPI()->__('Extensions (custom metadata) added to the input (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -126,7 +126,7 @@ class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             case 'defaultValue':
                 return $inputValue->getDefaultValue();
             case 'extensions':
-                return (object) $inputValue->getExtensions();
+                return $inputValue->getExtensions()->getID();
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\NamedTypeExtensions;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\NamedTypeExtensionsObjectTypeResolver;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
+
+class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+
+    final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
+    {
+        $this->stringScalarTypeResolver = $stringScalarTypeResolver;
+    }
+    final protected function getStringScalarTypeResolver(): StringScalarTypeResolver
+    {
+        return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
+    }
+
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            NamedTypeExtensionsObjectTypeResolver::class,
+        ];
+    }
+
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'elementName',
+            'namespacedName',
+        ];
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        return match ($fieldName) {
+            'elementName',
+            'namespacedName'
+                => SchemaTypeModifiers::NON_NULLABLE,
+            default
+                => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'elementName' => $this->getTranslationAPI()->__('The type\'s non-namespaced name', 'graphql-server'),
+            'namespacedName' => $this->getTranslationAPI()->__('The type\'s namespaced name', 'graphql-server'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
+     * @param array<string, mixed>|null $variables
+     * @param array<string, mixed>|null $expressions
+     * @param array<string, mixed> $options
+     */
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        string $fieldName,
+        array $fieldArgs,
+        ?array $variables = null,
+        ?array $expressions = null,
+        array $options = []
+    ): mixed {
+        /** @var NamedTypeExtensions */
+        $namedTypeExtensions = $object;
+        return match ($fieldName) {
+            'elementName' => $namedTypeExtensions->getTypeElementName(),
+            'namespacedName' => $namedTypeExtensions->getTypeNamespacedName(),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            'elementName',
+            'namespacedName'
+                => $this->getStringScalarTypeResolver(),
+            default
+                => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\SchemaExtensions;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\SchemaExtensionsObjectTypeResolver;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+
+class SchemaExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+
+    final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
+    {
+        $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+    }
+
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            SchemaExtensionsObjectTypeResolver::class,
+        ];
+    }
+
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'isNamespaced',
+        ];
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        return match ($fieldName) {
+            'isNamespaced' => SchemaTypeModifiers::NON_NULLABLE,
+            default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'isNamespaced' => $this->getTranslationAPI()->__('Is the schema namespaced?', 'graphql-server'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $fieldArgs
+     * @param array<string, mixed>|null $variables
+     * @param array<string, mixed>|null $expressions
+     * @param array<string, mixed> $options
+     */
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        string $fieldName,
+        array $fieldArgs,
+        ?array $variables = null,
+        ?array $expressions = null,
+        array $options = []
+    ): mixed {
+        /** @var SchemaExtensions */
+        $schemaExtensions = $object;
+        return match ($fieldName) {
+            'isNamespaced' => $schemaExtensions->isSchemaNamespaced(),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            'isNamespaced' => $this->getBooleanScalarTypeResolver(),
+            default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
@@ -6,6 +6,7 @@ namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
 use GraphQLByPoP\GraphQLServer\ObjectModels\Schema;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveObjectTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\SchemaExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\SchemaObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\TypeObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -18,6 +19,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?TypeObjectTypeResolver $typeObjectTypeResolver = null;
     private ?DirectiveObjectTypeResolver $directiveObjectTypeResolver = null;
+    private ?SchemaExtensionsObjectTypeResolver $schemaExtensionsObjectTypeResolver = null;
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
 
     final public function setTypeObjectTypeResolver(TypeObjectTypeResolver $typeObjectTypeResolver): void
@@ -35,6 +37,14 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     final protected function getDirectiveObjectTypeResolver(): DirectiveObjectTypeResolver
     {
         return $this->directiveObjectTypeResolver ??= $this->instanceManager->getInstance(DirectiveObjectTypeResolver::class);
+    }
+    final public function setSchemaExtensionsObjectTypeResolver(SchemaExtensionsObjectTypeResolver $schemaExtensionsObjectTypeResolver): void
+    {
+        $this->schemaExtensionsObjectTypeResolver = $schemaExtensionsObjectTypeResolver;
+    }
+    final protected function getSchemaExtensionsObjectTypeResolver(): SchemaExtensionsObjectTypeResolver
+    {
+        return $this->schemaExtensionsObjectTypeResolver ??= $this->instanceManager->getInstance(SchemaExtensionsObjectTypeResolver::class);
     }
     final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
     {
@@ -61,13 +71,15 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'types',
             'directives',
             'type',
+            'extensions',
         ];
     }
 
     public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
     {
         return match ($fieldName) {
-            'queryType'
+            'queryType',
+            'extensions'
                 => SchemaTypeModifiers::NON_NULLABLE,
             'types',
             'directives'
@@ -86,6 +98,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'types' => $this->getTranslationAPI()->__('All types registered in the data graph', 'graphql-server'),
             'directives' => $this->getTranslationAPI()->__('All directives registered in the data graph', 'graphql-server'),
             'type' => $this->getTranslationAPI()->__('Obtain a specific type from the schema', 'graphql-server'),
+            'extensions' => $this->getTranslationAPI()->__('Extensions (custom metadata) for the Schema type', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -140,6 +153,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'types' => $schema->getTypeIDs(),
             'directives' => $schema->getDirectiveIDs(),
             'type' => $schema->getTypeID($fieldArgs['name']),
+            'extensions' => $schema->getSchemaExtensions()->getID(),
             default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
         };
     }
@@ -155,6 +169,8 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 => $this->getTypeObjectTypeResolver(),
             'directives'
                 => $this->getDirectiveObjectTypeResolver(),
+            'extensions'
+                => $this->getSchemaExtensionsObjectTypeResolver(),
             default
                 => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
         };

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
@@ -153,7 +153,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'types' => $schema->getTypeIDs(),
             'directives' => $schema->getDirectiveIDs(),
             'type' => $schema->getTypeID($fieldArgs['name']),
-            'extensions' => $schema->getSchemaExtensions()->getID(),
+            'extensions' => $schema->getExtensions()->getID(),
             default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
         };
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
@@ -98,7 +98,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'types' => $this->getTranslationAPI()->__('All types registered in the data graph', 'graphql-server'),
             'directives' => $this->getTranslationAPI()->__('All directives registered in the data graph', 'graphql-server'),
             'type' => $this->getTranslationAPI()->__('Obtain a specific type from the schema', 'graphql-server'),
-            'extensions' => $this->getTranslationAPI()->__('Extensions (custom metadata) for the Schema type', 'graphql-server'),
+            'extensions' => $this->getTranslationAPI()->__('Extensions (custom metadata) added to the GraphQL schema', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
@@ -290,6 +290,7 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 // @see https://github.com/graphql/graphql-spec/issues/300
                 // Implementation based on the one by GraphQL Java
                 // @see https://github.com/graphql-java/graphql-java/pull/2221
+                // Non-null for named types, null for wrapping types (Non-Null and List)
                 if ($type instanceof NamedTypeInterface) {
                     return $type->getExtensions()->getID();
                 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
@@ -10,13 +10,14 @@ use GraphQLByPoP\GraphQLServer\ObjectModels\HasInterfacesTypeInterface;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasPossibleTypesTypeInterface;
 use GraphQLByPoP\GraphQLServer\ObjectModels\InputObjectType;
 use GraphQLByPoP\GraphQLServer\ObjectModels\NamedTypeInterface;
-use GraphQLByPoP\GraphQLServer\ObjectModels\WrappingTypeInterface;
 use GraphQLByPoP\GraphQLServer\ObjectModels\ScalarType;
 use GraphQLByPoP\GraphQLServer\ObjectModels\TypeInterface;
+use GraphQLByPoP\GraphQLServer\ObjectModels\WrappingTypeInterface;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumType\TypeKindEnumTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\EnumValueObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\FieldObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueObjectTypeResolver;
+use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\NamedTypeExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\TypeObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -24,13 +25,12 @@ use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
-use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\JSONObjectScalarTypeResolver;
 
 class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
     private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
-    private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
+    private ?NamedTypeExtensionsObjectTypeResolver $namedTypeExtensionsObjectTypeResolver = null;
     private ?FieldObjectTypeResolver $fieldObjectTypeResolver = null;
     private ?TypeObjectTypeResolver $typeObjectTypeResolver = null;
     private ?EnumValueObjectTypeResolver $enumValueObjectTypeResolver = null;
@@ -53,13 +53,13 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
     }
-    final public function setJSONObjectScalarTypeResolver(JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver): void
+    final public function setNamedTypeExtensionsObjectTypeResolver(NamedTypeExtensionsObjectTypeResolver $namedTypeExtensionsObjectTypeResolver): void
     {
-        $this->jsonObjectScalarTypeResolver = $jsonObjectScalarTypeResolver;
+        $this->namedTypeExtensionsObjectTypeResolver = $namedTypeExtensionsObjectTypeResolver;
     }
-    final protected function getJSONObjectScalarTypeResolver(): JSONObjectScalarTypeResolver
+    final protected function getNamedTypeExtensionsObjectTypeResolver(): NamedTypeExtensionsObjectTypeResolver
     {
-        return $this->jsonObjectScalarTypeResolver ??= $this->instanceManager->getInstance(JSONObjectScalarTypeResolver::class);
+        return $this->namedTypeExtensionsObjectTypeResolver ??= $this->instanceManager->getInstance(NamedTypeExtensionsObjectTypeResolver::class);
     }
     final public function setFieldObjectTypeResolver(FieldObjectTypeResolver $fieldObjectTypeResolver): void
     {
@@ -134,7 +134,7 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'specifiedByURL'
                 => $this->getStringScalarTypeResolver(),
             'extensions'
-                => $this->getJSONObjectScalarTypeResolver(),
+                => $this->getNamedTypeExtensionsObjectTypeResolver(),
             'fields'
                 => $this->getFieldObjectTypeResolver(),
             'interfaces',
@@ -180,7 +180,7 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'inputFields' => $this->getTranslationAPI()->__('Type\'s input Fields (available for InputObject type only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-HAJbLAuDABCBIu9N)', 'graphql-server'),
             'ofType' => $this->getTranslationAPI()->__('The type of the nested type (available for NonNull and List types only) as defined by the GraphQL spec (https://graphql.github.io/graphql-spec/draft/#sel-HAJbLA4DABCBIu9N)', 'graphql-server'),
             'specifiedByURL' => $this->getTranslationAPI()->__('A scalar specification URL (a String (in the form of a URL) for custom scalars, otherwise must be null) as defined by the GraphQL spec (https://spec.graphql.org/draft/#sel-IAJXNFA0EABABL9N)', 'graphql-server'),
-            'extensions' => $this->getTranslationAPI()->__('Custom metadata added to the field (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
+            'extensions' => $this->getTranslationAPI()->__('Extensions (custom metadata) added to the GraphQL type (for all \'named\' types: Object, Interface, Union, Scalar, Enum and InputObject) (see: https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306 and below comments, and https://github.com/graphql/graphql-js/issues/1527)', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -288,7 +288,7 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             case 'extensions':
                 // Custom development: this field is not in GraphQL spec yet!
                 if ($type instanceof NamedTypeInterface) {
-                    return (object) $type->getExtensions();
+                    return $type->getExtensions()->getID();
                 }
                 return null;
         }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
@@ -287,6 +287,9 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return null;
             case 'extensions':
                 // Custom development: this field is not in GraphQL spec yet!
+                // @see https://github.com/graphql/graphql-spec/issues/300
+                // Implementation based on the one by GraphQL Java
+                // @see https://github.com/graphql-java/graphql-java/pull/2221
                 if ($type instanceof NamedTypeInterface) {
                     return $type->getExtensions()->getID();
                 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractNamedType.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/AbstractNamedType.php
@@ -8,6 +8,21 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 
 abstract class AbstractNamedType extends AbstractSchemaDefinitionReferenceObject implements NamedTypeInterface
 {
+    protected NamedTypeExtensions $namedTypeExtensions;
+
+    public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath)
+    {
+        parent::__construct($fullSchemaDefinition, $schemaDefinitionPath);
+
+        $namedTypeExtensionsSchemaDefinitionPath = array_merge(
+            $schemaDefinitionPath,
+            [
+                SchemaDefinition::EXTENSIONS,
+            ]
+        );
+        $this->namedTypeExtensions = new NamedTypeExtensions($fullSchemaDefinition, $namedTypeExtensionsSchemaDefinitionPath);
+    }
+
     public function getNamespacedName(): string
     {
         return $this->schemaDefinition[SchemaDefinition::NAMESPACED_NAME];
@@ -28,9 +43,8 @@ abstract class AbstractNamedType extends AbstractSchemaDefinitionReferenceObject
         return $this->schemaDefinition[SchemaDefinition::DESCRIPTION] ?? null;
     }
 
-    public function getExtensions(): array
+    public function getExtensions(): NamedTypeExtensions
     {
-        $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
-        return $extensions;
+        return $this->namedTypeExtensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Directive.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Directive.php
@@ -13,9 +13,19 @@ class Directive extends AbstractSchemaDefinitionReferenceObject
 {
     use HasArgsSchemaDefinitionReferenceTrait;
 
+    protected DirectiveExtensions $directiveExtensions;
+
     public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath)
     {
         parent::__construct($fullSchemaDefinition, $schemaDefinitionPath);
+
+        $directiveExtensionsSchemaDefinitionPath = array_merge(
+            $schemaDefinitionPath,
+            [
+                SchemaDefinition::EXTENSIONS,
+            ]
+        );
+        $this->directiveExtensions = new DirectiveExtensions($fullSchemaDefinition, $directiveExtensionsSchemaDefinitionPath);
 
         $this->initArgs($fullSchemaDefinition, $schemaDefinitionPath);
     }
@@ -72,13 +82,13 @@ class Directive extends AbstractSchemaDefinitionReferenceObject
         return $this->schemaDefinition[SchemaDefinition::DIRECTIVE_IS_REPEATABLE];
     }
 
-    public function getExtensions(): array
+    public function getKind(): string
     {
-        $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
-        if ($version = $this->schemaDefinition[SchemaDefinition::VERSION] ?? null) {
-            $extensions[SchemaDefinition::VERSION] = $version;
-        }
-        $extensions[SchemaDefinition::DIRECTIVE_KIND] = $this->schemaDefinition[SchemaDefinition::DIRECTIVE_KIND];
-        return $extensions;
+        return $this->schemaDefinition[SchemaDefinition::DIRECTIVE_KIND];
+    }
+
+    public function getExtensions(): DirectiveExtensions
+    {
+        return $this->directiveExtensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/DirectiveExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/DirectiveExtensions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\ObjectModels;
+
+use PoP\ComponentModel\Schema\SchemaDefinition;
+
+class DirectiveExtensions extends AbstractSchemaDefinitionReferenceObject
+{
+    public function getVersion(): ?string
+    {
+        return $this->schemaDefinition[SchemaDefinition::VERSION] ?? null;
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/DirectiveExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/DirectiveExtensions.php
@@ -8,8 +8,8 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 
 class DirectiveExtensions extends AbstractSchemaDefinitionReferenceObject
 {
-    public function getVersion(): ?string
+    public function needsDataToExecute(): bool
     {
-        return $this->schemaDefinition[SchemaDefinition::VERSION] ?? null;
+        return $this->schemaDefinition[SchemaDefinition::DIRECTIVE_NEEDS_DATA_TO_EXECUTE];
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumType.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumType.php
@@ -22,20 +22,19 @@ class EnumType extends AbstractNamedType
     protected function initEnumValues(array &$fullSchemaDefinition, array $schemaDefinitionPath): void
     {
         $this->enumValues = [];
-        if ($enumItems = $this->schemaDefinition[SchemaDefinition::ITEMS] ?? null) {
-            foreach (array_keys($enumItems) as $enumValue) {
-                $enumValueSchemaDefinitionPath = array_merge(
-                    $schemaDefinitionPath,
-                    [
-                        SchemaDefinition::ITEMS,
-                        $enumValue,
-                    ]
-                );
-                $this->enumValues[] = new EnumValue(
-                    $fullSchemaDefinition,
-                    $enumValueSchemaDefinitionPath
-                );
-            }
+        $enumItems = $this->schemaDefinition[SchemaDefinition::ITEMS];
+        foreach (array_keys($enumItems) as $enumValue) {
+            $enumValueSchemaDefinitionPath = array_merge(
+                $schemaDefinitionPath,
+                [
+                    SchemaDefinition::ITEMS,
+                    $enumValue,
+                ]
+            );
+            $this->enumValues[] = new EnumValue(
+                $fullSchemaDefinition,
+                $enumValueSchemaDefinitionPath
+            );
         }
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumValue.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumValue.php
@@ -8,6 +8,21 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 
 class EnumValue extends AbstractSchemaDefinitionReferenceObject
 {
+    protected EnumValueExtensions $enumValueExtensions;
+
+    public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath)
+    {
+        parent::__construct($fullSchemaDefinition, $schemaDefinitionPath);
+
+        $enumValueExtensionsSchemaDefinitionPath = array_merge(
+            $schemaDefinitionPath,
+            [
+                SchemaDefinition::EXTENSIONS,
+            ]
+        );
+        $this->enumValueExtensions = new EnumValueExtensions($fullSchemaDefinition, $enumValueExtensionsSchemaDefinitionPath);
+    }
+
     public function getName(): string
     {
         return $this->getValue();
@@ -28,12 +43,8 @@ class EnumValue extends AbstractSchemaDefinitionReferenceObject
     {
         return $this->schemaDefinition[SchemaDefinition::DEPRECATION_MESSAGE] ?? null;
     }
-    public function getExtensions(): array
+    public function getExtensions(): EnumValueExtensions
     {
-        $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
-        if ($this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] ?? null) {
-            $extensions[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-        }
-        return $extensions;
+        return $this->enumValueExtensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumValueExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/EnumValueExtensions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\ObjectModels;
+
+use PoP\ComponentModel\Schema\SchemaDefinition;
+
+class EnumValueExtensions extends AbstractSchemaDefinitionReferenceObject
+{
+    public function isAdminElement(): bool
+    {
+        return $this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT];
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Field.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Field.php
@@ -8,12 +8,22 @@ use PoP\API\Schema\SchemaDefinition;
 
 class Field extends AbstractSchemaDefinitionReferenceObject
 {
+    protected FieldExtensions $fieldExtensions;
+
     use HasTypeSchemaDefinitionReferenceTrait;
     use HasArgsSchemaDefinitionReferenceTrait;
 
     public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath)
     {
         parent::__construct($fullSchemaDefinition, $schemaDefinitionPath);
+
+        $fieldExtensionsSchemaDefinitionPath = array_merge(
+            $schemaDefinitionPath,
+            [
+                SchemaDefinition::EXTENSIONS,
+            ]
+        );
+        $this->fieldExtensions = new FieldExtensions($fullSchemaDefinition, $fieldExtensionsSchemaDefinitionPath);
 
         $this->initArgs($fullSchemaDefinition, $schemaDefinitionPath);
     }
@@ -33,18 +43,8 @@ class Field extends AbstractSchemaDefinitionReferenceObject
     {
         return $this->schemaDefinition[SchemaDefinition::DEPRECATION_MESSAGE] ?? null;
     }
-    public function getExtensions(): array
+    public function getExtensions(): FieldExtensions
     {
-        $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
-        if ($version = $this->schemaDefinition[SchemaDefinition::VERSION] ?? null) {
-            $extensions[SchemaDefinition::VERSION] = $version;
-        }
-        if ($this->schemaDefinition[SchemaDefinition::FIELD_IS_MUTATION] ?? null) {
-            $extensions[SchemaDefinition::FIELD_IS_MUTATION] = true;
-        }
-        if ($this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] ?? null) {
-            $extensions[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-        }
-        return $extensions;
+        return $this->fieldExtensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/FieldExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/FieldExtensions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\ObjectModels;
+
+use PoP\ComponentModel\Schema\SchemaDefinition;
+
+class FieldExtensions extends AbstractSchemaDefinitionReferenceObject
+{
+    public function isMutation(): bool
+    {
+        return $this->schemaDefinition[SchemaDefinition::FIELD_IS_MUTATION];
+    }
+
+    public function isAdminElement(): bool
+    {
+        return $this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT];
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValue.php
@@ -8,7 +8,22 @@ use PoP\ComponentModel\Schema\SchemaDefinition;
 
 class InputValue extends AbstractSchemaDefinitionReferenceObject
 {
+    protected InputValueExtensions $inputValueExtensions;
+
     use HasTypeSchemaDefinitionReferenceTrait;
+
+    public function __construct(array &$fullSchemaDefinition, array $schemaDefinitionPath)
+    {
+        parent::__construct($fullSchemaDefinition, $schemaDefinitionPath);
+
+        $inputValueExtensionsSchemaDefinitionPath = array_merge(
+            $schemaDefinitionPath,
+            [
+                SchemaDefinition::EXTENSIONS,
+            ]
+        );
+        $this->inputValueExtensions = new InputValueExtensions($fullSchemaDefinition, $inputValueExtensionsSchemaDefinitionPath);
+    }
 
     public function getName(): string
     {
@@ -39,12 +54,8 @@ class InputValue extends AbstractSchemaDefinitionReferenceObject
         return null;
     }
 
-    public function getExtensions(): array
+    public function getExtensions(): InputValueExtensions
     {
-        $extensions = $this->schemaDefinition[SchemaDefinition::EXTENSIONS] ?? [];
-        if ($this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT] ?? null) {
-            $extensions[SchemaDefinition::IS_ADMIN_ELEMENT] = true;
-        }
-        return $extensions;
+        return $this->inputValueExtensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValueExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/InputValueExtensions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\ObjectModels;
+
+use PoP\ComponentModel\Schema\SchemaDefinition;
+
+class InputValueExtensions extends AbstractSchemaDefinitionReferenceObject
+{
+    public function isAdminElement(): bool
+    {
+        return $this->schemaDefinition[SchemaDefinition::IS_ADMIN_ELEMENT];
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeExtensions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\ObjectModels;
+
+use PoP\ComponentModel\Schema\SchemaDefinition;
+
+class NamedTypeExtensions extends AbstractSchemaDefinitionReferenceObject
+{
+    public function getTypeElementName(): string
+    {
+        return $this->schemaDefinition[SchemaDefinition::ELEMENT_NAME];
+    }
+
+    public function getTypeNamespacedName(): string
+    {
+        return $this->schemaDefinition[SchemaDefinition::NAMESPACED_NAME];
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeInterface.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeInterface.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\ObjectModels;
 
+use GraphQLByPoP\GraphQLServer\ObjectModels\NamedTypeExtensions;
+
 interface NamedTypeInterface extends TypeInterface, SchemaDefinitionReferenceObjectInterface
 {
     public function getNamespacedName(): string;
 
     public function getElementName(): string;
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getExtensions(): array;
+    public function getExtensions(): NamedTypeExtensions;
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
@@ -180,7 +180,7 @@ class Schema
         return null;
     }
 
-    public function getSchemaExtensions(): SchemaExtensions
+    public function getExtensions(): SchemaExtensions
     {
         return $this->schemaExtensions;
     }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/Schema.php
@@ -21,6 +21,7 @@ class Schema
     protected array $types;
     /** @var Directive[] */
     protected array $directives;
+    protected SchemaExtensions $schemaExtensions;
 
     public function __construct(
         array &$fullSchemaDefinition,
@@ -50,6 +51,11 @@ class Schema
                 $this->types[] = $this->getTypeInstance($fullSchemaDefinition, $typeKind, $typeName);
             }
         }
+
+        $schemaExtensionsSchemaDefinitionPath = [
+            SchemaDefinition::EXTENSIONS,
+        ];
+        $this->schemaExtensions = new SchemaExtensions($fullSchemaDefinition, $schemaExtensionsSchemaDefinitionPath);
     }
     protected function getTypeInstance(array &$fullSchemaDefinition, string $typeKind, string $typeName): NamedTypeInterface
     {
@@ -172,5 +178,10 @@ class Schema
             return $type->getID();
         }
         return null;
+    }
+
+    public function getSchemaExtensions(): SchemaExtensions
+    {
+        return $this->schemaExtensions;
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/SchemaExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/SchemaExtensions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\ObjectModels;
+
+use PoP\ComponentModel\Schema\SchemaDefinition;
+
+class SchemaExtensions extends AbstractSchemaDefinitionReferenceObject
+{
+    public function isSchemaNamespaced(): bool
+    {
+        return $this->schemaDefinition[SchemaDefinition::SCHEMA_IS_NAMESPACED] ?? false;
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -361,7 +361,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     protected function addMutationLabelToSchemaFieldDescription(array $fieldSchemaDefinitionPath): void
     {
         $fieldSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinitionForGraphQL, $fieldSchemaDefinitionPath);
-        if ($fieldSchemaDefinition[SchemaDefinition::FIELD_IS_MUTATION] ?? null) {
+        if ($fieldSchemaDefinition[SchemaDefinition::EXTENSIONS][SchemaDefinition::FIELD_IS_MUTATION]) {
             $fieldSchemaDefinition[SchemaDefinition::DESCRIPTION] = sprintf(
                 $this->getTranslationAPI()->__('[Mutation] %s', 'graphql-server'),
                 $fieldSchemaDefinition[SchemaDefinition::DESCRIPTION]

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -328,7 +328,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     protected function addVersionToGraphQLSchemaFieldDescription(array $fieldOrDirectiveSchemaDefinitionPath): void
     {
         $fieldOrDirectiveSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinitionForGraphQL, $fieldOrDirectiveSchemaDefinitionPath);
-        if ($schemaFieldVersion = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::EXTENSIONS][SchemaDefinition::VERSION] ?? null) {
+        if ($schemaFieldVersion = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::VERSION] ?? null) {
             $fieldOrDirectiveSchemaDefinition[SchemaDefinition::DESCRIPTION] .= sprintf(
                 sprintf(
                     $this->getTranslationAPI()->__(' _%s_', 'graphql-server'), // Make it italic using markdown

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Registries/SchemaDefinitionReferenceRegistry.php
@@ -328,7 +328,7 @@ class SchemaDefinitionReferenceRegistry implements SchemaDefinitionReferenceRegi
     protected function addVersionToGraphQLSchemaFieldDescription(array $fieldOrDirectiveSchemaDefinitionPath): void
     {
         $fieldOrDirectiveSchemaDefinition = &SchemaDefinitionHelpers::advancePointerToPath($this->fullSchemaDefinitionForGraphQL, $fieldOrDirectiveSchemaDefinitionPath);
-        if ($schemaFieldVersion = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::VERSION] ?? null) {
+        if ($schemaFieldVersion = $fieldOrDirectiveSchemaDefinition[SchemaDefinition::EXTENSIONS][SchemaDefinition::VERSION] ?? null) {
             $fieldOrDirectiveSchemaDefinition[SchemaDefinition::DESCRIPTION] .= sprintf(
                 sprintf(
                     $this->getTranslationAPI()->__(' _%s_', 'graphql-server'), // Make it italic using markdown

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/AbstractSchemaElementExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/AbstractSchemaElementExtensionsObjectTypeResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\SchemaDefinitionReferenceObjectInterface;
+use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+abstract class AbstractSchemaElementExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+{
+    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
+
+    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    {
+        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
+    }
+    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
+    {
+        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
+    }
+
+    /**
+     * Introspection names must start with "__".
+     * However, when doing so, graphql-js throws an error:
+     *
+     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
+     *
+     * To avoid it, prepend it with "_", as a temporary solution, until
+     * the GraphQL spec and graphql-js deal with the issue.
+     *
+     * @see https://github.com/graphql/graphql-spec/issues/300#issuecomment-808047303
+     */
+    final public function getTypeName(): string
+    {
+        return '_' . $this->getIntrospectionTypeName();
+    }
+    abstract protected function getIntrospectionTypeName(): string;
+
+    public function getID(object $object): string | int | null
+    {
+        /** @var SchemaDefinitionReferenceObjectInterface */
+        return $object->getID();
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getSchemaDefinitionReferenceTypeDataLoader();
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/AbstractSchemaElementExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/AbstractSchemaElementExtensionsObjectTypeResolver.php
@@ -40,7 +40,7 @@ abstract class AbstractSchemaElementExtensionsObjectTypeResolver extends Abstrac
 
     public function getID(object $object): string | int | null
     {
-        /** @var SchemaDefinitionReferenceObjectInterface */
+        /** @var SchemaDefinitionReferenceObjectInterface $object */
         return $object->getID();
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/DirectiveExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/DirectiveExtensionsObjectTypeResolver.php
@@ -4,47 +4,15 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use GraphQLByPoP\GraphQLServer\ObjectModels\DirectiveExtensions;
-use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
-use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
-
-class DirectiveExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+class DirectiveExtensionsObjectTypeResolver extends AbstractSchemaElementExtensionsObjectTypeResolver
 {
-    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
-
-    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    public function getIntrospectionTypeName(): string
     {
-        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
-    }
-    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
-    {
-        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
-    }
-
-    /**
-     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
-     *
-     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
-     */
-    public function getTypeName(): string
-    {
-        return '_DirectiveExtensions';
+        return 'DirectiveExtensions';
     }
 
     public function getTypeDescription(): ?string
     {
         return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the directive', 'graphql-server');
-    }
-
-    public function getID(object $object): string | int | null
-    {
-        /** @var DirectiveExtensions */
-        $directiveExtensions = $object;
-        return $directiveExtensions->getID();
-    }
-
-    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
-    {
-        return $this->getSchemaDefinitionReferenceTypeDataLoader();
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/DirectiveExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/DirectiveExtensionsObjectTypeResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\DirectiveExtensions;
+use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class DirectiveExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+{
+    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
+
+    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    {
+        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
+    }
+    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
+    {
+        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
+    }
+
+    /**
+     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
+     *
+     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
+     */
+    public function getTypeName(): string
+    {
+        return '_DirectiveExtensions';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the directive', 'graphql-server');
+    }
+
+    public function getID(object $object): string | int | null
+    {
+        /** @var DirectiveExtensions */
+        $directiveExtensions = $object;
+        return $directiveExtensions->getID();
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getSchemaDefinitionReferenceTypeDataLoader();
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/EnumValueExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/EnumValueExtensionsObjectTypeResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\EnumValueExtensions;
+use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class EnumValueExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+{
+    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
+
+    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    {
+        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
+    }
+    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
+    {
+        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
+    }
+
+    /**
+     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
+     *
+     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
+     */
+    public function getTypeName(): string
+    {
+        return '_EnumValueExtensions';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the enum value', 'graphql-server');
+    }
+
+    public function getID(object $object): string | int | null
+    {
+        /** @var EnumValueExtensions */
+        $enumValueExtensions = $object;
+        return $enumValueExtensions->getID();
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getSchemaDefinitionReferenceTypeDataLoader();
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/EnumValueExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/EnumValueExtensionsObjectTypeResolver.php
@@ -4,47 +4,15 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use GraphQLByPoP\GraphQLServer\ObjectModels\EnumValueExtensions;
-use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
-use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
-
-class EnumValueExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+class EnumValueExtensionsObjectTypeResolver extends AbstractSchemaElementExtensionsObjectTypeResolver
 {
-    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
-
-    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    public function getIntrospectionTypeName(): string
     {
-        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
-    }
-    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
-    {
-        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
-    }
-
-    /**
-     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
-     *
-     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
-     */
-    public function getTypeName(): string
-    {
-        return '_EnumValueExtensions';
+        return 'EnumValueExtensions';
     }
 
     public function getTypeDescription(): ?string
     {
         return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the enum value', 'graphql-server');
-    }
-
-    public function getID(object $object): string | int | null
-    {
-        /** @var EnumValueExtensions */
-        $enumValueExtensions = $object;
-        return $enumValueExtensions->getID();
-    }
-
-    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
-    {
-        return $this->getSchemaDefinitionReferenceTypeDataLoader();
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/FieldExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/FieldExtensionsObjectTypeResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\FieldExtensions;
+use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class FieldExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+{
+    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
+
+    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    {
+        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
+    }
+    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
+    {
+        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
+    }
+
+    /**
+     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
+     *
+     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
+     */
+    public function getTypeName(): string
+    {
+        return '_FieldExtensions';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the field', 'graphql-server');
+    }
+
+    public function getID(object $object): string | int | null
+    {
+        /** @var FieldExtensions */
+        $fieldExtensions = $object;
+        return $fieldExtensions->getID();
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getSchemaDefinitionReferenceTypeDataLoader();
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/FieldExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/FieldExtensionsObjectTypeResolver.php
@@ -4,47 +4,15 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use GraphQLByPoP\GraphQLServer\ObjectModels\FieldExtensions;
-use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
-use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
-
-class FieldExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+class FieldExtensionsObjectTypeResolver extends AbstractSchemaElementExtensionsObjectTypeResolver
 {
-    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
-
-    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    public function getIntrospectionTypeName(): string
     {
-        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
-    }
-    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
-    {
-        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
-    }
-
-    /**
-     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
-     *
-     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
-     */
-    public function getTypeName(): string
-    {
-        return '_FieldExtensions';
+        return 'FieldExtensions';
     }
 
     public function getTypeDescription(): ?string
     {
         return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the field', 'graphql-server');
-    }
-
-    public function getID(object $object): string | int | null
-    {
-        /** @var FieldExtensions */
-        $fieldExtensions = $object;
-        return $fieldExtensions->getID();
-    }
-
-    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
-    {
-        return $this->getSchemaDefinitionReferenceTypeDataLoader();
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/InputValueExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/InputValueExtensionsObjectTypeResolver.php
@@ -4,47 +4,15 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use GraphQLByPoP\GraphQLServer\ObjectModels\InputValueExtensions;
-use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
-use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
-
-class InputValueExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+class InputValueExtensionsObjectTypeResolver extends AbstractSchemaElementExtensionsObjectTypeResolver
 {
-    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
-
-    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    public function getIntrospectionTypeName(): string
     {
-        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
-    }
-    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
-    {
-        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
-    }
-
-    /**
-     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
-     *
-     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
-     */
-    public function getTypeName(): string
-    {
-        return '_InputValueExtensions';
+        return 'InputValueExtensions';
     }
 
     public function getTypeDescription(): ?string
     {
         return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the input value', 'graphql-server');
-    }
-
-    public function getID(object $object): string | int | null
-    {
-        /** @var InputValueExtensions */
-        $inputValueExtensions = $object;
-        return $inputValueExtensions->getID();
-    }
-
-    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
-    {
-        return $this->getSchemaDefinitionReferenceTypeDataLoader();
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/InputValueExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/InputValueExtensionsObjectTypeResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\InputValueExtensions;
+use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class InputValueExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+{
+    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
+
+    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    {
+        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
+    }
+    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
+    {
+        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
+    }
+
+    /**
+     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
+     *
+     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
+     */
+    public function getTypeName(): string
+    {
+        return '_InputValueExtensions';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the input value', 'graphql-server');
+    }
+
+    public function getID(object $object): string | int | null
+    {
+        /** @var InputValueExtensions */
+        $inputValueExtensions = $object;
+        return $inputValueExtensions->getID();
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getSchemaDefinitionReferenceTypeDataLoader();
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/NamedTypeExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/NamedTypeExtensionsObjectTypeResolver.php
@@ -4,47 +4,15 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use GraphQLByPoP\GraphQLServer\ObjectModels\NamedTypeExtensions;
-use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
-use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
-
-class NamedTypeExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+class NamedTypeExtensionsObjectTypeResolver extends AbstractSchemaElementExtensionsObjectTypeResolver
 {
-    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
-
-    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    public function getIntrospectionTypeName(): string
     {
-        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
-    }
-    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
-    {
-        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
-    }
-
-    /**
-     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
-     *
-     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
-     */
-    public function getTypeName(): string
-    {
-        return '_NamedTypeExtensions';
+        return 'NamedTypeExtensions';
     }
 
     public function getTypeDescription(): ?string
     {
         return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the GraphQL type (for all \'named\' types: Object, Interface, Union, Scalar, Enum and InputObject)', 'graphql-server');
-    }
-
-    public function getID(object $object): string | int | null
-    {
-        /** @var NamedTypeExtensions */
-        $namedTypeExtensions = $object;
-        return $namedTypeExtensions->getID();
-    }
-
-    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
-    {
-        return $this->getSchemaDefinitionReferenceTypeDataLoader();
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/NamedTypeExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/NamedTypeExtensionsObjectTypeResolver.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use GraphQLByPoP\GraphQLServer\ObjectModels\SchemaExtensions;
+use GraphQLByPoP\GraphQLServer\ObjectModels\NamedTypeExtensions;
 use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
 use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
 
-class SchemaExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+class NamedTypeExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
 {
     private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
 
@@ -28,19 +28,19 @@ class SchemaExtensionsObjectTypeResolver extends AbstractIntrospectionObjectType
      */
     public function getTypeName(): string
     {
-        return '_SchemaExtensions';
+        return '_NamedTypeExtensions';
     }
 
     public function getTypeDescription(): ?string
     {
-        return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the GraphQL schema', 'graphql-server');
+        return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the GraphQL type (for all \'named\' types: Object, Interface, Union, Scalar, Enum and InputObject)', 'graphql-server');
     }
 
     public function getID(object $object): string | int | null
     {
-        /** @var SchemaExtensions */
-        $schemaExtensions = $object;
-        return $schemaExtensions->getID();
+        /** @var NamedTypeExtensions */
+        $namedTypeExtensions = $object;
+        return $namedTypeExtensions->getID();
     }
 
     public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/SchemaExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/SchemaExtensionsObjectTypeResolver.php
@@ -4,47 +4,15 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
 
-use GraphQLByPoP\GraphQLServer\ObjectModels\SchemaExtensions;
-use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
-use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
-
-class SchemaExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+class SchemaExtensionsObjectTypeResolver extends AbstractSchemaElementExtensionsObjectTypeResolver
 {
-    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
-
-    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    public function getIntrospectionTypeName(): string
     {
-        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
-    }
-    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
-    {
-        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
-    }
-
-    /**
-     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
-     *
-     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
-     */
-    public function getTypeName(): string
-    {
-        return '_SchemaExtensions';
+        return 'SchemaExtensions';
     }
 
     public function getTypeDescription(): ?string
     {
         return $this->getTranslationAPI()->__('Extensions (custom metadata) added to the GraphQL schema', 'graphql-server');
-    }
-
-    public function getID(object $object): string | int | null
-    {
-        /** @var SchemaExtensions */
-        $schemaExtensions = $object;
-        return $schemaExtensions->getID();
-    }
-
-    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
-    {
-        return $this->getSchemaDefinitionReferenceTypeDataLoader();
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/SchemaExtensionsObjectTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/ObjectType/SchemaExtensionsObjectTypeResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType;
+
+use GraphQLByPoP\GraphQLServer\ObjectModels\SchemaExtensions;
+use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaDefinitionReferenceTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class SchemaExtensionsObjectTypeResolver extends AbstractIntrospectionObjectTypeResolver
+{
+    private ?SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader = null;
+
+    final public function setSchemaDefinitionReferenceTypeDataLoader(SchemaDefinitionReferenceTypeDataLoader $schemaDefinitionReferenceTypeDataLoader): void
+    {
+        $this->schemaDefinitionReferenceTypeDataLoader = $schemaDefinitionReferenceTypeDataLoader;
+    }
+    final protected function getSchemaDefinitionReferenceTypeDataLoader(): SchemaDefinitionReferenceTypeDataLoader
+    {
+        return $this->schemaDefinitionReferenceTypeDataLoader ??= $this->instanceManager->getInstance(SchemaDefinitionReferenceTypeDataLoader::class);
+    }
+
+    /**
+     * Prepending with only 1 "_" instead of 2 "__" to avoid error in graphql-js
+     *
+     * @see https://github.com/graphql-java/graphql-java/pull/2221#issuecomment-808044041
+     */
+    public function getTypeName(): string
+    {
+        return '_SchemaExtensions';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->getTranslationAPI()->__('Extensions (custom metadata) for the Schema type', 'graphql-server');
+    }
+
+    public function getID(object $object): string | int | null
+    {
+        /** @var SchemaExtensions */
+        $schemaExtensions = $object;
+        return $schemaExtensions->getID();
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getSchemaDefinitionReferenceTypeDataLoader();
+    }
+}


### PR DESCRIPTION
Custom metadata attached to schema elements can now be queried via field `extensions`. This is a feature [requested for the GraphQL spec](https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306), but not yet approved. This GraphQL server already implements it, though, since it is very useful.

All introspection elements of the schema have been upgraded with the new field, each of them returning an object of a corresponding "`Extensions`" type, which exposes the custom properties for that element.

```graphql
type SchemaExtensions {
  # Is the schema being namespaced?
  isNamespaced: Boolean!
}

extend type __Schema {
  extensions: SchemaExtensions!
}

type NamedTypeExtensions {
  # The type name
  elementName: String!

  # The "namespaced" type name
  namespacedName: String!
}

extend type __Type {
  # Non-null for named types, null for wrapping types (Non-Null and List)
  extensions: NamedTypeExtensions
}

type DirectiveExtensions {
  # If no objects are returned in the field (eg: because they failed validation), does the directive still need to be executed?
  needsDataToExecute: Boolean!
}

extend type __Directive {
  extensions: DirectiveExtensions!
}

type FieldExtensions {
  # Useful for nested mutations
  isMutation: Boolean!

  # `true` => Only exposed when "Expose admin elements" is enabled
  isAdminElement: Boolean!
}

extend type __Field {
  extensions: FieldExtensions!
}

type InputValueExtensions {
  isAdminElement: Boolean!
}

extend type __InputValue {
  extensions: InputValueExtensions!
}

type EnumValueExtensions {
  isAdminElement: Boolean!
}

extend type __EnumValue {
  extensions: EnumValueExtensions!
}
```

## Implemented extension `isAdminElement`

Several `extensions` fields expose property `isAdminElement`, to identify which are the "admin" elements from the schema (i.e. elements which can only be accessed when "Expose admin elements" is enabled in the Schema Configuration).

To retrieve this data, execute this query:

```graphql
query ViewAdminElements {
  __schema {
    types {
      name
      fields {
        name
        extensions {
          isAdminElement
        }
        args {
          name
          extensions {
            isAdminElement
          }
        }
      }
      inputFields {
        name
        extensions {
          isAdminElement
        }
      }
      enumValues {
        name
        extensions {
          isAdminElement
        }
      }
    }
  }
}
```

And then search for entries with `"isAdminElement": true` in the results.