### PR TITLE
Call `bootApplicationComponents` independently

### DIFF
--- a/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
+++ b/layers/Engine/packages/engine-wp-bootloader/pop-engine-wp-bootloader.php
@@ -29,4 +29,5 @@ if (!class_exists(App::class)) {
     App::getAppLoader()->initializeComponents();
     App::getAppLoader()->bootSystem();
     App::getAppLoader()->bootApplication();
+    App::getAppLoader()->bootApplicationComponents();
 });

--- a/layers/Engine/packages/root-wp/src/AppLoader.php
+++ b/layers/Engine/packages/root-wp/src/AppLoader.php
@@ -15,13 +15,13 @@ class AppLoader extends UpstreamAppLoader
      *
      * @param array<string,mixed> $initialAppState
      */
-    protected function bootApplicationComponents(array $initialAppState = []): void
+    public function bootApplicationComponents(array $initialAppState = []): void
     {
         $initialAppState = array_merge(
             $this->initialAppState,
             $initialAppState
         );
-        
+
         // Boot all the components
         App::getComponentManager()->beforeBoot();
 

--- a/layers/Engine/packages/root-wp/src/AppLoader.php
+++ b/layers/Engine/packages/root-wp/src/AppLoader.php
@@ -15,8 +15,13 @@ class AppLoader extends UpstreamAppLoader
      *
      * @param array<string,mixed> $initialAppState
      */
-    protected function bootApplicationComponents(array $initialAppState): void
+    protected function bootApplicationComponents(array $initialAppState = []): void
     {
+        $initialAppState = array_merge(
+            $this->initialAppState,
+            $initialAppState
+        );
+        
         // Boot all the components
         App::getComponentManager()->beforeBoot();
 

--- a/layers/Engine/packages/root-wp/src/AppLoader.php
+++ b/layers/Engine/packages/root-wp/src/AppLoader.php
@@ -15,7 +15,7 @@ class AppLoader extends UpstreamAppLoader
      *
      * @param array<string,mixed> $initialAppState
      */
-    protected function bootApplicationForComponents(array $initialAppState): void
+    protected function bootApplicationComponents(array $initialAppState): void
     {
         // Boot all the components
         App::getComponentManager()->beforeBoot();

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -252,7 +252,7 @@ class AppLoader implements AppLoaderInterface
         App::getSystemContainerBuilderFactory()->maybeCompileAndCacheContainer($systemCompilerPasses);
 
         // Finally boot the components
-        $this->bootSystemForComponents();
+        $this->bootSystemComponents();
     }
 
     /**
@@ -268,7 +268,7 @@ class AppLoader implements AppLoaderInterface
      * Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components,
      * for them to execute any custom extra logic
      */
-    protected function bootSystemForComponents(): void
+    protected function bootSystemComponents(): void
     {
         App::getComponentManager()->bootSystem();
     }
@@ -355,7 +355,7 @@ class AppLoader implements AppLoaderInterface
         App::getContainerBuilderFactory()->maybeCompileAndCacheContainer($systemCompilerPasses);
 
         // Finally boot the components
-        $this->bootApplicationForComponents($this->initialAppState);
+        $this->bootApplicationComponents($this->initialAppState);
     }
 
     public function skipSchemaForComponent(ComponentInterface $component): bool
@@ -373,7 +373,7 @@ class AppLoader implements AppLoaderInterface
      *
      * @param array<string,mixed> $initialAppState
      */
-    protected function bootApplicationForComponents(array $initialAppState): void
+    protected function bootApplicationComponents(array $initialAppState): void
     {
         App::getComponentManager()->beforeBoot();
         App::getAppStateManager()->initializeAppState($initialAppState);

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -353,9 +353,6 @@ class AppLoader implements AppLoaderInterface
         $systemCompilerPassRegistry = SystemCompilerPassRegistryFacade::getInstance();
         $systemCompilerPasses = $systemCompilerPassRegistry->getCompilerPasses();
         App::getContainerBuilderFactory()->maybeCompileAndCacheContainer($systemCompilerPasses);
-
-        // Finally boot the components
-        $this->bootApplicationComponents($this->initialAppState);
     }
 
     public function skipSchemaForComponent(ComponentInterface $component): bool
@@ -373,8 +370,12 @@ class AppLoader implements AppLoaderInterface
      *
      * @param array<string,mixed> $initialAppState
      */
-    protected function bootApplicationComponents(array $initialAppState): void
+    protected function bootApplicationComponents(array $initialAppState = []): void
     {
+        $initialAppState = array_merge(
+            $this->initialAppState,
+            $initialAppState
+        );
         App::getComponentManager()->beforeBoot();
         App::getAppStateManager()->initializeAppState($initialAppState);
         App::getComponentManager()->boot();

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -370,7 +370,7 @@ class AppLoader implements AppLoaderInterface
      *
      * @param array<string,mixed> $initialAppState
      */
-    protected function bootApplicationComponents(array $initialAppState = []): void
+    public function bootApplicationComponents(array $initialAppState = []): void
     {
         $initialAppState = array_merge(
             $this->initialAppState,

--- a/layers/Engine/packages/root/src/AppLoaderInterface.php
+++ b/layers/Engine/packages/root/src/AppLoaderInterface.php
@@ -94,5 +94,13 @@ interface AppLoaderInterface
         ?string $containerDirectory = null
     ): void;
 
+    /**
+     * Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components,
+     * for them to execute any custom extra logic.
+     *
+     * @param array<string,mixed> $initialAppState
+     */
+    public function bootApplicationComponents(array $initialAppState = []): void;
+
     public function skipSchemaForComponent(ComponentInterface $component): bool;
 }

--- a/layers/Engine/packages/root/tests/AbstractTestCase.php
+++ b/layers/Engine/packages/root/tests/AbstractTestCase.php
@@ -43,6 +43,7 @@ abstract class AbstractTestCase extends TestCase
         );
 
         App::getAppLoader()->bootApplication($cacheContainerConfiguration, $containerNamespace, $containerDirectory);
+        App::getAppLoader()->bootApplicationComponents();
     }
 
     protected static function getAppLoader(): AppLoaderInterface

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -516,11 +516,13 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         try {
             // Boot all PoP components, from this plugin and all extensions
             $containerCacheConfiguration = $this->pluginInitializationConfiguration->getContainerCacheConfiguration();
-            App::getAppLoader()->bootApplication(
+            $appLoader = App::getAppLoader();
+            $appLoader->bootApplication(
                 $containerCacheConfiguration->cacheContainerConfiguration(),
                 $containerCacheConfiguration->getContainerConfigurationCacheNamespace(),
                 $containerCacheConfiguration->getContainerConfigurationCacheDirectory(),
             );
+            $appLoader->bootApplicationComponents();
 
             // Custom logic
             $this->doBootApplication();


### PR DESCRIPTION
Remove calling `bootApplicationComponents` from within `bootApplication`, and call it explicitly.

This is so that we can pass an `$initialAppState` retrieving a value from the container, which is initialized in `bootApplication`.

Will be used to test the standalone GraphQLServer.