### PR TITLE
Order by meta value

### DIFF
--- a/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
+++ b/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
@@ -116,7 +116,7 @@ abstract class AbstractTagTypeAPI extends TaxonomyTypeAPI implements TagTypeAPII
 
         // Convert the parameters
         $query['taxonomy'] = $this->getTagTaxonomyName();
-        
+
         return $this->getHooksAPI()->applyFilters(
             self::HOOK_QUERY,
             $query,

--- a/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
+++ b/layers/Schema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\TagsWP\TypeAPIs;
 
-use PoP\ComponentModel\Services\BasicServiceTrait;
 use PoP\Engine\CMS\CMSHelperServiceInterface;
 use PoPSchema\SchemaCommons\Constants\QueryOptions;
 use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
@@ -17,8 +16,6 @@ use WP_Taxonomy;
  */
 abstract class AbstractTagTypeAPI extends TaxonomyTypeAPI implements TagTypeAPIInterface
 {
-    use BasicServiceTrait;
-
     public const HOOK_QUERY = __CLASS__ . ':query';
 
     private ?CMSHelperServiceInterface $cmsHelperService = null;
@@ -115,68 +112,13 @@ abstract class AbstractTagTypeAPI extends TaxonomyTypeAPI implements TagTypeAPII
 
     public function convertTagsQuery(array $query, array $options = []): array
     {
-        $query['taxonomy'] = $this->getTagTaxonomyName();
-
-        if ($return_type = $options[QueryOptions::RETURN_TYPE] ?? null) {
-            if ($return_type === ReturnTypes::IDS) {
-                $query['fields'] = 'ids';
-            } elseif ($return_type === ReturnTypes::NAMES) {
-                $query['fields'] = 'names';
-            }
-        }
-
-        if (isset($query['hide-empty'])) {
-            $query['hide_empty'] = $query['hide-empty'];
-            unset($query['hide-empty']);
-        } else {
-            // By default: do not hide empty tags
-            $query['hide_empty'] = false;
-        }
+        $query = $this->convertTaxonomiesQuery($query, $options);
 
         // Convert the parameters
-        if (isset($query['include']) && is_array($query['include'])) {
-            // It can be an array or a string
-            $query['include'] = implode(',', $query['include']);
-        }
-        if (isset($query['exclude-ids'])) {
-            $query['exclude'] = $query['exclude-ids'];
-            unset($query['exclude-ids']);
-        }
-        if (isset($query['order'])) {
-            $query['order'] = \esc_sql($query['order']);
-        }
-        if (isset($query['orderby'])) {
-            // This param can either be a string or an array. Eg:
-            // $query['orderby'] => array('date' => 'DESC', 'title' => 'ASC');
-            $query['orderby'] = \esc_sql($query['orderby']);
-        }
-        if (isset($query['offset'])) {
-            // Same param name, so do nothing
-        }
-        if (isset($query['limit'])) {
-            $limit = (int) $query['limit'];
-            // To bring all results, get_tags needs "number => 0" instead of -1
-            $query['number'] = ($limit == -1) ? 0 : $limit;
-            unset($query['limit']);
-        }
-        if (isset($query['search'])) {
-            // Same param name, so do nothing
-        }
-        if (isset($query['slugs'])) {
-            $query['slug'] = $query['slugs'];
-            unset($query['slugs']);
-        }
-        if (isset($query['slug'])) {
-            // Same param name, so do nothing
-        }
-
+        $query['taxonomy'] = $this->getTagTaxonomyName();
+        
         return $this->getHooksAPI()->applyFilters(
-            TaxonomyTypeAPI::HOOK_QUERY,
-            $this->getHooksAPI()->applyFilters(
-                self::HOOK_QUERY,
-                $query,
-                $options
-            ),
+            self::HOOK_QUERY,
             $query,
             $options
         );

--- a/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
+++ b/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace PoPSchema\TaxonomiesWP\TypeAPIs;
 
+use PoP\ComponentModel\Services\BasicServiceTrait;
+use PoPSchema\SchemaCommons\Constants\QueryOptions;
+use PoPSchema\SchemaCommons\DataLoading\ReturnTypes;
+use PoPSchema\Taxonomies\Constants\TaxonomyOrderBy;
 use PoPSchema\Taxonomies\TypeAPIs\TaxonomyTypeAPIInterface;
 
 /**
@@ -11,7 +15,10 @@ use PoPSchema\Taxonomies\TypeAPIs\TaxonomyTypeAPIInterface;
  */
 class TaxonomyTypeAPI implements TaxonomyTypeAPIInterface
 {
+    use BasicServiceTrait;
+
     public const HOOK_QUERY = __CLASS__ . ':query';
+    public const HOOK_ORDERBY_QUERY_ARG_VALUE = __CLASS__ . ':orderby-query-arg-value';
 
     protected function getTermObjectAndID(string | int | object $termObjectOrID): array
     {
@@ -37,5 +44,93 @@ class TaxonomyTypeAPI implements TaxonomyTypeAPIInterface
             $termObjectID,
         ) = $this->getTermObjectAndID($termObjectOrID);
         return $termObject->taxonomy;
+    }
+
+
+
+    public function convertTaxonomiesQuery(array $query, array $options = []): array
+    {
+        if ($return_type = $options[QueryOptions::RETURN_TYPE] ?? null) {
+            if ($return_type === ReturnTypes::IDS) {
+                $query['fields'] = 'ids';
+            } elseif ($return_type === ReturnTypes::NAMES) {
+                $query['fields'] = 'names';
+            }
+        }
+
+        if (isset($query['hide-empty'])) {
+            $query['hide_empty'] = $query['hide-empty'];
+            unset($query['hide-empty']);
+        } else {
+            // By default: do not hide empty categories
+            $query['hide_empty'] = false;
+        }
+
+        // Convert the parameters
+        if (isset($query['include']) && is_array($query['include'])) {
+            // It can be an array or a string
+            $query['include'] = implode(',', $query['include']);
+        }
+        if (isset($query['exclude-ids'])) {
+            $query['exclude'] = $query['exclude-ids'];
+            unset($query['exclude-ids']);
+        }
+        if (isset($query['order'])) {
+            $query['order'] = \esc_sql($query['order']);
+        }
+        if (isset($query['orderby'])) {
+            // This param can either be a string or an array. Eg:
+            // $query['orderby'] => array('date' => 'DESC', 'title' => 'ASC');
+            $query['orderby'] = \esc_sql($this->getOrderByQueryArgValue($query['orderby']));
+        }
+        if (isset($query['offset'])) {
+            // Same param name, so do nothing
+        }
+        if (isset($query['limit'])) {
+            $limit = (int) $query['limit'];
+            // To bring all results, get_categories/get_tags needs "number => 0" instead of -1
+            $query['number'] = ($limit == -1) ? 0 : $limit;
+            unset($query['limit']);
+        }
+        if (isset($query['search'])) {
+            // Same param name, so do nothing
+        }
+        if (isset($query['slugs'])) {
+            $query['slug'] = $query['slugs'];
+            unset($query['slugs']);
+        }
+        if (isset($query['slug'])) {
+            // Same param name, so do nothing
+        }
+        if (isset($query['parent-id'])) {
+            $query['parent'] = $query['parent-id'];
+            unset($query['parent-id']);
+        }
+
+        return $this->getHooksAPI()->applyFilters(
+            self::HOOK_QUERY,
+            $query,
+            $options
+        );
+    }
+
+    protected function getOrderByQueryArgValue(string $orderBy): string
+    {
+        $orderBy = match ($orderBy) {
+            TaxonomyOrderBy::NAME => 'name',
+            TaxonomyOrderBy::SLUG => 'slug',
+            TaxonomyOrderBy::ID => 'term_id',
+            TaxonomyOrderBy::PARENT => 'parent',
+            TaxonomyOrderBy::COUNT => 'count',
+            TaxonomyOrderBy::NONE => 'none',
+            TaxonomyOrderBy::INCLUDE => 'include',
+            TaxonomyOrderBy::SLUG__IN => 'slug__in',
+            TaxonomyOrderBy::DESCRIPTION => 'description',
+            default => $orderBy,
+        };
+        return $this->getHooksAPI()->applyFilters(
+            self::HOOK_ORDERBY_QUERY_ARG_VALUE,
+            $orderBy
+        );
     }
 }

--- a/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
+++ b/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
@@ -124,7 +124,7 @@ class TaxonomyTypeAPI implements TaxonomyTypeAPIInterface
             TaxonomyOrderBy::COUNT => 'count',
             TaxonomyOrderBy::NONE => 'none',
             TaxonomyOrderBy::INCLUDE => 'include',
-            TaxonomyOrderBy::SLUG_IN => 'slug__in',
+            TaxonomyOrderBy::SLUG__IN => 'slug__in',
             TaxonomyOrderBy::DESCRIPTION => 'description',
             default => $orderBy,
         };

--- a/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
+++ b/layers/Schema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTypeAPI.php
@@ -124,7 +124,7 @@ class TaxonomyTypeAPI implements TaxonomyTypeAPIInterface
             TaxonomyOrderBy::COUNT => 'count',
             TaxonomyOrderBy::NONE => 'none',
             TaxonomyOrderBy::INCLUDE => 'include',
-            TaxonomyOrderBy::SLUG__IN => 'slug__in',
+            TaxonomyOrderBy::SLUG_IN => 'slug__in',
             TaxonomyOrderBy::DESCRIPTION => 'description',
             default => $orderBy,
         };

