### PR TITLE
Pass error code in `AbstractParserException`

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Exception/Parser/AbstractParserException.php
+++ b/layers/Engine/packages/graphql-parser/src/Exception/Parser/AbstractParserException.php
@@ -12,9 +12,15 @@ abstract class AbstractParserException extends Exception implements Locationable
 {
     public function __construct(
         string $message,
+        private string $namespacedCode,
         private Location $location,
     ) {
         parent::__construct($message);
+    }
+
+    public function getNamespacedCode(): string
+    {
+        return $this->namespacedCode;
     }
 
     public function getLocation(): Location

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -82,6 +82,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
                 if (isset($composingMetaDirectiveRelativePosition[$directivePos + $affectDirectiveUnderPosition])) {
                     throw new InvalidRequestException(
                         $this->getGraphQLExtendedSpecErrorMessageProvider()->getMessage(GraphQLExtendedSpecErrorMessageProvider::E1, $directive->getName()),
+                        $this->getGraphQLExtendedSpecErrorMessageProvider()->getNamespacedCode(GraphQLExtendedSpecErrorMessageProvider::E1),
                         $directive->getLocation()
                     );
                 }
@@ -162,6 +163,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
         if ($argumentValue === null) {
             throw new InvalidRequestException(
                 $this->getGraphQLExtendedSpecErrorMessageProvider()->getMessage(GraphQLExtendedSpecErrorMessageProvider::E2, $argument->getName(), $directive->getName()),
+                $this->getGraphQLExtendedSpecErrorMessageProvider()->getNamespacedCode(GraphQLExtendedSpecErrorMessageProvider::E2),
                 $argument->getLocation()
             );
         }
@@ -174,6 +176,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
         if ($argumentValue === []) {
             throw new InvalidRequestException(
                 $this->getGraphQLExtendedSpecErrorMessageProvider()->getMessage(GraphQLExtendedSpecErrorMessageProvider::E2, $argument->getName(), $directive->getName()),
+                $this->getGraphQLExtendedSpecErrorMessageProvider()->getNamespacedCode(GraphQLExtendedSpecErrorMessageProvider::E2),
                 $argument->getLocation()
             );
         }
@@ -181,24 +184,16 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
         foreach ($argumentValue as $argumentValueItem) {
             if (!is_int($argumentValueItem) || ((int)$argumentValueItem <= 0)) {
                 throw new InvalidRequestException(
-                    $this->getGraphQLExtendedSpecErrorMessageProvider()->getMessage(
-                        GraphQLExtendedSpecErrorMessageProvider::E3,
-                        $argument->getName(),
-                        $directive->getName(),
-                        $argumentValueItem
-                    ),
+                    $this->getGraphQLExtendedSpecErrorMessageProvider()->getMessage(GraphQLExtendedSpecErrorMessageProvider::E3, $argument->getName(), $directive->getName(), $argumentValueItem),
+                    $this->getGraphQLExtendedSpecErrorMessageProvider()->getNamespacedCode(GraphQLExtendedSpecErrorMessageProvider::E3),
                     $argument->getLocation()
                 );
             }
             $nestedDirectivePos = $directivePos + (int)$argumentValueItem;
             if ($nestedDirectivePos >= $directiveCount) {
                 throw new InvalidRequestException(
-                    $this->getGraphQLExtendedSpecErrorMessageProvider()->getMessage(
-                        GraphQLExtendedSpecErrorMessageProvider::E4,
-                        $argumentValueItem,
-                        $directive->getName(),
-                        $argument->getName()
-                    ),
+                    $this->getGraphQLExtendedSpecErrorMessageProvider()->getMessage(GraphQLExtendedSpecErrorMessageProvider::E4, $argumentValueItem, $directive->getName(), $argument->getName()),
+                    $this->getGraphQLExtendedSpecErrorMessageProvider()->getNamespacedCode(GraphQLExtendedSpecErrorMessageProvider::E4),
                     $argument->getLocation()
                 );
             }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php
@@ -103,6 +103,7 @@ class ExecutableDocument implements ExecutableDocumentInterface
             if (count($this->document->getOperations()) > 1) {
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_6_1_B),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_6_1_B),
                     $this->getNonSpecificLocation()
                 );
             }
