### PR TITLE
Move `ErrorMessage` functions to new service `GraphQLErrorMessageProvider`

### DIFF
--- a/layers/Engine/packages/graphql-parser/config/services.yaml
+++ b/layers/Engine/packages/graphql-parser/config/services.yaml
@@ -13,5 +13,8 @@ services:
     PoP\GraphQLParser\Query\QueryAugmenterServiceInterface:
         class: \PoP\GraphQLParser\Query\QueryAugmenterService
 
+    PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface:
+        class: \PoP\GraphQLParser\Error\GraphQLErrorMessageProvider
+
     PoP\GraphQLParser\Response\OutputServiceInterface:
         class: \PoP\GraphQLParser\Response\OutputService

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
@@ -4,9 +4,194 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Error;
 
+use PoP\GraphQLParser\Response\OutputServiceInterface;
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
+use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
 use PoP\Root\Services\BasicServiceTrait;
+use stdClass;
 
 class GraphQLErrorMessageProvider implements GraphQLErrorMessageProviderInterface
 {
     use BasicServiceTrait;
+
+    private ?OutputServiceInterface $outputService = null;
+
+    final public function setOutputService(OutputServiceInterface $outputService): void
+    {
+        $this->outputService = $outputService;
+    }
+    final protected function getOutputService(): OutputServiceInterface
+    {
+        return $this->outputService ??= $this->instanceManager->getInstance(OutputServiceInterface::class);
+    }
+
+    public function getAffectedDirectivesReferencedMoreThanOnceErrorMessage(
+        Directive $directive,
+    ): string {
+        return \sprintf(
+            $this->__('Meta directive \'%s\' is nesting a directive already nested by another meta-directive', 'graphql-parser'),
+            $directive->getName()
+        );
+    }
+
+    public function getAffectedDirectivesUnderPosNotEmptyErrorMessage(
+        Directive $directive,
+        Argument $argument
+    ): string {
+        return \sprintf(
+            $this->__('Argument \'%s\' in directive \'%s\' cannot be null or empty', 'graphql-parser'),
+            $argument->getName(),
+            $directive->getName()
+        );
+    }
+
+    public function getAffectedDirectivesUnderPosNotPositiveIntErrorMessage(
+        Directive $directive,
+        Argument $argument,
+        mixed $itemValue
+    ): string {
+        return \sprintf(
+            $this->__('Argument \'%s\' in directive \'%s\' must be an array of positive integers, array item \'%s\' is not allowed', 'graphql-parser'),
+            $argument->getName(),
+            $directive->getName(),
+            is_array($itemValue) || ($itemValue instanceof stdClass)
+                ? $this->getOutputService()->jsonEncodeArrayOrStdClassValue($itemValue)
+                : $itemValue
+        );
+    }
+
+    public function getNoAffectedDirectiveUnderPosErrorMessage(
+        Directive $directive,
+        Argument $argument,
+        int $itemValue
+    ): string {
+        return \sprintf(
+            $this->__('There is no directive in relative position \'%s\' from meta directive \'%s\', as indicated in argument \'%s\'', 'graphql-parser'),
+            $itemValue,
+            $directive->getName(),
+            $argument->getName(),
+        );
+    }
+
+    public function getNoOperationMatchesNameErrorMessage(string $operationName): string
+    {
+        return \sprintf($this->__('Operation with name \'%s\' does not exist', 'graphql-server'), $operationName);
+    }
+
+    public function getNoOperationNameProvidedErrorMessage(): string
+    {
+        return 'The operation name must be provided';
+    }
+
+    public function getVariableHasntBeenSubmittedErrorMessage(string $variableName): string
+    {
+        return \sprintf($this->__('Variable \'%s\' hasn\'t been submitted', 'graphql-server'), $variableName);
+    }
+
+    public function getExecuteValidationErrorMessage(string $methodName): string
+    {
+        return \sprintf(
+            $this->__('Before executing `%s`, must call `%s`', 'graphql-server'),
+            $methodName,
+            'validateAndInitialize'
+        );
+    }
+
+    public function getIncorrectRequestSyntaxErrorMessage(?string $syntax): string
+    {
+        $errorMessage = $this->__('Incorrect request syntax', 'graphql-server');
+        if ($syntax === null) {
+            return $errorMessage;
+        }
+        return \sprintf(
+            $this->__('%s: \'%s\'', 'graphql-server'),
+            $errorMessage,
+            $syntax
+        );
+    }
+
+    public function getCantParseArgumentErrorMessage(): string
+    {
+        return $this->__('Can\'t parse argument', 'graphql-parser');
+    }
+
+    public function getDuplicateKeyInInputObjectSyntaxErrorMessage(string $key): string
+    {
+        return \sprintf($this->__('Input object has duplicate key \'%s\'', 'graphql-server'), $key);
+    }
+
+    public function getInvalidStringUnicodeEscapeSequenceErrorMessage(string $codepoint): string
+    {
+        return \sprintf($this->__('Invalid string unicode escape sequece \'%s\'', 'graphql-server'), $codepoint);
+    }
+
+    public function getUnexpectedStringEscapedCharacterErrorMessage(string $ch): string
+    {
+        return \sprintf($this->__('Unexpected string escaped character \'%s\'', 'graphql-server'), $ch);
+    }
+
+    public function getUnexpectedTokenErrorMessage(string $tokenName): string
+    {
+        return \sprintf($this->__('Unexpected token \'%s\'', 'graphql-server'), $tokenName);
+    }
+
+    public function getNoOperationsDefinedInQueryErrorMessage(): string
+    {
+        return $this->__('No operations defined in the query', 'graphql-server');
+    }
+
+    public function getDuplicateOperationNameErrorMessage(string $operationName): string
+    {
+        return \sprintf($this->__('Operation name \'%s\' is duplicated', 'graphql-server'), $operationName);
+    }
+
+    public function getEmptyOperationNameErrorMessage(): string
+    {
+        return $this->__('When submitting more than 1 operation, no operation name can be empty', 'graphql-server');
+    }
+
+    public function getFragmentNotDefinedInQueryErrorMessage(string $fragmentName): string
+    {
+        return \sprintf($this->__('Fragment \'%s\' is not defined in query', 'graphql-server'), $fragmentName);
+    }
+
+    public function getFragmentNotUsedErrorMessage(string $fragmentName): string
+    {
+        return \sprintf($this->__('Fragment \'%s\' is not used', 'graphql-server'), $fragmentName);
+    }
+
+    public function getDuplicateVariableNameErrorMessage(string $variableName): string
+    {
+        return \sprintf($this->__('Variable name \'%s\' is duplicated', 'graphql-server'), $variableName);
+    }
+
+    public function getVariableNotDefinedInOperationErrorMessage(string $variableName): string
+    {
+        return \sprintf($this->__('Variable \'%s\' has not been defined in the operation', 'graphql-server'), $variableName);
+    }
+
+    public function getVariableNotUsedErrorMessage(string $variableName): string
+    {
+        return \sprintf($this->__('Variable \'%s\' is not used', 'graphql-server'), $variableName);
+    }
+
+    public function getDuplicateArgumentErrorMessage(string $argumentName): string
+    {
+        return \sprintf($this->__('Argument \'%s\' is duplicated', 'graphql-server'), $argumentName);
+    }
+
+    public function getContextNotSetErrorMessage(string $variableName): string
+    {
+        return \sprintf($this->__('Context has not been set for variable \'%s\'', 'graphql-server'), $variableName);
+    }
+
+    public function getValueIsNotSetForVariableErrorMessage(string $variableName): string
+    {
+        return \sprintf($this->__('Value is not set for variable \'%s\'', 'graphql-server'), $variableName);
+    }
+
+    public function getVariableDoesNotExistErrorMessage(string $variableReferenceName): string
+    {
+        return \sprintf($this->__('No variable exists for variable reference \'%s\'', 'graphql-server'), $variableReferenceName);
+    }
 }

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\Error;
+
+use PoP\Root\Services\BasicServiceTrait;
+
+class GraphQLErrorMessageProvider implements GraphQLErrorMessageProviderInterface
+{
+    use BasicServiceTrait;
+}

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
@@ -80,7 +80,7 @@ class GraphQLErrorMessageProvider implements GraphQLErrorMessageProviderInterfac
 
     public function getNoOperationNameProvidedErrorMessage(): string
     {
-        return 'The operation name must be provided';
+        return $this->__('The operation name must be provided', 'graphql-server');
     }
 
     public function getVariableNotSubmittedErrorMessage(string $variableName): string

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
@@ -83,7 +83,7 @@ class GraphQLErrorMessageProvider implements GraphQLErrorMessageProviderInterfac
         return 'The operation name must be provided';
     }
 