--- a/layers/Schema/packages/taxonomies/src/Constants/TaxonomyOrderBy.php
+++ b/layers/Schema/packages/taxonomies/src/Constants/TaxonomyOrderBy.php
@@ -18,7 +18,7 @@ class TaxonomyOrderBy
     public const COUNT = 'COUNT';
     public const NONE = 'NONE';
     public const INCLUDE = 'INCLUDE';
-    public const SLUG_IN = 'SLUG_IN';
+    public const SLUG__IN = 'SLUG__IN';
     public const DESCRIPTION = 'DESCRIPTION';
 
     // public const TERM_GROUP = 'TERM_GROUP';

--- a/layers/Schema/packages/taxonomies/src/Constants/TaxonomyOrderBy.php
+++ b/layers/Schema/packages/taxonomies/src/Constants/TaxonomyOrderBy.php
@@ -18,7 +18,7 @@ class TaxonomyOrderBy
     public const COUNT = 'COUNT';
     public const NONE = 'NONE';
     public const INCLUDE = 'INCLUDE';
-    public const SLUG__IN = 'SLUG__IN';
+    public const SLUG_IN = 'SLUG_IN';
     public const DESCRIPTION = 'DESCRIPTION';
 
     // public const TERM_GROUP = 'TERM_GROUP';

