### PR TITLE
Validate allowed meta key and settings option name before resolving the field

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -992,7 +992,6 @@ Returns:
       "message": "There is no meta with key 'nothingHere'",
       "extensions": {
         "type": "Post",
-        "id": 1,
         "field": "metaValue(key:\"nothingHere\")"
       }
     }

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
@@ -30,6 +30,18 @@ abstract class AbstractCommentMetaTypeAPI extends AbstractMetaTypeAPI implements
     }
 
     /**
+     * @return string[]
+     */
+    public function getAllowOrDenyMetaEntries(): array
+    {
+        return ComponentConfiguration::getCommentMetaEntries();
+    }
+    public function getAllowOrDenyMetaBehavior(): string
+    {
+        return ComponentConfiguration::getCommentMetaBehavior();
+    }
+
+    /**
      * If the key is non-existent, return `null`.
      * Otherwise, return the value.
      */

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
@@ -11,15 +11,19 @@ use PoPSchema\Meta\TypeAPIs\AbstractMetaTypeAPI;
 abstract class AbstractCommentMetaTypeAPI extends AbstractMetaTypeAPI implements CommentMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    final public function getCommentMeta(string | int $commentID, string $key, bool $single = false): mixed
+    final public function getCommentMeta(string | int $commentID, string $key, bool $single = false, array $options = []): mixed
     {
-        $this->assertIsEntryAllowed($key);
+        if ($options['assert-is-meta-key-allowed'] ?? null) {
+            $this->assertIsMetaKeyAllowed($key);
+        }
         return $this->doGetCommentMeta($commentID, $key, $single);
     }
 

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/AbstractCommentMetaTypeAPI.php
@@ -19,13 +19,7 @@ abstract class AbstractCommentMetaTypeAPI extends AbstractMetaTypeAPI implements
      */
     final public function getCommentMeta(string | int $commentID, string $key, bool $single = false): mixed
     {
-        /**
-         * Check if the allow/denylist validation fails
-         * Compare for full match or regex
-         */
-        $entries = ComponentConfiguration::getCommentMetaEntries();
-        $behavior = ComponentConfiguration::getCommentMetaBehavior();
-        $this->assertIsEntryAllowed($entries, $behavior, $key);
+        $this->assertIsEntryAllowed($key);
         return $this->doGetCommentMeta($commentID, $key, $single);
     }
 

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
@@ -10,11 +10,13 @@ use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 interface CommentMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    public function getCommentMeta(string | int $commentID, string $key, bool $single = false): mixed;
+    public function getCommentMeta(string | int $commentID, string $key, bool $single = false, array $options = []): mixed;
 }

--- a/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/commentmeta/src/TypeAPIs/CommentMetaTypeAPIInterface.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace PoPSchema\CommentMeta\TypeAPIs;
 
 use InvalidArgumentException;
+use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 
-interface CommentMetaTypeAPIInterface
+interface CommentMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
      * If the allow/denylist validation fails, throw an exception.

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
@@ -19,9 +19,7 @@ abstract class AbstractCustomPostMetaTypeAPI extends AbstractMetaTypeAPI impleme
      */
     final public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed
     {
-        $entries = ComponentConfiguration::getCustomPostMetaEntries();
-        $behavior = ComponentConfiguration::getCustomPostMetaBehavior();
-        $this->assertIsEntryAllowed($entries, $behavior, $key);
+        $this->assertIsEntryAllowed($key);
         return $this->doGetCustomPostMeta($customPostID, $key, $single);
     }
 

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
@@ -26,6 +26,18 @@ abstract class AbstractCustomPostMetaTypeAPI extends AbstractMetaTypeAPI impleme
     }
 
     /**
+     * @return string[]
+     */
+    public function getAllowOrDenyMetaEntries(): array
+    {
+        return ComponentConfiguration::getCustomPostMetaEntries();
+    }
+    public function getAllowOrDenyMetaBehavior(): string
+    {
+        return ComponentConfiguration::getCustomPostMetaBehavior();
+    }
+
+    /**
      * If the key is non-existent, return `null`.
      * Otherwise, return the value.
      */

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/AbstractCustomPostMetaTypeAPI.php
@@ -11,15 +11,19 @@ use PoPSchema\CustomPostMeta\ComponentConfiguration;
 abstract class AbstractCustomPostMetaTypeAPI extends AbstractMetaTypeAPI implements CustomPostMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    final public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed
+    final public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false, array $options = []): mixed
     {
-        $this->assertIsEntryAllowed($key);
+        if ($options['assert-is-meta-key-allowed'] ?? null) {
+            $this->assertIsMetaKeyAllowed($key);
+        }
         return $this->doGetCustomPostMeta($customPostID, $key, $single);
     }
 

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
@@ -10,11 +10,13 @@ use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 interface CustomPostMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false): mixed;
+    public function getCustomPostMeta(string | int $customPostID, string $key, bool $single = false, array $options = []): mixed;
 }

--- a/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/custompostmeta/src/TypeAPIs/CustomPostMetaTypeAPIInterface.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace PoPSchema\CustomPostMeta\TypeAPIs;
 
 use InvalidArgumentException;
+use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 
-interface CustomPostMetaTypeAPIInterface
+interface CustomPostMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
      * If the allow/denylist validation fails, throw an exception.

--- a/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
@@ -23,7 +23,7 @@ abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
         return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
     }
 
-    final public function validateIsEntryAllowed(string $key): bool
+    final public function validateIsMetaKeyAllowed(string $key): bool
     {
         return $this->getAllowOrDenySettingsService()->isEntryAllowed(
             $key,
@@ -37,9 +37,9 @@ abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
      *
      * @throws InvalidArgumentException
      */
-    final protected function assertIsEntryAllowed(string $key): void
+    final protected function assertIsMetaKeyAllowed(string $key): void
     {
-        if (!$this->validateIsEntryAllowed($key)) {
+        if (!$this->validateIsMetaKeyAllowed($key)) {
             throw new InvalidArgumentException(
                 sprintf(
                     $this->getTranslationAPI()->__('There is no meta with key \'%s\'', 'commentmeta'),

--- a/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use PoP\ComponentModel\Services\BasicServiceTrait;
 use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface;
 
-abstract class AbstractMetaTypeAPI
+abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
 {
     use BasicServiceTrait;
 
@@ -21,6 +21,22 @@ abstract class AbstractMetaTypeAPI
     final protected function getAllowOrDenySettingsService(): AllowOrDenySettingsServiceInterface
     {
         return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
+    }
+
+    /**
+     * If the allow/denylist validation fails, throw an exception.
+     * If the key is allowed but non-existent, return `null`.
+     * Otherwise, return the value.
+     *
+     * @param string[] $entries
+     */
+    final public function validateIsEntryAllowed(string $key): bool
+    {
+        return $this->getAllowOrDenySettingsService()->isEntryAllowed(
+            $key,
+            $this->getAllowOrDenyMetaEntries(),
+            $this->getAllowOrDenyMetaBehavior()
+        );
     }
 
     /**

--- a/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
@@ -48,9 +48,9 @@ abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
      *
      * @throws InvalidArgumentException
      */
-    final protected function assertIsEntryAllowed(array $entries, string $behavior, string $key): bool
+    final protected function assertIsEntryAllowed(string $key): bool
     {
-        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($key, $entries, $behavior)) {
+        if (!$this->validateIsEntryAllowed($key)) {
             throw new InvalidArgumentException(
                 sprintf(
                     $this->getTranslationAPI()->__('There is no meta with key \'%s\'', 'commentmeta'),

--- a/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
@@ -23,13 +23,6 @@ abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
         return $this->allowOrDenySettingsService ??= $this->instanceManager->getInstance(AllowOrDenySettingsServiceInterface::class);
     }
 
-    /**
-     * If the allow/denylist validation fails, throw an exception.
-     * If the key is allowed but non-existent, return `null`.
-     * Otherwise, return the value.
-     *
-     * @param string[] $entries
-     */
     final public function validateIsEntryAllowed(string $key): bool
     {
         return $this->getAllowOrDenySettingsService()->isEntryAllowed(
@@ -41,10 +34,6 @@ abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
 
     /**
      * If the allow/denylist validation fails, throw an exception.
-     * If the key is allowed but non-existent, return `null`.
-     * Otherwise, return the value.
-     *
-     * @param string[] $entries
      *
      * @throws InvalidArgumentException
      */

--- a/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/AbstractMetaTypeAPI.php
@@ -48,7 +48,7 @@ abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
      *
      * @throws InvalidArgumentException
      */
-    final protected function assertIsEntryAllowed(string $key): bool
+    final protected function assertIsEntryAllowed(string $key): void
     {
         if (!$this->validateIsEntryAllowed($key)) {
             throw new InvalidArgumentException(
@@ -58,6 +58,5 @@ abstract class AbstractMetaTypeAPI implements MetaTypeAPIInterface
                 )
             );
         }
-        return true;
     }
 }

--- a/layers/Schema/packages/meta/src/TypeAPIs/MetaTypeAPIInterface.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/MetaTypeAPIInterface.php
@@ -6,6 +6,7 @@ namespace PoPSchema\Meta\TypeAPIs;
 
 interface MetaTypeAPIInterface
 {
+    public function validateIsMetaKeyAllowed(string $key): bool;
     /**
      * @return string[]
      */

--- a/layers/Schema/packages/meta/src/TypeAPIs/MetaTypeAPIInterface.php
+++ b/layers/Schema/packages/meta/src/TypeAPIs/MetaTypeAPIInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\Meta\TypeAPIs;
+
+interface MetaTypeAPIInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getAllowOrDenyMetaEntries(): array;
+    public function getAllowOrDenyMetaBehavior(): string;
+}

--- a/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -25,12 +25,15 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
     }
 
     /**
+     * If the allow/denylist validation fails, and passing option "assert-is-option-allowed",
+     * then throw an exception.
+     *
      * @param array<string,mixed> $options
-     * @throws InvalidArgumentException When the option does not exist, or is not in the allowlist
+     * @throws InvalidArgumentException When the option name is not in the allowlist. Enabled by passing option "assert-is-option-allowed"
      */
     final public function getOption(string $name, array $options = []): mixed
     {
-        if ($options['assert-is-entry-allowed'] ?? null) {
+        if ($options['assert-is-option-allowed'] ?? null) {
             $this->assertIsOptionAllowed($name);
         }
         return $this->doGetOption($name);

--- a/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -46,7 +46,7 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
      *
      * @throws InvalidArgumentException
      */
-    final protected function assertIsEntryAllowed(array $entries, string $behavior, string $name): bool
+    final protected function assertIsEntryAllowed(array $entries, string $behavior, string $name): void
     {
         if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($name, $entries, $behavior)) {
             throw new InvalidArgumentException(
@@ -56,7 +56,6 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
                 )
             );
         }
-        return true;
     }
 
     /**

--- a/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -25,11 +25,14 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
     }
 
     /**
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException When the option does not exist, or is not in the allowlist
      */
-    final public function getOption(string $name): mixed
+    final public function getOption(string $name, array $options = []): mixed
     {
-        $this->assertIsEntryAllowed($name);
+        if ($options['assert-is-entry-allowed'] ?? null) {
+            $this->assertIsOptionAllowed($name);
+        }
         return $this->doGetOption($name);
     }
 
@@ -45,10 +48,10 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
         return ComponentConfiguration::getSettingsBehavior();
     }
 
-    final public function validateIsEntryAllowed(string $key): bool
+    final public function validateIsOptionAllowed(string $name): bool
     {
         return $this->getAllowOrDenySettingsService()->isEntryAllowed(
-            $key,
+            $name,
             $this->getAllowOrDenyOptionEntries(),
             $this->getAllowOrDenyOptionBehavior()
         );
@@ -59,9 +62,9 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
      *
      * @throws InvalidArgumentException
      */
-    final protected function assertIsEntryAllowed(string $name): void
+    final protected function assertIsOptionAllowed(string $name): void
     {
-        if (!$this->validateIsEntryAllowed($name)) {
+        if (!$this->validateIsOptionAllowed($name)) {
             throw new InvalidArgumentException(
                 sprintf(
                     $this->getTranslationAPI()->__('There is no option with name \'%s\'', 'settings'),

--- a/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -29,26 +29,39 @@ abstract class AbstractSettingsTypeAPI implements SettingsTypeAPIInterface
      */
     final public function getOption(string $name): mixed
     {
-        /**
-         * Check if the allow/denylist validation fails
-         * Compare for full match or regex
-         */
-        $entries = ComponentConfiguration::getSettingsEntries();
-        $behavior = ComponentConfiguration::getSettingsBehavior();
-        $this->assertIsEntryAllowed($entries, $behavior, $name);
+        $this->assertIsEntryAllowed($name);
         return $this->doGetOption($name);
     }
 
     /**
+     * @return string[]
+     */
+    public function getAllowOrDenyOptionEntries(): array
+    {
+        return ComponentConfiguration::getSettingsEntries();
+    }
+    public function getAllowOrDenyOptionBehavior(): string
+    {
+        return ComponentConfiguration::getSettingsBehavior();
+    }
+
+    final public function validateIsEntryAllowed(string $key): bool
+    {
+        return $this->getAllowOrDenySettingsService()->isEntryAllowed(
+            $key,
+            $this->getAllowOrDenyOptionEntries(),
+            $this->getAllowOrDenyOptionBehavior()
+        );
+    }
+
+    /**
      * If the allow/denylist validation fails, throw an exception.
-     * If the key is allowed but non-existent, return `null`.
-     * Otherwise, return the value.
      *
      * @throws InvalidArgumentException
      */
-    final protected function assertIsEntryAllowed(array $entries, string $behavior, string $name): void
+    final protected function assertIsEntryAllowed(string $name): void
     {
-        if (!$this->getAllowOrDenySettingsService()->isEntryAllowed($name, $entries, $behavior)) {
+        if (!$this->validateIsEntryAllowed($name)) {
             throw new InvalidArgumentException(
                 sprintf(
                     $this->getTranslationAPI()->__('There is no option with name \'%s\'', 'settings'),

--- a/layers/Schema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
@@ -12,4 +12,9 @@ interface SettingsTypeAPIInterface
      * @throws InvalidArgumentException When the option does not exist, or is not in the allowlist
      */
     public function getOption(string $name): mixed;
+    /**
+     * @return string[]
+     */
+    public function getAllowOrDenyOptionEntries(): array;
+    public function getAllowOrDenyOptionBehavior(): string;
 }

--- a/layers/Schema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
+++ b/layers/Schema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
@@ -9,9 +9,11 @@ use InvalidArgumentException;
 interface SettingsTypeAPIInterface
 {
     /**
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException When the option does not exist, or is not in the allowlist
      */
-    public function getOption(string $name): mixed;
+    public function getOption(string $name, array $options = []): mixed;
+    public function validateIsOptionAllowed(string $key): bool;
     /**
      * @return string[]
      */

--- a/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\TaxonomyMeta\FieldResolvers\ObjectType;
 
-use InvalidArgumentException;
-use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPSchema\Meta\FieldResolvers\InterfaceType\WithMetaInterfaceTypeFieldResolver;
@@ -56,6 +54,30 @@ class TaxonomyObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
+    protected function doResolveSchemaValidationErrorDescriptions(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        string $fieldName,
+        array $fieldArgs
+    ): array {
+        // if (!FieldQueryUtils::isAnyFieldArgumentValueAField($fieldArgs)) {
+        switch ($fieldName) {
+            case 'metaValue':
+            case 'metaValues':
+                if (!$this->getTaxonomyMetaTypeAPI()->validateIsMetaKeyAllowed($fieldArgs['key'])) {
+                    return [
+                        sprintf(
+                            $this->getTranslationAPI()->__('There is no key with name \'%s\'', 'taxonomymeta'),
+                            $fieldArgs['key']
+                        ),
+                    ];
+                }
+                break;
+        }
+        // }
+
+        return parent::doResolveSchemaValidationErrorDescriptions($objectTypeResolver, $fieldName, $fieldArgs);
+    }
+
     /**
      * @param array<string, mixed> $fieldArgs
      * @param array<string, mixed>|null $variables
@@ -75,20 +97,11 @@ class TaxonomyObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         switch ($fieldName) {
             case 'metaValue':
             case 'metaValues':
-                try {
-                    $value = $this->getTaxonomyMetaTypeAPI()->getTaxonomyTermMeta(
-                        $objectTypeResolver->getID($taxonomy),
-                        $fieldArgs['key'],
-                        $fieldName === 'metaValue'
-                    );
-                } catch (InvalidArgumentException $e) {
-                    // If the meta key is not in the allowlist, it will throw an exception
-                    return new Error(
-                        'meta-key-not-exists',
-                        $e->getMessage()
-                    );
-                }
-                return $value;
+                return $this->getTaxonomyMetaTypeAPI()->getTaxonomyTermMeta(
+                    $objectTypeResolver->getID($taxonomy),
+                    $fieldArgs['key'],
+                    $fieldName === 'metaValue'
+                );
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
@@ -19,9 +19,7 @@ abstract class AbstractTaxonomyMetaTypeAPI extends AbstractMetaTypeAPI implement
      */
     final public function getTaxonomyTermMeta(string | int $termID, string $key, bool $single = false): mixed
     {
-        $entries = ComponentConfiguration::getTaxonomyMetaEntries();
-        $behavior = ComponentConfiguration::getTaxonomyMetaBehavior();
-        $this->assertIsEntryAllowed($entries, $behavior, $key);
+        $this->assertIsEntryAllowed($key);
         return $this->doGetTaxonomyMeta($termID, $key, $single);
     }
 

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
@@ -26,6 +26,18 @@ abstract class AbstractTaxonomyMetaTypeAPI extends AbstractMetaTypeAPI implement
     }
 
     /**
+     * @return string[]
+     */
+    public function getAllowOrDenyMetaEntries(): array
+    {
+        return ComponentConfiguration::getTaxonomyMetaEntries();
+    }
+    public function getAllowOrDenyMetaBehavior(): string
+    {
+        return ComponentConfiguration::getTaxonomyMetaBehavior();
+    }
+
+    /**
      * If the key is non-existent, return `null`.
      * Otherwise, return the value.
      */

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/AbstractTaxonomyMetaTypeAPI.php
@@ -11,15 +11,19 @@ use PoPSchema\TaxonomyMeta\ComponentConfiguration;
 abstract class AbstractTaxonomyMetaTypeAPI extends AbstractMetaTypeAPI implements TaxonomyMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    final public function getTaxonomyTermMeta(string | int $termID, string $key, bool $single = false): mixed
+    final public function getTaxonomyTermMeta(string | int $termID, string $key, bool $single = false, array $options = []): mixed
     {
-        $this->assertIsEntryAllowed($key);
+        if ($options['assert-is-meta-key-allowed'] ?? null) {
+            $this->assertIsMetaKeyAllowed($key);
+        }
         return $this->doGetTaxonomyMeta($termID, $key, $single);
     }
 

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
@@ -10,11 +10,13 @@ use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 interface TaxonomyMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    public function getTaxonomyTermMeta(string | int $termID, string $key, bool $single = false): mixed;
+    public function getTaxonomyTermMeta(string | int $termID, string $key, bool $single = false, array $options = []): mixed;
 }

--- a/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/taxonomymeta/src/TypeAPIs/TaxonomyMetaTypeAPIInterface.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace PoPSchema\TaxonomyMeta\TypeAPIs;
 
 use InvalidArgumentException;
+use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 
-interface TaxonomyMetaTypeAPIInterface
+interface TaxonomyMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
      * If the allow/denylist validation fails, throw an exception.

--- a/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PoPSchema\UserMeta\FieldResolvers\ObjectType;
 
-use InvalidArgumentException;
-use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPSchema\Meta\FieldResolvers\InterfaceType\WithMetaInterfaceTypeFieldResolver;
@@ -56,6 +54,30 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         ];
     }
 
+    protected function doResolveSchemaValidationErrorDescriptions(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        string $fieldName,
+        array $fieldArgs
+    ): array {
+        // if (!FieldQueryUtils::isAnyFieldArgumentValueAField($fieldArgs)) {
+        switch ($fieldName) {
+            case 'metaValue':
+            case 'metaValues':
+                if (!$this->getUserMetaTypeAPI()->validateIsMetaKeyAllowed($fieldArgs['key'])) {
+                    return [
+                        sprintf(
+                            $this->getTranslationAPI()->__('There is no key with name \'%s\'', 'usermeta'),
+                            $fieldArgs['key']
+                        ),
+                    ];
+                }
+                break;
+        }
+        // }
+
+        return parent::doResolveSchemaValidationErrorDescriptions($objectTypeResolver, $fieldName, $fieldArgs);
+    }
+
     /**
      * @param array<string, mixed> $fieldArgs
      * @param array<string, mixed>|null $variables
@@ -75,20 +97,11 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         switch ($fieldName) {
             case 'metaValue':
             case 'metaValues':
-                try {
-                    $value = $this->getUserMetaTypeAPI()->getUserMeta(
-                        $objectTypeResolver->getID($user),
-                        $fieldArgs['key'],
-                        $fieldName === 'metaValue'
-                    );
-                } catch (InvalidArgumentException $e) {
-                    // If the meta key is not in the allowlist, it will throw an exception
-                    return new Error(
-                        'meta-key-not-exists',
-                        $e->getMessage()
-                    );
-                }
-                return $value;
+                return $this->getUserMetaTypeAPI()->getUserMeta(
+                    $objectTypeResolver->getID($user),
+                    $fieldArgs['key'],
+                    $fieldName === 'metaValue'
+                );
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
@@ -11,15 +11,19 @@ use PoPSchema\UserMeta\ComponentConfiguration;
 abstract class AbstractUserMetaTypeAPI extends AbstractMetaTypeAPI implements UserMetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    final public function getUserMeta(string | int $userID, string $key, bool $single = false): mixed
+    final public function getUserMeta(string | int $userID, string $key, bool $single = false, array $options = []): mixed
     {
-        $this->assertIsEntryAllowed($key);
+        if ($options['assert-is-meta-key-allowed'] ?? null) {
+            $this->assertIsMetaKeyAllowed($key);
+        }
         return $this->doGetUserMeta($userID, $key, $single);
     }
 

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
@@ -26,6 +26,18 @@ abstract class AbstractUserMetaTypeAPI extends AbstractMetaTypeAPI implements Us
     }
 
     /**
+     * @return string[]
+     */
+    public function getAllowOrDenyMetaEntries(): array
+    {
+        return ComponentConfiguration::getUserMetaEntries();
+    }
+    public function getAllowOrDenyMetaBehavior(): string
+    {
+        return ComponentConfiguration::getUserMetaBehavior();
+    }
+
+    /**
      * If the key is non-existent, return `null`.
      * Otherwise, return the value.
      */

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/AbstractUserMetaTypeAPI.php
@@ -19,9 +19,7 @@ abstract class AbstractUserMetaTypeAPI extends AbstractMetaTypeAPI implements Us
      */
     final public function getUserMeta(string | int $userID, string $key, bool $single = false): mixed
     {
-        $entries = ComponentConfiguration::getUserMetaEntries();
-        $behavior = ComponentConfiguration::getUserMetaBehavior();
-        $this->assertIsEntryAllowed($entries, $behavior, $key);
+        $this->assertIsEntryAllowed($key);
         return $this->doGetUserMeta($userID, $key, $single);
     }
 

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
@@ -10,11 +10,13 @@ use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 interface UserMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
-     * If the allow/denylist validation fails, throw an exception.
+     * If the allow/denylist validation fails, and passing option "assert-is-meta-key-allowed",
+     * then throw an exception.
      * If the key is allowed but non-existent, return `null`.
      * Otherwise, return the value.
      *
+     * @param array<string,mixed> $options
      * @throws InvalidArgumentException
      */
-    public function getUserMeta(string | int $userID, string $key, bool $single = false): mixed;
+    public function getUserMeta(string | int $userID, string $key, bool $single = false, array $options = []): mixed;
 }

--- a/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
+++ b/layers/Schema/packages/usermeta/src/TypeAPIs/UserMetaTypeAPIInterface.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace PoPSchema\UserMeta\TypeAPIs;
 
 use InvalidArgumentException;
+use PoPSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
 
-interface UserMetaTypeAPIInterface
+interface UserMetaTypeAPIInterface extends MetaTypeAPIInterface
 {
     /**
      * If the allow/denylist validation fails, throw an exception.


### PR DESCRIPTION
Execute validation in `doResolveSchemaValidationErrorDescriptions`, not in `resolveValue`, for:

- `metaValue(key:)` and `metaValues(key:)` fields
- `Root.option(name:)`