### PR TITLE
Move `getRoutes` to `RoutingWP`

### DIFF
--- a/layers/Engine/packages/root/src/Routing/AbstractRoutingManager.php
+++ b/layers/Engine/packages/root/src/Routing/AbstractRoutingManager.php
@@ -33,7 +33,7 @@ abstract class AbstractRoutingManager implements RoutingManagerInterface
         if (isset($_REQUEST[Params::ROUTE])) {
             return trim(strtolower($_REQUEST[Params::ROUTE]), '/');
         }
-        
+
         // By default, use the "main" route
         return Routes::MAIN;
     }

--- a/layers/Engine/packages/root/src/Routing/AbstractRoutingManager.php
+++ b/layers/Engine/packages/root/src/Routing/AbstractRoutingManager.php
@@ -13,44 +13,6 @@ abstract class AbstractRoutingManager implements RoutingManagerInterface
     use BasicServiceTrait;
 
     /**
-     * @var string[]|null
-     */
-    private ?array $routes = null;
-
-    /**
-     * @return string[]
-     */
-    public function getRoutes(): array
-    {
-        if ($this->routes === null) {
-            $this->routes = array_filter(
-                (array) App::applyFilters(
-                    RouteHookNames::ROUTES,
-                    []
-                )
-            );
-
-            // // If there are partial endpoints, generate all the combinations of route + partial endpoint
-            // // For instance, route = "posts", endpoint = "/api/rest", combined route = "posts/api/rest"
-            // if ($partialEndpoints = array_filter(
-            //     (array) \PoP\Root\App::applyFilters(
-            //         'route-endpoints',
-            //         []
-            //     )
-            // )) {
-            //     // Attach the endpoints to each of the routes
-            //     $routes = $this->routes;
-            //     foreach ($routes as $route) {
-            //         foreach ($partialEndpoints as $endpoint) {
-            //             $this->routes[] = $route . '/' . trim($endpoint, '/');
-            //         }
-            //     }
-            // }
-        }
-        return $this->routes;
-    }
-
-    /**
      * By default, everything is a generic route
      */
     public function getCurrentNature(): string

--- a/layers/Engine/packages/root/src/Routing/AbstractRoutingManager.php
+++ b/layers/Engine/packages/root/src/Routing/AbstractRoutingManager.php
@@ -26,22 +26,15 @@ abstract class AbstractRoutingManager implements RoutingManagerInterface
 
         // If it is a ROUTE, then the URL path is already the route
         if ($nature === RouteNatures::GENERIC) {
-            $route = RoutingUtils::getURLPath();
-        } else {
-            // If having set URL param "route", then use it
-            if (isset($_REQUEST[Params::ROUTE])) {
-                $route = trim(strtolower($_REQUEST[Params::ROUTE]), '/');
-            } else {
-                // If not, use the "main" route
-                $route = Routes::MAIN;
-            }
+            return RoutingUtils::getURLPath();
         }
 
-        // Allow to change it
-        return (string) App::applyFilters(
-            RouteHookNames::CURRENT_ROUTE,
-            $route,
-            $nature
-        );
+        // If having set URL param "route", then use it
+        if (isset($_REQUEST[Params::ROUTE])) {
+            return trim(strtolower($_REQUEST[Params::ROUTE]), '/');
+        }
+        
+        // By default, use the "main" route
+        return Routes::MAIN;
     }
 }

--- a/layers/Engine/packages/root/src/Routing/RouteHookNames.php
+++ b/layers/Engine/packages/root/src/Routing/RouteHookNames.php
@@ -7,5 +7,4 @@ namespace PoP\Root\Routing;
 class RouteHookNames
 {
     public const ROUTES = __CLASS__ . ':routes';
-    public const CURRENT_ROUTE = __CLASS__ . ':currentRoute';
 }

