### PR TITLE
Fix: Uncaught TypeError: [...] Argument #2 ($post) must be of type WP_Post, null given

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/AbstractBlockCategory.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/BlockCategories/AbstractBlockCategory.php
@@ -65,6 +65,9 @@ abstract class AbstractBlockCategory extends AbstractAutomaticallyInstantiatedSe
      */
     public function getBlockCategoriesViaBlockEditorContext(array $categories, WP_Block_Editor_Context $blockEditorContext): array
     {
+        if ($blockEditorContext->post === null) {
+            return $categories;
+        }
         return $this->getBlockCategories(
             $categories,
             $blockEditorContext->post

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractCustomPostType.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/CustomPostTypes/AbstractCustomPostType.php
@@ -559,6 +559,9 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
      */
     public function allowGutenbergBlocksForCustomPostTypeViaBlockEditorContext(array|bool $allowedBlocks, WP_Block_Editor_Context $blockEditorContext): array|bool
     {
+        if ($blockEditorContext->post === null) {
+            return $allowedBlocks;
+        }
         return $this->allowGutenbergBlocksForCustomPostType(
             $allowedBlocks,
             $blockEditorContext->post


### PR DESCRIPTION
Fixes #1284 