--- a/layers/Schema/packages/taxonomies/src/TypeResolvers/EnumType/TaxonomyOrderByEnumTypeResolver.php
+++ b/layers/Schema/packages/taxonomies/src/TypeResolvers/EnumType/TaxonomyOrderByEnumTypeResolver.php
@@ -28,7 +28,7 @@ class TaxonomyOrderByEnumTypeResolver extends AbstractEnumTypeResolver
             TaxonomyOrderBy::COUNT,
             TaxonomyOrderBy::NONE,
             TaxonomyOrderBy::INCLUDE,
-            TaxonomyOrderBy::SLUG__IN,
+            TaxonomyOrderBy::SLUG_IN,
         ];
     }
 
@@ -43,7 +43,7 @@ class TaxonomyOrderByEnumTypeResolver extends AbstractEnumTypeResolver
             TaxonomyOrderBy::COUNT => $this->getTranslationAPI()->__('Order by number of objects associated with the term', 'taxonomies'),
             TaxonomyOrderBy::NONE => $this->getTranslationAPI()->__('Order by none, i.e. omit the ordering', 'taxonomies'),
             TaxonomyOrderBy::INCLUDE => $this->getTranslationAPI()->__('Match the \'order\' of the $include param', 'taxonomies'),
-            TaxonomyOrderBy::SLUG__IN => $this->getTranslationAPI()->__('Match the \'order\' of the $slug param', 'taxonomies'),
+            TaxonomyOrderBy::SLUG_IN => $this->getTranslationAPI()->__('Match the \'order\' of the $slug param', 'taxonomies'),
             default => parent::getEnumValueDescription($enumValue),
         };
     }

