### PR TITLE
Simplify `PoP/EngineWP/AppLoader`, renamed `beforeBoot` to `componentLoaded`

### DIFF
--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -51,9 +51,9 @@ class Component extends AbstractComponent
         $this->initSystemServices(dirname(__DIR__));
     }
 
-    public function beforeBoot(): void
+    public function componentLoaded(): void
     {
-        parent::beforeBoot();
+        parent::componentLoaded();
 
         $attachExtensionService = AttachExtensionServiceFacade::getInstance();
         $attachExtensionService->attachExtensions(ApplicationEvents::BEFORE_BOOT);

--- a/layers/Engine/packages/component-model/src/Component.php
+++ b/layers/Engine/packages/component-model/src/Component.php
@@ -56,7 +56,7 @@ class Component extends AbstractComponent
         parent::componentLoaded();
 
         $attachExtensionService = AttachExtensionServiceFacade::getInstance();
-        $attachExtensionService->attachExtensions(ApplicationEvents::BEFORE_BOOT);
+        $attachExtensionService->attachExtensions(ApplicationEvents::COMPONENT_LOADED);
     }
 
     public function boot(): void

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/BeforeBootAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/BeforeBootAttachExtensionCompilerPass.php
@@ -10,7 +10,7 @@ class BeforeBootAttachExtensionCompilerPass extends AbstractAttachExtensionCompi
 {
     protected function getAttachExtensionEvent(): string
     {
-        return ApplicationEvents::BEFORE_BOOT;
+        return ApplicationEvents::COMPONENT_LOADED;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Container/CompilerPasses/ComponentLoadedAttachExtensionCompilerPass.php
+++ b/layers/Engine/packages/component-model/src/Container/CompilerPasses/ComponentLoadedAttachExtensionCompilerPass.php
@@ -6,7 +6,7 @@ namespace PoP\ComponentModel\Container\CompilerPasses;
 
 use PoP\Root\Component\ApplicationEvents;
 
-class BeforeBootAttachExtensionCompilerPass extends AbstractAttachExtensionCompilerPass
+class ComponentLoadedAttachExtensionCompilerPass extends AbstractAttachExtensionCompilerPass
 {
     protected function getAttachExtensionEvent(): string
     {

--- a/layers/Engine/packages/root-wp/src/Component.php
+++ b/layers/Engine/packages/root-wp/src/Component.php
@@ -45,7 +45,7 @@ class Component extends AbstractComponent
         $this->initSystemServices(dirname(__DIR__), '', 'hybrid-services.yaml');
     }
 
-    public function beforeBoot(): void
+    public function componentLoaded(): void
     {
         Cortex::boot();
     }

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -353,6 +353,9 @@ class AppLoader implements AppLoaderInterface
         $systemCompilerPassRegistry = SystemCompilerPassRegistryFacade::getInstance();
         $systemCompilerPasses = $systemCompilerPassRegistry->getCompilerPasses();
         App::getContainerBuilderFactory()->maybeCompileAndCacheContainer($systemCompilerPasses);
+
+        // Initialize the components
+        App::getComponentManager()->beforeBoot();
     }
 
     public function skipSchemaForComponent(ComponentInterface $component): bool
@@ -370,7 +373,6 @@ class AppLoader implements AppLoaderInterface
      */
     public function bootApplicationComponents(): void
     {
-        App::getComponentManager()->beforeBoot();
         App::getAppStateManager()->initializeAppState($this->initialAppState);
         App::getComponentManager()->boot();
         App::getComponentManager()->afterBoot();

--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -265,7 +265,7 @@ class AppLoader implements AppLoaderInterface
     }
 
     /**
-     * Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components,
+     * Trigger "componentLoaded", "boot" and "afterBoot" events on all the Components,
      * for them to execute any custom extra logic
      */
     protected function bootSystemComponents(): void
@@ -297,7 +297,7 @@ class AppLoader implements AppLoaderInterface
      * Boot the application. It does these steps:
      *
      * 1. Initialize the Application Container, have all Components inject services, and compile it
-     * 2. Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components, for them to execute any custom extra logic
+     * 2. Trigger "componentLoaded", "boot" and "afterBoot" events on all the Components, for them to execute any custom extra logic
      *
      * @param boolean|null $cacheContainerConfiguration Indicate if to cache the container. If null, it gets the value from ENV
      * @param string|null $containerNamespace Provide the namespace, to regenerate the cache whenever the application is upgraded. If null, it gets the value from ENV
@@ -355,7 +355,7 @@ class AppLoader implements AppLoaderInterface
         App::getContainerBuilderFactory()->maybeCompileAndCacheContainer($systemCompilerPasses);
 
         // Initialize the components
-        App::getComponentManager()->beforeBoot();
+        App::getComponentManager()->componentLoaded();
     }
 
     public function skipSchemaForComponent(ComponentInterface $component): bool
@@ -368,7 +368,7 @@ class AppLoader implements AppLoaderInterface
     }
 
     /**
-     * Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components,
+     * Trigger "componentLoaded", "boot" and "afterBoot" events on all the Components,
      * for them to execute any custom extra logic.
      */
     public function bootApplicationComponents(): void

