### PR TITLE
Restore `RouteNatures::HOME`, but under `RouteNatures::QUERY_ROOT`

### DIFF
--- a/layers/API/packages/api-rest/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
+++ b/layers/API/packages/api-rest/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\RESTAPI\RouteModuleProcessors;
 
-use PoP\Root\App;
 use PoP\API\ModuleProcessors\RootRelationalFieldDataloadModuleProcessor;
 use PoP\API\Response\Schemes as APISchemes;
+use PoP\API\Routing\RouteNatures;
+use PoP\Root\App;
 
 class EntryRouteModuleProcessor extends AbstractRESTEntryRouteModuleProcessor
 {
@@ -16,13 +17,13 @@ class EntryRouteModuleProcessor extends AbstractRESTEntryRouteModuleProcessor
     }
 
     /**
-     * @return array<array>
+     * @return array<string, array<array>>
      */
-    public function getModulesVarsProperties(): array
+    public function getModulesVarsPropertiesByNature(): array
     {
         $ret = array();
 
-        $ret[] = [
+        $ret[RouteNatures::QUERY_ROOT][] = [
             'module' => [
                 RootRelationalFieldDataloadModuleProcessor::class,
                 RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_ROOT,

--- a/layers/API/packages/api/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
+++ b/layers/API/packages/api/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
@@ -19,7 +19,10 @@ class EntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
         $ret = array();
 
         $ret[RouteNatures::QUERY_ROOT][] = [
-            'module' => [RootRelationalFieldDataloadModuleProcessor::class, RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_ROOT],
+            'module' => [
+                RootRelationalFieldDataloadModuleProcessor::class,
+                RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_ROOT
+            ],
             'conditions' => [
                 'scheme' => APISchemes::API,
             ],

--- a/layers/API/packages/api/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
+++ b/layers/API/packages/api/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
@@ -6,18 +6,19 @@ namespace PoP\API\RouteModuleProcessors;
 
 use PoP\API\ModuleProcessors\RootRelationalFieldDataloadModuleProcessor;
 use PoP\API\Response\Schemes as APISchemes;
+use PoP\API\Routing\RouteNatures;
 use PoP\ModuleRouting\AbstractEntryRouteModuleProcessor;
 
 class EntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
 {
     /**
-     * @return array<array>
+     * @return array<string, array<array>>
      */
-    public function getModulesVarsProperties(): array
+    public function getModulesVarsPropertiesByNature(): array
     {
         $ret = array();
 
-        $ret[] = [
+        $ret[RouteNatures::QUERY_ROOT][] = [
             'module' => [RootRelationalFieldDataloadModuleProcessor::class, RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_ROOT],
             'conditions' => [
                 'scheme' => APISchemes::API,

--- a/layers/API/packages/api/src/Routing/RouteNatures.php
+++ b/layers/API/packages/api/src/Routing/RouteNatures.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\API\Routing;
+
+class RouteNatures
+{
+    public const QUERY_ROOT = 'query-root';
+}

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/State/AbstractGraphQLEndpointExecuterAppStateProvider.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/State/AbstractGraphQLEndpointExecuterAppStateProvider.php
@@ -7,6 +7,7 @@ namespace GraphQLAPI\GraphQLAPI\State;
 use GraphQLAPI\GraphQLAPI\Services\EndpointExecuters\GraphQLEndpointExecuterInterface;
 use GraphQLByPoP\GraphQLQuery\Schema\GraphQLQueryConvertorInterface;
 use PoP\API\Response\Schemes as APISchemes;
+use PoP\API\Routing\RouteNatures;
 use PoP\GraphQLAPI\DataStructureFormatters\GraphQLDataStructureFormatter;
 use PoP\Root\App;
 use PoP\Root\State\AbstractAppStateProvider;
@@ -44,6 +45,7 @@ abstract class AbstractGraphQLEndpointExecuterAppStateProvider extends AbstractA
     {
         $state['scheme'] = APISchemes::API;
         $state['datastructure'] = $this->getGraphQLDataStructureFormatter()->getName();
+        $state['nature'] = RouteNatures::QUERY_ROOT;
     }
 
     public function consolidate(array &$state): void

--- a/layers/GraphQLByPoP/packages/graphql-server/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
@@ -32,7 +32,10 @@ class EntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
         $ret = array();
 
         $ret[RouteNatures::QUERY_ROOT][] = [
-            'module' => [RootRelationalFieldDataloadModuleProcessor::class, RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_QUERYROOT],
+            'module' => [
+                RootRelationalFieldDataloadModuleProcessor::class,
+                RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_QUERYROOT
+            ],
             'conditions' => [
                 'scheme' => APISchemes::API,
                 'datastructure' => $this->getGraphQLDataStructureFormatter()->getName(),
@@ -40,7 +43,10 @@ class EntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
             ],
         ];
         $ret[RouteNatures::QUERY_ROOT][] = [
-            'module' => [RootRelationalFieldDataloadModuleProcessor::class, RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_MUTATIONROOT],
+            'module' => [
+                RootRelationalFieldDataloadModuleProcessor::class,
+                RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_MUTATIONROOT
+            ],
             'conditions' => [
                 'scheme' => APISchemes::API,
                 'datastructure' => $this->getGraphQLDataStructureFormatter()->getName(),

--- a/layers/GraphQLByPoP/packages/graphql-server/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/RouteModuleProcessors/EntryRouteModuleProcessor.php
@@ -7,6 +7,7 @@ namespace GraphQLByPoP\GraphQLServer\RouteModuleProcessors;
 use GraphQLByPoP\GraphQLQuery\Schema\OperationTypes;
 use GraphQLByPoP\GraphQLServer\ModuleProcessors\RootRelationalFieldDataloadModuleProcessor;
 use PoP\API\Response\Schemes as APISchemes;
+use PoP\API\Routing\RouteNatures;
 use PoP\GraphQLAPI\DataStructureFormatters\GraphQLDataStructureFormatter;
 use PoP\ModuleRouting\AbstractEntryRouteModuleProcessor;
 
@@ -24,13 +25,13 @@ class EntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
     }
 
     /**
-     * @return array<array>
+     * @return array<string, array<array>>
      */
-    public function getModulesVarsProperties(): array
+    public function getModulesVarsPropertiesByNature(): array
     {
         $ret = array();
 
-        $ret[] = [
+        $ret[RouteNatures::QUERY_ROOT][] = [
             'module' => [RootRelationalFieldDataloadModuleProcessor::class, RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_QUERYROOT],
             'conditions' => [
                 'scheme' => APISchemes::API,
@@ -38,7 +39,7 @@ class EntryRouteModuleProcessor extends AbstractEntryRouteModuleProcessor
                 'graphql-operation-type' => OperationTypes::QUERY,
             ],
         ];
-        $ret[] = [
+        $ret[RouteNatures::QUERY_ROOT][] = [
             'module' => [RootRelationalFieldDataloadModuleProcessor::class, RootRelationalFieldDataloadModuleProcessor::MODULE_DATALOAD_RELATIONALFIELDS_MUTATIONROOT],
             'conditions' => [
                 'scheme' => APISchemes::API,


### PR DESCRIPTION
Reverted #1352 since GraphQL stopped working on the frontend.

Solution: restored the route, but instead of pointing to `RouteNatures::HOME`, point to a new `RouteNatures::QUERY_ROOT`