@@ -117,6 +118,7 @@ class ExecutableDocument implements ExecutableDocumentInterface
         if ($requestedOperations === []) {
             throw new InvalidRequestException(
                 $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_6_1_A, $this->context->getOperationName()),
+                $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_6_1_A),
                 $this->getNonSpecificLocation()
             );
         }
@@ -148,6 +150,7 @@ class ExecutableDocument implements ExecutableDocumentInterface
                 }
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_8_5, $variableReference->getName()),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_8_5),
                     $variableReference->getLocation()
                 );
             }
@@ -170,6 +173,7 @@ class ExecutableDocument implements ExecutableDocumentInterface
         if ($this->requestedOperations === null) {
             throw new InvalidRequestException(
                 $this->getFeedbackMessageProvider()->getMessage(FeedbackMessageProvider::E1, __FUNCTION__),
+                $this->getFeedbackMessageProvider()->getNamespacedCode(FeedbackMessageProvider::E1),
                 $this->getNonSpecificLocation()
             );
         }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Variable.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Variable.php
@@ -138,6 +138,7 @@ class Variable extends AbstractAst implements WithValueInterface
         if ($this->context === null) {
             throw new InvalidRequestException(
                 $this->getFeedbackMessageProvider()->getMessage(FeedbackMessageProvider::E2, $this->name),
+                $this->getFeedbackMessageProvider()->getNamespacedCode(FeedbackMessageProvider::E2),
                 $this->getLocation()
             );
         }
@@ -157,6 +158,7 @@ class Variable extends AbstractAst implements WithValueInterface
         if ($this->isRequired()) {
             throw new InvalidRequestException(
                 $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_8_5, $this->name),
+                $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_8_5),
                 $this->getLocation()
             );
         }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
@@ -55,6 +55,7 @@ class VariableReference extends AbstractAst implements WithValueInterface
         if ($this->variable === null) {
             throw new InvalidRequestException(
                 $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_8_3, $this->name),
+                $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_8_3),
                 $this->getLocation()
             );
         }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php
@@ -89,6 +89,7 @@ class Document implements DocumentInterface
         if ($this->getOperations() === []) {
             throw new InvalidRequestException(
                 $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_6_1_C),
+                $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_6_1_C),
                 $this->getNonSpecificLocation()
             );
         }
@@ -110,6 +111,7 @@ class Document implements DocumentInterface
             if (in_array($operationName, $operationNames)) {
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_2_1_1, $operationName),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_2_1_1),
                     $this->getNonSpecificLocation()
                 );
             }
@@ -129,6 +131,7 @@ class Document implements DocumentInterface
             if (empty($operation->getName())) {
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_2_2_1),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_2_2_1),
                     $this->getNonSpecificLocation()
                 );
             }
@@ -147,6 +150,7 @@ class Document implements DocumentInterface
                 }
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_5_2_1, $fragmentReference->getName()),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_5_2_1),
                     $fragmentReference->getLocation()
                 );
             }
@@ -219,6 +223,7 @@ class Document implements DocumentInterface
             if (in_array($fragmentName, $fragmentNames)) {
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_5_1_1, $fragmentName),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_5_1_1),
                     $this->getNonSpecificLocation()
                 );
             }
@@ -239,6 +244,7 @@ class Document implements DocumentInterface
                 }
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_5_2_2, $fragmentReference->getName()),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_5_2_2),
                     $fragmentReference->getLocation()
                 );
             }
@@ -290,6 +296,7 @@ class Document implements DocumentInterface
             }
             throw new InvalidRequestException(
                 $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_5_1_4, $fragment->getName()),
+                $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_5_1_4),
                 $fragment->getLocation()
             );
         }
@@ -307,6 +314,7 @@ class Document implements DocumentInterface
                 if (in_array($variableName, $variableNames)) {
                     throw new InvalidRequestException(
                         $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_8_1, $variableName),
+                        $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_8_1),
                         $this->getNonSpecificLocation()
                     );
                 }
@@ -327,6 +335,7 @@ class Document implements DocumentInterface
                 }
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_8_3, $variableReference->getName()),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_8_3),
                     $variableReference->getLocation()
                 );
             }
@@ -477,6 +486,7 @@ class Document implements DocumentInterface
                 }
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_8_4, $variable->getName()),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_8_4),
                     $variable->getLocation()
                 );
             }
