### PR TITLE
Add `option` field to also retrieve arrays and objects

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesInDBItemsDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesInDBItemsDirectiveResolver.php
@@ -144,23 +144,25 @@ final class SerializeLeafOutputTypeValuesInDBItemsDirectiveResolver extends Abst
         }
 
         // If the value is an array of arrays, then serialize each subelement to the item type
+        // To make sure the array is not associative (on which case it should be treated
+        // as a JSONObject instead of an array), also apply `array_values`
         if ($fieldLeafOutputTypeIsArrayOfArrays) {
-            return array_map(
+            return array_values(array_map(
                 // If it contains a null value, return it as is
-                fn (?array $arrayValueElem) => $arrayValueElem === null ? null : array_map(
+                fn (?array $arrayValueElem) => $arrayValueElem === null ? null : array_values(array_map(
                     fn (mixed $arrayOfArraysValueElem) => $arrayOfArraysValueElem === null ? null : $fieldLeafOutputTypeResolver->serialize($arrayOfArraysValueElem),
                     $arrayValueElem
-                ),
+                )),
                 $value
-            );
+            ));
         }
 
         // If the value is an array, then serialize each element to the item type
         if ($fieldLeafOutputTypeIsArray) {
-            return array_map(
+            return array_values(array_map(
                 fn (mixed $arrayValueElem) => $arrayValueElem === null ? null : $fieldLeafOutputTypeResolver->serialize($arrayValueElem),
                 $value
-            );
+            ));
         }
 
         // Otherwise, simply serialize the given value directly

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -139,6 +139,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - `Media.modifiedDateStr: String`
   - `Media.mimeType: String`
   - `Media.sizes: String`
+- Added fields to query options:
+  - `Root.optionValues: [AnyBuiltInScalar]`
+  - `Root.optionObjectValue: JSONObject`
+  - `Root.optionValue: AnyBuiltInScalar` (renamed from `Root.option`)
 
 ### Added
 
@@ -185,6 +189,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Renamed module "Schema for the Admin" to "Schema Expose Admin Data"
 - Renamed scalar type `AnyScalar` to `AnyBuiltInScalar`
 - Renamed interface type `Elemental` to `Node`
+- Renamed field `Root.option` to `Root.optionValue`
 - All `date` fields (such as `Post.date`, `Media.date` and `Comment.date`) and `modified` fields are now of type `DateTime` (before they had type `String`)
 - Must update `content(format:PLAIN_TEXT)` to `rawContent`
 - Must update the inputs for mutations

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md
@@ -583,7 +583,57 @@ Added the following fields for media items:
 
 ### Settings
 