--- a/layers/Schema/packages/taxonomies/src/TypeResolvers/EnumType/TaxonomyOrderByEnumTypeResolver.php
+++ b/layers/Schema/packages/taxonomies/src/TypeResolvers/EnumType/TaxonomyOrderByEnumTypeResolver.php
@@ -28,7 +28,7 @@ class TaxonomyOrderByEnumTypeResolver extends AbstractEnumTypeResolver
             TaxonomyOrderBy::COUNT,
             TaxonomyOrderBy::NONE,
             TaxonomyOrderBy::INCLUDE,
-            TaxonomyOrderBy::SLUG_IN,
+            TaxonomyOrderBy::SLUG__IN,
         ];
     }
 
@@ -43,7 +43,7 @@ class TaxonomyOrderByEnumTypeResolver extends AbstractEnumTypeResolver
             TaxonomyOrderBy::COUNT => $this->getTranslationAPI()->__('Order by number of objects associated with the term', 'taxonomies'),
             TaxonomyOrderBy::NONE => $this->getTranslationAPI()->__('Order by none, i.e. omit the ordering', 'taxonomies'),
             TaxonomyOrderBy::INCLUDE => $this->getTranslationAPI()->__('Match the \'order\' of the $include param', 'taxonomies'),
-            TaxonomyOrderBy::SLUG_IN => $this->getTranslationAPI()->__('Match the \'order\' of the $slug param', 'taxonomies'),
+            TaxonomyOrderBy::SLUG__IN => $this->getTranslationAPI()->__('Match the \'order\' of the $slug param', 'taxonomies'),
             default => parent::getEnumValueDescription($enumValue),
         };
     }

--- a/layers/WPSchema/packages/commentmeta/config/services.yaml
+++ b/layers/WPSchema/packages/commentmeta/config/services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    PoPWPSchema\CommentMeta\Hooks\:
+        resource: '../src/Hooks/*'

--- a/layers/WPSchema/packages/commentmeta/src/Component.php
+++ b/layers/WPSchema/packages/commentmeta/src/Component.php
@@ -36,6 +36,7 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
+        self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/WPSchema/packages/commentmeta/src/Hooks/CommentMetaOrderByQueryHookSet.php
+++ b/layers/WPSchema/packages/commentmeta/src/Hooks/CommentMetaOrderByQueryHookSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoPWPSchema\CommentMeta\Hooks;
 
 use PoPSchema\CommentsWP\TypeAPIs\CommentTypeAPI;
+use PoPWPSchema\Meta\Constants\MetaOrderBy;
 use PoPWPSchema\Meta\Hooks\AbstractMetaOrderByQueryHookSet;
 
 class CommentMetaOrderByQueryHookSet extends AbstractMetaOrderByQueryHookSet
@@ -12,5 +13,13 @@ class CommentMetaOrderByQueryHookSet extends AbstractMetaOrderByQueryHookSet
     protected function getHookName(): string
     {
         return CommentTypeAPI::HOOK_ORDERBY_QUERY_ARG_VALUE;
+    }
+
+    public function getOrderByQueryArgValue(string $orderBy): string
+    {
+        return match ($orderBy) {
+            MetaOrderBy::META_VALUE => 'comment_meta_value',
+            default => parent::getOrderByQueryArgValue($orderBy),
+        };
     }
 }

