### PR TITLE
Removed `getVariableDoesNotExistErrorMessage`

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProvider.php
@@ -204,9 +204,4 @@ class GraphQLErrorMessageProvider implements GraphQLErrorMessageProviderInterfac
     {
         return \sprintf($this->__('Value is not set for variable \'%s\'', 'graphql-server'), $variableName);
     }
-
-    public function getVariableDoesNotExistErrorMessage(string $variableReferenceName): string
-    {
-        return \sprintf($this->__('No variable exists for variable reference \'%s\'', 'graphql-server'), $variableReferenceName);
-    }
 }

--- a/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Error/GraphQLErrorMessageProviderInterface.php
@@ -77,6 +77,4 @@ interface GraphQLErrorMessageProviderInterface
     public function getContextNotSetErrorMessage(string $variableName): string;
 
     public function getValueIsNotSetForVariableErrorMessage(string $variableName): string;
-
-    public function getVariableDoesNotExistErrorMessage(string $variableReferenceName): string;
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
@@ -53,7 +53,7 @@ class VariableReference extends AbstractAst implements WithValueInterface
     public function getValue(): mixed
     {
         if ($this->variable === null) {
-            throw new LogicException($this->getGraphQLErrorMessageProvider()->getVariableDoesNotExistErrorMessage($this->name));
+            throw new LogicException($this->getGraphQLErrorMessageProvider()->getVariableNotDefinedInOperationErrorMessage($this->name));
         }
 
         return $this->variable->getValue();


### PR DESCRIPTION
Use `getVariableNotDefinedInOperationErrorMessage` instead