-    public function getVariableHasntBeenSubmittedErrorMessage(string $variableName): string
+    public function getVariableNotSubmittedErrorMessage(string $variableName): string
     {
         return \sprintf($this->__('Variable \'%s\' hasn\'t been submitted', 'graphql-server'), $variableName);
     }

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
@@ -130,6 +130,11 @@ class GraphQLErrorMessageProvider implements GraphQLErrorMessageProviderInterfac
         return \sprintf($this->__('Unexpected string escaped character \'%s\'', 'graphql-server'), $ch);
     }
 
+    public function getCantRecognizeTokenTypeErrorMessage(): string
+    {
+        return $this->__('Can\t recognize token type', 'graphql-server');
+    }
+
     public function getUnexpectedTokenErrorMessage(string $tokenName): string
     {
         return \sprintf($this->__('Unexpected token \'%s\'', 'graphql-server'), $tokenName);

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
@@ -48,6 +48,8 @@ interface GraphQLErrorMessageProviderInterface
 
     public function getUnexpectedStringEscapedCharacterErrorMessage(string $ch): string;
 
+    public function getCantRecognizeTokenTypeErrorMessage(): string;
+    
     public function getUnexpectedTokenErrorMessage(string $tokenName): string;
 
     public function getNoOperationsDefinedInQueryErrorMessage(): string;

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\Error;
+
+interface GraphQLErrorMessageProviderInterface
+{
+}

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
@@ -49,7 +49,7 @@ interface GraphQLErrorMessageProviderInterface
     public function getUnexpectedStringEscapedCharacterErrorMessage(string $ch): string;
 
     public function getCantRecognizeTokenTypeErrorMessage(): string;
-    
+
     public function getUnexpectedTokenErrorMessage(string $tokenName): string;
 
     public function getNoOperationsDefinedInQueryErrorMessage(): string;

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
@@ -34,7 +34,7 @@ interface GraphQLErrorMessageProviderInterface
 
     public function getNoOperationNameProvidedErrorMessage(): string;
 
-    public function getVariableHasntBeenSubmittedErrorMessage(string $variableName): string;
+    public function getVariableNotSubmittedErrorMessage(string $variableName): string;
 
     public function getExecuteValidationErrorMessage(string $methodName): string;
 

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
@@ -4,6 +4,73 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Error;
 
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
+use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
+
 interface GraphQLErrorMessageProviderInterface
 {
+    public function getAffectedDirectivesReferencedMoreThanOnceErrorMessage(
+        Directive $directive,
+    ): string;
+
+    public function getAffectedDirectivesUnderPosNotEmptyErrorMessage(
+        Directive $directive,
+        Argument $argument
+    ): string;
+
+    public function getAffectedDirectivesUnderPosNotPositiveIntErrorMessage(
+        Directive $directive,
+        Argument $argument,
+        mixed $itemValue
+    ): string;
+
+    public function getNoAffectedDirectiveUnderPosErrorMessage(
+        Directive $directive,
+        Argument $argument,
+        int $itemValue
+    ): string;
+
+    public function getNoOperationMatchesNameErrorMessage(string $operationName): string;
+
+    public function getNoOperationNameProvidedErrorMessage(): string;
+
+    public function getVariableHasntBeenSubmittedErrorMessage(string $variableName): string;
+
+    public function getExecuteValidationErrorMessage(string $methodName): string;
+
+    public function getIncorrectRequestSyntaxErrorMessage(?string $syntax): string;
+
+    public function getCantParseArgumentErrorMessage(): string;
+
+    public function getDuplicateKeyInInputObjectSyntaxErrorMessage(string $key): string;
+
+    public function getInvalidStringUnicodeEscapeSequenceErrorMessage(string $codepoint): string;
+
+    public function getUnexpectedStringEscapedCharacterErrorMessage(string $ch): string;
+
+    public function getUnexpectedTokenErrorMessage(string $tokenName): string;
+
+    public function getNoOperationsDefinedInQueryErrorMessage(): string;
+
+    public function getDuplicateOperationNameErrorMessage(string $operationName): string;
+
+    public function getEmptyOperationNameErrorMessage(): string;
+
+    public function getFragmentNotDefinedInQueryErrorMessage(string $fragmentName): string;
+
+    public function getFragmentNotUsedErrorMessage(string $fragmentName): string;
+
+    public function getDuplicateVariableNameErrorMessage(string $variableName): string;
+
+    public function getVariableNotDefinedInOperationErrorMessage(string $variableName): string;
+
+    public function getVariableNotUsedErrorMessage(string $variableName): string;
+
+    public function getDuplicateArgumentErrorMessage(string $argumentName): string;
+
+    public function getContextNotSetErrorMessage(string $variableName): string;
+
+    public function getValueIsNotSetForVariableErrorMessage(string $variableName): string;
+
+    public function getVariableDoesNotExistErrorMessage(string $variableReferenceName): string;
 }

--- a/layers/Engine/packages/graphql-parser/src/Facades/Error/GraphQLErrorMessageProviderFacade.php
+++ b/layers/Engine/packages/graphql-parser/src/Facades/Error/GraphQLErrorMessageProviderFacade.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\Facades\Error;
+
+use PoP\Root\App;
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
+
+class GraphQLErrorMessageProviderFacade
+{
+    public static function getInstance(): GraphQLErrorMessageProviderInterface
+    {
+        /**
+         * @var GraphQLErrorMessageProviderInterface
+         */
+        $service = App::getContainer()->get(GraphQLErrorMessageProviderInterface::class);
+        return $service;
+    }
+}

--- a/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php
@@ -147,7 +147,7 @@ class ExecutableDocument implements ExecutableDocumentInterface
                     continue;
                 }
                 throw new InvalidRequestException(
-                    $this->getGraphQLErrorMessageProvider()->getVariableHasntBeenSubmittedErrorMessage($variableReference->getName()),
+                    $this->getGraphQLErrorMessageProvider()->getVariableNotSubmittedErrorMessage($variableReference->getName()),
                     $variableReference->getLocation()
                 );
             }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
 
 use LogicException;
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
+use PoP\GraphQLParser\Facades\Error\GraphQLErrorMessageProviderFacade;
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Location;
@@ -13,6 +15,17 @@ use PoP\Root\Services\StandaloneServiceTrait;
 class VariableReference extends AbstractAst implements WithValueInterface
 {
     use StandaloneServiceTrait;
+
+    private ?GraphQLErrorMessageProviderInterface $graphQLErrorMessageProvider = null;
+
+    final public function setGraphQLErrorMessageProvider(GraphQLErrorMessageProviderInterface $graphQLErrorMessageProvider): void
+    {
+        $this->graphQLErrorMessageProvider = $graphQLErrorMessageProvider;
+    }
+    final protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->graphQLErrorMessageProvider ??= GraphQLErrorMessageProviderFacade::getInstance();
+    }
 
     public function __construct(
         private string $name,
@@ -40,14 +53,9 @@ class VariableReference extends AbstractAst implements WithValueInterface
     public function getValue(): mixed
     {
         if ($this->variable === null) {
-            throw new LogicException($this->getVariableDoesNotExistErrorMessage($this->name));
+            throw new LogicException($this->getGraphQLErrorMessageProvider()->getVariableDoesNotExistErrorMessage($this->name));
         }
 
         return $this->variable->getValue();
-    }
-
-    protected function getVariableDoesNotExistErrorMessage(string $variableReferenceName): string
-    {
-        return \sprintf($this->__('No variable exists for variable reference \'%s\'', 'graphql-server'), $variableReferenceName);
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -55,7 +55,7 @@ class Parser extends Tokenizer implements ParserInterface
 
                 default:
                     throw new SyntaxErrorException(
-                        $this->getIncorrectRequestSyntaxErrorMessage($this->lookAhead->getData()),
+                        $this->getGraphQLErrorMessageProvider()->getIncorrectRequestSyntaxErrorMessage($this->lookAhead->getData()),
                         $this->getLocation()
                     );
             }
@@ -76,19 +76,6 @@ class Parser extends Tokenizer implements ParserInterface
         return new Document(
             $operations,
             $fragments,
-        );
-    }
-
-    protected function getIncorrectRequestSyntaxErrorMessage(?string $syntax): string
-    {
-        $errorMessage = $this->__('Incorrect request syntax', 'graphql-server');
-        if ($syntax === null) {
-            return $errorMessage;
-        }
-        return \sprintf(
-            $this->__('%s: \'%s\'', 'graphql-server'),
-            $errorMessage,
-            $syntax
         );
     }
 
