### PR TITLE
Write PHPUnit output to STDERR

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
   bootstrap="lib/bootstrap-phpunit.php"
   colors="true"
   verbose="true"
+  stderr="true"
 >
   <coverage processUncoveredFiles="true">
     <include>


### PR DESCRIPTION
When executing a GraphQL query, [headers are also sent](https://github.com/leoloso/PoP/blob/1c0749b0666b0f04c0ac817da31f09ae314ef6cf/layers/Engine/packages/component-model/src/DataStructure/AbstractDataStructureFormatter.php):

```php
protected function sendHeaders(array $headers = []): void
{
    // Add the content type header
    if ($contentType = $this->getContentType()) {
        $headers[] = sprintf(
            'Content-type: %s',
            $contentType
        );
    }
    foreach ($headers as $header) {
        header($header);
    }
}
```

Then, running PHPUnit fails:

```
GraphQLByPoP\GraphQLServer\StandaloneGraphQLAppTestCase::testHasDependedComponentClasses
Cannot modify header information - headers already sent by (output started at /Users/leo/GitRepos/GitHub/Projects/leoloso/PRO/vendor/phpunit/phpunit/src/Util/Printer.php:104)

/Users/leo/GitRepos/GitHub/Projects/leoloso/PRO/submodules/PoP/layers/Engine/packages/component-model/src/Engine/Engine.php:312
/Users/leo/GitRepos/GitHub/Projects/leoloso/PRO/submodules/PoP/layers/Engine/packages/component-model/src/Engine/Engine.php:398
/Users/leo/GitRepos/GitHub/Projects/leoloso/PRO/submodules/PoP/layers/Engine/packages/engine/src/Engine/Engine.php:48
/Users/leo/GitRepos/GitHub/Projects/leoloso/PRO/submodules/PoP/layers/Engine/packages/engine/src/Engine/Engine.php:54
/Users/leo/GitRepos/GitHub/Projects/leoloso/PRO/submodules/PoP/layers/GraphQLByPoP/packages/graphql-server/src/StandaloneGraphQLApp.php:57
/Users/leo/GitRepos/GitHub/Projects/leoloso/PRO/submodules/PoP/layers/GraphQLByPoP/packages/graphql-server/tests/StandaloneGraphQLAppTestCase.php:18
```

The solution is to [send the PHPUnit response to STDERR](https://stackoverflow.com/a/10815902).