--- a/layers/Engine/packages/root/src/Routing/RoutingManagerInterface.php
+++ b/layers/Engine/packages/root/src/Routing/RoutingManagerInterface.php
@@ -6,10 +6,6 @@ namespace PoP\Root\Routing;
 
 interface RoutingManagerInterface
 {
-    /**
-     * @return string[]
-     */
-    public function getRoutes(): array;
     public function getCurrentNature(): string;
     public function getCurrentRoute(): string;
 }

--- a/layers/Engine/packages/routing-wp/src/HookNames.php
+++ b/layers/Engine/packages/routing-wp/src/HookNames.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\RoutingWP;
 
-class RouteHookNames
+class HookNames
 {
     public const ROUTES = __CLASS__ . ':routes';
 }

--- a/layers/Engine/packages/routing-wp/src/HookNames.php
+++ b/layers/Engine/packages/routing-wp/src/HookNames.php
@@ -7,4 +7,5 @@ namespace PoP\RoutingWP;
 class HookNames
 {
     public const ROUTES = __CLASS__ . ':routes';
+    public const NATURE = __CLASS__ . ':nature';
 }

--- a/layers/Engine/packages/routing-wp/src/Hooks/SetupCortexHookSet.php
+++ b/layers/Engine/packages/routing-wp/src/Hooks/SetupCortexHookSet.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace PoP\RoutingWP\Hooks;
 
-use PoP\Root\App;
 use Brain\Cortex\Route\QueryRoute;
 use Brain\Cortex\Route\RouteCollectionInterface;
 use Brain\Cortex\Route\RouteInterface;
+use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
 use PoP\Root\Routing\RoutingManagerInterface;
 use PoP\RoutingWP\WPQueries;