@@ -627,15 +614,10 @@ class Parser extends Tokenizer implements ParserInterface
                 => $this->parseList(false),
             default
                 => throw new SyntaxErrorException(
-                    $this->getCantParseArgumentErrorMessage(),
+                    $this->getGraphQLErrorMessageProvider()->getCantParseArgumentErrorMessage(),
                     $this->getLocation()
                 ),
         };
-    }
-
-    protected function getCantParseArgumentErrorMessage(): string
-    {
-        return 'Can\'t parse argument';
     }
 
     /**
@@ -658,7 +640,7 @@ class Parser extends Tokenizer implements ParserInterface
             // Validate no duplicated keys in InputObject
             if (property_exists($object, $key)) {
                 throw new SyntaxErrorException(
-                    $this->getDuplicateKeyInInputObjectSyntaxErrorMessage($key),
+                    $this->getGraphQLErrorMessageProvider()->getDuplicateKeyInInputObjectSyntaxErrorMessage($key),
                     $this->getTokenLocation($keyToken)
                 );
             }
@@ -669,11 +651,6 @@ class Parser extends Tokenizer implements ParserInterface
         $this->eat(Token::TYPE_RBRACE);
 
         return $createType ? $this->createInputObject($object, $this->getTokenLocation($startToken)) : $object;
-    }
-
-    protected function getDuplicateKeyInInputObjectSyntaxErrorMessage(string $key): string
-    {
-        return \sprintf($this->__('Input object has duplicate key \'%s\'', 'graphql-server'), $key);
     }
 
     protected function createInputObject(

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\Root\Services\BasicServiceTrait;
 
@@ -15,8 +16,18 @@ class Tokenizer
     protected int $pos = 0;
     protected int $line = 1;
     protected int $lineStart = 0;
-
     protected Token $lookAhead;
+
+    private ?GraphQLErrorMessageProviderInterface $graphQLErrorMessageProvider = null;
+
+    final public function setGraphQLErrorMessageProvider(GraphQLErrorMessageProviderInterface $graphQLErrorMessageProvider): void
+    {
+        $this->graphQLErrorMessageProvider = $graphQLErrorMessageProvider;
+    }
+    final protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->graphQLErrorMessageProvider ??= $this->instanceManager->getInstance(GraphQLErrorMessageProviderInterface::class);
+    }
 
     protected function initTokenizer(string $source): void
     {
@@ -326,13 +337,13 @@ class Tokenizer
                     case 'u':
                         $codepoint = substr($this->source, $this->pos + 1, 4);
                         if (!preg_match('/[0-9A-Fa-f]{4}/', $codepoint)) {
-                            throw $this->createException($this->getInvalidStringUnicodeEscapeSequenceErrorMessage($codepoint));
+                            throw $this->createException($this->getGraphQLErrorMessageProvider()->getInvalidStringUnicodeEscapeSequenceErrorMessage($codepoint));
                         }
                         $ch = html_entity_decode("&#x{$codepoint};", ENT_QUOTES, 'UTF-8');
                         $this->pos += 4;
                         break;
                     default:
-                        throw $this->createException($this->getUnexpectedStringEscapedCharacterErrorMessage($ch));
+                        throw $this->createException($this->getGraphQLErrorMessageProvider()->getUnexpectedStringEscapedCharacterErrorMessage($ch));
                 }
             }
 
@@ -341,16 +352,6 @@ class Tokenizer
         }
 
         throw $this->createUnexpectedTokenTypeException(Token::TYPE_END);
-    }
-
-    protected function getInvalidStringUnicodeEscapeSequenceErrorMessage(string $codepoint): string
-    {
-        return \sprintf($this->__('Invalid string unicode escape sequece \'%s\'', 'graphql-server'), $codepoint);
-    }
-
-    protected function getUnexpectedStringEscapedCharacterErrorMessage(string $ch): string
-    {
-        return \sprintf($this->__('Unexpected string escaped character \'%s\'', 'graphql-server'), $ch);
     }
 
     protected function end(): bool
@@ -384,11 +385,6 @@ class Tokenizer
      */
     protected function createUnexpectedTokenTypeException($tokenType)
     {
-        return $this->createException($this->getUnexpectedTokenErrorMessage(Token::tokenName($tokenType)));
-    }
-
-    protected function getUnexpectedTokenErrorMessage(string $tokenName): string
-    {
-        return \sprintf($this->__('Unexpected token \'%s\'', 'graphql-server'), $tokenName);
+        return $this->createException($this->getGraphQLErrorMessageProvider()->getUnexpectedTokenErrorMessage(Token::tokenName($tokenType)));
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
@@ -165,7 +165,7 @@ class Tokenizer
             return $this->scanString();
         }
 