-Whitelist additional entries by default:
+Field `Root.option` was used to fetch options, from the `wp_options` table. However this was not enough, since it only allowed us to fetch single values, but not arrays or objects, which can [also be handled as options in WordPress](https://developer.wordpress.org/reference/functions/get_option/#return).
+
+This has been fixed now, with the introduction of 2 new fields:
+
+- `Root.optionValues: [AnyBuiltInScalar]`
+- `Root.optionObjectValue: JSONObject`
+
+For consistency, field `Root.option` has been renamed:
+
+- `Root.optionValue: AnyBuiltInScalar`
+
+Now, we can execute the following query:
+
+```graphql
+{
+  # This is a single value
+  siteURL: optionValue(name: "siteurl")
+
+  # This is an array
+  stickyPosts: optionValues(name: "sticky_posts")
+
+  # This is an object
+  themeMods: optionObjectValue(name: "theme_mods_twentytwentyone")
+}
+```
+
+...which will produce this response:
+
+```json
+{
+  "data": {
+    "siteURL": "https://graphql-api.com",
+    "stickyPosts": [
+      1241,
+      1788,
+      1785
+    ],
+    "themeMods": {
+      "custom_css_post_id": -1,
+      "nav_menu_locations": {
+        "primary": 178,
+        "footer": 0
+      }
+    }
+  }
+}
+```
+
+### Settings configuration
+
+Added additional entries to the default allowlist:
 
 - `"siteurl"`
 - `"WPLANG"`
@@ -1252,6 +1302,10 @@ Because custom scalar `AnyScalar` only represents the 5 built-in GraphQL scalar 
 ### Renamed interface type `Elemental` to `Node`
 
 The `Elemental` interface contains field `id: ID!`. It has been renamed to `Node` to follow the convention by most GraphQL implementations (for instance, by [GitHub's GraphQL API](https://docs.github.com/en/graphql/reference/interfaces#node)).
+
+### Renamed field `Root.option` to `Root.optionValue`
+
+For consistency, since adding fields `optionValues` and `optionObjectValue`.
 
 ### Changed type for `date` fields to the new `DateTime`
 

--- a/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -64,18 +64,18 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     public function getFieldNamesToResolve(): array
     {
         return [
-            'option',
-            'arrayOption',
-            'objectOption',
+            'optionValue',
+            'optionValues',
+            'optionObjectValue',
         ];
     }
 
     public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
     {
         return match ($fieldName) {
-            'option' => $this->getTranslationAPI()->__('Single-value option saved in the DB, of any built-in scalar type', 'pop-settings'),
-            'arrayOption' => $this->getTranslationAPI()->__('Array-value option saved in the DB, of any built-in scalar type', 'pop-settings'),
-            'objectOption' => $this->getTranslationAPI()->__('Object-value option saved in the DB', 'pop-settings'),
+            'optionValue' => $this->getTranslationAPI()->__('Single-value option saved in the DB, of any built-in scalar type', 'pop-settings'),
+            'optionValues' => $this->getTranslationAPI()->__('Array-value option saved in the DB, of any built-in scalar type', 'pop-settings'),
+            'optionObjectValue' => $this->getTranslationAPI()->__('Object-value option saved in the DB', 'pop-settings'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -83,10 +83,10 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
     {
         return match ($fieldName) {
-            'option',
-            'arrayOption'
+            'optionValue',
+            'optionValues'
                 => $this->getAnyBuiltInScalarScalarTypeResolver(),
-            'objectOption'
+            'optionObjectValue'
                 => $this->getJSONObjectScalarTypeResolver(),
             default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
         };
@@ -95,7 +95,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
     {
         return match ($fieldName) {
-            'arrayOption' => SchemaTypeModifiers::IS_ARRAY,
+            'optionValues' => SchemaTypeModifiers::IS_ARRAY,
             default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
         };
     }
@@ -103,9 +103,9 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     public function getFieldArgNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): array
     {
         return match ($fieldName) {
-            'option',
-            'arrayOption',
-            'objectOption'
+            'optionValue',
+            'optionValues',
+            'optionObjectValue'
                 => [
                     'name' => $this->getStringScalarTypeResolver(),
                 ],
@@ -137,9 +137,9 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     ): array {
         // if (!FieldQueryUtils::isAnyFieldArgumentValueAField($fieldArgs)) {
         switch ($fieldName) {
-            case 'option':
-            case 'arrayOption':
-            case 'objectOption':
+            case 'optionValue':
+            case 'optionValues':
+            case 'optionObjectValue':
                 if (!$this->getSettingsTypeAPI()->validateIsOptionAllowed($fieldArgs['name'])) {
                     return [
                         sprintf(
@@ -161,9 +161,9 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
     ): bool {
         switch ($fieldName) {
-            case 'option':
-            case 'arrayOption':
-            case 'objectOption':
+            case 'optionValue':
+            case 'optionValues':
+            case 'optionObjectValue':
                 return true;
         }
         return parent::validateResolvedFieldType(
@@ -189,14 +189,14 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $options = []
     ): mixed {
         switch ($fieldName) {
-            case 'option':
-            case 'arrayOption':
-            case 'objectOption':
+            case 'optionValue':
+            case 'optionValues':
+            case 'optionObjectValue':
                 $value = $this->getSettingsTypeAPI()->getOption($fieldArgs['name']);
-                if ($fieldName === 'arrayOption') {
+                if ($fieldName === 'optionValues') {
                     return (array) $value;
                 }
-                if ($fieldName === 'objectOption') {
+                if ($fieldName === 'optionObjectValue') {
                     return (object) $value;
                 }
                 return $value;

--- a/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/Schema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -11,11 +11,13 @@ use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\TypeResolvers\ObjectType\RootObjectTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\AnyBuiltInScalarScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\StringScalarTypeResolver;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\JSONObjectScalarTypeResolver;
 use PoPSchema\Settings\TypeAPIs\SettingsTypeAPIInterface;
 
 class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?AnyBuiltInScalarScalarTypeResolver $anyBuiltInScalarScalarTypeResolver = null;
+    private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
     private ?SettingsTypeAPIInterface $settingsTypeAPI = null;
 
@@ -26,6 +28,14 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     final protected function getAnyBuiltInScalarScalarTypeResolver(): AnyBuiltInScalarScalarTypeResolver
     {
         return $this->anyBuiltInScalarScalarTypeResolver ??= $this->instanceManager->getInstance(AnyBuiltInScalarScalarTypeResolver::class);
+    }
+    final public function setJSONObjectScalarTypeResolver(JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver): void
+    {
+        $this->jsonObjectScalarTypeResolver = $jsonObjectScalarTypeResolver;
+    }
+    final protected function getJSONObjectScalarTypeResolver(): JSONObjectScalarTypeResolver
+    {
+        return $this->jsonObjectScalarTypeResolver ??= $this->instanceManager->getInstance(JSONObjectScalarTypeResolver::class);
     }
     final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
     {
@@ -55,13 +65,17 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return [
             'option',
+            'arrayOption',
+            'objectOption',
         ];
     }
 
     public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
     {
         return match ($fieldName) {
-            'option' => $this->getTranslationAPI()->__('Option saved in the DB', 'pop-settings'),
+            'option' => $this->getTranslationAPI()->__('Single-value option saved in the DB, of any built-in scalar type', 'pop-settings'),
+            'arrayOption' => $this->getTranslationAPI()->__('Array-value option saved in the DB, of any built-in scalar type', 'pop-settings'),
+            'objectOption' => $this->getTranslationAPI()->__('Object-value option saved in the DB', 'pop-settings'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -69,33 +83,49 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
     {
         return match ($fieldName) {
-            'option' => $this->getAnyBuiltInScalarScalarTypeResolver(),
+            'option',
+            'arrayOption'
+                => $this->getAnyBuiltInScalarScalarTypeResolver(),
+            'objectOption'
+                => $this->getJSONObjectScalarTypeResolver(),
             default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        return match ($fieldName) {
+            'arrayOption' => SchemaTypeModifiers::IS_ARRAY,
+            default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
         };
     }
 
     public function getFieldArgNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): array
     {
         return match ($fieldName) {
-            'option' => [
-                'name' => $this->getStringScalarTypeResolver(),
-            ],
-            default => parent::getFieldArgNameTypeResolvers($objectTypeResolver, $fieldName),
+            'option',
+            'arrayOption',
+            'objectOption'
+                => [
+                    'name' => $this->getStringScalarTypeResolver(),
+                ],
+            default
+                => parent::getFieldArgNameTypeResolvers($objectTypeResolver, $fieldName),
         };
     }
 
     public function getFieldArgDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): ?string
     {
-        return match ([$fieldName => $fieldArgName]) {
-            ['option' => 'name'] => $this->getTranslationAPI()->__('The option name', 'pop-settings'),
+        return match ($fieldArgName) {
+            'name' => $this->getTranslationAPI()->__('The option name', 'pop-settings'),
             default => parent::getFieldArgDescription($objectTypeResolver, $fieldName, $fieldArgName),
         };
     }
 
     public function getFieldArgTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): int
     {
-        return match ([$fieldName => $fieldArgName]) {
-            ['option' => 'name'] => SchemaTypeModifiers::MANDATORY,
+        return match ($fieldArgName) {
+            'name' => SchemaTypeModifiers::MANDATORY,
             default => parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
         };
     }
@@ -108,6 +138,8 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         // if (!FieldQueryUtils::isAnyFieldArgumentValueAField($fieldArgs)) {
         switch ($fieldName) {
             case 'option':
+            case 'arrayOption':
+            case 'objectOption':
                 if (!$this->getSettingsTypeAPI()->validateIsOptionAllowed($fieldArgs['name'])) {
                     return [
                         sprintf(
@@ -130,6 +162,8 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     ): bool {
         switch ($fieldName) {
             case 'option':
+            case 'arrayOption':
+            case 'objectOption':
                 return true;
         }
         return parent::validateResolvedFieldType(
@@ -156,7 +190,16 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     ): mixed {
         switch ($fieldName) {
             case 'option':
-                return $this->getSettingsTypeAPI()->getOption($fieldArgs['name']);
+            case 'arrayOption':
+            case 'objectOption':
+                $value = $this->getSettingsTypeAPI()->getOption($fieldArgs['name']);
+                if ($fieldName === 'arrayOption') {
+                    return (array) $value;
+                }
+                if ($fieldName === 'objectOption') {
+                    return (object) $value;
+                }
+                return $value;
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);


### PR DESCRIPTION
Field `Root.option` was used to fetch options, from the `wp_options` table. However this was not enough, since it only allowed us to fetch single values, but not arrays or objects, which can [also be handled as options in WordPress](https://developer.wordpress.org/reference/functions/get_option/#return).

This has been fixed now, with the introduction of 2 new fields:

- `Root.optionValues: [AnyBuiltInScalar]`
- `Root.optionObjectValue: JSONObject`

For consistency, field `Root.option` has been renamed:

- `Root.optionValue: AnyBuiltInScalar`

Now, we can execute the following query:

```graphql
{
  # This is a single value
  siteURL: optionValue(name: "siteurl")

  # This is an array
  stickyPosts: optionValues(name: "sticky_posts")

  # This is an object
  themeMods: optionObjectValue(name: "theme_mods_twentytwentyone")
}
```

...which will produce this response:

```json
{
  "data": {
    "siteURL": "https://graphql-api.com",
    "stickyPosts": [
      1241,
      1788,
      1785
    ],
    "themeMods": {
      "custom_css_post_id": -1,
      "nav_menu_locations": {
        "primary": 178,
        "footer": 0
      }
    }
  }
}
```