### PR TITLE
Move `AbstractCMSBootHookSet` to Root...

### DIFF
--- a/layers/Engine/packages/access-control/composer.json
+++ b/layers/Engine/packages/access-control/composer.json
@@ -165,7 +165,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "getpop/engine": "^0.9",
+        "getpop/component-model": "^0.9",
         "getpop/mandatory-directives-by-configuration": "^0.9"
     },
     "require-dev": {

--- a/layers/Engine/packages/access-control/src/Component.php
+++ b/layers/Engine/packages/access-control/src/Component.php
@@ -20,7 +20,7 @@ class Component extends AbstractComponent
     {
         return [
             \PoP\MandatoryDirectivesByConfiguration\Component::class,
-            \PoP\Engine\Component::class,
+            \PoP\ComponentModel\Component::class,
         ];
     }
 

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
@@ -9,7 +9,7 @@ use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\TypeResolvers\HookHelpers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
-use PoP\Engine\Hooks\AbstractAfterAppBootHookSet;
+use PoP\Root\Hooks\AbstractAfterAppBootHookSet;
 
 abstract class AbstractAccessControlForDirectivesHookSet extends AbstractAfterAppBootHookSet
 {

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForDirectivesHookSet.php
@@ -9,9 +9,9 @@ use PoP\AccessControl\Services\AccessControlManagerInterface;
 use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\TypeResolvers\HookHelpers;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
-use PoP\Engine\Hooks\AbstractCMSBootHookSet;
+use PoP\Engine\Hooks\AbstractAfterAppBootHookSet;
 
-abstract class AbstractAccessControlForDirectivesHookSet extends AbstractCMSBootHookSet
+abstract class AbstractAccessControlForDirectivesHookSet extends AbstractAfterAppBootHookSet
 {
     private ?AccessControlManagerInterface $accessControlManager = null;
 

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
@@ -11,9 +11,9 @@ use PoP\ComponentModel\FieldResolvers\ObjectType\ObjectTypeFieldResolverInterfac
 use PoP\ComponentModel\TypeResolvers\HookHelpers;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
-use PoP\Engine\Hooks\AbstractCMSBootHookSet;
+use PoP\Engine\Hooks\AbstractAfterAppBootHookSet;
 
-abstract class AbstractAccessControlForFieldsHookSet extends AbstractCMSBootHookSet
+abstract class AbstractAccessControlForFieldsHookSet extends AbstractAfterAppBootHookSet
 {
     private ?AccessControlManagerInterface $accessControlManager = null;
 

--- a/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
+++ b/layers/Engine/packages/access-control/src/Hooks/AbstractAccessControlForFieldsHookSet.php
@@ -11,7 +11,7 @@ use PoP\ComponentModel\FieldResolvers\ObjectType\ObjectTypeFieldResolverInterfac
 use PoP\ComponentModel\TypeResolvers\HookHelpers;
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
-use PoP\Engine\Hooks\AbstractAfterAppBootHookSet;
+use PoP\Root\Hooks\AbstractAfterAppBootHookSet;
 
 abstract class AbstractAccessControlForFieldsHookSet extends AbstractAfterAppBootHookSet
 {

--- a/layers/Engine/packages/engine/src/Hooks/AbstractAfterAppBootHookSet.php
+++ b/layers/Engine/packages/engine/src/Hooks/AbstractAfterAppBootHookSet.php
@@ -8,7 +8,7 @@ use PoP\Root\App;
 use PoP\Root\Constants\HookNames;
 use PoP\Root\Hooks\AbstractHookSet;
 
-abstract class AbstractCMSBootHookSet extends AbstractHookSet
+abstract class AbstractAfterAppBootHookSet extends AbstractHookSet
 {
     /**
      * Initialize the hooks when the CMS initializes

--- a/layers/Engine/packages/root-wp/src/AppLoader.php
+++ b/layers/Engine/packages/root-wp/src/AppLoader.php
@@ -27,13 +27,13 @@ class AppLoader extends UpstreamAppLoader
          * available is "wp".
          *
          * Watch out:
-         * 
+         *
          * - "wp" doesn't trigger in the admin() => use "wp_loaded" instead.
          * - "wp" doesn't trigger in REST => use "rest_api_init" instead.
-         * 
+         *
          * (Eg for the latter: when editing an ACL in the WordPress editor
          * and clicking on Update, it uses a REST call.)
-         * 
+         *
          * Because we don't know yet if the current request is a REST call or not
          * (must wait until hook "parse_request" for that), simply
          * load the hook for both 'rest_api_init' and 'wp', knowing

--- a/layers/Engine/packages/root/src/Hooks/AbstractAfterAppBootHookSet.php
+++ b/layers/Engine/packages/root/src/Hooks/AbstractAfterAppBootHookSet.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoP\Engine\Hooks;
+namespace PoP\Root\Hooks;
 
 use PoP\Root\App;
 use PoP\Root\Constants\HookNames;

--- a/layers/Engine/packages/root/src/Hooks/AbstractAfterAppBootHookSet.php
+++ b/layers/Engine/packages/root/src/Hooks/AbstractAfterAppBootHookSet.php
@@ -26,6 +26,6 @@ abstract class AbstractAfterAppBootHookSet extends AbstractHookSet
     {
         return 10;
     }
-    
+
     abstract public function cmsBoot(): void;
 }


### PR DESCRIPTION
And switched the dependency of Access Control from `Engine` to `ComponentModel`