--- a/layers/WPSchema/packages/commentmeta/src/Hooks/CommentMetaOrderByQueryHookSet.php
+++ b/layers/WPSchema/packages/commentmeta/src/Hooks/CommentMetaOrderByQueryHookSet.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CommentMeta\Hooks;
+
+use PoPSchema\CommentsWP\TypeAPIs\CommentTypeAPI;
+use PoPWPSchema\Meta\Hooks\AbstractMetaOrderByQueryHookSet;
+
+class CommentMetaOrderByQueryHookSet extends AbstractMetaOrderByQueryHookSet
+{
+    protected function getHookName(): string
+    {
+        return CommentTypeAPI::HOOK_ORDERBY_QUERY_ARG_VALUE;
+    }
+}

--- a/layers/WPSchema/packages/commentmeta/src/SchemaHooks/CommentMetaOrderByEnumTypeHookSet.php
+++ b/layers/WPSchema/packages/commentmeta/src/SchemaHooks/CommentMetaOrderByEnumTypeHookSet.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CommentMeta\SchemaHooks;
+
+use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
+use PoPSchema\Comments\TypeResolvers\EnumType\CommentOrderByEnumTypeResolver;
+use PoPWPSchema\Meta\SchemaHooks\AbstractMetaOrderByEnumTypeHookSet;
+
+class CommentMetaOrderByEnumTypeHookSet extends AbstractMetaOrderByEnumTypeHookSet
+{
+    protected function isEnumTypeResolver(
+        EnumTypeResolverInterface $enumTypeResolver,
+    ): bool {
+        return $enumTypeResolver instanceof CommentOrderByEnumTypeResolver;
+    }
+}

--- a/layers/WPSchema/packages/custompostmeta/config/services.yaml
+++ b/layers/WPSchema/packages/custompostmeta/config/services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    PoPWPSchema\CustomPostMeta\Hooks\:
+        resource: '../src/Hooks/*'

--- a/layers/WPSchema/packages/custompostmeta/src/Component.php
+++ b/layers/WPSchema/packages/custompostmeta/src/Component.php
@@ -36,6 +36,7 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
+        self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/WPSchema/packages/custompostmeta/src/Hooks/CustomPostMetaOrderByQueryHookSet.php
+++ b/layers/WPSchema/packages/custompostmeta/src/Hooks/CustomPostMetaOrderByQueryHookSet.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CustomPostMeta\Hooks;
+
+use PoPSchema\CustomPostsWP\TypeAPIs\AbstractCustomPostTypeAPI;
+use PoPWPSchema\Meta\Hooks\AbstractMetaOrderByQueryHookSet;
+
+class CustomPostMetaOrderByQueryHookSet extends AbstractMetaOrderByQueryHookSet
+{
+    protected function getHookName(): string
+    {
+        return AbstractCustomPostTypeAPI::HOOK_ORDERBY_QUERY_ARG_VALUE;
+    }
+}

--- a/layers/WPSchema/packages/custompostmeta/src/SchemaHooks/CustomPostMetaOrderByEnumTypeHookSet.php
+++ b/layers/WPSchema/packages/custompostmeta/src/SchemaHooks/CustomPostMetaOrderByEnumTypeHookSet.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CustomPostMeta\SchemaHooks;
+
+use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
+use PoPSchema\CustomPosts\TypeResolvers\EnumType\CustomPostOrderByEnumTypeResolver;
+use PoPWPSchema\Meta\SchemaHooks\AbstractMetaOrderByEnumTypeHookSet;
+
+class CustomPostMetaOrderByEnumTypeHookSet extends AbstractMetaOrderByEnumTypeHookSet
+{
+    protected function isEnumTypeResolver(
+        EnumTypeResolverInterface $enumTypeResolver,
+    ): bool {
+        return $enumTypeResolver instanceof CustomPostOrderByEnumTypeResolver;
+    }
+}

--- a/layers/WPSchema/packages/meta/src/Constants/MetaOrderBy.php
+++ b/layers/WPSchema/packages/meta/src/Constants/MetaOrderBy.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\Meta\Constants;
+
+class MetaOrderBy
+{
+    public const META_VALUE = 'META_VALUE';
+}