--- a/layers/Engine/packages/root/src/AppLoaderInterface.php
+++ b/layers/Engine/packages/root/src/AppLoaderInterface.php
@@ -82,7 +82,7 @@ interface AppLoaderInterface
      * Boot the application. It does these steps:
      *
      * 1. Initialize the Application Container, have all Components inject services, and compile it
-     * 2. Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components, for them to execute any custom extra logic
+     * 2. Trigger "componentLoaded", "boot" and "afterBoot" events on all the Components, for them to execute any custom extra logic
      *
      * @param boolean|null $cacheContainerConfiguration Indicate if to cache the container. If null, it gets the value from ENV
      * @param string|null $containerNamespace Provide the namespace, to regenerate the cache whenever the application is upgraded. If null, it gets the value from ENV
@@ -95,7 +95,7 @@ interface AppLoaderInterface
     ): void;
 
     /**
-     * Trigger "beforeBoot", "boot" and "afterBoot" events on all the Components,
+     * Trigger "componentLoaded", "boot" and "afterBoot" events on all the Components,
      * for them to execute any custom extra logic.
      */
     public function bootApplicationComponents(): void;

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -84,7 +84,7 @@ class Component extends AbstractComponent
          * @var ServiceInstantiatorInterface
          */
         $serviceInstantiator = App::getContainer()->get(ServiceInstantiatorInterface::class);
-        $serviceInstantiator->initializeServices(ApplicationEvents::BEFORE_BOOT);
+        $serviceInstantiator->initializeServices(ApplicationEvents::COMPONENT_LOADED);
     }
 
     /**

--- a/layers/Engine/packages/root/src/Component.php
+++ b/layers/Engine/packages/root/src/Component.php
@@ -77,7 +77,7 @@ class Component extends AbstractComponent
     /**
      * Function called by the Bootloader after all components have been loaded
      */