@@ -565,6 +575,7 @@ class Document implements DocumentInterface
             if (in_array($argumentName, $argumentNames)) {
                 throw new InvalidRequestException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_4_2, $argumentName),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_4_2),
                     $argument->getLocation()
                 );
             }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -69,6 +69,7 @@ class Parser extends Tokenizer implements ParserInterface
                 default:
                     throw new SyntaxErrorException(
                         $this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_1, $this->lookAhead->getData()),
+                        $this->getGraphQLParserErrorMessageProvider()->getNamespacedCode(GraphQLParserErrorMessageProvider::E_1),
                         $this->getLocation()
                     );
             }
@@ -628,6 +629,7 @@ class Parser extends Tokenizer implements ParserInterface
             default
                 => throw new SyntaxErrorException(
                     $this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_2),
+                    $this->getGraphQLParserErrorMessageProvider()->getNamespacedCode(GraphQLParserErrorMessageProvider::E_2),
                     $this->getLocation()
                 ),
         };
@@ -654,6 +656,7 @@ class Parser extends Tokenizer implements ParserInterface
             if (property_exists($object, $key)) {
                 throw new SyntaxErrorException(
                     $this->getGraphQLSpecErrorMessageProvider()->getMessage(GraphQLSpecErrorMessageProvider::E_5_6_2, $key),
+                    $this->getGraphQLSpecErrorMessageProvider()->getNamespacedCode(GraphQLSpecErrorMessageProvider::E_5_6_2),
                     $this->getTokenLocation($keyToken)
                 );
             }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
@@ -165,7 +165,10 @@ class Tokenizer
             return $this->scanString();
         }
 
-        throw $this->createException($this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_5));
+        throw $this->createException(
+            $this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_5),
+            $this->getGraphQLParserErrorMessageProvider()->getNamespacedCode(GraphQLParserErrorMessageProvider::E_5)
+        );
     }
 
     protected function checkFragment(): bool
@@ -275,9 +278,9 @@ class Tokenizer
         }
     }
 
-    protected function createException(string $message): SyntaxErrorException
+    protected function createException(string $message, string $namespacedCode): SyntaxErrorException
     {
-        return new SyntaxErrorException($message, $this->getLocation());
+        return new SyntaxErrorException($message, $namespacedCode, $this->getLocation());
     }
 
     protected function getLocation(): Location
@@ -337,13 +340,19 @@ class Tokenizer
                     case 'u':
                         $codepoint = substr($this->source, $this->pos + 1, 4);
                         if (!preg_match('/[0-9A-Fa-f]{4}/', $codepoint)) {
-                            throw $this->createException($this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_3, $codepoint));
+                            throw $this->createException(
+                                $this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_3, $codepoint),
+                                $this->getGraphQLParserErrorMessageProvider()->getNamespacedCode(GraphQLParserErrorMessageProvider::E_3)
+                            );
                         }
                         $ch = html_entity_decode("&#x{$codepoint};", ENT_QUOTES, 'UTF-8');
                         $this->pos += 4;
                         break;
                     default:
-                        throw $this->createException($this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_4, $ch));
+                        throw $this->createException(
+                            $this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_4, $ch),
+                            $this->getGraphQLParserErrorMessageProvider()->getNamespacedCode(GraphQLParserErrorMessageProvider::E_4)
+                        );
                 }
             }
 
@@ -385,6 +394,9 @@ class Tokenizer
      */
     protected function createUnexpectedTokenTypeException($tokenType)
     {
-        return $this->createException($this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_6, Token::tokenName($tokenType)));
+        return $this->createException(
+            $this->getGraphQLParserErrorMessageProvider()->getMessage(GraphQLParserErrorMessageProvider::E_6, Token::tokenName($tokenType)),
+            $this->getGraphQLParserErrorMessageProvider()->getNamespacedCode(GraphQLParserErrorMessageProvider::E_6)
+        );
     }
 }

--- a/layers/Engine/packages/root/src/FeedbackMessage/AbstractFeedbackMessageProvider.php
+++ b/layers/Engine/packages/root/src/FeedbackMessage/AbstractFeedbackMessageProvider.php
@@ -14,7 +14,7 @@ abstract class AbstractFeedbackMessageProvider implements FeedbackMessageProvide
 
     final public function getNamespacedCode(string $code): string
     {
-        return $$this->getNamespace() . $code;
+        return $this->getNamespace() . $code;
     }
 
     protected function getNamespace(): string


### PR DESCRIPTION
In advance to printing the `code` and `specifiedByURL` entries in the GraphQL response for errors.