### PR TITLE
Downgrade `DateTimeInterface::ATOM` for PHP 7.1 / Temporary solution

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Polyfill/PHP72/DateTimeInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Polyfill/PHP72/DateTimeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLAPI\GraphQLAPI\Polyfill\PHP72;
+
+interface DateTimeInterface
+{
+    /**
+     * @see https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.atom
+     */
+    public const ATOM = 'Y-m-d\TH:i:sP';
+}

--- a/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
+++ b/layers/Schema/packages/schema-commons/src/ObjectSerializers/DateTimeObjectSerializer.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace PoPSchema\SchemaCommons\ObjectSerializers;
 
 use DateTime;
-use DateTimeInterface;
+// @todo Replace with \DateTimeInterface. See: https://github.com/leoloso/PoP/issues/1282
+use PoPSchema\SchemaCommons\Polyfill\PHP72\DateTimeInterface;
 use PoP\ComponentModel\ObjectSerialization\AbstractObjectSerializer;
 
 class DateTimeObjectSerializer extends AbstractObjectSerializer

--- a/layers/Schema/packages/schema-commons/src/Polyfill/PHP72/DateTimeInterface.php
+++ b/layers/Schema/packages/schema-commons/src/Polyfill/PHP72/DateTimeInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace GraphQLAPI\GraphQLAPI\Polyfill\PHP72;
+namespace PoPSchema\SchemaCommons\Polyfill\PHP72;
 
 interface DateTimeInterface
 {

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateScalarTypeResolver.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
 
-use DateTimeInterface;
+// @todo Replace with \DateTimeInterface. See: https://github.com/leoloso/PoP/issues/1282
+use PoPSchema\SchemaCommons\Polyfill\PHP72\DateTimeInterface;
 
 class DateScalarTypeResolver extends AbstractDateTimeScalarTypeResolver
 {

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/DateTimeScalarTypeResolver.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
 
-use DateTimeInterface;
+// @todo Replace with \DateTimeInterface. See: https://github.com/leoloso/PoP/issues/1282
+use PoPSchema\SchemaCommons\Polyfill\PHP72\DateTimeInterface;
 
 class DateTimeScalarTypeResolver extends AbstractDateTimeScalarTypeResolver
 {

--- a/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PoP\PoP\Config\Rector\Downgrade\Configurators;
 
 use DateTimeInterface;
-use GraphQLAPI\GraphQLAPI\Polyfill\PHP72\DateTimeInterface as PolyfillDateTimeInterface;
+use PoPSchema\SchemaCommons\Polyfill\PHP72\DateTimeInterface as PolyfillDateTimeInterface;
 use PoP\PoP\Config\Rector\Configurators\AbstractContainerConfigurationService;
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;

--- a/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
@@ -19,10 +19,16 @@ abstract class AbstractDowngradeContainerConfigurationService extends AbstractCo
     {
         $this->containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_71);
 
-        // Must also replace DateTimeInterface::ATOM for PHP 7.1
-        $services = $this->containerConfigurator->services();
-        $services->set(RenameClassConstFetchRector::class)
-            ->configure([new RenameClassAndConstFetch(DateTimeInterface::class, 'ATOM', PolyfillDateTimeInterface::class, 'ATOM')]);
+        /**
+         * @todo Uncomment this code
+         * Currently it doesn't work, maybe because `RenameClassConstFetchRector`
+         * doesn't handle interfaces, so it doesn't replace `DateTimeInterface`
+         * Solution: Create a similar rule
+         */
+        // // Must also replace DateTimeInterface::ATOM for PHP 7.1
+        // $services = $this->containerConfigurator->services();
+        // $services->set(RenameClassConstFetchRector::class)
+        //     ->configure([new RenameClassAndConstFetch(DateTimeInterface::class, 'ATOM', PolyfillDateTimeInterface::class, 'ATOM')]);
 
         $parameters = $this->containerConfigurator->parameters();
 

--- a/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace PoP\PoP\Config\Rector\Downgrade\Configurators;
 
+use DateTimeInterface;
+use GraphQLAPI\GraphQLAPI\Polyfill\PHP72\DateTimeInterface as PolyfillDateTimeInterface;
 use PoP\PoP\Config\Rector\Configurators\AbstractContainerConfigurationService;
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 use Rector\Set\ValueObject\DowngradeLevelSetList;
 
 abstract class AbstractDowngradeContainerConfigurationService extends AbstractContainerConfigurationService
@@ -14,6 +18,11 @@ abstract class AbstractDowngradeContainerConfigurationService extends AbstractCo
     public function configureContainer(): void
     {
         $this->containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_71);
+
+        // Must also replace DateTimeInterface::ATOM for PHP 7.1
+        $services = $this->containerConfigurator->services();
+        $services->set(RenameClassConstFetchRector::class)
+            ->configure([new RenameClassAndConstFetch(DateTimeInterface::class, 'ATOM', PolyfillDateTimeInterface::class, 'ATOM')]);
 
         $parameters = $this->containerConfigurator->parameters();
 


### PR DESCRIPTION
Temporary solution tackling #1282 