-    public function beforeBoot(): void
+    public function componentLoaded(): void
     {
         // Initialize container services through AutomaticallyInstantiatedServiceCompilerPass
         /**

--- a/layers/Engine/packages/root/src/Component/AbstractComponent.php
+++ b/layers/Engine/packages/root/src/Component/AbstractComponent.php
@@ -141,7 +141,7 @@ abstract class AbstractComponent implements ComponentInterface
     /**
      * Function called by the Bootloader after all components have been loaded
      */
-    public function beforeBoot(): void
+    public function componentLoaded(): void
     {
     }
 

--- a/layers/Engine/packages/root/src/Component/ApplicationEvents.php
+++ b/layers/Engine/packages/root/src/Component/ApplicationEvents.php
@@ -6,7 +6,7 @@ namespace PoP\Root\Component;
 
 class ApplicationEvents
 {
-    public const BEFORE_BOOT = 'componentLoaded';
+    public const COMPONENT_LOADED = 'componentLoaded';
     public const BOOT = 'boot';
     public const AFTER_BOOT = 'afterBoot';
 }

--- a/layers/Engine/packages/root/src/Component/ApplicationEvents.php
+++ b/layers/Engine/packages/root/src/Component/ApplicationEvents.php
@@ -6,7 +6,7 @@ namespace PoP\Root\Component;
 
 class ApplicationEvents
 {
-    public const BEFORE_BOOT = 'beforeBoot';
+    public const BEFORE_BOOT = 'componentLoaded';
     public const BOOT = 'boot';
     public const AFTER_BOOT = 'afterBoot';
 }

--- a/layers/Engine/packages/root/src/Component/ComponentInterface.php
+++ b/layers/Engine/packages/root/src/Component/ComponentInterface.php
@@ -61,7 +61,7 @@ interface ComponentInterface
     /**
      * Function called by the Bootloader after all components have been loaded
      */
-    public function beforeBoot(): void;
+    public function componentLoaded(): void;
 
     /**
      * Function called by the Bootloader when booting the system

--- a/layers/Engine/packages/root/src/Container/ServiceInstantiator.php
+++ b/layers/Engine/packages/root/src/Container/ServiceInstantiator.php
@@ -24,7 +24,7 @@ class ServiceInstantiator implements ServiceInstantiatorInterface
     }
     /**
      * The SystemContainer requires no events => pass null
-     * The ApplicationContainer has 3 events (beforeBoot, boot, afterBoot)
+     * The ApplicationContainer has 3 events (componentLoaded, boot, afterBoot)
      */
     public function initializeServices(?string $event = null): void
     {

--- a/layers/Engine/packages/root/src/Container/ServiceInstantiatorInterface.php
+++ b/layers/Engine/packages/root/src/Container/ServiceInstantiatorInterface.php
@@ -16,7 +16,7 @@ interface ServiceInstantiatorInterface
     public function addService(AutomaticallyInstantiatedServiceInterface $service): void;
     /**
      * The SystemContainer requires no events => pass null
-     * The ApplicationContainer has 3 events (beforeBoot, boot, afterBoot)
+     * The ApplicationContainer has 3 events (componentLoaded, boot, afterBoot)
      */
     public function initializeServices(?string $event = null): void;
 }

--- a/layers/Engine/packages/root/src/Services/AutomaticallyInstantiatedServiceTrait.php
+++ b/layers/Engine/packages/root/src/Services/AutomaticallyInstantiatedServiceTrait.php
@@ -22,6 +22,6 @@ trait AutomaticallyInstantiatedServiceTrait
 
     public function getInstantiationEvent(): string
     {
-        return ApplicationEvents::BEFORE_BOOT;
+        return ApplicationEvents::COMPONENT_LOADED;
     }
 }

--- a/layers/Engine/packages/root/src/StateManagers/ComponentManager.php
+++ b/layers/Engine/packages/root/src/StateManagers/ComponentManager.php
@@ -66,10 +66,10 @@ class ComponentManager implements ComponentManagerInterface
     /**
      * Boot all components
      */
-    public function beforeBoot(): void
+    public function componentLoaded(): void
     {
         foreach ($this->components as $component) {
-            $component->beforeBoot();
+            $component->componentLoaded();
         }
     }
 

--- a/layers/Engine/packages/root/src/StateManagers/ComponentManagerInterface.php
+++ b/layers/Engine/packages/root/src/StateManagers/ComponentManagerInterface.php
@@ -32,7 +32,7 @@ interface ComponentManagerInterface
     /**
      * Boot all components
      */
-    public function beforeBoot(): void;
+    public function componentLoaded(): void;
 
     /**
      * Boot all components

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Standalone/AbstractGraphQLServerTestCase.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Standalone/AbstractGraphQLServerTestCase.php
@@ -14,7 +14,9 @@ abstract class AbstractGraphQLServerTestCase extends TestCase
     public static function setUpBeforeClass(): void
     {
         self::$graphQLServer = new GraphQLServer(
-            static::getGraphQLServerComponentClasses()
+            static::getGraphQLServerComponentClasses(),
+            static::getGraphQLServerComponentClassConfiguration(),
+            false
         );
     }
 
@@ -27,6 +29,14 @@ abstract class AbstractGraphQLServerTestCase extends TestCase
      * @return string[]
      */
     protected static function getGraphQLServerComponentClasses(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected static function getGraphQLServerComponentClassConfiguration(): array
     {
         return [];
     }


### PR DESCRIPTION
Function `bootApplicationComponents` in the `AppLoader` in WP now reused the code from the parent class.