### PR TITLE
Pass param `ObjectTypeFieldResolutionFeedbackStore` to `resolveValue`

### DIFF
--- a/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPAPI\API\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoPAPI\API\PersistedQueries\PersistedFragmentManagerInterface;
 use PoPAPI\API\PersistedQueries\PersistedQueryManagerInterface;
 use PoPAPI\API\Schema\SchemaDefinitionServiceInterface;
@@ -121,7 +122,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -121,6 +121,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/API/packages/api/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -131,6 +131,6 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return (object) $schemaDefinitionService->getFullSchemaDefinition();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
@@ -113,6 +113,7 @@ abstract class AbstractCategoryObjectTypeFieldResolver extends AbstractObjectTyp
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $categoryTypeAPI = $this->getCategoryTypeAPI();

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
@@ -140,6 +140,6 @@ abstract class AbstractCategoryObjectTypeFieldResolver extends AbstractObjectTyp
                 return $categoryTypeAPI->getCategoryItemCount($category);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCategoryObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Categories\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -113,7 +114,7 @@ abstract class AbstractCategoryObjectTypeFieldResolver extends AbstractObjectTyp
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $categoryTypeAPI = $this->getCategoryTypeAPI();

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractChildCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractChildCategoryObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Categories\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -147,7 +148,7 @@ abstract class AbstractChildCategoryObjectTypeFieldResolver extends AbstractQuer
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $category = $object;

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractChildCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractChildCategoryObjectTypeFieldResolver.php
@@ -147,6 +147,7 @@ abstract class AbstractChildCategoryObjectTypeFieldResolver extends AbstractQuer
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $category = $object;

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractChildCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractChildCategoryObjectTypeFieldResolver.php
@@ -166,6 +166,6 @@ abstract class AbstractChildCategoryObjectTypeFieldResolver extends AbstractQuer
                 return $categoryTypeAPI->getCategoryCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Categories\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -147,7 +148,7 @@ abstract class AbstractCustomPostQueryableObjectTypeFieldResolver extends Abstra
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $categoryTypeAPI = $this->getCategoryTypeAPI();

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
@@ -147,6 +147,7 @@ abstract class AbstractCustomPostQueryableObjectTypeFieldResolver extends Abstra
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $categoryTypeAPI = $this->getCategoryTypeAPI();

--- a/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/categories/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
@@ -161,6 +161,6 @@ abstract class AbstractCustomPostQueryableObjectTypeFieldResolver extends Abstra
                 return $categoryTypeAPI->getCustomPostCategoryCount($objectTypeResolver->getID($post), $query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/comment-mutations/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comment-mutations/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -107,6 +107,6 @@ class CommentObjectTypeFieldResolver extends UpstreamCommentObjectTypeFieldResol
                 return $this->getUserTypeAPI()->getUserEmail($commentUserID);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/comment-mutations/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comment-mutations/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CommentMutations\ConditionalOnComponent\Users\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\CommentMutations\Component;
@@ -92,7 +93,7 @@ class CommentObjectTypeFieldResolver extends UpstreamCommentObjectTypeFieldResol
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/CMSSchema/packages/comment-mutations/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comment-mutations/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -92,6 +92,7 @@ class CommentObjectTypeFieldResolver extends UpstreamCommentObjectTypeFieldResol
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/CMSSchema/packages/comment-mutations/src/FieldResolvers/ObjectType/UserStateRootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comment-mutations/src/FieldResolvers/ObjectType/UserStateRootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CommentMutations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -201,7 +202,7 @@ class UserStateRootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/comment-mutations/src/FieldResolvers/ObjectType/UserStateRootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comment-mutations/src/FieldResolvers/ObjectType/UserStateRootObjectTypeFieldResolver.php
@@ -201,6 +201,7 @@ class UserStateRootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/comment-mutations/src/FieldResolvers/ObjectType/UserStateRootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comment-mutations/src/FieldResolvers/ObjectType/UserStateRootObjectTypeFieldResolver.php
@@ -221,6 +221,6 @@ class UserStateRootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -61,6 +61,6 @@ class CommentObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldReso
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -48,6 +48,7 @@ class CommentObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/CMSSchema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/commentmeta/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CommentMeta\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\CommentMeta\TypeAPIs\CommentMetaTypeAPIInterface;
 use PoPCMSSchema\Comments\TypeResolvers\ObjectType\CommentObjectTypeResolver;
@@ -48,7 +49,7 @@ class CommentObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/CMSSchema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentUserObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class CommentUserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
             $comment = $object;

--- a/layers/CMSSchema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentUserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Comments\ConditionalOnComponent\Users\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -68,7 +69,7 @@ class CommentUserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
             $comment = $object;

--- a/layers/CMSSchema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/CommentUserObjectTypeFieldResolver.php
@@ -76,7 +76,7 @@ class CommentUserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getCommentTypeAPI()->getCommentUserId($comment);
         }
 
-            return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+            return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -379,6 +379,6 @@ class CommentObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRes
                 return $this->getCommentTypeAPI()->getCommentCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -320,6 +320,7 @@ class CommentObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Comments\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use DateTime;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -320,7 +321,7 @@ class CommentObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Comments\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\Comments\FieldResolvers\InterfaceType\CommentableInterfaceTypeFieldResolver;
@@ -71,7 +72,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -71,6 +71,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -79,7 +79,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeField
                 return $this->getCommentTypeAPI()->areCommentsOpen($objectTypeResolver->getID($post));
 
             case 'hasComments':