--- a/layers/WPSchema/packages/meta/src/Hooks/AbstractMetaOrderByQueryHookSet.php
+++ b/layers/WPSchema/packages/meta/src/Hooks/AbstractMetaOrderByQueryHookSet.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\Meta\Hooks;
+
+use PoP\Hooks\AbstractHookSet;
+use PoPWPSchema\Meta\Constants\MetaOrderBy;
+
+abstract class AbstractMetaOrderByQueryHookSet extends AbstractHookSet
+{
+    protected function init(): void
+    {
+        $this->getHooksAPI()->addFilter(
+            $this->getHookName(),
+            [$this, 'getOrderByQueryArgValue']
+        );
+    }
+
+    abstract protected function getHookName(): string;
+
+    public function getOrderByQueryArgValue(string $orderBy): string
+    {
+        return match ($orderBy) {
+            MetaOrderBy::META_VALUE => 'meta_value',
+            default => $orderBy,
+        };
+    }
+}

--- a/layers/WPSchema/packages/meta/src/SchemaHooks/AbstractMetaOrderByEnumTypeHookSet.php
+++ b/layers/WPSchema/packages/meta/src/SchemaHooks/AbstractMetaOrderByEnumTypeHookSet.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\Meta\SchemaHooks;
+
+use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\EnumType\HookNames;
+use PoP\Hooks\AbstractHookSet;
+use PoPWPSchema\Meta\Constants\MetaOrderBy;
+
+abstract class AbstractMetaOrderByEnumTypeHookSet extends AbstractHookSet
+{
+    protected function init(): void
+    {
+        $this->getHooksAPI()->addFilter(
+            HookNames::ENUM_VALUES,
+            [$this, 'getEnumValues'],
+            10,
+            2
+        );
+        $this->getHooksAPI()->addFilter(
+            HookNames::ENUM_VALUE_DESCRIPTION,
+            [$this, 'getEnumValueDescription'],
+            10,
+            3
+        );
+    }
+
+    /**
+     * @param string[] $enumValues
+     */
+    public function getEnumValues(
+        array $enumValues,
+        EnumTypeResolverInterface $enumTypeResolver,
+    ): array {
+        if (!$this->isEnumTypeResolver($enumTypeResolver)) {
+            return $enumValues;
+        }
+        return array_merge(
+            $enumValues,
+            [
+                MetaOrderBy::META_VALUE,
+            ]
+        );
+    }
+
+    abstract protected function isEnumTypeResolver(
+        EnumTypeResolverInterface $enumTypeResolver,
+    ): bool;
+
+    public function getEnumValueDescription(
+        ?string $enumValueDescription,
+        EnumTypeResolverInterface $enumTypeResolver,
+        string $enumValue
+    ): ?string {
+        if (!$this->isEnumTypeResolver($enumTypeResolver)) {
+            return $enumValueDescription;
+        }
+        return match ($enumValue) {
+            MetaOrderBy::META_VALUE => $this->getTranslationAPI()->__('Order by meta value. See description for ‘meta_value‘ in: https://developer.wordpress.org/reference/classes/wp_query/#order-orderby-parameters', 'comments'),
+            default => $enumValueDescription,
+        };
+    }
+}

--- a/layers/WPSchema/packages/taxonomymeta/config/services.yaml
+++ b/layers/WPSchema/packages/taxonomymeta/config/services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    PoPWPSchema\TaxonomyMeta\Hooks\:
+        resource: '../src/Hooks/*'

--- a/layers/WPSchema/packages/taxonomymeta/src/Component.php
+++ b/layers/WPSchema/packages/taxonomymeta/src/Component.php
@@ -35,6 +35,7 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
+        self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/WPSchema/packages/taxonomymeta/src/Hooks/TaxonomyMetaOrderByQueryHookSet.php
+++ b/layers/WPSchema/packages/taxonomymeta/src/Hooks/TaxonomyMetaOrderByQueryHookSet.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\TaxonomyMeta\Hooks;
+
+use PoPSchema\TaxonomiesWP\TypeAPIs\TaxonomyTypeAPI;
+use PoPWPSchema\Meta\Hooks\AbstractMetaOrderByQueryHookSet;
+
+class TaxonomyMetaOrderByQueryHookSet extends AbstractMetaOrderByQueryHookSet
+{
+    protected function getHookName(): string
+    {
+        return TaxonomyTypeAPI::HOOK_ORDERBY_QUERY_ARG_VALUE;
+    }
+}