+use PoP\RoutingWP\WPQueryRoutingManagerInterface;
 
 class SetupCortexHookSet extends AbstractHookSet
 {
@@ -39,7 +40,9 @@ class SetupCortexHookSet extends AbstractHookSet
      */
     public function setupCortex(RouteCollectionInterface $routes): void
     {
-        foreach ($this->getRoutingManager()->getRoutes() as $route) {
+        /** @var WPQueryRoutingManagerInterface */
+        $routingManager = $this->getRoutingManager();
+        foreach ($routingManager->getRoutes() as $route) {
             $routes->addRoute(new QueryRoute(
                 $route,
                 fn (array $matches) => WPQueries::GENERIC_NATURE,

--- a/layers/Engine/packages/routing-wp/src/RouteHookNames.php
+++ b/layers/Engine/packages/routing-wp/src/RouteHookNames.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoP\Root\Routing;
+namespace PoP\RoutingWP;
 
 class RouteHookNames
 {

--- a/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
+++ b/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
@@ -26,7 +26,7 @@ class WPQueryRoutingManager extends AbstractRoutingManager implements WPQueryRou
         if ($this->routes === null) {
             $this->routes = array_filter(
                 (array) App::applyFilters(
-                    RouteHookNames::ROUTES,
+                    HookNames::ROUTES,
                     []
                 )
             );

--- a/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
+++ b/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
@@ -52,7 +52,7 @@ class WPQueryRoutingManager extends AbstractRoutingManager implements WPQueryRou
 
         // Allow plugins to implement their own natures
         return (string) App::applyFilters(
-            'WPCMSRoutingState:nature',
+            HookNames::NATURE,
             parent::getCurrentNature(),
             $this->query
         );

--- a/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
+++ b/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
@@ -30,23 +30,6 @@ class WPQueryRoutingManager extends AbstractRoutingManager implements WPQueryRou
                     []
                 )
             );
-
-            // // If there are partial endpoints, generate all the combinations of route + partial endpoint
-            // // For instance, route = "posts", endpoint = "/api/rest", combined route = "posts/api/rest"
-            // if ($partialEndpoints = array_filter(
-            //     (array) \PoP\Root\App::applyFilters(
-            //         'route-endpoints',
-            //         []
-            //     )
-            // )) {
-            //     // Attach the endpoints to each of the routes
-            //     $routes = $this->routes;
-            //     foreach ($routes as $route) {
-            //         foreach ($partialEndpoints as $endpoint) {
-            //             $this->routes[] = $route . '/' . trim($endpoint, '/');
-            //         }
-            //     }
-            // }
         }
         return $this->routes;
     }

--- a/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
+++ b/layers/Engine/packages/routing-wp/src/WPQueryRoutingManager.php
@@ -9,9 +9,47 @@ use PoP\Root\Routing\AbstractRoutingManager;
 use PoP\Root\Routing\RouteNatures;
 use WP_Query;
 
-class WPQueryRoutingManager extends AbstractRoutingManager
+class WPQueryRoutingManager extends AbstractRoutingManager implements WPQueryRoutingManagerInterface
 {
     use RoutingManagerTrait;
+
+    /**
+     * @var string[]|null
+     */
+    private ?array $routes = null;
+
+    /**
+     * @return string[]
+     */
+    public function getRoutes(): array
+    {
+        if ($this->routes === null) {
+            $this->routes = array_filter(
+                (array) App::applyFilters(
+                    RouteHookNames::ROUTES,
+                    []
+                )
+            );
+
+            // // If there are partial endpoints, generate all the combinations of route + partial endpoint
+            // // For instance, route = "posts", endpoint = "/api/rest", combined route = "posts/api/rest"
+            // if ($partialEndpoints = array_filter(
+            //     (array) \PoP\Root\App::applyFilters(
+            //         'route-endpoints',
+            //         []
+            //     )
+            // )) {
+            //     // Attach the endpoints to each of the routes
+            //     $routes = $this->routes;
+            //     foreach ($routes as $route) {
+            //         foreach ($partialEndpoints as $endpoint) {
+            //             $this->routes[] = $route . '/' . trim($endpoint, '/');
+            //         }
+            //     }
+            // }
+        }
+        return $this->routes;
+    }
 
     public function getCurrentNature(): string
     {

--- a/layers/Engine/packages/routing-wp/src/WPQueryRoutingManagerInterface.php
+++ b/layers/Engine/packages/routing-wp/src/WPQueryRoutingManagerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\RoutingWP;
+
+use PoP\Root\Routing\RoutingManagerInterface;
+
+interface WPQueryRoutingManagerInterface extends RoutingManagerInterface
+{
+    /**
+     * All the routes defined in the application.
+     *
+     * @return string[]
+     */
+    public function getRoutes(): array;
+}

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_ADDCOMMENTS_ROUTE_ADDCOMMENT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_ADDCOMMENTS_ROUTE_ADDCOMMENT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_ADDHIGHLIGHTS_ROUTE_EDITHIGHLIGHT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_ADDHIGHLIGHTS_ROUTE_EDITHIGHLIGHT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addlocations/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addlocations/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_ADDLOCATIONS_ROUTE_ADDLOCATION')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addlocations/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addlocations/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_ADDLOCATIONS_ROUTE_ADDLOCATION')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-blog/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-blog/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_BLOG_ROUTE_COMMENTS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-blog/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-blog/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_BLOG_ROUTE_COMMENTS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categoryposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categoryposts/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_CATEGORYPOSTS_ROUTE_CATEGORYPOSTS19')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categoryposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categoryposts/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_CATEGORYPOSTS_ROUTE_CATEGORYPOSTS19')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categorypostscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categorypostscreation/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_CATEGORYPOSTSCREATION_ROUTE_MYCATEGORYPOSTS19')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categorypostscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-categorypostscreation/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_CATEGORYPOSTSCREATION_ROUTE_MYCATEGORYPOSTS19')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_COMMONAUTOMATEDEMAILS_ROUTE_SINGLEPOST_SPECIAL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_COMMONAUTOMATEDEMAILS_ROUTE_SINGLEPOST_SPECIAL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-events/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-events/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_COMMONAUTOMATEDEMAILS_ROUTE_UPCOMINGEVENTS_WEEKLY')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-events/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-events/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_COMMONAUTOMATEDEMAILS_ROUTE_UPCOMINGEVENTS_WEEKLY')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-userplatform/plugins/pop-notifications/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-userplatform/plugins/pop-notifications/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_COMMONAUTOMATEDEMAILS_ROUTE_LATESTNOTIFICATIONS_DAILY')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-userplatform/plugins/pop-notifications/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails/plugins/pop-userplatform/plugins/pop-notifications/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_COMMONAUTOMATEDEMAILS_ROUTE_LATESTNOTIFICATIONS_DAILY')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonpages/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonpages/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_CLUSTERCOMMONPAGES_ROUTE_ABOUT_OURSPONSORS')) {
 // }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonpages/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonpages/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_CLUSTERCOMMONPAGES_ROUTE_ABOUT_OURSPONSORS')) {
 // }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/config/routes.php
@@ -25,7 +25,7 @@ if (!defined('POP_COMMONUSERROLES_ROUTE_INDIVIDUALS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/config/routes.php
@@ -25,7 +25,7 @@ if (!defined('POP_COMMONUSERROLES_ROUTE_INDIVIDUALS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contactus/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contactus/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_CONTACTUS_ROUTE_CONTACTUS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contactus/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contactus/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_CONTACTUS_ROUTE_CONTACTUS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_CONTENTCREATION_ROUTE_FLAG')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_CONTENTCREATION_ROUTE_FLAG')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_CONTENTPOSTLINKS_ROUTE_CONTENTPOSTLINKS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_CONTENTPOSTLINKS_ROUTE_CONTENTPOSTLINKS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_CONTENTPOSTLINKSCREATION_ROUTE_EDITCONTENTPOSTLINK')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_CONTENTPOSTLINKSCREATION_ROUTE_EDITCONTENTPOSTLINK')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-domain/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-domain/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_DOMAIN_ROUTE_LOADERS_INITIALIZEDOMAIN')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-domain/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-domain/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_DOMAIN_ROUTE_LOADERS_INITIALIZEDOMAIN')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-webplatform/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-webplatform/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_ENGINEWEBPLATFORM_ROUTE_APPSHELL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-webplatform/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-webplatform/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_ENGINEWEBPLATFORM_ROUTE_APPSHELL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_EVENTLINKSCREATION_ROUTE_EDITEVENTLINK')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_EVENTLINKSCREATION_ROUTE_EDITEVENTLINK')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_EVENTS_ROUTE_PASTEVENTS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_EVENTS_ROUTE_PASTEVENTS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_EVENTSCREATION_ROUTE_EDITEVENT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_EVENTSCREATION_ROUTE_EDITEVENT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_LOCATIONPOSTLINKSCREATION_ROUTE_EDITLOCATIONPOSTLINK')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_LOCATIONPOSTLINKSCREATION_ROUTE_EDITLOCATIONPOSTLINK')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_LOCATIONPOSTS_ROUTE_LOCATIONPOSTS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_LOCATIONPOSTS_ROUTE_LOCATIONPOSTS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_LOCATIONPOSTSCREATION_ROUTE_EDITLOCATIONPOST')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_LOCATIONPOSTSCREATION_ROUTE_EDITLOCATIONPOST')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-multidomain/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-multidomain/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_MULTIDOMAIN_ROUTE_EXTERNAL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-multidomain/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-multidomain/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_MULTIDOMAIN_ROUTE_EXTERNAL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-newsletter/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-newsletter/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_NEWSLETTER_ROUTE_NEWSLETTERUNSUBSCRIPTION')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-newsletter/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-newsletter/config/routes.php
@@ -13,7 +13,7 @@ if (!defined('POP_NEWSLETTER_ROUTE_NEWSLETTERUNSUBSCRIPTION')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategoryposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategoryposts/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_NOSEARCHCATEGORYPOSTS_ROUTE_NOSEARCHCATEGORYPOSTS19')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategoryposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategoryposts/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_NOSEARCHCATEGORYPOSTS_ROUTE_NOSEARCHCATEGORYPOSTS19')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategorypostscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategorypostscreation/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_NOSEARCHCATEGORYPOSTSCREATION_ROUTE_MYNOSEARCHCATEGORYPOSTS19'
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategorypostscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-nosearchcategorypostscreation/config/routes.php
@@ -64,7 +64,7 @@ if (!defined('POP_NOSEARCHCATEGORYPOSTSCREATION_ROUTE_MYNOSEARCHCATEGORYPOSTS19'
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_NOTIFICATIONS_ROUTE_NOTIFICATIONS_MARKASUNREAD')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/config/routes.php
@@ -19,7 +19,7 @@ if (!defined('POP_NOTIFICATIONS_ROUTE_NOTIFICATIONS_MARKASUNREAD')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_POSTSCREATION_ROUTE_EDITPOST')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_POSTSCREATION_ROUTE_EDITPOST')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_RELATEDPOSTS_ROUTE_RELATEDCONTENT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_RELATEDPOSTS_ROUTE_RELATEDCONTENT')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-share/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-share/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SHARE_ROUTE_SHAREBYEMAIL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-share/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-share/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SHARE_ROUTE_SHAREBYEMAIL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/config/routes.php
@@ -65,7 +65,7 @@ if (!defined('POP_SOCIALNETWORK_ROUTE_SUBSCRIBEDTO')) {
 
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/config/routes.php
@@ -65,7 +65,7 @@ if (!defined('POP_SOCIALNETWORK_ROUTE_SUBSCRIBEDTO')) {
 
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-persistentdefinitions/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-persistentdefinitions/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SYSTEM_ROUTE_SYSTEM_SAVEDEFINITIONFILE')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-persistentdefinitions/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-persistentdefinitions/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SYSTEM_ROUTE_SYSTEM_SAVEDEFINITIONFILE')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-wp/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-wp/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SYSTEMWP_ROUTE_SYSTEM_ACTIVATEPLUGINS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-wp/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system-wp/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SYSTEMWP_ROUTE_SYSTEM_ACTIVATEPLUGINS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_SYSTEM_ROUTE_SYSTEM_INSTALL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/config/routes.php
@@ -16,7 +16,7 @@ if (!defined('POP_SYSTEM_ROUTE_SYSTEM_INSTALL')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/plugins/pop-theme/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/plugins/pop-theme/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SYSTEM_ROUTE_SYSTEM_GENERATETHEME')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/plugins/pop-theme/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-system/plugins/pop-theme/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_SYSTEM_ROUTE_SYSTEM_GENERATETHEME')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-trendingtags/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-trendingtags/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_TRENDINGTAGS_ROUTE_TRENDINGTAGS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-trendingtags/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-trendingtags/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_TRENDINGTAGS_ROUTE_TRENDINGTAGS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_USERAVATAR_ROUTE_EDITAVATAR')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_USERAVATAR_ROUTE_EDITAVATAR')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/config/routes.php
@@ -28,7 +28,7 @@ if (!defined('POP_USERCOMMUNITIES_ROUTE_INVITENEWMEMBERS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/config/routes.php
@@ -28,7 +28,7 @@ if (!defined('POP_USERCOMMUNITIES_ROUTE_INVITENEWMEMBERS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userlogin/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userlogin/config/routes.php
@@ -22,7 +22,7 @@ if (!defined('POP_USERLOGIN_ROUTE_LOGGEDINUSERDATA')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userlogin/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userlogin/config/routes.php
@@ -22,7 +22,7 @@ if (!defined('POP_USERLOGIN_ROUTE_LOGGEDINUSERDATA')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/config/routes.php
@@ -28,7 +28,7 @@ if (!defined('POP_USERPLATFORM_ROUTE_CHANGEPASSWORDPROFILE')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/config/routes.php
@@ -28,7 +28,7 @@ if (!defined('POP_USERPLATFORM_ROUTE_CHANGEPASSWORDPROFILE')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/config/routes.php
@@ -55,7 +55,7 @@ if (!defined('POP_USERSTANCE_ROUTE_STANCES_BYINDIVIDUALS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/config/routes.php
@@ -55,7 +55,7 @@ if (!defined('POP_USERSTANCE_ROUTE_STANCES_BYINDIVIDUALS')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_VOLUNTEERING_ROUTE_VOLUNTEER')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/config/routes.php
@@ -10,7 +10,7 @@ if (!defined('POP_VOLUNTEERING_ROUTE_VOLUNTEER')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/config/routes.php
@@ -22,7 +22,7 @@ if (!defined('POPTHEME_WASSUP_ROUTE_LOADERS_INITIALFRAMES')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\Root\Routing\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\RouteHookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/config/routes.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/poptheme-wassup/config/routes.php
@@ -22,7 +22,7 @@ if (!defined('POPTHEME_WASSUP_ROUTE_LOADERS_INITIALFRAMES')) {
 }
 
 \PoP\Root\App::addFilter(
-    \PoP\RoutingWP\RouteHookNames::ROUTES,
+    \PoP\RoutingWP\HookNames::ROUTES,
     function($routes) {
     	return array_merge(
     		$routes,

--- a/layers/Schema/packages/categories-wp/src/Hooks/RoutingStateHookSet.php
+++ b/layers/Schema/packages/categories-wp/src/Hooks/RoutingStateHookSet.php
@@ -6,6 +6,7 @@ namespace PoPSchema\CategoriesWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\Categories\Routing\RouteNatures;
 use WP_Query;
 
@@ -14,7 +15,7 @@ class RoutingStateHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addFilter(
-            'WPCMSRoutingState:nature',
+            HookNames::NATURE,
             [$this, 'getNature'],
             10,
             2

--- a/layers/Schema/packages/customposts-wp/src/Hooks/RoutingStateHookSet.php
+++ b/layers/Schema/packages/customposts-wp/src/Hooks/RoutingStateHookSet.php
@@ -6,6 +6,7 @@ namespace PoPSchema\CustomPostsWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\CustomPosts\Routing\RouteNatures;
 use WP_Query;
 
@@ -14,7 +15,7 @@ class RoutingStateHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addFilter(
-            'WPCMSRoutingState:nature',
+            HookNames::NATURE,
             [$this, 'getNature'],
             10,
             2

--- a/layers/Schema/packages/pages-wp/src/Hooks/RoutingStateHookSet.php
+++ b/layers/Schema/packages/pages-wp/src/Hooks/RoutingStateHookSet.php
@@ -6,6 +6,7 @@ namespace PoPSchema\PagesWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\Pages\Routing\RouteNatures;
 use WP_Query;
 
@@ -14,7 +15,7 @@ class RoutingStateHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addFilter(
-            'WPCMSRoutingState:nature',
+            HookNames::NATURE,
             [$this, 'getNature'],
             10,
             2

--- a/layers/Schema/packages/post-categories-wp/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-categories-wp/src/Hooks/RoutingHookSet.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PoPSchema\Posts\Hooks;
+namespace PoPSchema\PostCategoriesWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
 use PoP\RoutingWP\HookNames;
-use PoPSchema\Posts\Component;
-use PoPSchema\Posts\ComponentConfiguration;
+use PoPSchema\PostCategories\Component;
+use PoPSchema\PostCategories\ComponentConfiguration;
 
 class RoutingHookSet extends AbstractHookSet
 {
@@ -26,7 +26,7 @@ class RoutingHookSet extends AbstractHookSet
         $componentConfiguration = App::getComponent(Component::class)->getConfiguration();
         return [
             ...$routes,
-            $componentConfiguration->getPostsRoute(),
+            $componentConfiguration->getPostCategoriesRoute(),
         ];
     }
 }

--- a/layers/Schema/packages/post-categories/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-categories/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\PostCategories\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\Root\Routing\RouteHookNames;
+use PoP\RoutingWP\RouteHookNames;
 use PoPSchema\PostCategories\Component;
 use PoPSchema\PostCategories\ComponentConfiguration;
 

--- a/layers/Schema/packages/post-categories/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-categories/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\PostCategories\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\RoutingWP\RouteHookNames;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\PostCategories\Component;
 use PoPSchema\PostCategories\ComponentConfiguration;
 

--- a/layers/Schema/packages/post-categories/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-categories/src/Hooks/RoutingHookSet.php
@@ -15,7 +15,7 @@ class RoutingHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addAction(
-            RouteHookNames::ROUTES,
+            HookNames::ROUTES,
             [$this, 'registerRoutes']
         );
     }

--- a/layers/Schema/packages/post-tags-wp/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-tags-wp/src/Hooks/RoutingHookSet.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PoPSchema\PostCategories\Hooks;
+namespace PoPSchema\PostTagsWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
 use PoP\RoutingWP\HookNames;
-use PoPSchema\PostCategories\Component;
-use PoPSchema\PostCategories\ComponentConfiguration;
+use PoPSchema\PostTags\Component;
+use PoPSchema\PostTags\ComponentConfiguration;
 
 class RoutingHookSet extends AbstractHookSet
 {
@@ -26,7 +26,7 @@ class RoutingHookSet extends AbstractHookSet
         $componentConfiguration = App::getComponent(Component::class)->getConfiguration();
         return [
             ...$routes,
-            $componentConfiguration->getPostCategoriesRoute(),
+            $componentConfiguration->getPostTagsRoute(),
         ];
     }
 }

--- a/layers/Schema/packages/post-tags/config/services.yaml
+++ b/layers/Schema/packages/post-tags/config/services.yaml
@@ -4,8 +4,5 @@ services:
         autowire: true
         autoconfigure: true
 
-    PoPSchema\PostTags\Hooks\:
-        resource: '../src/Hooks/*'
-
     PoPSchema\PostTags\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'

--- a/layers/Schema/packages/post-tags/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-tags/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\PostTags\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\RoutingWP\RouteHookNames;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\PostTags\Component;
 use PoPSchema\PostTags\ComponentConfiguration;
 

--- a/layers/Schema/packages/post-tags/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-tags/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\PostTags\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\Root\Routing\RouteHookNames;
+use PoP\RoutingWP\RouteHookNames;
 use PoPSchema\PostTags\Component;
 use PoPSchema\PostTags\ComponentConfiguration;
 

--- a/layers/Schema/packages/post-tags/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/post-tags/src/Hooks/RoutingHookSet.php
@@ -15,7 +15,7 @@ class RoutingHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addAction(
-            RouteHookNames::ROUTES,
+            HookNames::ROUTES,
             [$this, 'registerRoutes']
         );
     }

--- a/layers/Schema/packages/posts-wp/config/services.yaml
+++ b/layers/Schema/packages/posts-wp/config/services.yaml
@@ -6,3 +6,6 @@ services:
 
     PoPSchema\Posts\TypeAPIs\PostTypeAPIInterface:
         class: \PoPSchema\PostsWP\TypeAPIs\PostTypeAPI
+
+    PoPSchema\PostsWP\Hooks\:
+        resource: '../src/Hooks/*'

--- a/layers/Schema/packages/posts-wp/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/posts-wp/src/Hooks/RoutingHookSet.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PoPSchema\PostTags\Hooks;
+namespace PoPSchema\PostsWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
 use PoP\RoutingWP\HookNames;
-use PoPSchema\PostTags\Component;
-use PoPSchema\PostTags\ComponentConfiguration;
+use PoPSchema\Posts\Component;
+use PoPSchema\Posts\ComponentConfiguration;
 
 class RoutingHookSet extends AbstractHookSet
 {
@@ -26,7 +26,7 @@ class RoutingHookSet extends AbstractHookSet
         $componentConfiguration = App::getComponent(Component::class)->getConfiguration();
         return [
             ...$routes,
-            $componentConfiguration->getPostTagsRoute(),
+            $componentConfiguration->getPostsRoute(),
         ];
     }
 }

--- a/layers/Schema/packages/posts/config/services.yaml
+++ b/layers/Schema/packages/posts/config/services.yaml
@@ -6,6 +6,3 @@ services:
 
     PoPSchema\Posts\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'
-
-    PoPSchema\Posts\Hooks\:
-        resource: '../src/Hooks/*'

--- a/layers/Schema/packages/posts/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/posts/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\Posts\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\RoutingWP\RouteHookNames;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\Posts\Component;
 use PoPSchema\Posts\ComponentConfiguration;
 

--- a/layers/Schema/packages/posts/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/posts/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\Posts\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\Root\Routing\RouteHookNames;
+use PoP\RoutingWP\RouteHookNames;
 use PoPSchema\Posts\Component;
 use PoPSchema\Posts\ComponentConfiguration;
 

--- a/layers/Schema/packages/posts/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/posts/src/Hooks/RoutingHookSet.php
@@ -15,7 +15,7 @@ class RoutingHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addAction(
-            RouteHookNames::ROUTES,
+            HookNames::ROUTES,
             [$this, 'registerRoutes']
         );
     }

--- a/layers/Schema/packages/tags-wp/src/Hooks/RoutingStateHookSet.php
+++ b/layers/Schema/packages/tags-wp/src/Hooks/RoutingStateHookSet.php
@@ -6,6 +6,7 @@ namespace PoPSchema\TagsWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\Tags\Routing\RouteNatures;
 use WP_Query;
 
@@ -14,7 +15,7 @@ class RoutingStateHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addFilter(
-            'WPCMSRoutingState:nature',
+            HookNames::NATURE,
             [$this, 'getNature'],
             10,
             2

--- a/layers/Schema/packages/users-wp/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/users-wp/src/Hooks/RoutingHookSet.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoPSchema\Users\Hooks;
+namespace PoPSchema\UsersWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;

--- a/layers/Schema/packages/users-wp/src/Hooks/RoutingStateHookSet.php
+++ b/layers/Schema/packages/users-wp/src/Hooks/RoutingStateHookSet.php
@@ -6,6 +6,7 @@ namespace PoPSchema\UsersWP\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\Users\Routing\RouteNatures;
 use WP_Query;
 
@@ -14,7 +15,7 @@ class RoutingStateHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addFilter(
-            'WPCMSRoutingState:nature',
+            HookNames::NATURE,
             [$this, 'getNature'],
             10,
             2

--- a/layers/Schema/packages/users/config/services.yaml
+++ b/layers/Schema/packages/users/config/services.yaml
@@ -15,6 +15,3 @@ services:
 
     PoPSchema\Users\ModuleProcessors\:
         resource: '../src/ModuleProcessors/*'
-
-    PoPSchema\Users\Hooks\:
-        resource: '../src/Hooks/*'

--- a/layers/Schema/packages/users/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/users/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\Users\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\RoutingWP\RouteHookNames;
+use PoP\RoutingWP\HookNames;
 use PoPSchema\Users\Component;
 use PoPSchema\Users\ComponentConfiguration;
 

--- a/layers/Schema/packages/users/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/users/src/Hooks/RoutingHookSet.php
@@ -15,7 +15,7 @@ class RoutingHookSet extends AbstractHookSet
     protected function init(): void
     {
         App::addAction(
-            RouteHookNames::ROUTES,
+            HookNames::ROUTES,
             [$this, 'registerRoutes']
         );
     }

--- a/layers/Schema/packages/users/src/Hooks/RoutingHookSet.php
+++ b/layers/Schema/packages/users/src/Hooks/RoutingHookSet.php
@@ -6,7 +6,7 @@ namespace PoPSchema\Users\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
-use PoP\Root\Routing\RouteHookNames;
+use PoP\RoutingWP\RouteHookNames;
 use PoPSchema\Users\Component;
 use PoPSchema\Users\ComponentConfiguration;
 


### PR DESCRIPTION
Since declaring the routes in advance is not needed for most systems (Laravel, Symfony, etc), only needed for Cortex to replace WordPress's routing system.