-                return $objectTypeResolver->resolveValue($post, 'commentCount', $variables, $expressions, $options) > 0;
+                return $objectTypeResolver->resolveValue($post, 'commentCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options) > 0;
         }
 
         $query = array_merge(
@@ -96,6 +96,6 @@ class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeField
                 return $this->getCommentTypeAPI()->getComments($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -258,6 +258,6 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -221,6 +221,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/comments/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Comments\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\FilterInput\FilterInputHelper;
@@ -221,7 +222,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/custompost-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompost-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CustomPostMutations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -211,7 +212,7 @@ class RootQueryableObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/custompost-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompost-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
@@ -231,6 +231,6 @@ class RootQueryableObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/custompost-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompost-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
@@ -211,6 +211,7 @@ class RootQueryableObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -67,6 +67,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/CMSSchema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CustomPostMedia\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\CustomPostMedia\FieldResolvers\InterfaceType\SupportingFeaturedImageInterfaceTypeFieldResolver;
@@ -67,7 +68,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/CMSSchema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompostmedia/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -78,6 +78,6 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getCustomPostMediaTypeAPI()->getCustomPostThumbnailID($objectTypeResolver->getID($post));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CustomPostMeta\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\CustomPostMeta\TypeAPIs\CustomPostMetaTypeAPIInterface;
 use PoPCMSSchema\CustomPosts\TypeResolvers\ObjectType\AbstractCustomPostObjectTypeResolver;
@@ -48,7 +49,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPost = $object;

--- a/layers/CMSSchema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -61,6 +61,6 @@ class CustomPostObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldR
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/custompostmeta/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -48,6 +48,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPost = $object;

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostListObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostListObjectTypeFieldResolver.php
@@ -159,6 +159,6 @@ abstract class AbstractCustomPostListObjectTypeFieldResolver extends AbstractQue
                 return $this->getCustomPostTypeAPI()->getCustomPostCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostListObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostListObjectTypeFieldResolver.php
@@ -145,6 +145,7 @@ abstract class AbstractCustomPostListObjectTypeFieldResolver extends AbstractQue
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostListObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostListObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -145,7 +146,7 @@ abstract class AbstractCustomPostListObjectTypeFieldResolver extends AbstractQue
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use DateTime;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -78,7 +79,7 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = $this->getCustomPostTypeAPI();

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -132,6 +132,6 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
                 return $customPostTypeAPI->getCustomPostType($customPost);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -78,6 +78,7 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = $this->getCustomPostTypeAPI();

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -138,6 +138,7 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FilterInput\FilterInputHelper;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -138,7 +139,7 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/customposts/src/FieldResolvers/ObjectType/RootCustomPostListObjectTypeFieldResolver.php
@@ -152,7 +152,7 @@ class RootCustomPostListObjectTypeFieldResolver extends AbstractCustomPostListOb
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/CMSSchema/packages/generic-customposts/src/FieldResolvers/ObjectType/RootGenericCustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/generic-customposts/src/FieldResolvers/ObjectType/RootGenericCustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\GenericCustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\FilterInput\FilterInputHelper;
@@ -228,7 +229,7 @@ class RootGenericCustomPostObjectTypeFieldResolver extends AbstractQueryableObje
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/generic-customposts/src/FieldResolvers/ObjectType/RootGenericCustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/generic-customposts/src/FieldResolvers/ObjectType/RootGenericCustomPostObjectTypeFieldResolver.php
@@ -243,6 +243,6 @@ class RootGenericCustomPostObjectTypeFieldResolver extends AbstractQueryableObje
                 return $this->getCustomPostTypeAPI()->getCustomPostCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/generic-customposts/src/FieldResolvers/ObjectType/RootGenericCustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/generic-customposts/src/FieldResolvers/ObjectType/RootGenericCustomPostObjectTypeFieldResolver.php
@@ -228,6 +228,7 @@ class RootGenericCustomPostObjectTypeFieldResolver extends AbstractQueryableObje
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/MediaUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/MediaUserObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class MediaUserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $media = $object;

--- a/layers/CMSSchema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/MediaUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/MediaUserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Media\ConditionalOnComponent\Users\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -68,7 +69,7 @@ class MediaUserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $media = $object;

--- a/layers/CMSSchema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/MediaUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/ConditionalOnComponent/Users/FieldResolvers/ObjectType/MediaUserObjectTypeFieldResolver.php
@@ -73,7 +73,7 @@ class MediaUserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         $media = $object;
         return match ($fieldName) {
             'author' => $this->getUserMediaTypeAPI()->getMediaAuthorId($media),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Media\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use DateTime;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -207,7 +208,7 @@ class MediaObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResol
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $media = $object;

--- a/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -207,6 +207,7 @@ class MediaObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResol
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $media = $object;

--- a/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -254,7 +254,7 @@ class MediaObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResol
                 return $this->getMediaTypeAPI()->getMimeType($media);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     /**

--- a/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -186,6 +186,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Media\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -186,7 +187,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -201,6 +201,6 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuItemObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuItemObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Menus\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -159,7 +160,7 @@ class MenuItemObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var MenuItem */

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuItemObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuItemObjectTypeFieldResolver.php
@@ -159,6 +159,7 @@ class MenuItemObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var MenuItem */

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuItemObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuItemObjectTypeFieldResolver.php
@@ -187,6 +187,6 @@ class MenuItemObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             //     return $menuItem->$fieldName;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
@@ -139,6 +139,7 @@ class MenuObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $menu = $object;

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
@@ -203,7 +203,7 @@ class MenuObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     protected function findEntryPosition(string | int $menuItemID, array $entries): int

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Menus\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -139,7 +140,7 @@ class MenuObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $menu = $object;

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Menus\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -180,7 +181,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -204,6 +204,6 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 return $this->getMenuTypeAPI()->getMenuCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/menus/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -180,6 +180,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
@@ -161,6 +161,7 @@ class PageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $page = $object;

--- a/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Pages\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -161,7 +162,7 @@ class PageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $page = $object;

--- a/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
@@ -182,6 +182,6 @@ class PageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 return $this->getPageTypeAPI()->getPageCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/RootPageObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/RootPageObjectTypeFieldResolver.php
@@ -201,6 +201,6 @@ class RootPageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRe
                 return $this->getPageTypeAPI()->getPageCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/RootPageObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/RootPageObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Pages\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -186,7 +187,7 @@ class RootPageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRe
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/RootPageObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/pages/src/FieldResolvers/ObjectType/RootPageObjectTypeFieldResolver.php
@@ -186,6 +186,7 @@ class RootPageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRe
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
@@ -222,6 +222,6 @@ class RootPostCategoryObjectTypeFieldResolver extends AbstractQueryableObjectTyp
                 return $this->getPostCategoryTypeAPI()->getCategoryCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
@@ -205,6 +205,7 @@ class RootPostCategoryObjectTypeFieldResolver extends AbstractQueryableObjectTyp
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\PostCategories\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -205,7 +206,7 @@ class RootPostCategoryObjectTypeFieldResolver extends AbstractQueryableObjectTyp
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/post-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
@@ -223,6 +223,7 @@ class RootQueryableObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/post-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
@@ -243,6 +243,6 @@ class RootQueryableObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/post-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-mutations/src/FieldResolvers/ObjectType/RootQueryableObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\PostMutations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -223,7 +224,7 @@ class RootQueryableObjectTypeFieldResolver extends AbstractQueryableObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\PostTags\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -205,7 +206,7 @@ class RootPostTagObjectTypeFieldResolver extends AbstractQueryableObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
@@ -205,6 +205,7 @@ class RootPostTagObjectTypeFieldResolver extends AbstractQueryableObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
@@ -222,6 +222,6 @@ class RootPostTagObjectTypeFieldResolver extends AbstractQueryableObjectTypeFiel
                 return $this->getPostTagTypeAPI()->getTagCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/AbstractPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/AbstractPostObjectTypeFieldResolver.php
@@ -175,6 +175,6 @@ abstract class AbstractPostObjectTypeFieldResolver extends AbstractQueryableObje
                 return $this->getPostTypeAPI()->getPostCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/AbstractPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/AbstractPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Posts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -161,7 +162,7 @@ abstract class AbstractPostObjectTypeFieldResolver extends AbstractQueryableObje
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/AbstractPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/AbstractPostObjectTypeFieldResolver.php
@@ -161,6 +161,7 @@ abstract class AbstractPostObjectTypeFieldResolver extends AbstractQueryableObje
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = array_merge(

--- a/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/RootPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/RootPostObjectTypeFieldResolver.php
@@ -121,6 +121,7 @@ class RootPostObjectTypeFieldResolver extends AbstractPostObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/RootPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/RootPostObjectTypeFieldResolver.php
@@ -132,7 +132,7 @@ class RootPostObjectTypeFieldResolver extends AbstractPostObjectTypeFieldResolve
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/RootPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/posts/src/FieldResolvers/ObjectType/RootPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Posts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FilterInput\FilterInputHelper;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -121,7 +122,7 @@ class RootPostObjectTypeFieldResolver extends AbstractPostObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Settings\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -186,7 +187,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -186,6 +186,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -202,6 +202,6 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $value;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
@@ -161,6 +161,6 @@ abstract class AbstractCustomPostQueryableObjectTypeFieldResolver extends Abstra
                 return $tagTypeAPI->getCustomPostTagCount($objectTypeResolver->getID($customPost), $query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Tags\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -147,7 +148,7 @@ abstract class AbstractCustomPostQueryableObjectTypeFieldResolver extends Abstra
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $tagTypeAPI = $this->getTagTypeAPI();

--- a/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractCustomPostQueryableObjectTypeFieldResolver.php
@@ -147,6 +147,7 @@ abstract class AbstractCustomPostQueryableObjectTypeFieldResolver extends Abstra
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $tagTypeAPI = $this->getTagTypeAPI();

--- a/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
@@ -110,6 +110,7 @@ abstract class AbstractTagObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $tagTypeAPI = $this->getTagTypeAPI();

--- a/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Tags\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -110,7 +111,7 @@ abstract class AbstractTagObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $tagTypeAPI = $this->getTagTypeAPI();

--- a/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/tags/src/FieldResolvers/ObjectType/AbstractTagObjectTypeFieldResolver.php
@@ -134,6 +134,6 @@ abstract class AbstractTagObjectTypeFieldResolver extends AbstractObjectTypeFiel
                 return $tagTypeAPI->getTagItemCount($tag);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\TaxonomyMeta\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\Meta\FieldResolvers\ObjectType\AbstractWithMetaObjectTypeFieldResolver;
 use PoPCMSSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
@@ -48,7 +49,7 @@ class TaxonomyObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $taxonomy = $object;

--- a/layers/CMSSchema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
@@ -48,6 +48,7 @@ class TaxonomyObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $taxonomy = $object;

--- a/layers/CMSSchema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/taxonomymeta/src/FieldResolvers/ObjectType/TaxonomyObjectTypeFieldResolver.php
@@ -61,6 +61,6 @@ class TaxonomyObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldRes
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/user-avatars/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-avatars/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -120,6 +120,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/user-avatars/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-avatars/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -143,7 +143,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $avatarID;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/CMSSchema/packages/user-avatars/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-avatars/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserAvatars\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -120,7 +121,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
@@ -113,6 +113,6 @@ class RootRolesObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getUserRoleTypeAPI()->getRoleNames();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserRolesWP\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -106,7 +107,7 @@ class RootRolesObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
@@ -106,6 +106,7 @@ class RootRolesObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -103,6 +103,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserRolesWP\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -103,7 +104,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles-wp/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -111,6 +111,6 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getUserRoleTypeAPI()->getUserRoles($user);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
@@ -77,6 +77,6 @@ class RootRolesObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getUserRoleTypeAPI()->getCapabilities();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserRoles\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -68,7 +69,7 @@ class RootRolesObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/RootRolesObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class RootRolesObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -187,6 +187,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -209,6 +209,6 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return !empty(array_intersect($fieldArgs['capabilities'], $userCapabilities));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-roles/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserRoles\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -187,7 +188,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class GlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
@@ -75,6 +75,6 @@ class GlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldResolve
                 return App::getState('is-user-logged-in');
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserState\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractGlobalObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -68,7 +69,7 @@ class GlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalUserStateObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalUserStateObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserState\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -58,7 +59,7 @@ class GlobalUserStateObjectTypeFieldResolver extends AbstractGlobalUserStateObje
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalUserStateObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalUserStateObjectTypeFieldResolver.php
@@ -58,6 +58,7 @@ class GlobalUserStateObjectTypeFieldResolver extends AbstractGlobalUserStateObje
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalUserStateObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/GlobalUserStateObjectTypeFieldResolver.php
@@ -65,6 +65,6 @@ class GlobalUserStateObjectTypeFieldResolver extends AbstractGlobalUserStateObje
                 return App::getState('current-user-id');
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/RootMeObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/RootMeObjectTypeFieldResolver.php
@@ -65,7 +65,7 @@ class RootMeObjectTypeFieldResolver extends AbstractUserStateObjectTypeFieldReso
                 return App::getState('current-user-id');
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/RootMeObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/RootMeObjectTypeFieldResolver.php
@@ -58,6 +58,7 @@ class RootMeObjectTypeFieldResolver extends AbstractUserStateObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/RootMeObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-state/src/FieldResolvers/ObjectType/RootMeObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserState\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -58,7 +59,7 @@ class RootMeObjectTypeFieldResolver extends AbstractUserStateObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -48,6 +48,7 @@ class UserObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -61,6 +61,6 @@ class UserObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldResolve
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/usermeta/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserMeta\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\Meta\FieldResolvers\ObjectType\AbstractWithMetaObjectTypeFieldResolver;
 use PoPCMSSchema\Meta\TypeAPIs\MetaTypeAPIInterface;
@@ -48,7 +49,7 @@ class UserObjectTypeFieldResolver extends AbstractWithMetaObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Users\ConditionalOnComponent\CustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\CustomPosts\TypeResolvers\ObjectType\AbstractCustomPostObjectTypeResolver;
@@ -74,7 +75,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -74,6 +74,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/CMSSchema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/ConditionalOnComponent/CustomPosts/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -81,6 +81,6 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getCustomPostUserTypeAPI()->getAuthorID($object);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/AbstractUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/AbstractUserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Users\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -148,7 +149,7 @@ abstract class AbstractUserObjectTypeFieldResolver extends AbstractQueryableObje
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/AbstractUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/AbstractUserObjectTypeFieldResolver.php
@@ -159,6 +159,6 @@ abstract class AbstractUserObjectTypeFieldResolver extends AbstractQueryableObje
                 return $this->getUserTypeAPI()->getUserCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/AbstractUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/AbstractUserObjectTypeFieldResolver.php
@@ -148,6 +148,7 @@ abstract class AbstractUserObjectTypeFieldResolver extends AbstractQueryableObje
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/RootUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/RootUserObjectTypeFieldResolver.php
@@ -107,7 +107,7 @@ class RootUserObjectTypeFieldResolver extends AbstractUserObjectTypeFieldResolve
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/RootUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/RootUserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Users\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -96,7 +97,7 @@ class RootUserObjectTypeFieldResolver extends AbstractUserObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/RootUserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/RootUserObjectTypeFieldResolver.php
@@ -96,6 +96,7 @@ class RootUserObjectTypeFieldResolver extends AbstractUserObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = $this->convertFieldArgsToFilteringQueryArgs($objectTypeResolver, $fieldName, $fieldArgs);

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -167,6 +167,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -203,6 +203,6 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getUserTypeAPI()->getUserWebsiteUrl($user);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Users\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -167,7 +168,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedback.php
+++ b/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedback.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Feedback;
+
+class ObjectTypeFieldResolutionFeedback extends AbstractQueryFeedback implements ObjectTypeFieldResolutionFeedbackInterface
+{
+}

--- a/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackInterface.php
+++ b/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Feedback;
+
+interface ObjectTypeFieldResolutionFeedbackInterface extends QueryFeedbackInterface
+{
+}

--- a/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackStore.php
+++ b/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackStore.php
@@ -6,94 +6,94 @@ namespace PoP\ComponentModel\Feedback;
 
 class ObjectTypeFieldResolutionFeedbackStore
 {
-    // /** @var FieldResolutionFeedbackInterface[] */
-    // private array $fieldResolutionErrors = [];
-    // /** @var FieldResolutionFeedbackInterface[] */
-    // private array $fieldResolutionWarnings = [];
-    // /** @var FieldResolutionFeedbackInterface[] */
-    // private array $fieldResolutionDeprecations = [];
-    // /** @var FieldResolutionFeedbackInterface[] */
-    // private array $fieldResolutionNotices = [];
-    // /** @var FieldResolutionFeedbackInterface[] */
-    // private array $fieldResolutionLogs = [];
-    // /** @var FieldResolutionFeedbackInterface[] */
-    // private array $fieldResolutionTraces = [];
+    /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
+    private array $objectTypeFieldResolutionErrors = [];
+    /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
+    private array $objectTypeFieldResolutionWarnings = [];
+    /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
+    private array $objectTypeFieldResolutionDeprecations = [];
+    /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
+    private array $objectTypeFieldResolutionNotices = [];
+    /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
+    private array $objectTypeFieldResolutionLogs = [];
+    /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
+    private array $objectTypeFieldResolutionTraces = [];
 
-    // /**
-    //  * @return FieldResolutionFeedbackInterface[]
-    //  */
-    // public function getFieldResolutionErrors(): array
-    // {
-    //     return $this->fieldResolutionErrors;
-    // }
+    /**
+     * @return ObjectTypeFieldResolutionFeedbackInterface[]
+     */
+    public function getFieldResolutionErrors(): array
+    {
+        return $this->objectTypeFieldResolutionErrors;
+    }
 
-    // public function addFieldResolutionError(FieldResolutionFeedbackInterface $fieldResolutionError): void
-    // {
-    //     $this->fieldResolutionErrors[] = $fieldResolutionError;
-    // }
+    public function addFieldResolutionError(ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionError): void
+    {
+        $this->objectTypeFieldResolutionErrors[] = $objectTypeFieldResolutionError;
+    }
 
-    // /**
-    //  * @return FieldResolutionFeedbackInterface[]
-    //  */
-    // public function getFieldResolutionWarnings(): array
-    // {
-    //     return $this->fieldResolutionWarnings;
-    // }
+    /**
+     * @return ObjectTypeFieldResolutionFeedbackInterface[]
+     */
+    public function getFieldResolutionWarnings(): array
+    {
+        return $this->objectTypeFieldResolutionWarnings;
+    }
 
-    // public function addFieldResolutionWarning(FieldResolutionFeedbackInterface $fieldResolutionWarning): void
-    // {
-    //     $this->fieldResolutionWarnings[] = $fieldResolutionWarning;
-    // }
+    public function addFieldResolutionWarning(ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionWarning): void
+    {
+        $this->objectTypeFieldResolutionWarnings[] = $objectTypeFieldResolutionWarning;
+    }
 
-    // /**
-    //  * @return FieldResolutionFeedbackInterface[]
-    //  */
-    // public function getFieldResolutionDeprecations(): array
-    // {
-    //     return $this->fieldResolutionDeprecations;
-    // }
+    /**
+     * @return ObjectTypeFieldResolutionFeedbackInterface[]
+     */
+    public function getFieldResolutionDeprecations(): array
+    {
+        return $this->objectTypeFieldResolutionDeprecations;
+    }
 
-    // public function addFieldResolutionDeprecation(FieldResolutionFeedbackInterface $fieldResolutionDeprecation): void
-    // {
-    //     $this->fieldResolutionDeprecations[] = $fieldResolutionDeprecation;
-    // }
+    public function addFieldResolutionDeprecation(ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionDeprecation): void
+    {
+        $this->objectTypeFieldResolutionDeprecations[] = $objectTypeFieldResolutionDeprecation;
+    }
 
-    // /**
-    //  * @return FieldResolutionFeedbackInterface[]
-    //  */
-    // public function getFieldResolutionNotices(): array
-    // {
-    //     return $this->fieldResolutionNotices;
-    // }
+    /**
+     * @return ObjectTypeFieldResolutionFeedbackInterface[]
+     */
+    public function getFieldResolutionNotices(): array
+    {
+        return $this->objectTypeFieldResolutionNotices;
+    }
 
-    // public function addFieldResolutionNotice(FieldResolutionFeedbackInterface $fieldResolutionNotice): void
-    // {
-    //     $this->fieldResolutionNotices[] = $fieldResolutionNotice;
-    // }
+    public function addFieldResolutionNotice(ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionNotice): void
+    {
+        $this->objectTypeFieldResolutionNotices[] = $objectTypeFieldResolutionNotice;
+    }
 
-    // /**
-    //  * @return FieldResolutionFeedbackInterface[]
-    //  */
-    // public function getFieldResolutionLogs(): array
-    // {
-    //     return $this->fieldResolutionLogs;
-    // }
+    /**
+     * @return ObjectTypeFieldResolutionFeedbackInterface[]
+     */
+    public function getFieldResolutionLogs(): array
+    {
+        return $this->objectTypeFieldResolutionLogs;
+    }
 
-    // public function addFieldResolutionLog(FieldResolutionFeedbackInterface $fieldResolutionLog): void
-    // {
-    //     $this->fieldResolutionLogs[] = $fieldResolutionLog;
-    // }
+    public function addFieldResolutionLog(ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionLog): void
+    {
+        $this->objectTypeFieldResolutionLogs[] = $objectTypeFieldResolutionLog;
+    }
 
-    // /**
-    //  * @return FieldResolutionFeedbackInterface[]
-    //  */
-    // public function getFieldResolutionTraces(): array
-    // {
-    //     return $this->fieldResolutionTraces;
-    // }
+    /**
+     * @return ObjectTypeFieldResolutionFeedbackInterface[]
+     */
+    public function getFieldResolutionTraces(): array
+    {
+        return $this->objectTypeFieldResolutionTraces;
+    }
 
-    // public function addFieldResolutionTrace(FieldResolutionFeedbackInterface $fieldResolutionTrace): void
-    // {
-    //     $this->fieldResolutionTraces[] = $fieldResolutionTrace;
-    // }
+    public function addFieldResolutionTrace(ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionTrace): void
+    {
+        $this->objectTypeFieldResolutionTraces[] = $objectTypeFieldResolutionTrace;
+    }
 }

--- a/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackStore.php
+++ b/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackStore.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Feedback;
+
+class ObjectTypeFieldResolutionFeedbackStore
+{
+    // /** @var FieldResolutionFeedbackInterface[] */
+    // private array $fieldResolutionErrors = [];
+    // /** @var FieldResolutionFeedbackInterface[] */
+    // private array $fieldResolutionWarnings = [];
+    // /** @var FieldResolutionFeedbackInterface[] */
+    // private array $fieldResolutionDeprecations = [];
+    // /** @var FieldResolutionFeedbackInterface[] */
+    // private array $fieldResolutionNotices = [];
+    // /** @var FieldResolutionFeedbackInterface[] */
+    // private array $fieldResolutionLogs = [];
+    // /** @var FieldResolutionFeedbackInterface[] */
+    // private array $fieldResolutionTraces = [];
+
+    // /**
+    //  * @return FieldResolutionFeedbackInterface[]
+    //  */
+    // public function getFieldResolutionErrors(): array
+    // {
+    //     return $this->fieldResolutionErrors;
+    // }
+
+    // public function addFieldResolutionError(FieldResolutionFeedbackInterface $fieldResolutionError): void
+    // {
+    //     $this->fieldResolutionErrors[] = $fieldResolutionError;
+    // }
+
+    // /**
+    //  * @return FieldResolutionFeedbackInterface[]
+    //  */
+    // public function getFieldResolutionWarnings(): array
+    // {
+    //     return $this->fieldResolutionWarnings;
+    // }
+
+    // public function addFieldResolutionWarning(FieldResolutionFeedbackInterface $fieldResolutionWarning): void
+    // {
+    //     $this->fieldResolutionWarnings[] = $fieldResolutionWarning;
+    // }
+
+    // /**
+    //  * @return FieldResolutionFeedbackInterface[]
+    //  */
+    // public function getFieldResolutionDeprecations(): array
+    // {
+    //     return $this->fieldResolutionDeprecations;
+    // }
+
+    // public function addFieldResolutionDeprecation(FieldResolutionFeedbackInterface $fieldResolutionDeprecation): void
+    // {
+    //     $this->fieldResolutionDeprecations[] = $fieldResolutionDeprecation;
+    // }
+
+    // /**
+    //  * @return FieldResolutionFeedbackInterface[]
+    //  */
+    // public function getFieldResolutionNotices(): array
+    // {
+    //     return $this->fieldResolutionNotices;
+    // }
+
+    // public function addFieldResolutionNotice(FieldResolutionFeedbackInterface $fieldResolutionNotice): void
+    // {
+    //     $this->fieldResolutionNotices[] = $fieldResolutionNotice;
+    // }
+
+    // /**
+    //  * @return FieldResolutionFeedbackInterface[]
+    //  */
+    // public function getFieldResolutionLogs(): array
+    // {
+    //     return $this->fieldResolutionLogs;
+    // }
+
+    // public function addFieldResolutionLog(FieldResolutionFeedbackInterface $fieldResolutionLog): void
+    // {
+    //     $this->fieldResolutionLogs[] = $fieldResolutionLog;
+    // }
+
+    // /**
+    //  * @return FieldResolutionFeedbackInterface[]
+    //  */
+    // public function getFieldResolutionTraces(): array
+    // {
+    //     return $this->fieldResolutionTraces;
+    // }
+
+    // public function addFieldResolutionTrace(FieldResolutionFeedbackInterface $fieldResolutionTrace): void
+    // {
+    //     $this->fieldResolutionTraces[] = $fieldResolutionTrace;
+    // }
+}

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use Exception;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionManagerInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
@@ -1219,7 +1220,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         // If a MutationResolver is declared, let it resolve the value

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -1219,6 +1219,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         // If a MutationResolver is declared, let it resolve the value

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractReflectionPropertyObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractReflectionPropertyObjectTypeFieldResolver.php
@@ -150,6 +150,7 @@ abstract class AbstractReflectionPropertyObjectTypeFieldResolver extends Abstrac
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         // Simply return the value of the property in the object

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractReflectionPropertyObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractReflectionPropertyObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use ReflectionClass;
@@ -150,7 +151,7 @@ abstract class AbstractReflectionPropertyObjectTypeFieldResolver extends Abstrac
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         // Simply return the value of the property in the object

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -442,7 +443,7 @@ trait AliasSchemaObjectTypeFieldResolverTrait
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $aliasedObjectTypeFieldResolver = $this->getAliasedObjectTypeFieldResolver();

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
@@ -452,6 +452,7 @@ trait AliasSchemaObjectTypeFieldResolverTrait
             $fieldArgs,
             $variables,
             $expressions,
+            $objectTypeFieldResolutionFeedbackStore,
             $options
         );
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
@@ -440,8 +440,9 @@ trait AliasSchemaObjectTypeFieldResolverTrait
         $object,
         string $fieldName,
         array $fieldArgs,
-        ?array $variables = null,
-        ?array $expressions = null,
+        array $variables,
+        array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $aliasedObjectTypeFieldResolver = $this->getAliasedObjectTypeFieldResolver();

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
@@ -129,6 +129,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
@@ -204,6 +204,6 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
                 return in_array($interface, $implementedInterfaceNames);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\Schema\SchemaDefinitionTokens;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -129,7 +130,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
@@ -74,6 +74,7 @@ class NodeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         return match ($fieldName) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\InterfaceType\NodeInterfaceTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -74,7 +75,7 @@ class NodeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         return match ($fieldName) {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/NodeObjectTypeFieldResolver.php
@@ -81,7 +81,7 @@ class NodeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'self'
                 => $objectTypeResolver->getID($object),
             default
-                => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+                => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
@@ -71,6 +71,7 @@ interface ObjectTypeFieldResolverInterface extends FieldResolverInterface, Objec
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed;
     /**

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\FieldResolverInterface;
 use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -71,7 +72,7 @@ interface ObjectTypeFieldResolverInterface extends FieldResolverInterface, Objec
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed;
     /**

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1836,7 +1836,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             $options = [
                 AbstractRelationalTypeResolver::OPTION_VALIDATE_SCHEMA_ON_RESULT_ITEM => true,
             ];
-            $resolvedValue = $relationalTypeResolver->resolveValue($object, (string)$fieldArgValue, $variables, $expressions, $options);
+            $resolvedValue = $relationalTypeResolver->resolveValue($object, (string)$fieldArgValue, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
             if (GeneralUtils::isError($resolvedValue)) {
                 // Show the error message, and return nothing
                 /** @var Error */

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -481,7 +481,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
             // catch it and return the equivalent GraphQL error so that it
             // fails gracefully in production (but not on development!)
             try {
-                $value = $objectTypeFieldResolver->resolveValue($this, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+                $value = $objectTypeFieldResolver->resolveValue($this, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
             } catch (Exception $e) {
                 if (RootEnvironment::isApplicationEnvironmentDev()) {
                     throw $e;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -10,6 +10,7 @@ use PoP\ComponentModel\AttachableExtensions\AttachableExtensionGroups;
 use PoP\ComponentModel\Environment;
 use PoP\ComponentModel\Error\Error;
 use PoP\ComponentModel\Feedback\ObjectFeedback;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\Feedback\SchemaFeedback;
 use PoP\ComponentModel\Feedback\Tokens;
 use PoP\ComponentModel\FieldResolvers\InterfaceType\InterfaceTypeFieldResolverInterface;
@@ -477,6 +478,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
                 return $this->getErrorProvider()->getValidationFailedError($fieldName, $fieldArgs, $validationErrorDescriptions);
             }
 
+            $objectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
             // Resolve the value. If the field resolver throws an Exception,
             // catch it and return the equivalent GraphQL error so that it
             // fails gracefully in production (but not on development!)

--- a/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php
@@ -411,7 +411,7 @@ abstract class AbstractUnionTypeResolver extends AbstractRelationalTypeResolver 
         // Delegate to that typeResolver to obtain the value
         // Because the schema validation cannot be performed through the UnionTypeResolver, since it depends on each dbObject, indicate that it must be done in resolveValue
         $options[self::OPTION_VALIDATE_SCHEMA_ON_RESULT_ITEM] = true;
-        return $targetObjectTypeResolver->resolveValue($object, $field, $variables, $expressions, $options);
+        return $targetObjectTypeResolver->resolveValue($object, $field, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     /**

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -467,7 +467,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
             foreach ((array) $addExpressions as $key => $value) {
                 // Evaluate the $value, since it may be a function
                 if ($this->getFieldQueryInterpreter()->isFieldArgumentValueAField($value)) {
-                    $resolvedValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $value, $variables, $expressions, $options);
+                    $resolvedValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $value, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                     if (GeneralUtils::isError($resolvedValue)) {
                         // Show the error message, and return nothing
                         /** @var Error */
@@ -492,7 +492,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                 $existingValue = $this->getExpressionForObject($id, (string) $key, $messages) ?? [];
                 // Evaluate the $value, since it may be a function
                 if ($this->getFieldQueryInterpreter()->isFieldArgumentValueAField($value)) {
-                    $resolvedValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $value, $variables, $expressions, $options);
+                    $resolvedValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $value, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                     if (GeneralUtils::isError($resolvedValue)) {
                         // Show the error message, and return nothing
                         /** @var Error */

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ApplyFunctionDirectiveResolver.php
@@ -250,7 +250,7 @@ class ApplyFunctionDirectiveResolver extends AbstractGlobalDirectiveResolver
                 $options = [
                     AbstractRelationalTypeResolver::OPTION_VALIDATE_SCHEMA_ON_RESULT_ITEM => true,
                 ];
-                $functionValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $validFunction, $variables, $expressions, $options);
+                $functionValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $validFunction, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
 
                 // If there was an error (eg: a missing mandatory argument), then the function will be of type Error
                 if (GeneralUtils::isError($functionValue)) {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/ForEachDirectiveResolver.php
@@ -97,7 +97,7 @@ class ForEachDirectiveResolver extends AbstractApplyNestedDirectivesOnArrayOrObj
                     $this->addExpressionForObject($id, Expressions::NAME_KEY, $key, $messages);
                     $this->addExpressionForObject($id, Expressions::NAME_VALUE, $value, $messages);
                     $expressions = $this->getExpressionsForObject($id, $variables, $messages);
-                    $resolvedValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $if, $variables, $expressions, $options);
+                    $resolvedValue = $relationalTypeResolver->resolveValue($objectIDItems[(string)$id], $if, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                     if (GeneralUtils::isError($resolvedValue)) {
                         // Show the error message, and return nothing
                         /** @var Error */

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/AppStateOperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/AppStateOperatorGlobalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Engine\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractGlobalObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\FieldQueryUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -144,7 +145,7 @@ class AppStateOperatorGlobalObjectTypeFieldResolver extends AbstractGlobalObject
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/AppStateOperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/AppStateOperatorGlobalObjectTypeFieldResolver.php
@@ -144,6 +144,7 @@ class AppStateOperatorGlobalObjectTypeFieldResolver extends AbstractGlobalObject
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/AppStateOperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/AppStateOperatorGlobalObjectTypeFieldResolver.php
@@ -153,6 +153,6 @@ class AppStateOperatorGlobalObjectTypeFieldResolver extends AbstractGlobalObject
                 return App::getAppStateManager()->all();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/FunctionGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/FunctionGlobalObjectTypeFieldResolver.php
@@ -105,6 +105,7 @@ class FunctionGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/FunctionGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/FunctionGlobalObjectTypeFieldResolver.php
@@ -115,6 +115,6 @@ class FunctionGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFiel
                 $property = $fieldArgs['property'];
                 return array_key_exists($property, $self['dbItems']) ? $self['dbItems'][$property] : ($self['previousDBItems'][$property] ?? null);
         }
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/FunctionGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/FunctionGlobalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Engine\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractGlobalObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -105,7 +106,7 @@ class FunctionGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Engine\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use ArgumentCountError;
 use Exception;
 use PoP\ComponentModel\Error\Error;
@@ -228,7 +229,7 @@ class OperatorGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
@@ -228,6 +228,7 @@ class OperatorGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
@@ -288,6 +288,6 @@ class OperatorGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFiel
                 }
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/ObjectType/AbstractListOfCPTEntitiesRootObjectTypeFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/ObjectType/AbstractListOfCPTEntitiesRootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLAPI\GraphQLAPI\ConditionalOnContext\Admin\ConditionalOnContext\Editor\SchemaServices\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLAPI\GraphQLAPI\Constants\QueryOptions;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -73,7 +74,7 @@ abstract class AbstractListOfCPTEntitiesRootObjectTypeFieldResolver extends Abst
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = [

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/ObjectType/AbstractListOfCPTEntitiesRootObjectTypeFieldResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ConditionalOnContext/Admin/ConditionalOnContext/Editor/SchemaServices/FieldResolvers/ObjectType/AbstractListOfCPTEntitiesRootObjectTypeFieldResolver.php
@@ -73,6 +73,7 @@ abstract class AbstractListOfCPTEntitiesRootObjectTypeFieldResolver extends Abst
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $query = [

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
@@ -76,7 +76,7 @@ class DirectiveExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         $directiveExtensions = $object;
         return match ($fieldName) {
             'needsDataToExecute' => $directiveExtensions->needsDataToExecute(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
@@ -70,6 +70,7 @@ class DirectiveExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var DirectiveExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveExtensionsObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\DirectiveExtensions;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveExtensionsObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -70,7 +71,7 @@ class DirectiveExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var DirectiveExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\Directive;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumType\DirectiveLocationEnumTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveExtensionsObjectTypeResolver;
@@ -138,7 +139,7 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Directive */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
@@ -157,6 +157,6 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $directive->getExtensions()->getID();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/DirectiveObjectTypeFieldResolver.php
@@ -138,6 +138,7 @@ class DirectiveObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Directive */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EmbeddableFields/EchoOperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EmbeddableFields/EchoOperatorGlobalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType\EmbeddableFields;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -111,7 +112,7 @@ class EchoOperatorGlobalObjectTypeFieldResolver extends OperatorGlobalObjectType
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EmbeddableFields/EchoOperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EmbeddableFields/EchoOperatorGlobalObjectTypeFieldResolver.php
@@ -111,6 +111,7 @@ class EchoOperatorGlobalObjectTypeFieldResolver extends OperatorGlobalObjectType
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EmbeddableFields/EchoOperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EmbeddableFields/EchoOperatorGlobalObjectTypeFieldResolver.php
@@ -118,6 +118,6 @@ class EchoOperatorGlobalObjectTypeFieldResolver extends OperatorGlobalObjectType
                 return $fieldArgs['value'];
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class EnumValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var EnumValueExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\EnumValueExtensions;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\EnumValueExtensionsObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -68,7 +69,7 @@ class EnumValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var EnumValueExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueExtensionsObjectTypeFieldResolver.php
@@ -74,7 +74,7 @@ class EnumValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         $enumValueExtensions = $object;
         return match ($fieldName) {
             'isAdminElement' => $enumValueExtensions->isAdminElement(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
@@ -129,6 +129,6 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $enumValue->getExtensions()->getID();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\EnumValue;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\EnumValueExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\EnumValueObjectTypeResolver;
@@ -112,7 +113,7 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var EnumValue */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/EnumValueObjectTypeFieldResolver.php
@@ -112,6 +112,7 @@ class EnumValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var EnumValue */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
@@ -92,7 +92,7 @@ class DirectiveSchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         $directive = $object;
         return match ($fieldName) {
             'kind' => $directive->getKind(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType\Extensions;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\Directive;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumType\DirectiveKindEnumTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveObjectTypeResolver;
@@ -86,7 +87,7 @@ class DirectiveSchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Directive */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/DirectiveSchemaObjectTypeFieldResolver.php
@@ -86,6 +86,7 @@ class DirectiveSchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Directive */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
@@ -113,6 +113,7 @@ class FilterSystemDirectiveSchemaObjectTypeFieldResolver extends SchemaObjectTyp
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Schema */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType\Extensions;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType\SchemaObjectTypeFieldResolver;
 use GraphQLByPoP\GraphQLServer\ObjectModels\Schema;
 use GraphQLByPoP\GraphQLServer\Schema\SchemaDefinitionHelpers;
@@ -113,7 +114,7 @@ class FilterSystemDirectiveSchemaObjectTypeFieldResolver extends SchemaObjectTyp
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Schema */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
@@ -147,6 +147,6 @@ class FilterSystemDirectiveSchemaObjectTypeFieldResolver extends SchemaObjectTyp
                 return $directiveIDs;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/NamespacedTypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/NamespacedTypeObjectTypeFieldResolver.php
@@ -128,6 +128,7 @@ class NamespacedTypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResol
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var NamedTypeInterface */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/NamespacedTypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/NamespacedTypeObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType\Extensions;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\NamedTypeInterface;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\TypeObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -128,7 +129,7 @@ class NamespacedTypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResol
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var NamedTypeInterface */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/NamespacedTypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/NamespacedTypeObjectTypeFieldResolver.php
@@ -140,6 +140,6 @@ class NamespacedTypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResol
                 return $type->getElementName();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\FieldExtensions;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\FieldExtensionsObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -73,7 +74,7 @@ class FieldExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var FieldExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
@@ -80,7 +80,7 @@ class FieldExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         return match ($fieldName) {
             'isMutation' => $fieldExtensions->isMutation(),
             'isAdminElement' => $fieldExtensions->isAdminElement(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldExtensionsObjectTypeFieldResolver.php
@@ -73,6 +73,7 @@ class FieldExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var FieldExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
@@ -162,6 +162,6 @@ class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $field->getExtensions()->getID();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
@@ -141,6 +141,7 @@ class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Field */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/FieldObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\Field;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\FieldExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\FieldObjectTypeResolver;
@@ -141,7 +142,7 @@ class FieldObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Field */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
@@ -67,6 +67,7 @@ class GlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractGlobalObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -67,7 +68,7 @@ class GlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/GlobalObjectTypeFieldResolver.php
@@ -74,6 +74,6 @@ class GlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldResolve
                 return $objectTypeResolver->getMaybeNamespacedTypeName();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class InputValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var InputValueExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\InputValueExtensions;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueExtensionsObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -68,7 +69,7 @@ class InputValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var InputValueExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueExtensionsObjectTypeFieldResolver.php
@@ -74,7 +74,7 @@ class InputValueExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFiel
         $inputValueExtensions = $object;
         return match ($fieldName) {
             'isAdminElement' => $inputValueExtensions->isAdminElement(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\InputValue;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueExtensionsObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\InputValueObjectTypeResolver;
@@ -112,7 +113,7 @@ class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var InputValue */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
@@ -129,6 +129,6 @@ class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $inputValue->getExtensions()->getID();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/InputValueObjectTypeFieldResolver.php
@@ -112,6 +112,7 @@ class InputValueObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var InputValue */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
@@ -80,7 +80,7 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         return match ($fieldName) {
             'elementName' => $namedTypeExtensions->getTypeElementName(),
             'namespacedName' => $namedTypeExtensions->getTypeNamespacedName(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
@@ -73,6 +73,7 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var NamedTypeExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\NamedTypeExtensions;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\NamedTypeExtensionsObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -73,7 +74,7 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var NamedTypeExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use GraphQLByPoP\GraphQLServer\RelationalTypeDataLoaders\ObjectType\SchemaTypeDataLoader;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\SchemaObjectTypeResolver;
@@ -135,7 +136,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $root = $object;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -151,6 +151,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                     ),
                     $variables,
                     $expressions,
+                    $objectTypeFieldResolutionFeedbackStore,
                     $options
                 );
                 if (GeneralUtils::isError($schemaID)) {
@@ -162,7 +163,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $schema->getTypeID($fieldArgs['name']);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -135,6 +135,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $root = $object;

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class SchemaExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var SchemaExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\SchemaExtensions;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\SchemaExtensionsObjectTypeResolver;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -68,7 +69,7 @@ class SchemaExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var SchemaExtensions */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaExtensionsObjectTypeFieldResolver.php
@@ -74,7 +74,7 @@ class SchemaExtensionsObjectTypeFieldResolver extends AbstractObjectTypeFieldRes
         $schemaExtensions = $object;
         return match ($fieldName) {
             'isNamespaced' => $schemaExtensions->isSchemaNamespaced(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\Schema;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\DirectiveObjectTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\SchemaExtensionsObjectTypeResolver;
@@ -142,7 +143,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Schema */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
@@ -154,7 +154,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'directives' => $schema->getDirectiveIDs(),
             'type' => $schema->getTypeID($fieldArgs['name']),
             'extensions' => $schema->getExtensions()->getID(),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options),
+            default => parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
         };
     }
 

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/SchemaObjectTypeFieldResolver.php
@@ -142,6 +142,7 @@ class SchemaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Schema */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
@@ -225,6 +225,7 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var TypeInterface */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
@@ -297,6 +297,6 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/TypeObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use GraphQLByPoP\GraphQLServer\ObjectModels\EnumType;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasFieldsTypeInterface;
 use GraphQLByPoP\GraphQLServer\ObjectModels\HasInterfacesTypeInterface;
@@ -225,7 +226,7 @@ class TypeObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var TypeInterface */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Standalone/GraphQLServer.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Standalone/GraphQLServer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GraphQLByPoP\GraphQLServer\Standalone;
 
+use GraphQLByPoP\GraphQLServer\Component;
 use GraphQLByPoP\GraphQLQuery\Facades\GraphQLQueryConvertorFacade;
 use GraphQLByPoP\GraphQLQuery\Schema\OperationTypes;
 use PoP\Engine\Facades\Engine\EngineFacade;
@@ -34,7 +35,7 @@ class GraphQLServer implements GraphQLServerInterface
             [
                 // This is the one Component that is required to produce the GraphQL server.
                 // The other classes provide the schema and extra functionality.
-                \GraphQLByPoP\GraphQLServer\Component::class,
+                Component::class,
             ]
         );
 

--- a/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -72,6 +72,6 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
                 return $dateFormatter->format($format, $date);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\CustomPosts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\Engine\Facades\Formatters\DateFormatterFacade;
@@ -55,7 +56,7 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $dateFormatter = DateFormatterFacade::getInstance();

--- a/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/customposts/src/FieldResolvers/ObjectType/AbstractCustomPostObjectTypeFieldResolver.php
@@ -55,6 +55,7 @@ abstract class AbstractCustomPostObjectTypeFieldResolver extends AbstractObjectT
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $dateFormatter = DateFormatterFacade::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/AbstractLocationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/AbstractLocationFunctionalObjectTypeFieldResolver.php
@@ -69,7 +69,7 @@ abstract class AbstractLocationFunctionalObjectTypeFieldResolver extends Abstrac
     ): mixed {
         switch ($fieldName) {
             case 'locationsmapURL':
-                $locations = $objectTypeResolver->resolveValue($object, 'locations', $variables, $expressions, $options);
+                $locations = $objectTypeResolver->resolveValue($object, 'locations', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($locations)) {
                     return null;
                 }
@@ -86,6 +86,6 @@ abstract class AbstractLocationFunctionalObjectTypeFieldResolver extends Abstrac
                     );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/AbstractLocationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/AbstractLocationFunctionalObjectTypeFieldResolver.php
@@ -65,6 +65,7 @@ abstract class AbstractLocationFunctionalObjectTypeFieldResolver extends Abstrac
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/AbstractLocationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/AbstractLocationFunctionalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Locations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -65,7 +66,7 @@ abstract class AbstractLocationFunctionalObjectTypeFieldResolver extends Abstrac
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CatEventObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CatEventObjectTypeFieldResolver.php
@@ -81,6 +81,7 @@ class CatEventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $eventTypeAPI = EventTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CatEventObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CatEventObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\EverythingElse\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -81,7 +82,7 @@ class CatEventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $eventTypeAPI = EventTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CatEventObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CatEventObjectTypeFieldResolver.php
@@ -97,7 +97,7 @@ class CatEventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $value;
 
             case 'catName':
-                $cat = $objectTypeResolver->resolveValue($event, 'mainCategory', $variables, $expressions, $options);
+                $cat = $objectTypeResolver->resolveValue($event, 'mainCategory', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($cat)) {
                     return $cat;
                 } elseif ($cat) {
@@ -106,6 +106,6 @@ class CatEventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CommentsCustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CommentsCustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\EverythingElse\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -66,7 +67,7 @@ class CommentsCustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CommentsCustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CommentsCustomPostObjectTypeFieldResolver.php
@@ -72,9 +72,9 @@ class CommentsCustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         switch ($fieldName) {
             case 'commentsURL':
                 // @todo: fix this, add the ?#comment_id=... to the post URL
-                return $objectTypeResolver->resolveValue($post, 'url', $variables, $expressions, $options);
+                return $objectTypeResolver->resolveValue($post, 'url', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CommentsCustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CommentsCustomPostObjectTypeFieldResolver.php
@@ -66,6 +66,7 @@ class CommentsCustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostAndUserObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostAndUserObjectTypeFieldResolver.php
@@ -91,6 +91,7 @@ class CustomPostAndUserObjectTypeFieldResolver extends AbstractObjectTypeFieldRe
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostAndUserObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostAndUserObjectTypeFieldResolver.php
@@ -95,14 +95,14 @@ class CustomPostAndUserObjectTypeFieldResolver extends AbstractObjectTypeFieldRe
     ): mixed {
         switch ($fieldName) {
             case 'hasLocation':
-                $locations = $objectTypeResolver->resolveValue($object, 'locations', $variables, $expressions, $options);
+                $locations = $objectTypeResolver->resolveValue($object, 'locations', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($locations)) {
                     return $locations;
                 }
                 return !empty($locations);
 
             case 'location':
-                $locations = $objectTypeResolver->resolveValue($object, 'locations', $variables, $expressions, $options);
+                $locations = $objectTypeResolver->resolveValue($object, 'locations', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($locations)) {
                     return $locations;
                 } elseif ($locations) {
@@ -111,6 +111,6 @@ class CustomPostAndUserObjectTypeFieldResolver extends AbstractObjectTypeFieldRe
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostAndUserObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostAndUserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Locations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -91,7 +92,7 @@ class CustomPostAndUserObjectTypeFieldResolver extends AbstractObjectTypeFieldRe
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -76,7 +76,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_LOCATIONS) ?? [];
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Locations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -68,7 +69,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventFunctionalObjectTypeFieldResolver.php
@@ -83,6 +83,7 @@ class EventFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $eventTypeAPI = EventTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventFunctionalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Events\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -83,7 +84,7 @@ class EventFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $eventTypeAPI = EventTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventFunctionalObjectTypeFieldResolver.php
@@ -90,7 +90,7 @@ class EventFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
         switch ($fieldName) {
             case 'multilayoutKeys':
                 // Override the "post" implementation: instead of depending on categories, depend on the scope of the event (future/current/past)
-                $scope = $objectTypeResolver->resolveValue($event, 'scope', $variables, $expressions, $options);
+                $scope = $objectTypeResolver->resolveValue($event, 'scope', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($scope)) {
                     return $scope;
                 }
@@ -101,7 +101,7 @@ class EventFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
                 );
 
             case 'latestcountsTriggerValues':
-                $scope = $objectTypeResolver->resolveValue($event, 'scope', $variables, $expressions, $options);
+                $scope = $objectTypeResolver->resolveValue($event, 'scope', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($scope)) {
                     return $scope;
                 }
@@ -111,6 +111,6 @@ class EventFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldReso
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventObjectTypeFieldResolver.php
@@ -124,6 +124,7 @@ class EventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $eventTypeAPI = EventTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventObjectTypeFieldResolver.php
@@ -133,7 +133,7 @@ class EventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             case 'locations':
                 // Events can have no location
                 $value = array();
-                $location = $objectTypeResolver->resolveValue($event, 'location', $variables, $expressions, $options);
+                $location = $objectTypeResolver->resolveValue($event, 'location', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($location)) {
                     return $location;
                 } elseif ($location) {
@@ -171,6 +171,6 @@ class EventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/EventObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Events\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -124,7 +125,7 @@ class EventObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $eventTypeAPI = EventTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/LocationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/LocationFunctionalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Locations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -77,7 +78,7 @@ class LocationFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/LocationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/LocationFunctionalObjectTypeFieldResolver.php
@@ -87,6 +87,6 @@ class LocationFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldR
                 ], RouteUtils::getRouteURL(POP_LOCATIONS_ROUTE_LOCATIONSMAP)));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/LocationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/LocationFunctionalObjectTypeFieldResolver.php
@@ -77,6 +77,7 @@ class LocationFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/QueryableObjectPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/QueryableObjectPostObjectTypeFieldResolver.php
@@ -71,9 +71,9 @@ class QueryableObjectPostObjectTypeFieldResolver extends AbstractObjectTypeField
     ): mixed {
         switch ($fieldName) {
             case 'endpoint':
-                return APIUtils::getEndpoint($objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $options));
+                return APIUtils::getEndpoint($objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/QueryableObjectPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/QueryableObjectPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\EverythingElse\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -67,7 +68,7 @@ class QueryableObjectPostObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/QueryableObjectPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/QueryableObjectPostObjectTypeFieldResolver.php
@@ -67,6 +67,7 @@ class QueryableObjectPostObjectTypeFieldResolver extends AbstractObjectTypeField
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/TagFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/TagFunctionalObjectTypeFieldResolver.php
@@ -95,6 +95,6 @@ class TagFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolv
                 return $applicationtaxonomyapi->getTagSymbolName($tag);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/TagFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/TagFunctionalObjectTypeFieldResolver.php
@@ -77,6 +77,7 @@ class TagFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $applicationtaxonomyapi = FunctionAPIFactory::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/TagFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/TagFunctionalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\EverythingElse\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ApplicationTaxonomies\FunctionAPIFactory;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -77,7 +78,7 @@ class TagFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $applicationtaxonomyapi = FunctionAPIFactory::getInstance();

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -68,6 +68,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -76,7 +76,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return Utils::getUserMeta($objectTypeResolver->getID($user), GD_METAKEY_PROFILE_LOCATIONS) ?? [];
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/everythingelse/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Locations\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -68,7 +69,7 @@ class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
@@ -96,6 +96,6 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
                 ], RouteUtils::getRouteURL($route));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Highlights\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -77,7 +78,7 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
@@ -77,6 +77,7 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -111,6 +111,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPost = $object;

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -134,20 +134,20 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $customPostTypeAPI->getCustomPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'hasHighlights':
-                $referencedbyCount = $objectTypeResolver->resolveValue($object, 'highlightsCount', $variables, $expressions, $options);
+                $referencedbyCount = $objectTypeResolver->resolveValue($object, 'highlightsCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($referencedbyCount)) {
                     return $referencedbyCount;
                 }
                 return $referencedbyCount > 0;
 
             case 'highlightsCount':
-                $referencedby = $objectTypeResolver->resolveValue($object, 'highlights', $variables, $expressions, $options);
+                $referencedby = $objectTypeResolver->resolveValue($object, 'highlights', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($referencedby)) {
                     return $referencedby;
                 }
                 return count($referencedby);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Highlights\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -111,7 +112,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPost = $object;

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/HighlightObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/HighlightObjectTypeFieldResolver.php
@@ -129,13 +129,13 @@ class HighlightObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return Utils::getCustomPostMeta($objectTypeResolver->getID($highlight), GD_METAKEY_POST_HIGHLIGHTEDPOST, true);
 
             case 'highlightedPostURL':
-                $highlightedPost = $objectTypeResolver->resolveValue($highlight, 'highlightedpost', $variables, $expressions, $options);
+                $highlightedPost = $objectTypeResolver->resolveValue($highlight, 'highlightedpost', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($highlightedPost)) {
                     return $highlightedPost;
                 }
                 return $customPostTypeAPI->getPermalink($highlightedPost);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/HighlightObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/HighlightObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Highlights\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -106,7 +107,7 @@ class HighlightObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/HighlightObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/highlights/src/FieldResolvers/ObjectType/HighlightObjectTypeFieldResolver.php
@@ -106,6 +106,7 @@ class HighlightObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/menus/src/FieldResolvers/MenuItemObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/menus/src/FieldResolvers/MenuItemObjectTypeFieldResolver.php
@@ -28,6 +28,7 @@ abstract class MenuItemObjectTypeFieldResolver extends AbstractObjectTypeFieldRe
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $menuItemTypeAPI = MenuItemTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/menus/src/FieldResolvers/MenuItemObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/menus/src/FieldResolvers/MenuItemObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Menus\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -28,7 +29,7 @@ abstract class MenuItemObjectTypeFieldResolver extends AbstractObjectTypeFieldRe
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $menuItemTypeAPI = MenuItemTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/menus/src/FieldResolvers/MenuItemObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/menus/src/FieldResolvers/MenuItemObjectTypeFieldResolver.php
@@ -49,6 +49,6 @@ abstract class MenuItemObjectTypeFieldResolver extends AbstractObjectTypeFieldRe
                 return App::applyFilters('menuitem:classes', array_filter($classes), $menuItem, array());
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -59,7 +59,7 @@ class PS_POP_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObjectTypeFi
         switch ($fieldName) {
             case 'thumbFullDimensions':
                 // This is the format needed by PhotoSwipe under attr data-size
-                $thumb = $objectTypeResolver->resolveValue($object, FieldQueryInterpreterFacade::getInstance()->getField('thumb', ['size' => 'full', 'addDescription' => true]), $variables, $expressions, $options);
+                $thumb = $objectTypeResolver->resolveValue($object, FieldQueryInterpreterFacade::getInstance()->getField('thumb', ['size' => 'full', 'addDescription' => true]), $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($thumb)) {
                     return $thumb;
                 }
@@ -70,7 +70,7 @@ class PS_POP_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObjectTypeFi
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/photoswipe-pop/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -52,6 +52,7 @@ class PS_POP_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -115,7 +115,7 @@ class PoP_AddComments_DataLoad_ObjectTypeFieldResolver_Notifications extends Abs
                 switch ($notification->action) {
                     case AAL_POP_ACTION_COMMENT_ADDED:
                         // comment-object-id is the object-id
-                        return $objectTypeResolver->resolveValue($object, FieldQueryInterpreterFacade::getInstance()->getField('objectID', $fieldArgs), $variables, $expressions, $options);
+                        return $objectTypeResolver->resolveValue($object, FieldQueryInterpreterFacade::getInstance()->getField('objectID', $fieldArgs), $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 }
                 return null;
 
@@ -194,7 +194,7 @@ class PoP_AddComments_DataLoad_ObjectTypeFieldResolver_Notifications extends Abs
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addcomments/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -101,6 +101,7 @@ class PoP_AddComments_DataLoad_ObjectTypeFieldResolver_Notifications extends Abs
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $commentTypeAPI = CommentTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -112,7 +112,7 @@ class PoPTheme_Wassup_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications ext
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -77,6 +77,7 @@ class PoPTheme_Wassup_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications ext
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userTypeAPI = UserTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -59,6 +59,7 @@ class PoP_AddPostLinks_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -70,7 +70,7 @@ class PoP_AddPostLinks_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 return (!is_ssl() || substr($link, 0, 8) == 'https://') && !in_array($host, $nonembeddable);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -71,7 +71,7 @@ class PoP_AddPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
                 return PoP_AddPostLinks_Utils::getLink($objectTypeResolver->getID($post));
 
             case 'hasLink':
-                $link = $objectTypeResolver->resolveValue($post, 'link', $variables, $expressions, $options);
+                $link = $objectTypeResolver->resolveValue($post, 'link', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($link)) {
                     return $link;
                 } elseif ($link) {
@@ -80,7 +80,7 @@ class PoP_AddPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
                 return false;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -63,6 +63,7 @@ class PoP_AddPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -75,7 +75,7 @@ class GD_ApplicationProcessors_DataLoad_ObjectTypeFieldResolver_Posts extends Ab
                 return array();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -66,6 +66,7 @@ class GD_ApplicationProcessors_DataLoad_ObjectTypeFieldResolver_Posts extends Ab
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -65,6 +65,7 @@ class PoPGenericForms_DataLoad_ObjectTypeFieldResolver_Comments extends Abstract
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -70,14 +70,14 @@ class PoPGenericForms_DataLoad_ObjectTypeFieldResolver_Comments extends Abstract
         $comment = $object;
         switch ($fieldName) {
             case 'contentClipped':
-                $content = $objectTypeResolver->resolveValue($object, 'content', $variables, $expressions, $options);
+                $content = $objectTypeResolver->resolveValue($object, 'content', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($content)) {
                     return $content;
                 }
                 return limitString(strip_tags($content), 250);
 
             case 'replycommentURL':
-                $customPostID = $objectTypeResolver->resolveValue($object, 'customPostID', $variables, $expressions, $options);
+                $customPostID = $objectTypeResolver->resolveValue($object, 'customPostID', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($customPostID)) {
                     return null;
                 }
@@ -90,7 +90,7 @@ class PoPGenericForms_DataLoad_ObjectTypeFieldResolver_Comments extends Abstract
                 ], RouteUtils::getRouteURL(POP_ADDCOMMENTS_ROUTE_ADDCOMMENT));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -91,6 +91,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends A
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -110,7 +110,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends A
                 $value = array();
                 $type = strtolower($objectTypeResolver->getTypeName());
                 // If it has categories, use it. Otherwise, only use the post type
-                if ($cats = $objectTypeResolver->resolveValue($post, 'categories', $variables, $expressions, $options)) {
+                if ($cats = $objectTypeResolver->resolveValue($post, 'categories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     foreach ($cats as $cat) {
                         $value[] = $type.'-'.$cat;
                     }
@@ -121,7 +121,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends A
 
          // Needed for using handlebars helper "compare" to compare a category id in a buttongroup, which is taken as a string, inside a list of cats, which must then also be strings
             case 'catsByName':
-                $cats = $objectTypeResolver->resolveValue($post, 'categories', $variables, $expressions, $options);
+                $cats = $objectTypeResolver->resolveValue($post, 'categories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $value = array();
                 foreach ($cats as $cat) {
                     $value[] = strval($cat);
@@ -140,7 +140,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends A
                 ], RouteUtils::getRouteURL(POP_ADDCOMMENTS_ROUTE_ADDCOMMENT));
 
             case 'topicsByName':
-                $selected = $objectTypeResolver->resolveValue($post, 'topics', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($post, 'topics', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -148,7 +148,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends A
                 return $categories->getSelectedValue();
 
             case 'appliestoByName':
-                $selected = $objectTypeResolver->resolveValue($post, 'appliesto', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($post, 'appliesto', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -156,7 +156,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends A
                 return $appliesto->getSelectedValue();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -177,7 +177,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObj
                 return $this->getThumb($post, $objectTypeResolver, $fieldArgs['size'], $fieldArgs['addDescription']);
 
             case 'thumbFullSrc':
-                $thumb = $objectTypeResolver->resolveValue($post, FieldQueryInterpreterFacade::getInstance()->getField('thumb', ['size' => 'full', 'addDescription' => true]), $variables, $expressions, $options);
+                $thumb = $objectTypeResolver->resolveValue($post, FieldQueryInterpreterFacade::getInstance()->getField('thumb', ['size' => 'full', 'addDescription' => true]), $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($thumb)) {
                     return $thumb;
                 }
@@ -190,7 +190,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObj
                 return \PoPCMSSchema\CustomPostMeta\Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_CATEGORIES);
 
             case 'hasTopics':
-                $topics = $objectTypeResolver->resolveValue($post, 'topics', $variables, $expressions, $options);
+                $topics = $objectTypeResolver->resolveValue($post, 'topics', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($topics)) {
                     return $topics;
                 } elseif ($topics) {
@@ -202,7 +202,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObj
                 return \PoPCMSSchema\CustomPostMeta\Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_APPLIESTO);
 
             case 'hasAppliesto':
-                $appliesto = $objectTypeResolver->resolveValue($post, 'appliesto', $variables, $expressions, $options);
+                $appliesto = $objectTypeResolver->resolveValue($post, 'appliesto', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($appliesto)) {
                     return $appliesto;
                 } elseif ($appliesto) {
@@ -212,15 +212,15 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObj
 
             case 'hasUserpostactivity':
                 // User Post Activity: Comments + Responses/Additionals + Hightlights
-                $hasComments = $objectTypeResolver->resolveValue($object, 'hasComments', $variables, $expressions, $options);
+                $hasComments = $objectTypeResolver->resolveValue($object, 'hasComments', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if ($hasComments) {
                     return $hasComments;
                 }
-                $hasReferencedBy = $objectTypeResolver->resolveValue($object, 'hasReferencedBy', $variables, $expressions, $options);
+                $hasReferencedBy = $objectTypeResolver->resolveValue($object, 'hasReferencedBy', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if ($hasReferencedBy) {
                     return $hasReferencedBy;
                 }
-                $hasHighlights = $objectTypeResolver->resolveValue($object, 'hasHighlights', $variables, $expressions, $options);
+                $hasHighlights = $objectTypeResolver->resolveValue($object, 'hasHighlights', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if ($hasHighlights) {
                     return $hasHighlights;
                 }
@@ -228,22 +228,22 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObj
 
             case 'userPostActivityCount':
                 // User Post Activity: Comments + Responses/Additionals + Hightlights
-                $commentCount = $objectTypeResolver->resolveValue($object, 'commentCount', $variables, $expressions, $options);
+                $commentCount = $objectTypeResolver->resolveValue($object, 'commentCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if ($commentCount) {
                     return $commentCount;
                 }
-                $referencedByCount = $objectTypeResolver->resolveValue($object, 'referencedByCount', $variables, $expressions, $options);
+                $referencedByCount = $objectTypeResolver->resolveValue($object, 'referencedByCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if ($referencedByCount) {
                     return $referencedByCount;
                 }
-                $highlightsCount = $objectTypeResolver->resolveValue($object, 'highlightsCount', $variables, $expressions, $options);
+                $highlightsCount = $objectTypeResolver->resolveValue($object, 'highlightsCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if ($highlightsCount) {
                     return $highlightsCount;
                 }
                 return $commentCount + $referencedByCount + $highlightsCount;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -168,6 +168,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObj
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -77,15 +77,15 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
         switch ($fieldName) {
             case 'multilayoutKeys':
                 return array(
-                    $objectTypeResolver->resolveValue($user, 'role', $variables, $expressions, $options),
+                    $objectTypeResolver->resolveValue($user, 'role', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
                 );
 
              // Needed for tinyMCE-mention plug-in
             case 'mentionQueryby':
-                return $objectTypeResolver->resolveValue($user, 'displayName', $variables, $expressions, $options);
+                return $objectTypeResolver->resolveValue($user, 'displayName', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
 
             case 'descriptionFormatted':
-                $value = $objectTypeResolver->resolveValue($user, 'description', $variables, $expressions, $options);
+                $value = $objectTypeResolver->resolveValue($user, 'description', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return $cmsapplicationhelpers->makeClickable($cmsapplicationhelpers->convertLinebreaksToHTML(strip_tags($value)));
 
             case 'excerpt':
@@ -98,7 +98,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
                 return $cmsapplicationhelpers->makeClickable(limitString(strip_tags($cmsapplicationhelpers->convertLinebreaksToHTML($userTypeAPI->getUserDescription($objectTypeResolver->getID($user)))), $length, $readmore));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -69,6 +69,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -87,6 +87,7 @@ class PoP_Application_UserAvatar_DataLoad_ObjectTypeFieldResolver_Users extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-avatar-foundation/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -96,7 +96,7 @@ class PoP_Application_UserAvatar_DataLoad_ObjectTypeFieldResolver_Users extends 
                 return gdGetAvatar($objectTypeResolver->getID($user), (int) $fieldArgs['size']);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -56,10 +56,10 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Tags extends AbstractObje
         switch ($fieldName) {
              // Needed for tinyMCE-mention plug-in
             case 'mentionQueryby':
-                return $objectTypeResolver->resolveValue($tag, 'name', $variables, $expressions, $options);
+                return $objectTypeResolver->resolveValue($tag, 'name', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/plugins/pop-taxonomies/library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -50,6 +50,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_Tags extends AbstractObje
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $tag = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -50,6 +50,7 @@ class PoP_Avatar_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObjectTy
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $cmsengineapi = \PoP\Engine\FunctionAPIFactory::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -64,7 +64,7 @@ class PoP_Avatar_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObjectTy
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
@@ -66,7 +66,7 @@ class GD_URE_Custom_DataLoad_ObjectTypeFieldResolver_FunctionalIndividualUsers e
         $user = $object;
         switch ($fieldName) {
             case 'individualInterestsByName':
-                $selected = $objectTypeResolver->resolveValue($user, 'individualinterests', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($user, 'individualinterests', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -74,7 +74,7 @@ class GD_URE_Custom_DataLoad_ObjectTypeFieldResolver_FunctionalIndividualUsers e
                 return $individualinterests->getSelectedValue();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-functionalhook.php
@@ -61,6 +61,7 @@ class GD_URE_Custom_DataLoad_ObjectTypeFieldResolver_FunctionalIndividualUsers e
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -65,6 +65,7 @@ class ObjectTypeFieldResolver_IndividualUsers extends AbstractObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -73,10 +73,10 @@ class ObjectTypeFieldResolver_IndividualUsers extends AbstractObjectTypeFieldRes
                 return \PoPCMSSchema\UserMeta\Utils::getUserMeta($objectTypeResolver->getID($user), GD_URE_METAKEY_PROFILE_INDIVIDUALINTERESTS);
 
             case 'hasIndividualDetails':
-                return !empty($objectTypeResolver->resolveValue($user, 'individualinterests', $variables, $expressions, $options));
+                return !empty($objectTypeResolver->resolveValue($user, 'individualinterests', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
@@ -72,7 +72,7 @@ class GD_URE_Custom_DataLoad_ObjectTypeFieldResolver_FunctionalOrganizationUsers
         $user = $object;
         switch ($fieldName) {
             case 'organizationTypesByName':
-                $selected = $objectTypeResolver->resolveValue($user, 'organizationtypes', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($user, 'organizationtypes', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -80,7 +80,7 @@ class GD_URE_Custom_DataLoad_ObjectTypeFieldResolver_FunctionalOrganizationUsers
                 return $organizationtypes->getSelectedValue();
 
             case 'organizationCategoriesByName':
-                $selected = $objectTypeResolver->resolveValue($user, 'organizationcategories', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($user, 'organizationcategories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -88,7 +88,7 @@ class GD_URE_Custom_DataLoad_ObjectTypeFieldResolver_FunctionalOrganizationUsers
                 return $organizationcategories->getSelectedValue();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-functionalhook.php
@@ -67,6 +67,7 @@ class GD_URE_Custom_DataLoad_ObjectTypeFieldResolver_FunctionalOrganizationUsers
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -78,6 +78,7 @@ class ObjectTypeFieldResolver_OrganizationUsers extends AbstractObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -96,13 +96,13 @@ class ObjectTypeFieldResolver_OrganizationUsers extends AbstractObjectTypeFieldR
 
             case 'hasOrganizationDetails':
                 return
-                    $objectTypeResolver->resolveValue($user, 'organizationtypes', $variables, $expressions, $options) ||
-                    $objectTypeResolver->resolveValue($user, 'organizationcategories', $variables, $expressions, $options) ||
-                    $objectTypeResolver->resolveValue($user, 'contactPerson', $variables, $expressions, $options) ||
-                    $objectTypeResolver->resolveValue($user, 'contactNumber', $variables, $expressions, $options);
+                    $objectTypeResolver->resolveValue($user, 'organizationtypes', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
+                    $objectTypeResolver->resolveValue($user, 'organizationcategories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
+                    $objectTypeResolver->resolveValue($user, 'contactPerson', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
+                    $objectTypeResolver->resolveValue($user, 'contactNumber', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -65,7 +65,7 @@ class GD_ContentCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extend
                 ], RouteUtils::getRouteURL(POP_CONTENTCREATION_ROUTE_FLAG));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -53,6 +53,7 @@ class GD_ContentCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extend
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -111,7 +111,7 @@ class GD_ContentCreation_DataLoad_ObjectTypeFieldResolver_Posts extends Abstract
                 return $cmseditpostsapi->getDeletePostLink($objectTypeResolver->getID($post));
 
             case 'coauthors':
-                $authors = $objectTypeResolver->resolveValue($object, FieldQueryInterpreterFacade::getInstance()->getField('authors', $fieldArgs), $variables, $expressions, $options);
+                $authors = $objectTypeResolver->resolveValue($object, FieldQueryInterpreterFacade::getInstance()->getField('authors', $fieldArgs), $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
 
                 // This function only makes sense when the user is logged in
                 if (\PoP\Root\App::getState('is-user-logged-in')) {
@@ -123,7 +123,7 @@ class GD_ContentCreation_DataLoad_ObjectTypeFieldResolver_Posts extends Abstract
                 return $authors;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -79,6 +79,7 @@ class GD_ContentCreation_DataLoad_ObjectTypeFieldResolver_Posts extends Abstract
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -52,6 +52,7 @@ class GD_ContentCreation_Media_DataLoad_ObjectTypeFieldResolver_FunctionalPosts 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostMediaTypeAPI = CustomPostMediaTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-media/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -65,7 +65,7 @@ class GD_ContentCreation_Media_DataLoad_ObjectTypeFieldResolver_FunctionalPosts 
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -89,6 +89,7 @@ class PoP_ContentCreation_DataLoad_ObjectTypeFieldResolver_Notifications extends
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userTypeAPI = UserTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -209,7 +209,7 @@ class PoP_ContentCreation_DataLoad_ObjectTypeFieldResolver_Notifications extends
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -160,7 +160,7 @@ class PoP_ContentPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends Abstra
                 return \PoPCMSSchema\CustomPostMeta\Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_LINKACCESS, true);
 
             case 'linkAccessByName':
-                $selected = $objectTypeResolver->resolveValue($post, 'linkaccess', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($post, 'linkaccess', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -171,7 +171,7 @@ class PoP_ContentPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends Abstra
                 return \PoPCMSSchema\CustomPostMeta\Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_LINKCATEGORIES);
 
             case 'linkCategoriesByName':
-                $selected = $objectTypeResolver->resolveValue($post, 'linkcategories', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($post, 'linkcategories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -179,13 +179,13 @@ class PoP_ContentPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends Abstra
                 return $linkcategories->getSelectedValue();
 
             case 'hasLinkCategories':
-                if ($objectTypeResolver->resolveValue($post, 'linkcategories', $variables, $expressions, $options)) {
+                if ($objectTypeResolver->resolveValue($post, 'linkcategories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return true;
                 }
                 return false;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -143,6 +143,7 @@ class PoP_ContentPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends Abstra
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -67,7 +67,7 @@ class GD_ContentPostLinksCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPos
                 ], RouteUtils::getRouteURL($route));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -52,6 +52,7 @@ class GD_ContentPostLinksCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPos
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-fObjectTypeunctionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-fObjectTypeunctionalhook.php
@@ -57,6 +57,7 @@ class GD_DataLoad_FunctionalObjectTypeFieldResolver extends AbstractObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-fObjectTypeunctionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/dataload/fieldprocessors/fieldprocessor-postsuserstags-fObjectTypeunctionalhook.php
@@ -61,15 +61,15 @@ class GD_DataLoad_FunctionalObjectTypeFieldResolver extends AbstractObjectTypeFi
     ): mixed {
         switch ($fieldName) {
             case 'printURL':
-                $url = $objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $options);
+                $url = $objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return PoP_Application_Engine_Utils::getPrintUrl($url);
 
             case 'embedURL':
-                $url = $objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $options);
+                $url = $objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return PoP_Application_Engine_Utils::getEmbedUrl($url);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -81,6 +81,7 @@ class GD_EM_DataLoad_ObjectTypeFieldResolver_Events extends AbstractObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $event = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-events-hook.php
@@ -92,7 +92,7 @@ class GD_EM_DataLoad_ObjectTypeFieldResolver_Events extends AbstractObjectTypeFi
                 return PoP_ContentPostLinks_Utils::getLinkContent($event);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -92,7 +92,7 @@ class GD_EM_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObjectTypeFie
                 return PoP_ContentPostLinks_Utils::getLinkContent($event);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -81,6 +81,7 @@ class GD_EM_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractObjectTypeFie
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $event = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
@@ -68,7 +68,7 @@ class PoP_EventLinksCreation_DataLoad_FunctionalObjectTypeFieldResolver extends 
                 ], RouteUtils::getRouteURL($route));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
@@ -52,6 +52,7 @@ class PoP_EventLinksCreation_DataLoad_FunctionalObjectTypeFieldResolver extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
@@ -68,7 +68,7 @@ class PoP_EventsCreation_DataLoad_FunctionalObjectTypeFieldResolver extends Abst
                 ], RouteUtils::getRouteURL($route));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-fObjectTypeunctionalhook.php
@@ -52,6 +52,7 @@ class PoP_EventsCreation_DataLoad_FunctionalObjectTypeFieldResolver extends Abst
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -83,6 +83,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_ObjectTypeFieldResolver_Post
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $locationpost = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinks/library/dataload/fieldprocessors/fieldprocessor-locationposts-hook.php
@@ -94,7 +94,7 @@ class GD_Custom_Locations_ContentPostLinks_DataLoad_ObjectTypeFieldResolver_Post
                 return PoP_ContentPostLinks_Utils::getLinkContent($locationpost);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -68,7 +68,7 @@ class PoP_LocationPostLinksCreation_DataLoad_ObjectTypeFieldResolver_FunctionalP
                 ], RouteUtils::getRouteURL($route));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostlinkscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -52,6 +52,7 @@ class PoP_LocationPostLinksCreation_DataLoad_ObjectTypeFieldResolver_FunctionalP
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -52,6 +52,7 @@ class PoP_LocationPostsCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPosts
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -68,7 +68,7 @@ class PoP_LocationPostsCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPosts
                 ], RouteUtils::getRouteURL($route));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -76,6 +76,7 @@ class PoP_Notifications_UserLogin_DataLoad_ObjectTypeFieldResolver_Notifications
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userlogin/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -102,7 +102,7 @@ class PoP_Notifications_UserLogin_DataLoad_ObjectTypeFieldResolver_Notifications
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -77,6 +77,7 @@ class PoP_Notifications_UserPlatform_DataLoad_ObjectTypeFieldResolver_Notificati
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $cmsapplicationapi = \PoP\Application\FunctionAPIFactory::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -128,7 +128,7 @@ class PoP_Notifications_UserPlatform_DataLoad_ObjectTypeFieldResolver_Notificati
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -52,6 +52,7 @@ class GD_PostsCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postscreation/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -68,7 +68,7 @@ class GD_PostsCreation_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL($route));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -60,7 +60,7 @@ class PPPPoP_DataLoad_ObjectTypeFieldResolver_FunctionalProfiles extends Abstrac
                 return $pluginapi->getPreviewLink($objectTypeResolver->getID($post));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-previewcontent/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -50,6 +50,7 @@ class PPPPoP_DataLoad_ObjectTypeFieldResolver_FunctionalProfiles extends Abstrac
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $pluginapi = PoP_PreviewContent_FunctionsAPIFactory::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -85,6 +85,7 @@ class PoP_RelatedPosts_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -93,22 +93,22 @@ class PoP_RelatedPosts_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
                 return \PoPCMSSchema\CustomPostMeta\Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_REFERENCES) ?? [];
 
             case 'hasReferences':
-                $references = $objectTypeResolver->resolveValue($object, 'references', $variables, $expressions, $options);
+                $references = $objectTypeResolver->resolveValue($object, 'references', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return !empty($references);
 
             case 'referencedby':
                 return PoP_RelatedPosts_SectionUtils::getReferencedby($objectTypeResolver->getID($post));
 
             case 'hasReferencedBy':
-                $referencedby = $objectTypeResolver->resolveValue($object, 'referencedby', $variables, $expressions, $options);
+                $referencedby = $objectTypeResolver->resolveValue($object, 'referencedby', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return !empty($referencedby);
 
             case 'referencedByCount':
-                $referencedby = $objectTypeResolver->resolveValue($object, 'referencedby', $variables, $expressions, $options);
+                $referencedby = $objectTypeResolver->resolveValue($object, 'referencedby', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return count($referencedby);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -77,6 +77,7 @@ class PoP_RelatedPosts_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications ex
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userTypeAPI = UserTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-relatedposts/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -114,7 +114,7 @@ class PoP_RelatedPosts_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications ex
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -111,7 +111,7 @@ class WSL_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends Abstrac
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -76,6 +76,7 @@ class WSL_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends Abstrac
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
@@ -75,7 +75,7 @@ class GD_WSL_ObjectTypeFieldResolver_Users extends AbstractObjectTypeFieldResolv
                 return $userTypeAPI->getUserWebsiteUrl($user);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-sociallogin/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functions.php
@@ -65,6 +65,7 @@ class GD_WSL_ObjectTypeFieldResolver_Users extends AbstractObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-socialmediaitems-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-socialmediaitems-base.php
@@ -107,11 +107,11 @@ abstract class PoP_SocialMediaProviders_DataLoad_ObjectTypeFieldResolver_Functio
     ): mixed {
         switch ($fieldName) {
             case 'shareURL':
-                $url = $objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $options);
+                $url = $objectTypeResolver->resolveValue($object, 'url', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($url)) {
                     return $url;
                 }
-                $title = $objectTypeResolver->resolveValue($object, $this->getTitleField(), $variables, $expressions, $options);
+                $title = $objectTypeResolver->resolveValue($object, $this->getTitleField(), $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($title)) {
                     return $title;
                 }
@@ -119,6 +119,6 @@ abstract class PoP_SocialMediaProviders_DataLoad_ObjectTypeFieldResolver_Functio
                 return $this->getShareUrl($url, $title, $providerURLs[$fieldArgs['provider']]);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-socialmediaitems-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialmediaproviders-processors/library/dataload/fieldprocessors/fieldprocessor-socialmediaitems-base.php
@@ -103,6 +103,7 @@ abstract class PoP_SocialMediaProviders_DataLoad_ObjectTypeFieldResolver_Functio
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -62,7 +62,7 @@ class PoPGenericForms_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_CONTACTUSER));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -52,6 +52,7 @@ class PoPGenericForms_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -100,6 +100,7 @@ class PoP_SocialNetwork_DataLoad_ObjectTypeFieldResolver_Notifications extends A
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userTypeAPI = UserTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -260,7 +260,7 @@ class PoP_SocialNetwork_DataLoad_ObjectTypeFieldResolver_Notifications extends A
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -52,6 +52,7 @@ class GD_DataLoad_ObjectTypeFieldResolver_Comments extends AbstractObjectTypeFie
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $comment = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-comments-hook.php
@@ -61,7 +61,7 @@ class GD_DataLoad_ObjectTypeFieldResolver_Comments extends AbstractObjectTypeFie
                 return \PoPCMSSchema\CommentMeta\Utils::getCommentMeta($objectTypeResolver->getID($comment), GD_METAKEY_COMMENT_TAGGEDUSERS) ?? [];
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): \PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -76,6 +76,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -91,7 +91,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNRECOMMENDPOST));
 
             case 'recommendPostCountPlus1':
-                if ($count = $objectTypeResolver->resolveValue($object, 'recommendPostCount', $variables, $expressions, $options)) {
+                if ($count = $objectTypeResolver->resolveValue($object, 'recommendPostCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return $count+1;
                 }
                 return 1;
@@ -107,7 +107,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNDOUPVOTEPOST));
 
             case 'upvotePostCountPlus1':
-                if ($count = $objectTypeResolver->resolveValue($object, 'upvotePostCount', $variables, $expressions, $options)) {
+                if ($count = $objectTypeResolver->resolveValue($object, 'upvotePostCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return $count+1;
                 }
                 return 1;
@@ -123,13 +123,13 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNDODOWNVOTEPOST));
 
             case 'downvotePostCountPlus1':
-                if ($count = $objectTypeResolver->resolveValue($object, 'downvotePostCount', $variables, $expressions, $options)) {
+                if ($count = $objectTypeResolver->resolveValue($object, 'downvotePostCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return $count+1;
                 }
                 return 1;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -109,7 +109,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
                 return (int) \PoPCMSSchema\CustomPostMeta\Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_DOWNVOTECOUNT, true);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -85,6 +85,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userTypeAPI = UserTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -70,7 +70,7 @@ class GD_DataLoad_ObjectTypeFieldResolver_Tags extends AbstractObjectTypeFieldRe
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNSUBSCRIBEFROMTAG));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-tags-functionalhook.php
@@ -55,6 +55,7 @@ class GD_DataLoad_ObjectTypeFieldResolver_Tags extends AbstractObjectTypeFieldRe
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $tag = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -55,6 +55,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -70,7 +70,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends 
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNFOLLOWUSER));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -84,6 +84,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_Users extends AbstractOb
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userTypeAPI = UserTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -109,7 +109,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_Users extends AbstractOb
                 return \PoPCMSSchema\UserMeta\Utils::getUserMeta($objectTypeResolver->getID($user), GD_METAKEY_PROFILE_FOLLOWERSCOUNT, true);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -56,10 +56,10 @@ class PoP_UserAvatar_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends Ab
         switch ($fieldName) {
             case 'fileUploadPictureURL':
                 // URL which will upload the images for the user
-                return GD_FileUpload_Picture_Utils::getFileuploadUrl($objectTypeResolver->resolveValue($object, 'id', $variables, $expressions, $options));
+                return GD_FileUpload_Picture_Utils::getFileuploadUrl($objectTypeResolver->resolveValue($object, 'id', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -50,6 +50,7 @@ class PoP_UserAvatar_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends Ab
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -75,6 +75,7 @@ class PoP_AAL_UserAvatar_DataLoad_ObjectTypeFieldResolver_Notification extends A
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -104,7 +104,7 @@ class PoP_AAL_UserAvatar_DataLoad_ObjectTypeFieldResolver_Notification extends A
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -76,10 +76,10 @@ class ObjectTypeFieldResolver_CommunityUsers extends AbstractObjectTypeFieldReso
                 return URE_CommunityUtils::getCommunityMembers($objectTypeResolver->getID($user));
 
             case 'hasMembers':
-                return !empty($objectTypeResolver->resolveValue($user, 'members', $variables, $expressions, $options));
+                return !empty($objectTypeResolver->resolveValue($user, 'members', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -68,6 +68,7 @@ class ObjectTypeFieldResolver_CommunityUsers extends AbstractObjectTypeFieldReso
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -86,7 +86,7 @@ class GD_UserCommunities_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extend
                 return gdUreEditMembershipUrl($objectTypeResolver->getID($user), true);
 
             case 'memberStatusByName':
-                $selected = $objectTypeResolver->resolveValue($user, 'memberstatus', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($user, 'memberstatus', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -94,7 +94,7 @@ class GD_UserCommunities_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extend
                 return $status->getSelectedValue();
 
             case 'memberPrivilegesByName':
-                $selected = $objectTypeResolver->resolveValue($user, 'memberprivileges', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($user, 'memberprivileges', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -102,7 +102,7 @@ class GD_UserCommunities_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extend
                 return $privileges->getSelectedValue();
 
             case 'memberTagsByName':
-                $selected = $objectTypeResolver->resolveValue($user, 'membertags', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($user, 'membertags', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -110,7 +110,7 @@ class GD_UserCommunities_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extend
                 return $tags->getSelectedValue();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -75,6 +75,7 @@ class GD_UserCommunities_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extend
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -92,6 +92,7 @@ class GD_UserCommunities_DataLoad_ObjectTypeFieldResolver_Users extends Abstract
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -130,11 +130,11 @@ class GD_UserCommunities_DataLoad_ObjectTypeFieldResolver_Users extends Abstract
                 return gdUreGetCommunitiesStatusActive($objectTypeResolver->getID($user));
 
             case 'hasActiveCommunities':
-                $communities = $objectTypeResolver->resolveValue($object, 'activeCommunities', $variables, $expressions, $options);
+                $communities = $objectTypeResolver->resolveValue($object, 'activeCommunities', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return !empty($communities);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -130,6 +130,7 @@ class URE_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends Abstrac
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -154,7 +154,7 @@ class URE_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends Abstrac
                 return gdUreCommunityMembershipstatusFilterbycommunity($status, $notification->user_id);
 
             case 'memberStatusByName':
-                $selected = $objectTypeResolver->resolveValue($notification, 'memberstatus', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($notification, 'memberstatus', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -168,7 +168,7 @@ class URE_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends Abstrac
                 return gdUreCommunityMembershipstatusFilterbycommunity($privileges, $notification->user_id);
 
             case 'memberPrivilegesByName':
-                $selected = $objectTypeResolver->resolveValue($notification, 'memberprivileges', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($notification, 'memberprivileges', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -182,7 +182,7 @@ class URE_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends Abstrac
                 return gdUreCommunityMembershipstatusFilterbycommunity($tags, $notification->user_id);
 
             case 'memberTagsByName':
-                $selected = $objectTypeResolver->resolveValue($notification, 'membertags', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($notification, 'membertags', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -244,7 +244,7 @@ class URE_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends Abstrac
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -72,12 +72,12 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
         switch ($fieldName) {
             case 'shortDescriptionFormatted':
                 // doing esc_html so that single quotes ("'") do not screw the map output
-                $value = $objectTypeResolver->resolveValue($user, 'shortDescription', $variables, $expressions, $options);
+                $value = $objectTypeResolver->resolveValue($user, 'shortDescription', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return $cmsapplicationhelpers->makeClickable($cmsapplicationhelpers->escapeHTML($value));
 
             case 'contactSmall':
                 $value = array();
-                $contacts = $objectTypeResolver->resolveValue($user, 'contact', $variables, $expressions, $options);
+                $contacts = $objectTypeResolver->resolveValue($user, 'contact', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 // Remove text, replace all icons with their shorter version
                 foreach ($contacts as $contact) {
                     $value[] = array(
@@ -93,7 +93,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
                 return \PoPCMSSchema\UserMeta\Utils::getUserMeta($objectTypeResolver->getID($user), GD_METAKEY_PROFILE_USERPREFERENCES);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -65,6 +65,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -107,7 +107,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
             case 'contact':
                 $value = array();
                 // This one is a quasi copy/paste from the typeResolver
-                if ($user_url = $objectTypeResolver->resolveValue($user, 'websiteURL', $variables, $expressions, $options)) {
+                if ($user_url = $objectTypeResolver->resolveValue($user, 'websiteURL', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Website', 'pop-coreprocessors'),
                         'url' => maybeAddHttp($user_url),
@@ -116,8 +116,8 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'fontawesome' => 'fa-home',
                     );
                 }
-                if ($objectTypeResolver->resolveValue($user, 'displayEmail', $variables, $expressions, $options)) {
-                    if ($email = $objectTypeResolver->resolveValue($user, 'email', $variables, $expressions, $options)) {
+                if ($objectTypeResolver->resolveValue($user, 'displayEmail', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                    if ($email = $objectTypeResolver->resolveValue($user, 'email', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                         $value[] = array(
                             'fontawesome' => 'fa-envelope',
                             'tooltip' => TranslationAPIFacade::getInstance()->__('Email', 'pop-coreprocessors'),
@@ -126,7 +126,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         );
                     }
                 }
-                // if ($blog = $objectTypeResolver->resolveValue($user, 'blog', $variables, $expressions, $options)) {
+                // if ($blog = $objectTypeResolver->resolveValue($user, 'blog', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
 
                 //     $value[] = array(
                 //         'tooltip' => TranslationAPIFacade::getInstance()->__('Blog', 'poptheme-wassup'),
@@ -136,7 +136,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                 //         'fontawesome' => 'fa-pencil',
                 //     );
                 // }
-                if ($facebook = $objectTypeResolver->resolveValue($user, 'facebook', $variables, $expressions, $options)) {
+                if ($facebook = $objectTypeResolver->resolveValue($user, 'facebook', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Facebook', 'poptheme-wassup'),
                         'fontawesome' => 'fa-facebook',
@@ -145,7 +145,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'target' => '_blank'
                     );
                 }
-                if ($twitter = $objectTypeResolver->resolveValue($user, 'twitter', $variables, $expressions, $options)) {
+                if ($twitter = $objectTypeResolver->resolveValue($user, 'twitter', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Twitter', 'poptheme-wassup'),
                         'fontawesome' => 'fa-twitter',
@@ -154,7 +154,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'target' => '_blank'
                     );
                 }
-                if ($linkedin = $objectTypeResolver->resolveValue($user, 'linkedin', $variables, $expressions, $options)) {
+                if ($linkedin = $objectTypeResolver->resolveValue($user, 'linkedin', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('LinkedIn', 'poptheme-wassup'),
                         'url' => maybeAddHttp($linkedin),
@@ -163,7 +163,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'fontawesome' => 'fa-linkedin'
                     );
                 }
-                if ($youtube = $objectTypeResolver->resolveValue($user, 'youtube', $variables, $expressions, $options)) {
+                if ($youtube = $objectTypeResolver->resolveValue($user, 'youtube', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Youtube', 'poptheme-wassup'),
                         'url' => maybeAddHttp($youtube),
@@ -172,7 +172,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'fontawesome' => 'fa-youtube',
                     );
                 }
-                if ($instagram = $objectTypeResolver->resolveValue($user, 'instagram', $variables, $expressions, $options)) {
+                if ($instagram = $objectTypeResolver->resolveValue($user, 'instagram', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Instagram', 'poptheme-wassup'),
                         'url' => maybeAddHttp($instagram),
@@ -184,7 +184,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                 return $value;
 
             case 'hasContact':
-                $contact = $objectTypeResolver->resolveValue($object, 'contact', $variables, $expressions, $options);
+                $contact = $objectTypeResolver->resolveValue($object, 'contact', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return !empty($contact);
 
             case 'facebook':
@@ -206,7 +206,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                 return isProfile($objectTypeResolver->getID($user));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -89,6 +89,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $user = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -128,14 +128,14 @@ class ObjectTypeFieldResolver_Users extends AbstractObjectTypeFieldResolver
                     $objectTypeResolver->getID($user)
                 );
             case 'hasRole':
-                $role = $objectTypeResolver->resolveValue($user, 'role', $variables, $expressions, $options);
+                $role = $objectTypeResolver->resolveValue($user, 'role', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 if (GeneralUtils::isError($role)) {
                     return $role;
                 }
                 return $role == $fieldArgs['role'];
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userroles/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -113,6 +113,7 @@ class ObjectTypeFieldResolver_Users extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userRoleTypeAPI = UserRoleTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -77,6 +77,7 @@ class UserStance_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $userTypeAPI = UserTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance/plugins/pop-notifications/library/dataload/fieldprocessors/fieldprocessor-notifications-hooks.php
@@ -112,7 +112,7 @@ class UserStance_AAL_PoP_DataLoad_ObjectTypeFieldResolver_Notifications extends 
                 return null;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -53,6 +53,7 @@ class PoP_Volunteering_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -65,7 +65,7 @@ class PoP_Volunteering_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL(POP_VOLUNTEERING_ROUTE_VOLUNTEER));
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -59,6 +59,7 @@ class PoP_Volunteering_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-volunteering/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -67,7 +67,7 @@ class PoP_Volunteering_DataLoad_ObjectTypeFieldResolver_Posts extends AbstractOb
                 return (bool)\PoPCMSSchema\CustomPostMeta\Utils::getCustomPostMeta($objectTypeResolver->getID($post), GD_METAKEY_POST_VOLUNTEERSNEEDED, true);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }
 

--- a/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationFunctionalObjectTypeFieldResolver.php
@@ -75,6 +75,7 @@ class NotificationFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationFunctionalObjectTypeFieldResolver.php
@@ -81,13 +81,13 @@ class NotificationFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFi
         switch ($fieldName) {
             case 'multilayoutKeys':
                 // If multiple-layouts, then we need 'objectType' and 'action' data-fields
-                $object_type = $objectTypeResolver->resolveValue($notification, 'objectType', $variables, $expressions, $options);
-                $action = $objectTypeResolver->resolveValue($notification, 'action', $variables, $expressions, $options);
+                $object_type = $objectTypeResolver->resolveValue($notification, 'objectType', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
+                $action = $objectTypeResolver->resolveValue($notification, 'action', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return array(
                     $object_type . '-' . $action,
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationFunctionalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Notifications\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -75,7 +76,7 @@ class NotificationFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFi
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationObjectTypeFieldResolver.php
@@ -321,11 +321,11 @@ class NotificationObjectTypeFieldResolver extends AbstractObjectTypeFieldResolve
                 return $value;
 
             case 'isStatusRead':
-                $status = $objectTypeResolver->resolveValue($object, 'status', $variables, $expressions, $options);
+                $status = $objectTypeResolver->resolveValue($object, 'status', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return ($status == AAL_POP_STATUS_READ);
 
             case 'isStatusNotRead':
-                $is_read = $objectTypeResolver->resolveValue($object, 'isStatusRead', $variables, $expressions, $options);
+                $is_read = $objectTypeResolver->resolveValue($object, 'isStatusRead', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return !$is_read;
 
             case 'markAsReadURL':
@@ -387,6 +387,6 @@ class NotificationObjectTypeFieldResolver extends AbstractObjectTypeFieldResolve
                 return $fieldArgs['action'] == $notification->action;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationObjectTypeFieldResolver.php
@@ -273,6 +273,7 @@ class NotificationObjectTypeFieldResolver extends AbstractObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/notifications/src/FieldResolvers/ObjectType/NotificationObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Notifications\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -273,7 +274,7 @@ class NotificationObjectTypeFieldResolver extends AbstractObjectTypeFieldResolve
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $notification = $object;

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
@@ -157,6 +157,7 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
@@ -189,11 +189,11 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
                 return $customPostTypeAPI->getCustomPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'hasLoggedInUserStances':
-                $referencedby = $objectTypeResolver->resolveValue($object, 'loggedInUserStances', $variables, $expressions, $options);
+                $referencedby = $objectTypeResolver->resolveValue($object, 'loggedInUserStances', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return !empty($referencedby);
 
             case 'editStanceURL':
-                if ($referencedby = $objectTypeResolver->resolveValue($object, 'loggedInUserStances', $variables, $expressions, $options)) {
+                if ($referencedby = $objectTypeResolver->resolveValue($object, 'loggedInUserStances', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return urldecode($cmseditpostsapi->getEditPostLink($referencedby[0]));
                 }
                 return null;
@@ -218,7 +218,7 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
 
             case 'stanceName':
             case 'catName':
-                $selected = $objectTypeResolver->resolveValue($object, 'stance', $variables, $expressions, $options);
+                $selected = $objectTypeResolver->resolveValue($object, 'stance', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 $params = array(
                     'selected' => $selected
                 );
@@ -226,6 +226,6 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
                 return $stance->getSelectedValue();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostFunctionalObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Stances\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\Root\App;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Misc\GeneralUtils;
@@ -157,7 +158,7 @@ class CustomPostFunctionalObjectTypeFieldResolver extends AbstractObjectTypeFiel
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -118,6 +118,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -134,7 +134,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $customPostTypeAPI->getCustomPosts($query, [QueryOptions::RETURN_TYPE => ReturnTypes::IDS]);
 
             case 'hasStances':
-                $referencedby = $objectTypeResolver->resolveValue($object, 'stances', $variables, $expressions, $options);
+                $referencedby = $objectTypeResolver->resolveValue($object, 'stances', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 return !empty($referencedby);
 
             case 'stanceProCount':
@@ -161,6 +161,6 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $customPostTypeAPI->getCustomPostCount($query);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Stances\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -118,7 +119,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/StanceObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/StanceObjectTypeFieldResolver.php
@@ -164,7 +164,7 @@ class StanceObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 
             case 'stance':
                 // The stance is the category
-                return $objectTypeResolver->resolveValue($object, 'mainCategory', $variables, $expressions, $options);
+                return $objectTypeResolver->resolveValue($object, 'mainCategory', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
 
             // The Stance has no title, so return the excerpt instead.
             // Needed for when adding a comment on the Stance, where it will say: Add comment for...
@@ -185,9 +185,9 @@ class StanceObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 
             case 'hasStanceTarget':
                 // Cannot use !is_null because getCustomPostMeta returns "" when there's no entry, instead of null
-                return $objectTypeResolver->resolveValue($object, 'stancetarget', $variables, $expressions, $options);
+                return $objectTypeResolver->resolveValue($object, 'stancetarget', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/StanceObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/StanceObjectTypeFieldResolver.php
@@ -138,6 +138,7 @@ class StanceObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();

--- a/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/StanceObjectTypeFieldResolver.php
+++ b/layers/Legacy/Schema/packages/stances/src/FieldResolvers/ObjectType/StanceObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPSchema\Stances\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -138,7 +139,7 @@ class StanceObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $customPostTypeAPI = CustomPostTypeAPIFacade::getInstance();

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Multisite\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -80,7 +81,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
             $root = $object;

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -92,7 +92,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $this->getSite()->getID();
         }
 
-            return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+            return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 
     public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -80,6 +80,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
             $root = $object;

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/SiteObjectTypeFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/SiteObjectTypeFieldResolver.php
@@ -82,6 +82,7 @@ class SiteObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Site */

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/SiteObjectTypeFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/SiteObjectTypeFieldResolver.php
@@ -93,6 +93,6 @@ class SiteObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $site->getHost();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/SiteObjectTypeFieldResolver.php
+++ b/layers/SiteBuilder/packages/multisite/src/FieldResolvers/ObjectType/SiteObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\Multisite\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -82,7 +83,7 @@ class SiteObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var Site */

--- a/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
@@ -182,6 +182,6 @@ class PostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return (object) $block_metadata;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\BlockMetadataWP\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use Leoloso\BlockMetadata\Data;
 use Leoloso\BlockMetadata\Metadata;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
@@ -141,7 +142,7 @@ class PostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
@@ -141,6 +141,7 @@ class PostObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         $post = $object;

--- a/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/TryNewFeaturesPostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/TryNewFeaturesPostObjectTypeFieldResolver.php
@@ -91,10 +91,11 @@ class TryNewFeaturesPostObjectTypeFieldResolver extends AbstractObjectTypeFieldR
                     $this->getFieldQueryInterpreter()->getField('blockMetadata', $fieldArgs),
                     $variables,
                     $expressions,
+                    $objectTypeFieldResolutionFeedbackStore,
                     $options
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/TryNewFeaturesPostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/TryNewFeaturesPostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\BlockMetadataWP\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -80,7 +81,7 @@ class TryNewFeaturesPostObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/TryNewFeaturesPostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/block-metadata-for-wp/src/FieldResolvers/ObjectType/TryNewFeaturesPostObjectTypeFieldResolver.php
@@ -80,6 +80,7 @@ class TryNewFeaturesPostObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/WPSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Comments\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -89,7 +90,7 @@ class CommentObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Comment */

--- a/layers/WPSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -100,6 +100,6 @@ class CommentObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRes
                 return $comment->comment_author_IP;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/comments/src/FieldResolvers/ObjectType/CommentObjectTypeFieldResolver.php
@@ -89,6 +89,7 @@ class CommentObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldRes
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Comment */

--- a/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Media\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\SchemaCommons\CMS\CMSHelperServiceInterface;
@@ -89,7 +90,7 @@ class MediaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Post */

--- a/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -89,6 +89,7 @@ class MediaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Post */

--- a/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/MediaObjectTypeFieldResolver.php
@@ -106,6 +106,6 @@ class MediaObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 return $mediaItem->post_name;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Media\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -95,7 +96,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -95,6 +95,7 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/media/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -102,6 +102,6 @@ class RootObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 return \get_intermediate_image_sizes();
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
@@ -135,6 +135,6 @@ class MenuObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
@@ -113,6 +113,7 @@ class MenuObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Term */

--- a/layers/WPSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/menus/src/FieldResolvers/ObjectType/MenuObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Menus\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -113,7 +114,7 @@ class MenuObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Term */

--- a/layers/WPSchema/packages/menus/src/Overrides/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/menus/src/Overrides/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -22,6 +22,7 @@ class RootObjectTypeFieldResolver extends UpstreamRootObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/WPSchema/packages/menus/src/Overrides/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/menus/src/Overrides/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Menus\Overrides\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoPCMSSchema\Menus\FieldResolvers\ObjectType\RootObjectTypeFieldResolver as UpstreamRootObjectTypeFieldResolver;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 
@@ -22,7 +23,7 @@ class RootObjectTypeFieldResolver extends UpstreamRootObjectTypeFieldResolver
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         switch ($fieldName) {

--- a/layers/WPSchema/packages/menus/src/Overrides/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/menus/src/Overrides/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -38,7 +38,7 @@ class RootObjectTypeFieldResolver extends UpstreamRootObjectTypeFieldResolver
                     }
                 }
                 if ($menuParam === null) {
-                    return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+                    return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
                 }
                 $menu = wp_get_nav_menu_object($menuParam);
                 if ($menu === false) {
@@ -47,6 +47,6 @@ class RootObjectTypeFieldResolver extends UpstreamRootObjectTypeFieldResolver
                 return $menu->term_id;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Pages\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -76,7 +77,7 @@ class PageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Post */

--- a/layers/WPSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
@@ -76,6 +76,7 @@ class PageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Post */

--- a/layers/WPSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/pages/src/FieldResolvers/ObjectType/PageObjectTypeFieldResolver.php
@@ -85,6 +85,6 @@ class PageObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 return $page->menu_order;
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/posts/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/posts/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
@@ -92,6 +92,7 @@ class PostObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Post */

--- a/layers/WPSchema/packages/posts/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/posts/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
@@ -108,6 +108,6 @@ class PostObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 return \is_sticky($post->ID);
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/posts/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/posts/src/FieldResolvers/ObjectType/PostObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Posts\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
@@ -92,7 +93,7 @@ class PostObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_Post */

--- a/layers/WPSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -144,6 +144,6 @@ class UserObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
                 );
         }
 
-        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $options);
+        return parent::resolveValue($objectTypeResolver, $object, $fieldName, $fieldArgs, $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options);
     }
 }

--- a/layers/WPSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\Users\FieldResolvers\ObjectType;
 
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use DateTime;
 use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
@@ -124,7 +125,7 @@ class UserObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
-        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_User */

--- a/layers/WPSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/users/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -124,6 +124,7 @@ class UserObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolv
         array $fieldArgs,
         array $variables,
         array $expressions,
+        \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
         /** @var WP_User */


### PR DESCRIPTION
Params `$schemaErrors`, `$schemaWarnings`, `$objectErrors`, etc will be replaced with some single `FeedbackStore` param, containing all of these properties.

In advance of doing that, pass a parameter of new class `ObjectTypeFieldResolutionFeedbackStore` to all `ObjectTypeFieldResolver->resolveValue()`