### PR TITLE
Make `Location` in the extended GraphQLParser nullable

### DIFF
--- a/layers/Backbone/packages/graphql-parser/src/Exception/Parser/AbstractParserError.php
+++ b/layers/Backbone/packages/graphql-parser/src/Exception/Parser/AbstractParserError.php
@@ -10,8 +10,10 @@ use PoPBackbone\GraphQLParser\Parser\Location;
 
 abstract class AbstractParserError extends Exception implements LocationableExceptionInterface
 {
-    public function __construct(string $message, private Location $location)
-    {
+    public function __construct(
+        string $message,
+        private Location $location,
+    ) {
         parent::__construct($message);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Execution/Request.php
+++ b/layers/Backbone/packages/graphql-parser/src/Execution/Request.php
@@ -39,8 +39,10 @@ class Request
      * @param array<string, mixed> $data
      * @param array<string, mixed> $variableValues
      */
-    public function __construct(array $data = [], array $variableValues = [])
-    {
+    public function __construct(
+        array $data = [],
+        array $variableValues = [],
+    ) {
         if (array_key_exists('queries', $data)) {
             $this->addQueries($data['queries']);
         }

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Argument.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Argument.php
@@ -9,8 +9,11 @@ use PoPBackbone\GraphQLParser\Parser\Location;
 
 class Argument extends AbstractAst
 {
-    public function __construct(private string $name, private ValueInterface $value, Location $location)
-    {
+    public function __construct(
+        private string $name,
+        private ValueInterface $value,
+        Location $location,
+    ) {
         parent::__construct($location);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputList.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputList.php
@@ -13,8 +13,10 @@ class InputList extends AbstractAst implements ValueInterface
     /**
      * @param mixed[] $list
      */
-    public function __construct(protected array $list, Location $location)
-    {
+    public function __construct(
+        protected array $list,
+        Location $location,
+    ) {
         parent::__construct($location);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputObject.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/InputObject.php
@@ -11,8 +11,10 @@ use stdClass;
 
 class InputObject extends AbstractAst implements ValueInterface
 {
-    public function __construct(protected stdClass $object, Location $location)
-    {
+    public function __construct(
+        protected stdClass $object,
+        Location $location,
+    ) {
         parent::__construct($location);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Literal.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Literal.php
@@ -13,8 +13,10 @@ class Literal extends AbstractAst implements ValueInterface
     /**
      * @param string|int|float|bool|null $value
      */
-    public function __construct(private string|int|float|bool|null $value, Location $location)
-    {
+    public function __construct(
+        private string|int|float|bool|null $value,
+        Location $location
+    ) {
         parent::__construct($location);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Variable.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/Variable.php
@@ -19,8 +19,14 @@ class Variable extends AbstractAst implements ValueInterface
 
     private mixed $defaultValue = null;
 
-    public function __construct(private string $name, private string $type, private bool $nullable, private bool $isArray, private bool $arrayElementNullable, Location $location)
-    {
+    public function __construct(
+        private string $name,
+        private string $type,
+        private bool $nullable,
+        private bool $isArray,
+        private bool $arrayElementNullable,
+        Location $location,
+    ) {
         parent::__construct($location);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/VariableReference.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/ArgumentValue/VariableReference.php
@@ -12,8 +12,11 @@ class VariableReference extends AbstractAst implements ValueInterface
 {
     private mixed $value;
 
-    public function __construct(private string $name, private ?Variable $variable, Location $location)
-    {
+    public function __construct(
+        private string $name,
+        private ?Variable $variable,
+        Location $location,
+    ) {
         parent::__construct($location);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Directive.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Directive.php
@@ -13,8 +13,11 @@ class Directive extends AbstractAst
     /**
      * @param Argument[] $arguments
      */
-    public function __construct(private $name, array $arguments, Location $location)
-    {
+    public function __construct(
+        private $name,
+        array $arguments,
+        Location $location,
+    ) {
         parent::__construct($location);
         $this->setArguments($arguments);
     }

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Field.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Field.php
@@ -16,8 +16,13 @@ class Field extends AbstractAst implements FieldInterface
      * @param Argument[] $arguments
      * @param Directive[] $directives
      */
-    public function __construct(private string $name, private ?string $alias, array $arguments, array $directives, Location $location)
-    {
+    public function __construct(
+        private string $name,
+        private ?string $alias,
+        array $arguments,
+        array $directives,
+        Location $location,
+    ) {
         parent::__construct($location);
         $this->setArguments($arguments);
         $this->setDirectives($directives);

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Fragment.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Fragment.php
@@ -17,8 +17,13 @@ class Fragment extends AbstractAst implements WithDirectivesInterface
      * @param Directive[] $directives
      * @param Field[]|Query[] $fields
      */
-    public function __construct(protected string $name, protected string $model, array $directives, protected array $fields, Location $location)
-    {
+    public function __construct(
+        protected string $name,
+        protected string $model,
+        array $directives,
+        protected array $fields,
+        Location $location,
+    ) {
         parent::__construct($location);
         $this->setDirectives($directives);
     }

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/FragmentReference.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/FragmentReference.php
@@ -9,8 +9,10 @@ use PoPBackbone\GraphQLParser\Parser\Location;
 
 class FragmentReference extends AbstractAst implements FragmentInterface
 {
-    public function __construct(protected string $name, Location $location)
-    {
+    public function __construct(
+        protected string $name,
+        Location $location,
+    ) {
         parent::__construct($location);
     }
 

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Query.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/Query.php
@@ -21,8 +21,14 @@ class Query extends AbstractAst implements FieldInterface
      * @param Field[]|Query[]|FragmentReference[]|TypedFragmentReference[] $fields
      * @param Directive[] $directives
      */
-    public function __construct(protected string $name, protected ?string $alias, array $arguments, array $fields, array $directives, Location $location)
-    {
+    public function __construct(
+        protected string $name,
+        protected ?string $alias,
+        array $arguments,
+        array $fields,
+        array $directives,
+        Location $location,
+    ) {
         parent::__construct($location);
         $this->setFields($fields);
         $this->setArguments($arguments);

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Ast/TypedFragmentReference.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Ast/TypedFragmentReference.php
@@ -16,8 +16,12 @@ class TypedFragmentReference extends AbstractAst implements FragmentInterface, W
      * @param Field[]|Query[] $fields
      * @param Directive[] $directives
      */
-    public function __construct(protected string $typeName, protected array $fields, array $directives, Location $location)
-    {
+    public function __construct(
+        protected string $typeName,
+        protected array $fields,
+        array $directives,
+        Location $location,
+    ) {
         parent::__construct($location);
         $this->setDirectives($directives);
     }

--- a/layers/Backbone/packages/graphql-parser/src/Parser/Location.php
+++ b/layers/Backbone/packages/graphql-parser/src/Parser/Location.php
@@ -6,8 +6,10 @@ namespace PoPBackbone\GraphQLParser\Parser;
 
 class Location
 {
-    public function __construct(private int $line, private int $column)
-    {
+    public function __construct(
+        private int $line,
+        private int $column,
+    ) {
     }
 
     public function getLine(): int

--- a/layers/Engine/packages/graphql-parser/src/Parser/Ast/Directive.php
+++ b/layers/Engine/packages/graphql-parser/src/Parser/Ast/Directive.php
@@ -5,7 +5,21 @@ declare(strict_types=1);
 namespace PoP\GraphQLParser\Parser\Ast;
 
 use PoPBackbone\GraphQLParser\Parser\Ast\Directive as UpstreamDirective;
+use PoPBackbone\GraphQLParser\Parser\Location;
 
 class Directive extends UpstreamDirective
 {
+    /**
+     * For the SiteBuilder, the generated GraphQL query will have no Location
+     *
+     * @param Argument[] $arguments
+     */
+    public function __construct(
+        private string $name,
+        array $arguments,
+        ?Location $location = null,
+    ) {
+        $location ??= new Location(0, 0);
+        parent::__construct($name, $arguments, $location);
+    }
 }

--- a/layers/Engine/packages/graphql-parser/src/Parser/Ast/Directive.php
+++ b/layers/Engine/packages/graphql-parser/src/Parser/Ast/Directive.php
@@ -9,9 +9,9 @@ use PoPBackbone\GraphQLParser\Parser\Location;
 
 class Directive extends UpstreamDirective
 {
+    use MaybeNonLocatableAstTrait;
+
     /**
-     * For the SiteBuilder, the generated GraphQL query will have no Location
-     *
      * @param Argument[] $arguments
      */
     public function __construct(
@@ -19,7 +19,10 @@ class Directive extends UpstreamDirective
         array $arguments,
         ?Location $location = null,
     ) {
-        $location ??= new Location(0, 0);
-        parent::__construct($name, $arguments, $location);
+        parent::__construct(
+            $name,
+            $arguments,
+            $this->getLocation($location),
+        );
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/Parser/Ast/Field.php
+++ b/layers/Engine/packages/graphql-parser/src/Parser/Ast/Field.php
@@ -4,8 +4,27 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Parser\Ast;
 
+use PoPBackbone\GraphQLParser\Parser\Ast\Argument;
+use PoPBackbone\GraphQLParser\Parser\Ast\Directive;
 use PoPBackbone\GraphQLParser\Parser\Ast\Field as UpstreamField;
+use PoPBackbone\GraphQLParser\Parser\Location;
 
 class Field extends UpstreamField
 {
+    /**
+     * For the SiteBuilder, the generated GraphQL query will have no Location
+     *
+     * @param Argument[] $arguments
+     * @param Directive[] $directives
+     */
+    public function __construct(
+        private string $name,
+        private ?string $alias,
+        array $arguments,
+        array $directives,
+        ?Location $location = null,
+    ) {
+        $location ??= new Location(0, 0);
+        parent::__construct($name, $alias, $arguments, $directives, $location);
+    }
 }

--- a/layers/Engine/packages/graphql-parser/src/Parser/Ast/Field.php
+++ b/layers/Engine/packages/graphql-parser/src/Parser/Ast/Field.php
@@ -11,9 +11,9 @@ use PoPBackbone\GraphQLParser\Parser\Location;
 
 class Field extends UpstreamField
 {
+    use MaybeNonLocatableAstTrait;
+
     /**
-     * For the SiteBuilder, the generated GraphQL query will have no Location
-     *
      * @param Argument[] $arguments
      * @param Directive[] $directives
      */
@@ -24,7 +24,12 @@ class Field extends UpstreamField
         array $directives,
         ?Location $location = null,
     ) {
-        $location ??= new Location(0, 0);
-        parent::__construct($name, $alias, $arguments, $directives, $location);
+        parent::__construct(
+            $name,
+            $alias,
+            $arguments,
+            $directives,
+            $this->getLocation($location),
+        );
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/Parser/Ast/MaybeNonLocatableAstTrait.php
+++ b/layers/Engine/packages/graphql-parser/src/Parser/Ast/MaybeNonLocatableAstTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\Parser\Ast;
+
+use PoPBackbone\GraphQLParser\Parser\Location;
+
+trait MaybeNonLocatableAstTrait
+{
+    /**
+     * For the SiteBuilder, the generated GraphQL query will have no Location.
+     * Because the parent class does need a Location, create a "dummy" one,
+     * with coordinates [0, 0]
+     */
+    public function getLocation(?Location $location = null): Location
+    {
+        return $location ?? new Location(0, 0);
+    }
+}


### PR DESCRIPTION
For the SiteBuilder, the generated GraphQL query will have no Location for the added Fields. Because the Backbone library does need a Location, create a "dummy" one, with coordinates [0, 0].