### PR TITLE
Add "allow plugins" to Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -537,7 +537,12 @@
         "pop-wp-schema/users": "self.version"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "boxuk/wp-muplugin-loader": true,
+            "composer/installers": true,
+            "oomphinc/composer-installers-extender": true
+        }
     },
     "scripts": {
         "all": [

--- a/layers/API/packages/api-clients/composer.json
+++ b/layers/API/packages/api-clients/composer.json
@@ -200,7 +200,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/API/packages/api-endpoints-for-wp/composer.json
+++ b/layers/API/packages/api-endpoints-for-wp/composer.json
@@ -203,7 +203,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/API/packages/api-endpoints/composer.json
+++ b/layers/API/packages/api-endpoints/composer.json
@@ -200,7 +200,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/API/packages/api-graphql/composer.json
+++ b/layers/API/packages/api-graphql/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/API/packages/api-mirrorquery/composer.json
+++ b/layers/API/packages/api-mirrorquery/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/API/packages/api-rest/composer.json
+++ b/layers/API/packages/api-rest/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/API/packages/api/composer.json
+++ b/layers/API/packages/api/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Backbone/packages/graphql-parser/composer.json
+++ b/layers/Backbone/packages/graphql-parser/composer.json
@@ -42,7 +42,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "conflict": {
         "getpop/modulerouting": "<0.8.9",

--- a/layers/Backbone/packages/php-hooks/composer.json
+++ b/layers/Backbone/packages/php-hooks/composer.json
@@ -23,6 +23,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/CMSSchema/packages/categories-wp/composer.json
+++ b/layers/CMSSchema/packages/categories-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/categories/composer.json
+++ b/layers/CMSSchema/packages/categories/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/comment-mutations-wp/composer.json
+++ b/layers/CMSSchema/packages/comment-mutations-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/comment-mutations/composer.json
+++ b/layers/CMSSchema/packages/comment-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/commentmeta-wp/composer.json
+++ b/layers/CMSSchema/packages/commentmeta-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/commentmeta/composer.json
+++ b/layers/CMSSchema/packages/commentmeta/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/comments-wp/composer.json
+++ b/layers/CMSSchema/packages/comments-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/comments/composer.json
+++ b/layers/CMSSchema/packages/comments/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompost-categories-wp/composer.json
+++ b/layers/CMSSchema/packages/custompost-categories-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompost-category-mutations/composer.json
+++ b/layers/CMSSchema/packages/custompost-category-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompost-mutations-wp/composer.json
+++ b/layers/CMSSchema/packages/custompost-mutations-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompost-mutations/composer.json
+++ b/layers/CMSSchema/packages/custompost-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompost-tag-mutations/composer.json
+++ b/layers/CMSSchema/packages/custompost-tag-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompost-tags-wp/composer.json
+++ b/layers/CMSSchema/packages/custompost-tags-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompostmedia-mutations-wp/composer.json
+++ b/layers/CMSSchema/packages/custompostmedia-mutations-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompostmedia-mutations/composer.json
+++ b/layers/CMSSchema/packages/custompostmedia-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompostmedia-wp/composer.json
+++ b/layers/CMSSchema/packages/custompostmedia-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompostmedia/composer.json
+++ b/layers/CMSSchema/packages/custompostmedia/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompostmeta-wp/composer.json
+++ b/layers/CMSSchema/packages/custompostmeta-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/custompostmeta/composer.json
+++ b/layers/CMSSchema/packages/custompostmeta/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/customposts-wp/composer.json
+++ b/layers/CMSSchema/packages/customposts-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/customposts/composer.json
+++ b/layers/CMSSchema/packages/customposts/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/generic-customposts/composer.json
+++ b/layers/CMSSchema/packages/generic-customposts/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/media-wp/composer.json
+++ b/layers/CMSSchema/packages/media-wp/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/media/composer.json
+++ b/layers/CMSSchema/packages/media/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/menus-wp/composer.json
+++ b/layers/CMSSchema/packages/menus-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/menus/composer.json
+++ b/layers/CMSSchema/packages/menus/composer.json
@@ -196,7 +196,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/meta/composer.json
+++ b/layers/CMSSchema/packages/meta/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/metaquery-wp/composer.json
+++ b/layers/CMSSchema/packages/metaquery-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/pages-wp/composer.json
+++ b/layers/CMSSchema/packages/pages-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/pages/composer.json
+++ b/layers/CMSSchema/packages/pages/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-categories-wp/composer.json
+++ b/layers/CMSSchema/packages/post-categories-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-categories/composer.json
+++ b/layers/CMSSchema/packages/post-categories/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-category-mutations-wp/composer.json
+++ b/layers/CMSSchema/packages/post-category-mutations-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-category-mutations/composer.json
+++ b/layers/CMSSchema/packages/post-category-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-mutations/composer.json
+++ b/layers/CMSSchema/packages/post-mutations/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-tag-mutations-wp/composer.json
+++ b/layers/CMSSchema/packages/post-tag-mutations-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-tag-mutations/composer.json
+++ b/layers/CMSSchema/packages/post-tag-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-tags-wp/composer.json
+++ b/layers/CMSSchema/packages/post-tags-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/post-tags/composer.json
+++ b/layers/CMSSchema/packages/post-tags/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/postmedia-mutations/composer.json
+++ b/layers/CMSSchema/packages/postmedia-mutations/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/posts-wp/composer.json
+++ b/layers/CMSSchema/packages/posts-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/posts/composer.json
+++ b/layers/CMSSchema/packages/posts/composer.json
@@ -203,7 +203,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/queriedobject-wp/composer.json
+++ b/layers/CMSSchema/packages/queriedobject-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/queriedobject/composer.json
+++ b/layers/CMSSchema/packages/queriedobject/composer.json
@@ -194,7 +194,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/schema-commons-wp/composer.json
+++ b/layers/CMSSchema/packages/schema-commons-wp/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/schema-commons/composer.json
+++ b/layers/CMSSchema/packages/schema-commons/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/settings-wp/composer.json
+++ b/layers/CMSSchema/packages/settings-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/settings/composer.json
+++ b/layers/CMSSchema/packages/settings/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/tags-wp/composer.json
+++ b/layers/CMSSchema/packages/tags-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/tags/composer.json
+++ b/layers/CMSSchema/packages/tags/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/taxonomies-wp/composer.json
+++ b/layers/CMSSchema/packages/taxonomies-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/taxonomies/composer.json
+++ b/layers/CMSSchema/packages/taxonomies/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/taxonomymeta-wp/composer.json
+++ b/layers/CMSSchema/packages/taxonomymeta-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/taxonomymeta/composer.json
+++ b/layers/CMSSchema/packages/taxonomymeta/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/taxonomyquery-wp/composer.json
+++ b/layers/CMSSchema/packages/taxonomyquery-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/taxonomyquery/composer.json
+++ b/layers/CMSSchema/packages/taxonomyquery/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-avatars-wp/composer.json
+++ b/layers/CMSSchema/packages/user-avatars-wp/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-avatars/composer.json
+++ b/layers/CMSSchema/packages/user-avatars/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-roles-access-control/composer.json
+++ b/layers/CMSSchema/packages/user-roles-access-control/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-roles-acl/composer.json
+++ b/layers/CMSSchema/packages/user-roles-acl/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-roles-wp/composer.json
+++ b/layers/CMSSchema/packages/user-roles-wp/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-roles/composer.json
+++ b/layers/CMSSchema/packages/user-roles/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-state-access-control/composer.json
+++ b/layers/CMSSchema/packages/user-state-access-control/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-state-mutations-wp/composer.json
+++ b/layers/CMSSchema/packages/user-state-mutations-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-state-mutations/composer.json
+++ b/layers/CMSSchema/packages/user-state-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-state-wp/composer.json
+++ b/layers/CMSSchema/packages/user-state-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/user-state/composer.json
+++ b/layers/CMSSchema/packages/user-state/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/usermeta-wp/composer.json
+++ b/layers/CMSSchema/packages/usermeta-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/usermeta/composer.json
+++ b/layers/CMSSchema/packages/usermeta/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/users-wp/composer.json
+++ b/layers/CMSSchema/packages/users-wp/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/CMSSchema/packages/users/composer.json
+++ b/layers/CMSSchema/packages/users/composer.json
@@ -203,7 +203,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/access-control/composer.json
+++ b/layers/Engine/packages/access-control/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/cache-control/composer.json
+++ b/layers/Engine/packages/cache-control/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/component-model/composer.json
+++ b/layers/Engine/packages/component-model/composer.json
@@ -202,7 +202,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/definitions/composer.json
+++ b/layers/Engine/packages/definitions/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/engine-wp-bootloader/composer.json
+++ b/layers/Engine/packages/engine-wp-bootloader/composer.json
@@ -27,7 +27,11 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "boxuk/wp-muplugin-loader": true,
+            "composer/installers": true
+        }
     },
     "conflict": {
         "getpop/modulerouting": "<0.8.9",

--- a/layers/Engine/packages/engine-wp/composer.json
+++ b/layers/Engine/packages/engine-wp/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/engine/composer.json
+++ b/layers/Engine/packages/engine/composer.json
@@ -191,7 +191,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/field-query/composer.json
+++ b/layers/Engine/packages/field-query/composer.json
@@ -194,7 +194,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/filestore/composer.json
+++ b/layers/Engine/packages/filestore/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/graphql-parser/composer.json
+++ b/layers/Engine/packages/graphql-parser/composer.json
@@ -194,7 +194,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/guzzle-helpers/composer.json
+++ b/layers/Engine/packages/guzzle-helpers/composer.json
@@ -196,7 +196,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/loosecontracts/composer.json
+++ b/layers/Engine/packages/loosecontracts/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
+++ b/layers/Engine/packages/mandatory-directives-by-configuration/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/modulerouting/composer.json
+++ b/layers/Engine/packages/modulerouting/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/query-parsing/composer.json
+++ b/layers/Engine/packages/query-parsing/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/root-wp/composer.json
+++ b/layers/Engine/packages/root-wp/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Engine/packages/root/composer.json
+++ b/layers/Engine/packages/root/composer.json
@@ -52,7 +52,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "conflict": {
         "getpop/modulerouting": "<0.8.9",

--- a/layers/GraphQLAPIForWP/packages/external-dependency-wrappers/composer.json
+++ b/layers/GraphQLAPIForWP/packages/external-dependency-wrappers/composer.json
@@ -196,7 +196,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLAPIForWP/packages/markdown-convertor/composer.json
+++ b/layers/GraphQLAPIForWP/packages/markdown-convertor/composer.json
@@ -196,7 +196,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLAPIForWP/packages/plugin-utils/composer.json
+++ b/layers/GraphQLAPIForWP/packages/plugin-utils/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLAPIForWP/plugins/extension-demo/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/extension-demo/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "replace": {
         "getpop/cache-control": "^0.9",

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/composer.json
@@ -217,7 +217,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLByPoP/clients/GraphQL-Voyager/composer.json
+++ b/layers/GraphQLByPoP/clients/GraphQL-Voyager/composer.json
@@ -18,7 +18,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "conflict": {
         "getpop/modulerouting": "<0.8.9",

--- a/layers/GraphQLByPoP/clients/GraphiQL/composer.json
+++ b/layers/GraphQLByPoP/clients/GraphiQL/composer.json
@@ -18,7 +18,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "conflict": {
         "getpop/modulerouting": "<0.8.9",

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-endpoint-for-wp/composer.json
@@ -203,7 +203,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLByPoP/packages/graphql-query/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-query/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLByPoP/packages/graphql-request/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-request/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/GraphQLByPoP/packages/graphql-server/composer.json
+++ b/layers/GraphQLByPoP/packages/graphql-server/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Legacy/Schema/packages/everythingelse-wp/composer.json
+++ b/layers/Legacy/Schema/packages/everythingelse-wp/composer.json
@@ -53,6 +53,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/composer.json
+++ b/layers/Legacy/Schema/packages/everythingelse/composer.json
@@ -47,6 +47,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/highlights-wp/composer.json
+++ b/layers/Legacy/Schema/packages/highlights-wp/composer.json
@@ -49,6 +49,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/highlights/composer.json
+++ b/layers/Legacy/Schema/packages/highlights/composer.json
@@ -46,6 +46,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/composer.json
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/composer.json
@@ -26,6 +26,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/notifications-wp/composer.json
+++ b/layers/Legacy/Schema/packages/notifications-wp/composer.json
@@ -49,6 +49,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/notifications/composer.json
+++ b/layers/Legacy/Schema/packages/notifications/composer.json
@@ -51,6 +51,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/stances-wp/composer.json
+++ b/layers/Legacy/Schema/packages/stances-wp/composer.json
@@ -49,6 +49,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Schema/packages/stances/composer.json
+++ b/layers/Legacy/Schema/packages/stances/composer.json
@@ -46,6 +46,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/SiteBuilder/packages/migrate-component-model-configuration/composer.json
+++ b/layers/Legacy/SiteBuilder/packages/migrate-component-model-configuration/composer.json
@@ -23,6 +23,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/SiteBuilder/packages/migrate-static-site-generator/composer.json
+++ b/layers/Legacy/SiteBuilder/packages/migrate-static-site-generator/composer.json
@@ -23,6 +23,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/composer.json
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/composer.json
@@ -46,6 +46,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Legacy/Wassup/packages/wassup/composer.json
+++ b/layers/Legacy/Wassup/packages/wassup/composer.json
@@ -96,6 +96,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     }
 }

--- a/layers/Schema/packages/schema-commons/composer.json
+++ b/layers/Schema/packages/schema-commons/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/application-wp/composer.json
+++ b/layers/SiteBuilder/packages/application-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/application/composer.json
+++ b/layers/SiteBuilder/packages/application/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/component-model-configuration/composer.json
+++ b/layers/SiteBuilder/packages/component-model-configuration/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/definitionpersistence/composer.json
+++ b/layers/SiteBuilder/packages/definitionpersistence/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/definitions-base36/composer.json
+++ b/layers/SiteBuilder/packages/definitions-base36/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/definitions-emoji/composer.json
+++ b/layers/SiteBuilder/packages/definitions-emoji/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/multisite/composer.json
+++ b/layers/SiteBuilder/packages/multisite/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/resourceloader/composer.json
+++ b/layers/SiteBuilder/packages/resourceloader/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/resources/composer.json
+++ b/layers/SiteBuilder/packages/resources/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/site-builder-api/composer.json
+++ b/layers/SiteBuilder/packages/site-builder-api/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/site-wp/composer.json
+++ b/layers/SiteBuilder/packages/site-wp/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/site/composer.json
+++ b/layers/SiteBuilder/packages/site/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/spa/composer.json
+++ b/layers/SiteBuilder/packages/spa/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/SiteBuilder/packages/static-site-generator/composer.json
+++ b/layers/SiteBuilder/packages/static-site-generator/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/block-metadata-for-wp/composer.json
+++ b/layers/WPSchema/packages/block-metadata-for-wp/composer.json
@@ -207,7 +207,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/commentmeta/composer.json
+++ b/layers/WPSchema/packages/commentmeta/composer.json
@@ -202,7 +202,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/comments/composer.json
+++ b/layers/WPSchema/packages/comments/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/custompostmeta/composer.json
+++ b/layers/WPSchema/packages/custompostmeta/composer.json
@@ -202,7 +202,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/customposts/composer.json
+++ b/layers/WPSchema/packages/customposts/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/media/composer.json
+++ b/layers/WPSchema/packages/media/composer.json
@@ -199,7 +199,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/menus/composer.json
+++ b/layers/WPSchema/packages/menus/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/meta/composer.json
+++ b/layers/WPSchema/packages/meta/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/pages/composer.json
+++ b/layers/WPSchema/packages/pages/composer.json
@@ -198,7 +198,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/posts/composer.json
+++ b/layers/WPSchema/packages/posts/composer.json
@@ -205,7 +205,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/schema-commons/composer.json
+++ b/layers/WPSchema/packages/schema-commons/composer.json
@@ -200,7 +200,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/taxonomymeta/composer.json
+++ b/layers/WPSchema/packages/taxonomymeta/composer.json
@@ -201,7 +201,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/usermeta/composer.json
+++ b/layers/WPSchema/packages/usermeta/composer.json
@@ -202,7 +202,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/WPSchema/packages/users/composer.json
+++ b/layers/WPSchema/packages/users/composer.json
@@ -197,7 +197,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/comment-mutations/composer.json
+++ b/layers/Wassup/packages/comment-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/contactus-mutations/composer.json
+++ b/layers/Wassup/packages/contactus-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/contactuser-mutations/composer.json
+++ b/layers/Wassup/packages/contactuser-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/custompost-mutations/composer.json
+++ b/layers/Wassup/packages/custompost-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/custompostlink-mutations/composer.json
+++ b/layers/Wassup/packages/custompostlink-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/flag-mutations/composer.json
+++ b/layers/Wassup/packages/flag-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/form-mutations/composer.json
+++ b/layers/Wassup/packages/form-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/gravityforms-mutations/composer.json
+++ b/layers/Wassup/packages/gravityforms-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/highlight-mutations/composer.json
+++ b/layers/Wassup/packages/highlight-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/newsletter-mutations/composer.json
+++ b/layers/Wassup/packages/newsletter-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/notification-mutations/composer.json
+++ b/layers/Wassup/packages/notification-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/post-mutations/composer.json
+++ b/layers/Wassup/packages/post-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/postlink-mutations/composer.json
+++ b/layers/Wassup/packages/postlink-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/share-mutations/composer.json
+++ b/layers/Wassup/packages/share-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/socialnetwork-mutations/composer.json
+++ b/layers/Wassup/packages/socialnetwork-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/stance-mutations/composer.json
+++ b/layers/Wassup/packages/stance-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/system-mutations/composer.json
+++ b/layers/Wassup/packages/system-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/user-state-mutations/composer.json
+++ b/layers/Wassup/packages/user-state-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/layers/Wassup/packages/volunteer-mutations/composer.json
+++ b/layers/Wassup/packages/volunteer-mutations/composer.json
@@ -195,7 +195,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/webservers/graphql-api-for-wp/composer.json
+++ b/webservers/graphql-api-for-wp/composer.json
@@ -32,7 +32,8 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {}
     },
     "scripts": {
         "ssh-server": "lando ssh",

--- a/webservers/graphql-by-pop/composer.json
+++ b/webservers/graphql-by-pop/composer.json
@@ -78,7 +78,12 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "boxuk/wp-muplugin-loader": true,
+            "composer/installers": true,
+            "oomphinc/composer-installers-extender": true
+        }
     },
     "scripts": {
         "ssh-server": "lando ssh",

--- a/webservers/wassup/composer.json
+++ b/webservers/wassup/composer.json
@@ -44,7 +44,12 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "boxuk/wp-muplugin-loader": true,
+            "composer/installers": true,
+            "oomphinc/composer-installers-extender": true
+        }
     },
     "scripts": {
         "ssh-server": "lando ssh",


### PR DESCRIPTION
`"allow settings"` is a [new config property added to `composer.json`](https://getcomposer.org/doc/06-config.md#allow-plugins). Since it's not set, actions are triggering warnings, as shown here: https://github.com/leoloso/PoP/runs/4840664673?check_suite_focus=true

```
For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins
You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.
```

Add this configuration to remove the warning.