-        throw $this->createException('Can\t recognize token type');
+        throw $this->createException($this->getGraphQLErrorMessageProvider()->getCantRecognizeTokenTypeErrorMessage());
     }
 
     protected function checkFragment(): bool

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Execution;
 
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
@@ -19,6 +20,11 @@ class ExecutableDocumentTest extends AbstractTestCase
     protected function getParser(): ParserInterface
     {
         return $this->getService(ParserInterface::class);
+    }
+
+    protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->getService(GraphQLErrorMessageProviderInterface::class);
     }
 
     public function testGetVariableFromContext()

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
@@ -109,7 +109,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testNonUniqueOperation()
     {
         $this->expectException(InvalidRequestException::class);
-        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateOperationNameErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getNoOperationNameProvidedErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -135,7 +135,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testMissingVariableValue()
     {
         $this->expectException(InvalidRequestException::class);
-        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getValueIsNotSetForVariableErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotSubmittedErrorMessage('format'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($format: String) {
@@ -153,7 +153,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testMissingVariableValueForDirective()
     {
         $this->expectException(InvalidRequestException::class);
-        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getValueIsNotSetForVariableErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotSubmittedErrorMessage('includeUsers'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($includeUsers: Boolean) {
@@ -171,7 +171,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testOperationDoesNotExist()
     {
         $this->expectException(InvalidRequestException::class);
-        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getNoOperationMatchesNameErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getNoOperationMatchesNameErrorMessage('AnotherOp'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
@@ -109,7 +109,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testNonUniqueOperation()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateOperationNameErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -135,7 +135,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testMissingVariableValue()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getValueIsNotSetForVariableErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($format: String) {
@@ -153,7 +153,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testMissingVariableValueForDirective()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getValueIsNotSetForVariableErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($includeUsers: Boolean) {
@@ -171,7 +171,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testOperationDoesNotExist()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getNoOperationMatchesNameErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -189,7 +189,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testNonInitializedRequest()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getExecuteValidationErrorMessage('getRequestedOperations'));
         $parser = $this->getParser();
         $document = $parser->parse('{ id }');
         $context = new Context();

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
@@ -109,6 +109,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testNonUniqueOperation()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -134,6 +135,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testMissingVariableValue()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($format: String) {
@@ -151,6 +153,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testMissingVariableValueForDirective()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($includeUsers: Boolean) {
@@ -168,6 +171,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testOperationDoesNotExist()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -185,6 +189,7 @@ class ExecutableDocumentTest extends AbstractTestCase
     public function testNonInitializedRequest()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('{ id }');
         $context = new Context();

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
@@ -38,7 +38,7 @@ class RequestValidatorTest extends AbstractTestCase
             'fragment-not-defined-2' => $this->getGraphQLErrorMessageProvider()->getFragmentNotDefinedInQueryErrorMessage('reference2'),
             'fragment-not-used' => $this->getGraphQLErrorMessageProvider()->getFragmentNotUsedErrorMessage('reference2'),
             'variable-not-defined' => $this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage('test'),
-            'variable-not-submitted' => $this->getGraphQLErrorMessageProvider()->getVariableHasntBeenSubmittedErrorMessage('test'),
+            'variable-not-submitted' => $this->getGraphQLErrorMessageProvider()->getVariableNotSubmittedErrorMessage('test'),
         ];
         $this->expectExceptionMessage($exceptionMessages[$this->dataName()] ?? '');
         $executableDocument->validateAndInitialize();

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
@@ -33,6 +33,7 @@ class RequestValidatorTest extends AbstractTestCase
     public function testInvalidRequests(ExecutableDocument $executableDocument)
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $executableDocument->validateAndInitialize();
     }
 

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Library\Validator;
 
-use PHPUnit\Framework\TestCase;
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Execution\ExecutableDocument;
@@ -12,15 +12,21 @@ use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Variable;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\VariableReference;
 use PoP\GraphQLParser\Spec\Parser\Ast\Document;
-use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
+use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\Spec\Parser\Ast\QueryOperation;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\Spec\Parser\Location;
+use PoP\Root\AbstractTestCase;
 
-class RequestValidatorTest extends TestCase
+class RequestValidatorTest extends AbstractTestCase
 {
+    protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->getService(GraphQLErrorMessageProviderInterface::class);
+    }
+
     /**
      * @dataProvider invalidRequestProvider
      */

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Library/Validator/RequestValidatorTest.php
@@ -33,7 +33,14 @@ class RequestValidatorTest extends AbstractTestCase
     public function testInvalidRequests(ExecutableDocument $executableDocument)
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $exceptionMessages = [
+            'fragment-not-defined' => $this->getGraphQLErrorMessageProvider()->getFragmentNotDefinedInQueryErrorMessage('reference'),
+            'fragment-not-defined-2' => $this->getGraphQLErrorMessageProvider()->getFragmentNotDefinedInQueryErrorMessage('reference2'),
+            'fragment-not-used' => $this->getGraphQLErrorMessageProvider()->getFragmentNotUsedErrorMessage('reference2'),
+            'variable-not-defined' => $this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage('test'),
+            'variable-not-submitted' => $this->getGraphQLErrorMessageProvider()->getVariableHasntBeenSubmittedErrorMessage('test'),
+        ];
+        $this->expectExceptionMessage($exceptionMessages[$this->dataName()] ?? '');
         $executableDocument->validateAndInitialize();
     }
 
@@ -52,7 +59,7 @@ class RequestValidatorTest extends AbstractTestCase
         $variable3->setContext($context);
 
         return [
-            [
+            'fragment-not-defined' => [
                 (new ExecutableDocument(
                     new Document([
                         new QueryOperation(
@@ -70,7 +77,7 @@ class RequestValidatorTest extends AbstractTestCase
                     new Context()
                 )),
             ],
-            [
+            'fragment-not-defined-2' => [
                 (new ExecutableDocument(
                     new Document([
                         new QueryOperation(
@@ -89,9 +96,9 @@ class RequestValidatorTest extends AbstractTestCase
                         new Fragment('reference', 'TestType', [], [], new Location(1, 1))
                     ]),
                     new Context()
-                ))
+                )),
             ],
-            [
+            'fragment-not-used' => [
                 (new ExecutableDocument(
                     new Document([
                         new QueryOperation(
@@ -110,9 +117,9 @@ class RequestValidatorTest extends AbstractTestCase
                             new Fragment('reference2', 'TestType', [], [], new Location(1, 1))
                         ]),
                     new Context()
-                ))
+                )),
             ],
-            [
+            'variable-not-defined' => [
                 (new ExecutableDocument(
                     new Document([
                         new QueryOperation(
@@ -137,9 +144,9 @@ class RequestValidatorTest extends AbstractTestCase
                         )
                         ]),
                     new Context()
-                ))
+                )),
             ],
-            [
+            'variable-not-submitted' => [
                 (new ExecutableDocument(
                     new Document([
                         new QueryOperation(
@@ -158,7 +165,7 @@ class RequestValidatorTest extends AbstractTestCase
                         )
                         ]),
                     new Context()
-                ))
+                )),
             ]
         ];
     }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
@@ -4,21 +4,27 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
-use PHPUnit\Framework\TestCase;
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\InputList;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\InputObject;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Variable;
-use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
-use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\Spec\Parser\Ast\InlineFragment;
+use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
+use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
+use PoP\Root\AbstractTestCase;
 
-class AstTest extends TestCase
+class AstTest extends AbstractTestCase
 {
+    protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->getService(GraphQLErrorMessageProviderInterface::class);
+    }
+
     public function testArgument()
     {
         $argument = new Argument('test', new Literal('test', new Location(1, 1)), new Location(1, 1));

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
+use LogicException;
 use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
@@ -193,7 +194,8 @@ class AstTest extends AbstractTestCase
 
     public function testVariableLogicException()
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $variable = new Variable('id', 'int', false, false, true, new Location(1, 1));
         $variable->getValue();
     }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
@@ -195,7 +195,7 @@ class AstTest extends AbstractTestCase
     public function testVariableLogicException()
     {
         $this->expectException(LogicException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getContextNotSetErrorMessage('id'));
         $variable = new Variable('id', 'int', false, false, true, new Location(1, 1));
         $variable->getValue();
     }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
@@ -14,7 +14,7 @@ class DocumentTest extends AbstractTestCase
     {
         return $this->getService(ParserInterface::class);
     }
-    
+
     protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
     {
         return $this->getService(GraphQLErrorMessageProviderInterface::class);

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
@@ -67,6 +67,7 @@ class DocumentTest extends AbstractTestCase
     public function testMissingFragmentReferencedByFragment()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -85,6 +86,7 @@ class DocumentTest extends AbstractTestCase
     public function testFragmentNotUsed()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -123,6 +125,7 @@ class DocumentTest extends AbstractTestCase
     public function testFragmentMissing()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -138,6 +141,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableNotUsed()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String, $notUsedVar: Boolean) {
@@ -152,6 +156,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissing()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -166,6 +171,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInDirective()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -181,6 +187,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInInputObject()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query {
@@ -196,6 +203,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInInputList()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query {
@@ -231,6 +239,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInFragment()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute {
@@ -251,6 +260,7 @@ class DocumentTest extends AbstractTestCase
     public function testNoOperationsDefined()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             fragment F0 on Ship {
@@ -264,6 +274,7 @@ class DocumentTest extends AbstractTestCase
     public function testUniqueOperationName()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -284,6 +295,7 @@ class DocumentTest extends AbstractTestCase
     public function testUniqueOperationNameAcrossOps()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -304,6 +316,7 @@ class DocumentTest extends AbstractTestCase
     public function testUniqueVariableName()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($someVar: String, $someVar: Boolean) {
@@ -319,6 +332,7 @@ class DocumentTest extends AbstractTestCase
     public function testNonEmptyOperationName()
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -342,6 +356,7 @@ class DocumentTest extends AbstractTestCase
     public function testDuplicateArgument($query)
     {
         $this->expectException(InvalidRequestException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse($query);
         $document->validate();

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
@@ -67,7 +67,7 @@ class DocumentTest extends AbstractTestCase
     public function testMissingFragmentReferencedByFragment()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getFragmentNotDefinedInQueryErrorMessage('F1'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -86,7 +86,7 @@ class DocumentTest extends AbstractTestCase
     public function testFragmentNotUsed()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getFragmentNotDefinedInQueryErrorMessage('F0'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -125,7 +125,7 @@ class DocumentTest extends AbstractTestCase
     public function testFragmentMissing()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getFragmentNotDefinedInQueryErrorMessage('F2'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -141,7 +141,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableNotUsed()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotUsedErrorMessage('notUsedVar'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String, $notUsedVar: Boolean) {
@@ -156,7 +156,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissing()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage('missingVar'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -171,7 +171,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInDirective()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage('missingVar'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute($names_0:[String!]!, $query: String) {
@@ -187,7 +187,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInInputObject()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage('search'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query {
@@ -203,7 +203,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInInputList()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage('id'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query {
@@ -239,7 +239,7 @@ class DocumentTest extends AbstractTestCase
     public function testVariableMissingInFragment()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage('missingVar'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query StarWarsAppHomeRoute {
@@ -260,7 +260,7 @@ class DocumentTest extends AbstractTestCase
     public function testNoOperationsDefined()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getNoOperationsDefinedInQueryErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             fragment F0 on Ship {
@@ -274,7 +274,7 @@ class DocumentTest extends AbstractTestCase
     public function testUniqueOperationName()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateOperationNameErrorMessage('SomeQuery'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -295,7 +295,7 @@ class DocumentTest extends AbstractTestCase
     public function testUniqueOperationNameAcrossOps()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateOperationNameErrorMessage('SomeQuery'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -316,7 +316,7 @@ class DocumentTest extends AbstractTestCase
     public function testUniqueVariableName()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateVariableNameErrorMessage('someVar'));
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery($someVar: String, $someVar: Boolean) {
@@ -332,7 +332,7 @@ class DocumentTest extends AbstractTestCase
     public function testNonEmptyOperationName()
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getEmptyOperationNameErrorMessage());
         $parser = $this->getParser();
         $document = $parser->parse('
             query SomeQuery {
@@ -356,7 +356,7 @@ class DocumentTest extends AbstractTestCase
     public function testDuplicateArgument($query)
     {
         $this->expectException(InvalidRequestException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateArgumentErrorMessage('format'));
         $parser = $this->getParser();
         $document = $parser->parse($query);
         $document->validate();
@@ -375,7 +375,7 @@ class DocumentTest extends AbstractTestCase
             '],
             ['
                 {
-                    posts(limit: 3, limit: 5) {
+                    posts(format: 3, format: 5) {
                         id
                     }
                 }
@@ -415,7 +415,7 @@ class DocumentTest extends AbstractTestCase
             '],
             ['
                 {
-                    posts @include(if: true, if: false) {
+                    posts @caramelize(format: true, format: false) {
                         id
                     }
                 }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\Root\AbstractTestCase;
 
@@ -12,6 +13,11 @@ class DocumentTest extends AbstractTestCase
     protected function getParser(): ParserInterface
     {
         return $this->getService(ParserInterface::class);
+    }
+    
+    protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->getService(GraphQLErrorMessageProviderInterface::class);
     }
 
     public function testValidationWorks()

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -148,7 +148,6 @@ GRAPHQL;
     public function testWrongQueries(string $query)
     {
         $this->expectException(SyntaxErrorException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
 
         $parser->parse($query);
@@ -1230,8 +1229,8 @@ GRAPHQL;
     public function testNoDuplicateKeysInInputObjectInVariable()
     {
         $this->expectException(SyntaxErrorException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
-        $parser          = $this->getParser();
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateKeyInInputObjectSyntaxErrorMessage('name'));
+        $parser = $this->getParser();
         $parser->parse('
             query FilterUsers($filter: UserFilterInput = { name: "Pedro", name: "Juancho" }) {
               users(filter: $filter) {

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -49,7 +49,7 @@ class ParserTest extends AbstractTestCase
     public function testInvalidSelection()
     {
         $this->expectException(SyntaxErrorException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getUnexpectedTokenErrorMessage(Token::tokenName(Token::TYPE_RBRACE)));
         $parser = $this->getParser();
         $parser->parse('
         {

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -49,6 +49,7 @@ class ParserTest extends AbstractTestCase
     public function testInvalidSelection()
     {
         $this->expectException(SyntaxErrorException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
         $parser->parse('
         {
@@ -147,6 +148,7 @@ GRAPHQL;
     public function testWrongQueries(string $query)
     {
         $this->expectException(SyntaxErrorException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser = $this->getParser();
 
         $parser->parse($query);
@@ -1228,6 +1230,7 @@ GRAPHQL;
     public function testNoDuplicateKeysInInputObjectInVariable()
     {
         $this->expectException(SyntaxErrorException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser          = $this->getParser();
         $parser->parse('
             query FilterUsers($filter: UserFilterInput = { name: "Pedro", name: "Juancho" }) {
@@ -1242,6 +1245,7 @@ GRAPHQL;
     public function testNoDuplicateKeysInInputObjectInArgument()
     {
         $this->expectException(SyntaxErrorException::class);
+        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
         $parser          = $this->getParser();
         $parser->parse('
             query FilterUsers {

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -154,6 +154,21 @@ GRAPHQL;
         $parser->parse($query);
     }
 
+    public function wrongQueriesProvider()
+    {
+        return [
+            ['{ test (a: "asd", b: <basd>) { id }'],
+            ['{ test (asd: [..., asd]) { id } }'],
+            ['{ test (asd: { "a": 4, "m": null, "asd": false  "b": 5, "c" : { a }}) { id } }'],
+            ['asdasd'],
+            ['mutation { test(asd: ... ){ ...,asd, asd } }'],
+            ['mutation { test{ . test on Test { id } } }'],
+            ['mutation { test( a: "asdd'],
+            ['mutation { test( a: { "asd": 12 12'],
+            ['mutation { test( a: { "asd": 12'],
+        ];
+    }
+
     public function testCommas()
     {
         $parser = $this->getParser();
@@ -413,21 +428,6 @@ GRAPHQL;
                 ], new Location(62, 22)),
             ]
         ), $document);
-    }
-
-    public function wrongQueriesProvider()
-    {
-        return [
-            ['{ test (a: "asd", b: <basd>) { id }'],
-            ['{ test (asd: [..., asd]) { id } }'],
-            ['{ test (asd: { "a": 4, "m": null, "asd": false  "b": 5, "c" : { a }}) { id } }'],
-            ['asdasd'],
-            ['mutation { test(asd: ... ){ ...,asd, asd } }'],
-            ['mutation { test{ . test on Test { id } } }'],
-            ['mutation { test( a: "asdd'],
-            ['mutation { test( a: { "asd": 12 12'],
-            ['mutation { test( a: { "asd": 12'],
-        ];
     }
 
     public function testInlineFragment()

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -1244,7 +1244,7 @@ GRAPHQL;
     public function testNoDuplicateKeysInInputObjectInArgument()
     {
         $this->expectException(SyntaxErrorException::class);
-        // $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getErrorMessage());
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getDuplicateKeyInInputObjectSyntaxErrorMessage('name'));
         $parser          = $this->getParser();
         $parser->parse('
             query FilterUsers {

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
@@ -30,6 +31,11 @@ class ParserTest extends AbstractTestCase
     protected function getParser(): ParserInterface
     {
         return $this->getService(ParserInterface::class);
+    }
+
+    protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->getService(GraphQLErrorMessageProviderInterface::class);
     }
 
     public function testEmptyParser()

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/VariableTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/VariableTest.php
@@ -2,13 +2,19 @@
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
-use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Variable;
-use PHPUnit\Framework\TestCase;
+use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
+use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Variable;
+use PoP\Root\AbstractTestCase;
 
-class VariableTest extends TestCase
+class VariableTest extends AbstractTestCase
 {
+    protected function getGraphQLErrorMessageProvider(): GraphQLErrorMessageProviderInterface
+    {
+        return $this->getService(GraphQLErrorMessageProviderInterface::class);
+    }
+
     /**
      * Test if variable value equals expected value
      *

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/VariableTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/VariableTest.php
@@ -2,6 +2,7 @@
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
+use LogicException;
 use PoP\GraphQLParser\Error\GraphQLErrorMessageProviderInterface;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
@@ -29,8 +30,8 @@ class VariableTest extends AbstractTestCase
 
     public function testGetNullValueException()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Context has not been set for variable \'foo\'');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage($this->getGraphQLErrorMessageProvider()->getContextNotSetErrorMessage('foo'));
         $var = new Variable('foo', 'bar', false, false, true, new Location(1, 1));
         $var->getValue()->getValue();
     }


### PR DESCRIPTION
And invoke this functions to validate PHPUnit tests with `expectExceptionMessage`