--- a/layers/WPSchema/packages/taxonomymeta/src/SchemaHooks/TaxonomyMetaOrderByEnumTypeHookSet.php
+++ b/layers/WPSchema/packages/taxonomymeta/src/SchemaHooks/TaxonomyMetaOrderByEnumTypeHookSet.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\TaxonomyMeta\SchemaHooks;
+
+use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
+use PoPSchema\Taxonomies\TypeResolvers\EnumType\TaxonomyOrderByEnumTypeResolver;
+use PoPWPSchema\Meta\SchemaHooks\AbstractMetaOrderByEnumTypeHookSet;
+
+class TaxonomyMetaOrderByEnumTypeHookSet extends AbstractMetaOrderByEnumTypeHookSet
+{
+    protected function isEnumTypeResolver(
+        EnumTypeResolverInterface $enumTypeResolver,
+    ): bool {
+        return $enumTypeResolver instanceof TaxonomyOrderByEnumTypeResolver;
+    }
+}

--- a/layers/WPSchema/packages/usermeta/config/services.yaml
+++ b/layers/WPSchema/packages/usermeta/config/services.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        public: true
+        autowire: true
+        autoconfigure: true
+
+    PoPWPSchema\UserMeta\Hooks\:
+        resource: '../src/Hooks/*'

--- a/layers/WPSchema/packages/usermeta/src/Component.php
+++ b/layers/WPSchema/packages/usermeta/src/Component.php
@@ -36,6 +36,7 @@ class Component extends AbstractComponent
         bool $skipSchema = false,
         array $skipSchemaComponentClasses = []
     ): void {
+        self::initServices(dirname(__DIR__));
         self::initSchemaServices(dirname(__DIR__), $skipSchema);
     }
 }

--- a/layers/WPSchema/packages/usermeta/src/Hooks/UserMetaOrderByQueryHookSet.php
+++ b/layers/WPSchema/packages/usermeta/src/Hooks/UserMetaOrderByQueryHookSet.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\UserMeta\Hooks;
+
+use PoPSchema\UsersWP\TypeAPIs\UserTypeAPI;
+use PoPWPSchema\Meta\Hooks\AbstractMetaOrderByQueryHookSet;
+
+class UserMetaOrderByQueryHookSet extends AbstractMetaOrderByQueryHookSet
+{
+    protected function getHookName(): string
+    {
+        return UserTypeAPI::HOOK_ORDERBY_QUERY_ARG_VALUE;
+    }
+}

--- a/layers/WPSchema/packages/usermeta/src/SchemaHooks/UserMetaOrderByEnumTypeHookSet.php
+++ b/layers/WPSchema/packages/usermeta/src/SchemaHooks/UserMetaOrderByEnumTypeHookSet.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\UserMeta\SchemaHooks;
+
+use PoP\ComponentModel\TypeResolvers\EnumType\EnumTypeResolverInterface;
+use PoPSchema\Users\TypeResolvers\EnumType\UserOrderByEnumTypeResolver;
+use PoPWPSchema\Meta\SchemaHooks\AbstractMetaOrderByEnumTypeHookSet;
+
+class UserMetaOrderByEnumTypeHookSet extends AbstractMetaOrderByEnumTypeHookSet
+{
+    protected function isEnumTypeResolver(
+        EnumTypeResolverInterface $enumTypeResolver,
+    ): bool {
+        return $enumTypeResolver instanceof UserOrderByEnumTypeResolver;
+    }
+}


### PR DESCRIPTION
Order custom posts, users, comments and taxonomies (categories and tags) by `meta_value`.

Eg:

```graphql
{
  pages(filter: {
    metaQuery: {
      key: "_wp_page_template",
      compareBy:{
        key: {
          operator: EXISTS
        }
      }
    }
  }, sort: {
    by: META_VALUE
    order: DESC
  }) {
    id
    metaValue(key: "_wp_page_template")
  }
}
```