### PR TITLE
Update PHP-Scoper to v0.17

### DIFF
--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -93,7 +93,7 @@ jobs:
 
             # Prepare for testing on PHP 7.1
             -   name: Install PHP Parallel Lint
-                run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi
+                run: composer create-project php-parallel-lint/php-parallel-lint php-parallel-lint --ansi --no-dev
 
             # Only PROD dependencies must be tested
             # --ignore-platform-reqs to avoid Composer checking the PHP 8.0 requirement

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -120,6 +120,7 @@ jobs:
             ################################################################################
             # Temporary hack: fix the return type in Trait, not yet handled by Rector
             # @see https://github.com/rectorphp/rector/issues/6962
+            # @see https://github.com/leoloso/PoP/issues/1470
             -   name: Temporary hack - fix the return type in Trait
                 run: |
                     sed -i 's/function getItem($key): CacheItem/function getItem($key): \\Psr\\Cache\\CacheItemInterface/' vendor/symfony/cache/Traits/AbstractAdapterTrait.php

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -118,7 +118,8 @@ jobs:
                 run: ci/downgrade/downgrade_code.sh "${{ matrix.pluginConfig.rector_downgrade_config }}" "" "${{ matrix.pluginConfig.path }}" "${{ matrix.pluginConfig.additional_rector_configs }}" "${{ needs.provide_data.outputs.local_package_owners }}"
 
             ################################################################################
-            # Temporary hack: fix the return type in Trait, not yet handled by Rector: https://github.com/rectorphp/rector/issues/???
+            # Temporary hack: fix the return type in Trait, not yet handled by Rector
+            # @see https://github.com/rectorphp/rector/issues/6962
             -   name: Temporary hack - fix the return type in Trait
                 run: |
                     sed -i 's/function getItem($key): CacheItem/function getItem($key): \\Psr\\Cache\\CacheItemInterface/' vendor/symfony/cache/Traits/AbstractAdapterTrait.php

--- a/ci/scoping/scoper-graphql-api.inc.php
+++ b/ci/scoping/scoper-graphql-api.inc.php
@@ -95,7 +95,7 @@ return [
         // (unless adding the files to the autoload path)
         'PoPContainer\*',
     ])),
-    'files-whitelist' => [
+    'exclude-files' => [
         // Class Composer\InstalledVersions will be regenerated without scope when
         // doing `composer dumpautoload`, so skip it
         convertRelativeToFullPath('vendor/composer/InstalledVersions.php'),

--- a/ci/scoping/scoper-graphql-api.inc.php
+++ b/ci/scoping/scoper-graphql-api.inc.php
@@ -174,42 +174,6 @@ return [
 
                 return $content;
             }
-            /**
-             * In these files, it prefixes the return type `parent`.
-             * Undo it!
-             */
-            $symfonyPolyfillFilesWithParentReturnType = array_map(
-                'convertRelativeToFullPath',
-                [
-                    'vendor/symfony/string/AbstractUnicodeString.php',
-                    'vendor/symfony/string/ByteString.php',
-                    'vendor/symfony/string/UnicodeString.php',
-                ]
-            );
-            if (in_array($filePath, $symfonyPolyfillFilesWithParentReturnType)) {
-                return str_replace(
-                    "\\${prefix}\\parent",
-                    'parent',
-                    $content
-                );
-            }
-            /**
-             * In these files, it prefixes the return type `self`.
-             * Undo it!
-             */
-            $symfonyPolyfillFilesWithSelfReturnType = array_map(
-                'convertRelativeToFullPath',
-                [
-                    'vendor/symfony/dependency-injection/Compiler/AutowirePass.php',
-                ]
-            );
-            if (in_array($filePath, $symfonyPolyfillFilesWithSelfReturnType)) {
-                return str_replace(
-                    "\\${prefix}\\self",
-                    'self',
-                    $content
-                );
-            }
 
             return $content;
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a92ba261bf5f4c06ba5eb0895aaf9993",
+    "content-hash": "b9b6e3f4cbaebffe4e4a13a88852400f",
     "packages": [
         {
             "name": "boxuk/wp-muplugin-loader",
@@ -277,23 +277,23 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.2.7",
+            "version": "3.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "deac27056b57e46faf136fae7b449eeaa71661ee"
+                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/deac27056b57e46faf136fae7b449eeaa71661ee",
-                "reference": "deac27056b57e46faf136fae7b449eeaa71661ee",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a951f614bd64dcd26137bc9b7b2637ddcfc57649",
+                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.54",
+                "phpstan/phpstan": "^1.4",
                 "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
@@ -338,7 +338,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.7"
+                "source": "https://github.com/composer/semver/tree/3.2.9"
             },
             "funding": [
                 {
@@ -354,7 +354,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T09:57:54+00:00"
+            "time": "2022-02-04T13:58:43+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -400,12 +400,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -507,12 +507,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -861,12 +861,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "FastRoute\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "FastRoute\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1298,16 +1298,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "41bdcb2d067c68f338b0cfd46a86abd8309b4153"
+                "reference": "ac6859b9216350046fa3f00d9f0b51e0f3de28fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/41bdcb2d067c68f338b0cfd46a86abd8309b4153",
-                "reference": "41bdcb2d067c68f338b0cfd46a86abd8309b4153",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/ac6859b9216350046fa3f00d9f0b51e0f3de28fd",
+                "reference": "ac6859b9216350046fa3f00d9f0b51e0f3de28fd",
                 "shasum": ""
             },
             "require": {
@@ -1371,7 +1371,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.0.2"
+                "source": "https://github.com/symfony/cache/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -1387,7 +1387,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-29T13:00:11+00:00"
+            "time": "2022-02-21T17:15:17+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -1470,16 +1470,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "990e6d603da7b9556645e5689c7b082f564790e7"
+                "reference": "c14f32ae4cd2a3c29d8825c5093463ac08ade7d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/990e6d603da7b9556645e5689c7b082f564790e7",
-                "reference": "990e6d603da7b9556645e5689c7b082f564790e7",
+                "url": "https://api.github.com/repos/symfony/config/zipball/c14f32ae4cd2a3c29d8825c5093463ac08ade7d8",
+                "reference": "c14f32ae4cd2a3c29d8825c5093463ac08ade7d8",
                 "shasum": ""
             },
             "require": {
@@ -1528,7 +1528,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.0.2"
+                "source": "https://github.com/symfony/config/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -1544,20 +1544,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-28T14:01:53+00:00"
+            "time": "2022-01-03T09:53:43+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "a9346ef44ea8a7b60f1f1edc8d802ffb91baa6a8"
+                "reference": "481846cbd2441cf3444340ee53486fc24da525bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a9346ef44ea8a7b60f1f1edc8d802ffb91baa6a8",
-                "reference": "a9346ef44ea8a7b60f1f1edc8d802ffb91baa6a8",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/481846cbd2441cf3444340ee53486fc24da525bd",
+                "reference": "481846cbd2441cf3444340ee53486fc24da525bd",
                 "shasum": ""
             },
             "require": {
@@ -1616,7 +1616,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.0.2"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -1632,7 +1632,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-29T10:14:09+00:00"
+            "time": "2022-02-24T10:01:27+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1703,16 +1703,16 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "5c43c5515e549a8c2c426be36d40f47daf196968"
+                "reference": "1c2288fdfd0787288cd04b9868f879f2212159c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/5c43c5515e549a8c2c426be36d40f47daf196968",
-                "reference": "5c43c5515e549a8c2c426be36d40f47daf196968",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/1c2288fdfd0787288cd04b9868f879f2212159c4",
+                "reference": "1c2288fdfd0787288cd04b9868f879f2212159c4",
                 "shasum": ""
             },
             "require": {
@@ -1753,7 +1753,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v6.0.2"
+                "source": "https://github.com/symfony/dotenv/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -1769,20 +1769,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T22:05:41+00:00"
+            "time": "2022-02-21T17:15:17+00:00"
         },
         {
             "name": "symfony/expression-language",
-            "version": "v6.0.1",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/expression-language.git",
-                "reference": "a7da7f58a99007971b0d45d00bc1f6804300d001"
+                "reference": "7adc90f7f09659606996f78de22830b5a2db5be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/expression-language/zipball/a7da7f58a99007971b0d45d00bc1f6804300d001",
-                "reference": "a7da7f58a99007971b0d45d00bc1f6804300d001",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/7adc90f7f09659606996f78de22830b5a2db5be4",
+                "reference": "7adc90f7f09659606996f78de22830b5a2db5be4",
                 "shasum": ""
             },
             "require": {
@@ -1816,7 +1816,7 @@
             "description": "Provides an engine that can compile and evaluate expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/expression-language/tree/v6.0.1"
+                "source": "https://github.com/symfony/expression-language/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -1832,20 +1832,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-08T15:13:44+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.0",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "52b3c9cce673b014915445a432339f282e002ce6"
+                "reference": "6646c13f787057d64701a3a0235cf9567c6ccbbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/52b3c9cce673b014915445a432339f282e002ce6",
-                "reference": "52b3c9cce673b014915445a432339f282e002ce6",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6646c13f787057d64701a3a0235cf9567c6ccbbd",
+                "reference": "6646c13f787057d64701a3a0235cf9567c6ccbbd",
                 "shasum": ""
             },
             "require": {
@@ -1879,7 +1879,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.0"
+                "source": "https://github.com/symfony/filesystem/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -1895,20 +1895,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-29T07:35:21+00:00"
+            "time": "2022-02-28T07:42:30+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "ac1cd9b84bdea9a3a06cd2127e910afc8b276798"
+                "reference": "b460fb15905eef449c4c43a4f0c113eccee103b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/ac1cd9b84bdea9a3a06cd2127e910afc8b276798",
-                "reference": "ac1cd9b84bdea9a3a06cd2127e910afc8b276798",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b460fb15905eef449c4c43a4f0c113eccee103b9",
+                "reference": "b460fb15905eef449c4c43a4f0c113eccee103b9",
                 "shasum": ""
             },
             "require": {
@@ -1951,7 +1951,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.0.2"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -1967,7 +1967,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-28T17:22:37+00:00"
+            "time": "2022-02-21T17:15:17+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2003,12 +2003,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2082,12 +2082,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2163,12 +2163,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2250,12 +2250,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2327,12 +2327,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2403,12 +2403,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2482,12 +2482,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php74\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php74\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2562,12 +2562,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2645,12 +2645,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -2698,16 +2698,16 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "3f237ffd38a54592181ac62f63c6cabbca00051f"
+                "reference": "e23f2c9a4f339c351546b12f29c8b122e2fc2f74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/3f237ffd38a54592181ac62f63c6cabbca00051f",
-                "reference": "3f237ffd38a54592181ac62f63c6cabbca00051f",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/e23f2c9a4f339c351546b12f29c8b122e2fc2f74",
+                "reference": "e23f2c9a4f339c351546b12f29c8b122e2fc2f74",
                 "shasum": ""
             },
             "require": {
@@ -2757,7 +2757,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v6.0.2"
+                "source": "https://github.com/symfony/property-access/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -2773,20 +2773,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-11T16:36:28+00:00"
+            "time": "2022-02-04T19:03:38+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "fc23cfd8fe8faa0712a8909f956cf2e46c72f6cf"
+                "reference": "46e4e6d254f80d103689f2bb103b52a6f5ac2fe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/fc23cfd8fe8faa0712a8909f956cf2e46c72f6cf",
-                "reference": "fc23cfd8fe8faa0712a8909f956cf2e46c72f6cf",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/46e4e6d254f80d103689f2bb103b52a6f5ac2fe2",
+                "reference": "46e4e6d254f80d103689f2bb103b52a6f5ac2fe2",
                 "shasum": ""
             },
             "require": {
@@ -2846,7 +2846,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v6.0.2"
+                "source": "https://github.com/symfony/property-info/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -2862,7 +2862,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-27T21:05:08+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2948,16 +2948,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "bae261d0c3ac38a1f802b4dfed42094296100631"
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/bae261d0c3ac38a1f802b4dfed42094296100631",
-                "reference": "bae261d0c3ac38a1f802b4dfed42094296100631",
+                "url": "https://api.github.com/repos/symfony/string/zipball/522144f0c4c004c80d56fa47e40e17028e2eefc2",
+                "reference": "522144f0c4c004c80d56fa47e40e17028e2eefc2",
                 "shasum": ""
             },
             "require": {
@@ -2978,12 +2978,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -3013,7 +3013,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.2"
+                "source": "https://github.com/symfony/string/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3029,20 +3029,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T22:13:01+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.0.0",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "32cf62f12d35d441da1ca4a4c0fc1cd5f2a207af"
+                "reference": "1261b2d4a23081cb2b59a4caa311a5ac43b845b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/32cf62f12d35d441da1ca4a4c0fc1cd5f2a207af",
-                "reference": "32cf62f12d35d441da1ca4a4c0fc1cd5f2a207af",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/1261b2d4a23081cb2b59a4caa311a5ac43b845b6",
+                "reference": "1261b2d4a23081cb2b59a4caa311a5ac43b845b6",
                 "shasum": ""
             },
             "require": {
@@ -3085,7 +3085,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.0.0"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3101,20 +3101,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-22T10:44:58+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "ed602f38b8636a2ea21af760d2578f3d2f92fc60"
+                "reference": "e77f3ea0b21141d771d4a5655faa54f692b34af5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ed602f38b8636a2ea21af760d2578f3d2f92fc60",
-                "reference": "ed602f38b8636a2ea21af760d2578f3d2f92fc60",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e77f3ea0b21141d771d4a5655faa54f692b34af5",
+                "reference": "e77f3ea0b21141d771d4a5655faa54f692b34af5",
                 "shasum": ""
             },
             "require": {
@@ -3159,7 +3159,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.0.2"
+                "source": "https://github.com/symfony/yaml/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -3175,36 +3175,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T22:13:01+00:00"
+            "time": "2022-01-26T17:23:29+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "composer/pcre",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "symfony/phpunit-bridge": "^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -3232,7 +3232,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.1"
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3248,24 +3248,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-21T20:24:37+00:00"
+            "time": "2022-02-25T20:21:48+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "3.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8"
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/12f1b79476638a5615ed00ea6adbb269cec96fd8",
-                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
                 "shasum": ""
             },
             "require": {
-                "composer/pcre": "^1",
+                "composer/pcre": "^1 || ^2 || ^3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
@@ -3298,7 +3298,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/3.0.1"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
             },
             "funding": [
                 {
@@ -3314,31 +3314,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T18:29:42+00:00"
+            "time": "2022-02-25T21:32:43+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -3359,6 +3359,10 @@
                     "email": "franck.nijhof@dealerdirect.com",
                     "homepage": "http://www.frenck.nl",
                     "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -3370,6 +3374,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -3384,7 +3389,7 @@
                 "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2020-12-07T18:04:37+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -3460,29 +3465,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -3509,7 +3515,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -3525,20 +3531,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c"
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c",
-                "reference": "9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
                 "shasum": ""
             },
             "require": {
@@ -3546,7 +3552,7 @@
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9.0",
-                "phpstan/phpstan": "1.3",
+                "phpstan/phpstan": "^1.3",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
                 "vimeo/psalm": "^4.11"
             },
@@ -3585,7 +3591,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.2"
+                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -3601,20 +3607,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-12T08:27:12+00:00"
+            "time": "2022-02-28T11:07:21+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.5.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "333f15e07c866e33e2765e84ba1e0b88e6a3af3b"
+                "reference": "1975e4453eb2726d1f50da0ce7fa91295029a4fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/333f15e07c866e33e2765e84ba1e0b88e6a3af3b",
-                "reference": "333f15e07c866e33e2765e84ba1e0b88e6a3af3b",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/1975e4453eb2726d1f50da0ce7fa91295029a4fa",
+                "reference": "1975e4453eb2726d1f50da0ce7fa91295029a4fa",
                 "shasum": ""
             },
             "require": {
@@ -3682,7 +3688,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.5.0"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3690,24 +3696,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-14T00:29:20+00:00"
+            "time": "2022-02-07T18:02:40+00:00"
         },
         {
             "name": "johnpbloch/wordpress",
-            "version": "5.9.0",
+            "version": "5.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "6ada7243daf56881a1a09b5fbba60b993e38fa74"
+                "reference": "37734d678aac2d8cae73271583e638eaa82823d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/6ada7243daf56881a1a09b5fbba60b993e38fa74",
-                "reference": "6ada7243daf56881a1a09b5fbba60b993e38fa74",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/37734d678aac2d8cae73271583e638eaa82823d2",
+                "reference": "37734d678aac2d8cae73271583e638eaa82823d2",
                 "shasum": ""
             },
             "require": {
-                "johnpbloch/wordpress-core": "5.9.0",
+                "johnpbloch/wordpress-core": "5.9.1",
                 "johnpbloch/wordpress-core-installer": "^1.0 || ^2.0",
                 "php": ">=5.6.20"
             },
@@ -3736,20 +3742,20 @@
                 "source": "http://core.trac.wordpress.org/browser",
                 "wiki": "http://codex.wordpress.org/"
             },
-            "time": "2022-01-25T20:11:11+00:00"
+            "time": "2022-02-22T15:31:51+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.9.0",
+            "version": "5.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "51241ed9138dd1fb552f6b85fc2025e6135fc03f"
+                "reference": "2c3acb773b91a72ab83ee039532d2c7e0b6f2127"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/51241ed9138dd1fb552f6b85fc2025e6135fc03f",
-                "reference": "51241ed9138dd1fb552f6b85fc2025e6135fc03f",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/2c3acb773b91a72ab83ee039532d2c7e0b6f2127",
+                "reference": "2c3acb773b91a72ab83ee039532d2c7e0b6f2127",
                 "shasum": ""
             },
             "require": {
@@ -3757,7 +3763,7 @@
                 "php": ">=5.6.20"
             },
             "provide": {
-                "wordpress/core-implementation": "5.9.0"
+                "wordpress/core-implementation": "5.9.1"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -3784,7 +3790,7 @@
                 "source": "https://core.trac.wordpress.org/browser",
                 "wiki": "https://codex.wordpress.org/"
             },
-            "time": "2022-01-25T20:28:49+00:00"
+            "time": "2022-02-22T15:31:48+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -3842,37 +3848,38 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3888,7 +3895,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -3896,7 +3903,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "nette/neon",
@@ -4169,16 +4176,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
@@ -4214,9 +4221,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
@@ -4272,16 +4279,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.9.0",
+            "version": "v5.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "0fa8dd9a1bd2a1b60e85afc6c798fca1f599cc1b"
+                "reference": "29d7ca925b7ec49d7ee05932f9e753f130d794aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/0fa8dd9a1bd2a1b60e85afc6c798fca1f599cc1b",
-                "reference": "0fa8dd9a1bd2a1b60e85afc6c798fca1f599cc1b",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/29d7ca925b7ec49d7ee05932f9e753f130d794aa",
+                "reference": "29d7ca925b7ec49d7ee05932f9e753f130d794aa",
                 "shasum": ""
             },
             "replace": {
@@ -4313,9 +4320,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.9.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.9.1"
             },
-            "time": "2022-01-26T00:27:45+00:00"
+            "time": "2022-02-23T08:39:50+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4595,16 +4602,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.4.2",
+            "version": "1.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1dd8f3e40bf7aa30031a75c65cece99220a161b8"
+                "reference": "15087679960d72ae56bfcbf0d728d19941d3f7c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1dd8f3e40bf7aa30031a75c65cece99220a161b8",
-                "reference": "1dd8f3e40bf7aa30031a75c65cece99220a161b8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/15087679960d72ae56bfcbf0d728d19941d3f7c2",
+                "reference": "15087679960d72ae56bfcbf0d728d19941d3f7c2",
                 "shasum": ""
             },
             "require": {
@@ -4635,7 +4642,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.4.2"
+                "source": "https://github.com/phpstan/phpstan/tree/1.4.7"
             },
             "funding": [
                 {
@@ -4655,20 +4662,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-18T16:09:11+00:00"
+            "time": "2022-03-02T16:04:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.10",
+            "version": "9.2.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
+                "reference": "9f4d60b6afe5546421462b76cd4e633ebc364ab4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f4d60b6afe5546421462b76cd4e633ebc364ab4",
+                "reference": "9f4d60b6afe5546421462b76cd4e633ebc364ab4",
                 "shasum": ""
             },
             "require": {
@@ -4724,7 +4731,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.14"
             },
             "funding": [
                 {
@@ -4732,7 +4739,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-05T09:12:13+00:00"
+            "time": "2022-02-28T12:38:02+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4977,16 +4984,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.13",
+            "version": "9.5.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
+                "reference": "5ff8c545a50226c569310a35f4fa89d79f1ddfdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
-                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5ff8c545a50226c569310a35f4fa89d79f1ddfdc",
+                "reference": "5ff8c545a50226c569310a35f4fa89d79f1ddfdc",
                 "shasum": ""
             },
             "require": {
@@ -5002,7 +5009,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -5037,11 +5044,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -5064,7 +5071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.16"
             },
             "funding": [
                 {
@@ -5076,7 +5083,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-24T07:33:35+00:00"
+            "time": "2022-02-23T17:10:58+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -5130,21 +5137,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.12.14",
+            "version": "0.12.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "333852550dba389576cc4dd8e38515b932f5bcf0"
+                "reference": "4f32575b718a4d7032423dc8e9d1e530ad859782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/333852550dba389576cc4dd8e38515b932f5bcf0",
-                "reference": "333852550dba389576cc4dd8e38515b932f5bcf0",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/4f32575b718a4d7032423dc8e9d1e530ad859782",
+                "reference": "4f32575b718a4d7032423dc8e9d1e530ad859782",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1|^8.0",
-                "phpstan/phpstan": "^1.4"
+                "phpstan/phpstan": "^1.4.6"
             },
             "conflict": {
                 "phpstan/phpdoc-parser": "<1.2",
@@ -5178,7 +5185,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.12.14"
+                "source": "https://github.com/rectorphp/rector/tree/0.12.17"
             },
             "funding": [
                 {
@@ -5186,7 +5193,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-25T19:33:08+00:00"
+            "time": "2022-03-03T12:18:11+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5694,16 +5701,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
@@ -5746,7 +5753,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -5754,7 +5761,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -6154,32 +6161,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.18",
+            "version": "7.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc"
+                "reference": "bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37",
+                "reference": "bef66a43815bbf9b5f49775e9ded3f7c6ba0cc37",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.1 || ^8.0",
                 "phpstan/phpdoc-parser": "^1.0.0",
-                "squizlabs/php_codesniffer": "^3.6.1"
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phing/phing": "2.17.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.1",
-                "phpstan/phpstan": "1.2.0",
+                "phing/phing": "2.17.2",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.6",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
                 "phpstan/phpstan-phpunit": "1.0.0",
                 "phpstan/phpstan-strict-rules": "1.1.0",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.10"
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.16"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -6199,7 +6206,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.18"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.19"
             },
             "funding": [
                 {
@@ -6211,7 +6218,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-07T17:19:06+00:00"
+            "time": "2022-03-01T18:01:41+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -6271,16 +6278,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "dd434fa8d69325e5d210f63070014d889511fcb3"
+                "reference": "3bebf4108b9e07492a2a4057d207aa5a77d146b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/dd434fa8d69325e5d210f63070014d889511fcb3",
-                "reference": "dd434fa8d69325e5d210f63070014d889511fcb3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3bebf4108b9e07492a2a4057d207aa5a77d146b1",
+                "reference": "3bebf4108b9e07492a2a4057d207aa5a77d146b1",
                 "shasum": ""
             },
             "require": {
@@ -6346,7 +6353,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.2"
+                "source": "https://github.com/symfony/console/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -6362,20 +6369,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-27T21:05:08+00:00"
+            "time": "2022-02-25T10:48:52+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7093f25359e2750bfe86842c80c4e4a6a852d05c"
+                "reference": "6472ea2dd415e925b90ca82be64b8bc6157f3934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7093f25359e2750bfe86842c80c4e4a6a852d05c",
-                "reference": "7093f25359e2750bfe86842c80c4e4a6a852d05c",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6472ea2dd415e925b90ca82be64b8bc6157f3934",
+                "reference": "6472ea2dd415e925b90ca82be64b8bc6157f3934",
                 "shasum": ""
             },
             "require": {
@@ -6429,7 +6436,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.2"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -6445,7 +6452,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-21T10:43:13+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -6528,16 +6535,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v6.0.2",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "03d2833e677d48317cac852f9c0287fb048c3c5c"
+                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/03d2833e677d48317cac852f9c0287fb048c3c5c",
-                "reference": "03d2833e677d48317cac852f9c0287fb048c3c5c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8661b74dbabc23223f38c9b99d3f8ade71170430",
+                "reference": "8661b74dbabc23223f38c9b99d3f8ade71170430",
                 "shasum": ""
             },
             "require": {
@@ -6569,7 +6576,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.0.2"
+                "source": "https://github.com/symfony/finder/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -6585,20 +6592,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-20T16:21:45+00:00"
+            "time": "2022-01-26T17:23:29+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.0.0",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "be0facf48a42a232d6c0daadd76e4eb5657a4798"
+                "reference": "51f7006670febe4cbcbae177cbffe93ff833250d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/be0facf48a42a232d6c0daadd76e4eb5657a4798",
-                "reference": "be0facf48a42a232d6c0daadd76e4eb5657a4798",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/51f7006670febe4cbcbae177cbffe93ff833250d",
+                "reference": "51f7006670febe4cbcbae177cbffe93ff833250d",
                 "shasum": ""
             },
             "require": {
@@ -6636,7 +6643,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.0.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.0.3"
             },
             "funding": [
                 {
@@ -6652,20 +6659,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T19:05:29+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "71da2b7f3fdba460fcf61a97c8d3d14bbf3391ad"
+                "reference": "1ccceccc6497e96f4f646218f04b97ae7d9fa7a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/71da2b7f3fdba460fcf61a97c8d3d14bbf3391ad",
-                "reference": "71da2b7f3fdba460fcf61a97c8d3d14bbf3391ad",
+                "url": "https://api.github.com/repos/symfony/process/zipball/1ccceccc6497e96f4f646218f04b97ae7d9fa7a1",
+                "reference": "1ccceccc6497e96f4f646218f04b97ae7d9fa7a1",
                 "shasum": ""
             },
             "require": {
@@ -6697,7 +6704,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.0.2"
+                "source": "https://github.com/symfony/process/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -6713,20 +6720,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-27T21:05:08+00:00"
+            "time": "2022-01-30T18:19:12+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v6.0.0",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "0e0ed55d1ffdfadd03af180443fbdca9876483b3"
+                "reference": "f2c1780607ec6502f2121d9729fd8150a655d337"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/0e0ed55d1ffdfadd03af180443fbdca9876483b3",
-                "reference": "0e0ed55d1ffdfadd03af180443fbdca9876483b3",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f2c1780607ec6502f2121d9729fd8150a655d337",
+                "reference": "f2c1780607ec6502f2121d9729fd8150a655d337",
                 "shasum": ""
             },
             "require": {
@@ -6759,7 +6766,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v6.0.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -6775,20 +6782,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T19:05:29+00:00"
+            "time": "2022-02-21T17:15:17+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.0.2",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "41e46f64084a205459a862751158ce2190bd5cb5"
+                "reference": "60d6a756d5f485df5e6e40b337334848f79f61ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/41e46f64084a205459a862751158ce2190bd5cb5",
-                "reference": "41e46f64084a205459a862751158ce2190bd5cb5",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/60d6a756d5f485df5e6e40b337334848f79f61ce",
+                "reference": "60d6a756d5f485df5e6e40b337334848f79f61ce",
                 "shasum": ""
             },
             "require": {
@@ -6847,7 +6854,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.0.2"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -6863,7 +6870,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-29T10:14:09+00:00"
+            "time": "2022-02-21T17:15:17+00:00"
         },
         {
             "name": "symplify/autowire-array-parameter",
@@ -6871,50 +6878,46 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/autowire-array-parameter.git",
-                "reference": "2d3532d8f3ef15a62b4d96fdb259c74c19ca22cb"
+                "reference": "4cc10418ad60c1b400795edb98f9d351b65def77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/2d3532d8f3ef15a62b4d96fdb259c74c19ca22cb",
-                "reference": "2d3532d8f3ef15a62b4d96fdb259c74c19ca22cb",
+                "url": "https://api.github.com/repos/symplify/autowire-array-parameter/zipball/4cc10418ad60c1b400795edb98f9d351b65def77",
+                "reference": "4cc10418ad60c1b400795edb98f9d351b65def77",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
-                "symplify/package-builder": "^10.1"
+                "symplify/package-builder": "^10.2"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/smart-file-system": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.1",
+                "symplify/astral": "<10.1.1",
+                "symplify/coding-standard": "<10.1.1",
+                "symplify/composer-json-manipulator": "<10.1.1",
+                "symplify/config-transformer": "<10.1.1",
+                "symplify/easy-ci": "<10.1.1",
+                "symplify/easy-coding-standard": "<10.1.1",
+                "symplify/easy-parallel": "<10.1.1",
+                "symplify/easy-testing": "<10.1.1",
+                "symplify/git-wrapper": "<10.1.1",
+                "symplify/latte-phpstan-compiler": "<10.1.1",
+                "symplify/monorepo-builder": "<10.1.1",
+                "symplify/neon-config-dumper": "<10.1.1",
+                "symplify/php-config-printer": "<10.1.1",
+                "symplify/phpstan-extensions": "<10.1.1",
+                "symplify/phpstan-latte-rules": "<10.1.1",
+                "symplify/phpstan-rules": "<10.1.1",
+                "symplify/rule-doc-generator": "<10.1.1",
+                "symplify/rule-doc-generator-contracts": "<10.1.1",
+                "symplify/skipper": "<10.1.1",
+                "symplify/smart-file-system": "<10.1.1",
+                "symplify/symfony-static-dumper": "<10.1.1",
+                "symplify/symplify-kernel": "<10.1.1",
+                "symplify/template-phpstan-compiler": "<10.1.1",
+                "symplify/vendor-patches": "<10.1.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -6923,7 +6926,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -6949,7 +6952,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:21:22+00:00"
+            "time": "2022-03-03T17:27:08+00:00"
         },
         {
             "name": "symplify/composer-json-manipulator",
@@ -6957,12 +6960,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/composer-json-manipulator.git",
-                "reference": "2e1ce6c5db49140f6371b79c1343817a35779990"
+                "reference": "ab5c4e6ba7b9bbbc08a2c34011933a7823284edc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/2e1ce6c5db49140f6371b79c1343817a35779990",
-                "reference": "2e1ce6c5db49140f6371b79c1343817a35779990",
+                "url": "https://api.github.com/repos/symplify/composer-json-manipulator/zipball/ab5c4e6ba7b9bbbc08a2c34011933a7823284edc",
+                "reference": "ab5c4e6ba7b9bbbc08a2c34011933a7823284edc",
                 "shasum": ""
             },
             "require": {
@@ -6971,39 +6974,35 @@
                 "symfony/config": "^5.4|^6.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
                 "symfony/filesystem": "^5.4|^6.0",
-                "symplify/package-builder": "^10.1",
-                "symplify/smart-file-system": "^10.1",
-                "symplify/symplify-kernel": "^10.1"
+                "symplify/package-builder": "^10.2",
+                "symplify/smart-file-system": "^10.2",
+                "symplify/symplify-kernel": "^10.2"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
+                "symplify/amnesia": "<10.1.1",
+                "symplify/astral": "<10.1.1",
+                "symplify/autowire-array-parameter": "<10.1.1",
+                "symplify/coding-standard": "<10.1.1",
+                "symplify/config-transformer": "<10.1.1",
+                "symplify/easy-ci": "<10.1.1",
+                "symplify/easy-coding-standard": "<10.1.1",
+                "symplify/easy-parallel": "<10.1.1",
+                "symplify/easy-testing": "<10.1.1",
+                "symplify/git-wrapper": "<10.1.1",
+                "symplify/latte-phpstan-compiler": "<10.1.1",
+                "symplify/monorepo-builder": "<10.1.1",
+                "symplify/neon-config-dumper": "<10.1.1",
+                "symplify/php-config-printer": "<10.1.1",
+                "symplify/phpstan-extensions": "<10.1.1",
+                "symplify/phpstan-latte-rules": "<10.1.1",
+                "symplify/phpstan-rules": "<10.1.1",
+                "symplify/rule-doc-generator": "<10.1.1",
+                "symplify/rule-doc-generator-contracts": "<10.1.1",
+                "symplify/skipper": "<10.1.1",
+                "symplify/symfony-static-dumper": "<10.1.1",
                 "symplify/symplify-kernel": "<9.4.70",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/template-phpstan-compiler": "<10.1.1",
+                "symplify/vendor-patches": "<10.1.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -7012,7 +7011,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -7038,95 +7037,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:21:24+00:00"
-        },
-        {
-            "name": "symplify/console-color-diff",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symplify/console-color-diff.git",
-                "reference": "bb73e4765d3f87856abd59532ced81bf1b092ed6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symplify/console-color-diff/zipball/bb73e4765d3f87856abd59532ced81bf1b092ed6",
-                "reference": "bb73e4765d3f87856abd59532ced81bf1b092ed6",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^3.2",
-                "php": ">=8.0",
-                "sebastian/diff": "^4.0",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symplify/package-builder": "^10.1"
-            },
-            "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/smart-file-system": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5"
-            },
-            "default-branch": true,
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "10.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symplify\\ConsoleColorDiff\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Package to print diffs in console with colors",
-            "support": {
-                "source": "https://github.com/symplify/console-color-diff/tree/main"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.me/rectorphp",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/tomasvotruba",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-01-26T01:21:34+00:00"
+            "time": "2022-03-03T17:27:20+00:00"
         },
         {
             "name": "symplify/easy-testing",
@@ -7134,12 +7045,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/easy-testing.git",
-                "reference": "1b24c624b7493c8e152e5f94f5c289a96670c568"
+                "reference": "f8df13a197eeb58457ba2974caef328c0fbbdf1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/1b24c624b7493c8e152e5f94f5c289a96670c568",
-                "reference": "1b24c624b7493c8e152e5f94f5c289a96670c568",
+                "url": "https://api.github.com/repos/symplify/easy-testing/zipball/f8df13a197eeb58457ba2974caef328c0fbbdf1b",
+                "reference": "f8df13a197eeb58457ba2974caef328c0fbbdf1b",
                 "shasum": ""
             },
             "require": {
@@ -7148,38 +7059,34 @@
                 "symfony/console": "^5.4|^6.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
                 "symfony/finder": "^5.4|^6.0",
-                "symplify/package-builder": "^10.1",
-                "symplify/smart-file-system": "^10.1",
-                "symplify/symplify-kernel": "^10.1"
+                "symplify/package-builder": "^10.2",
+                "symplify/smart-file-system": "^10.2",
+                "symplify/symplify-kernel": "^10.2"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.1",
+                "symplify/astral": "<10.1.1",
+                "symplify/autowire-array-parameter": "<10.1.1",
+                "symplify/coding-standard": "<10.1.1",
+                "symplify/composer-json-manipulator": "<10.1.1",
+                "symplify/config-transformer": "<10.1.1",
+                "symplify/easy-ci": "<10.1.1",
+                "symplify/easy-coding-standard": "<10.1.1",
+                "symplify/easy-parallel": "<10.1.1",
+                "symplify/git-wrapper": "<10.1.1",
+                "symplify/latte-phpstan-compiler": "<10.1.1",
+                "symplify/monorepo-builder": "<10.1.1",
+                "symplify/neon-config-dumper": "<10.1.1",
+                "symplify/php-config-printer": "<10.1.1",
+                "symplify/phpstan-extensions": "<10.1.1",
+                "symplify/phpstan-latte-rules": "<10.1.1",
+                "symplify/phpstan-rules": "<10.1.1",
+                "symplify/rule-doc-generator": "<10.1.1",
+                "symplify/rule-doc-generator-contracts": "<10.1.1",
+                "symplify/skipper": "<10.1.1",
+                "symplify/symfony-static-dumper": "<10.1.1",
+                "symplify/template-phpstan-compiler": "<10.1.1",
+                "symplify/vendor-patches": "<10.1.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -7191,7 +7098,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -7217,20 +7124,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:21:41+00:00"
+            "time": "2022-03-03T17:27:24+00:00"
         },
         {
             "name": "symplify/monorepo-builder",
-            "version": "10.0.19",
+            "version": "10.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/leoloso/monorepo-builder.git",
-                "reference": "1d89c0e9beb5f10f904548cc16a82c253e36c224"
+                "reference": "26c8c666ca98701f6eb497dae0af652f92fdf3c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/leoloso/monorepo-builder/zipball/1d89c0e9beb5f10f904548cc16a82c253e36c224",
-                "reference": "1d89c0e9beb5f10f904548cc16a82c253e36c224",
+                "url": "https://api.github.com/repos/leoloso/monorepo-builder/zipball/26c8c666ca98701f6eb497dae0af652f92fdf3c1",
+                "reference": "26c8c666ca98701f6eb497dae0af652f92fdf3c1",
                 "shasum": ""
             },
             "require": {
@@ -7241,38 +7148,34 @@
                 "symfony/dependency-injection": "^5.4|^6.0",
                 "symfony/finder": "^5.4|^6.0",
                 "symfony/process": "^5.4|^6.0",
-                "symplify/composer-json-manipulator": "^10.1",
-                "symplify/console-color-diff": "^10.1",
-                "symplify/package-builder": "^10.1",
-                "symplify/smart-file-system": "^10.1",
-                "symplify/symplify-kernel": "^10.1"
+                "symplify/composer-json-manipulator": "^10.2",
+                "symplify/package-builder": "^10.2",
+                "symplify/smart-file-system": "^10.2",
+                "symplify/symplify-kernel": "^10.2"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.1",
+                "symplify/astral": "<10.1.1",
+                "symplify/autowire-array-parameter": "<10.1.1",
+                "symplify/coding-standard": "<10.1.1",
+                "symplify/config-transformer": "<10.1.1",
+                "symplify/easy-ci": "<10.1.1",
+                "symplify/easy-coding-standard": "<10.1.1",
+                "symplify/easy-parallel": "<10.1.1",
+                "symplify/easy-testing": "<10.1.1",
+                "symplify/git-wrapper": "<10.1.1",
+                "symplify/latte-phpstan-compiler": "<10.1.1",
+                "symplify/neon-config-dumper": "<10.1.1",
+                "symplify/php-config-printer": "<10.1.1",
+                "symplify/phpstan-extensions": "<10.1.1",
+                "symplify/phpstan-latte-rules": "<10.1.1",
+                "symplify/phpstan-rules": "<10.1.1",
+                "symplify/rule-doc-generator": "<10.1.1",
+                "symplify/rule-doc-generator-contracts": "<10.1.1",
+                "symplify/skipper": "<10.1.1",
+                "symplify/symfony-static-dumper": "<10.1.1",
+                "symplify/template-phpstan-compiler": "<10.1.1",
+                "symplify/vendor-patches": "<10.1.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -7283,7 +7186,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -7307,7 +7210,7 @@
             ],
             "description": "Not only Composer tools to build a Monorepo.",
             "support": {
-                "source": "https://github.com/leoloso/monorepo-builder/tree/10.0.19"
+                "source": "https://github.com/leoloso/monorepo-builder/tree/10.1.1"
             },
             "funding": [
                 {
@@ -7319,7 +7222,7 @@
                     "url": "https://www.paypal.me/rectorphp"
                 }
             ],
-            "time": "2022-01-26T06:46:10+00:00"
+            "time": "2022-03-04T06:32:27+00:00"
         },
         {
             "name": "symplify/package-builder",
@@ -7327,54 +7230,51 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/package-builder.git",
-                "reference": "11099b5a7cb0cb542102b31f537867d13a4c34d5"
+                "reference": "75994025d4c9673872adefc6b762491201f45686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/package-builder/zipball/11099b5a7cb0cb542102b31f537867d13a4c34d5",
-                "reference": "11099b5a7cb0cb542102b31f537867d13a4c34d5",
+                "url": "https://api.github.com/repos/symplify/package-builder/zipball/75994025d4c9673872adefc6b762491201f45686",
+                "reference": "75994025d4c9673872adefc6b762491201f45686",
                 "shasum": ""
             },
             "require": {
                 "nette/neon": "^3.3.2",
                 "nette/utils": "^3.2",
                 "php": ">=8.0",
+                "sebastian/diff": "^4.0",
                 "symfony/config": "^5.4|^6.0",
                 "symfony/console": "^5.4|^6.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
                 "symfony/finder": "^5.4|^6.0",
-                "symplify/easy-testing": "^10.1",
-                "symplify/symplify-kernel": "^10.1"
+                "symplify/easy-testing": "^10.2",
+                "symplify/symplify-kernel": "^10.2"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/smart-file-system": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.1",
+                "symplify/astral": "<10.1.1",
+                "symplify/autowire-array-parameter": "<10.1.1",
+                "symplify/coding-standard": "<10.1.1",
+                "symplify/composer-json-manipulator": "<10.1.1",
+                "symplify/config-transformer": "<10.1.1",
+                "symplify/easy-ci": "<10.1.1",
+                "symplify/easy-coding-standard": "<10.1.1",
+                "symplify/easy-parallel": "<10.1.1",
+                "symplify/git-wrapper": "<10.1.1",
+                "symplify/latte-phpstan-compiler": "<10.1.1",
+                "symplify/monorepo-builder": "<10.1.1",
+                "symplify/neon-config-dumper": "<10.1.1",
+                "symplify/php-config-printer": "<10.1.1",
+                "symplify/phpstan-extensions": "<10.1.1",
+                "symplify/phpstan-latte-rules": "<10.1.1",
+                "symplify/phpstan-rules": "<10.1.1",
+                "symplify/rule-doc-generator": "<10.1.1",
+                "symplify/rule-doc-generator-contracts": "<10.1.1",
+                "symplify/skipper": "<10.1.1",
+                "symplify/smart-file-system": "<10.1.1",
+                "symplify/symfony-static-dumper": "<10.1.1",
+                "symplify/template-phpstan-compiler": "<10.1.1",
+                "symplify/vendor-patches": "<10.1.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -7383,7 +7283,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -7409,7 +7309,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:21:56+00:00"
+            "time": "2022-03-03T17:26:25+00:00"
         },
         {
             "name": "symplify/smart-file-system",
@@ -7417,12 +7317,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/smart-file-system.git",
-                "reference": "ddf5369d240f7da11f570815308326fce2ecf6d3"
+                "reference": "81c8efe633e0026868c143b76b7db73a8b0e5dfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/ddf5369d240f7da11f570815308326fce2ecf6d3",
-                "reference": "ddf5369d240f7da11f570815308326fce2ecf6d3",
+                "url": "https://api.github.com/repos/symplify/smart-file-system/zipball/81c8efe633e0026868c143b76b7db73a8b0e5dfd",
+                "reference": "81c8efe633e0026868c143b76b7db73a8b0e5dfd",
                 "shasum": ""
             },
             "require": {
@@ -7432,36 +7332,32 @@
                 "symfony/finder": "^5.4|^6.0"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/autowire-array-parameter": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/composer-json-manipulator": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/package-builder": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/symplify-kernel": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.1",
+                "symplify/astral": "<10.1.1",
+                "symplify/autowire-array-parameter": "<10.1.1",
+                "symplify/coding-standard": "<10.1.1",
+                "symplify/composer-json-manipulator": "<10.1.1",
+                "symplify/config-transformer": "<10.1.1",
+                "symplify/easy-ci": "<10.1.1",
+                "symplify/easy-coding-standard": "<10.1.1",
+                "symplify/easy-parallel": "<10.1.1",
+                "symplify/easy-testing": "<10.1.1",
+                "symplify/git-wrapper": "<10.1.1",
+                "symplify/latte-phpstan-compiler": "<10.1.1",
+                "symplify/monorepo-builder": "<10.1.1",
+                "symplify/neon-config-dumper": "<10.1.1",
+                "symplify/package-builder": "<10.1.1",
+                "symplify/php-config-printer": "<10.1.1",
+                "symplify/phpstan-extensions": "<10.1.1",
+                "symplify/phpstan-latte-rules": "<10.1.1",
+                "symplify/phpstan-rules": "<10.1.1",
+                "symplify/rule-doc-generator": "<10.1.1",
+                "symplify/rule-doc-generator-contracts": "<10.1.1",
+                "symplify/skipper": "<10.1.1",
+                "symplify/symfony-static-dumper": "<10.1.1",
+                "symplify/symplify-kernel": "<10.1.1",
+                "symplify/template-phpstan-compiler": "<10.1.1",
+                "symplify/vendor-patches": "<10.1.1"
             },
             "require-dev": {
                 "nette/finder": "^2.5",
@@ -7471,7 +7367,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -7485,7 +7381,7 @@
             ],
             "description": "Sanitized FileInfo with safe getRealPath() and other handy methods",
             "support": {
-                "source": "https://github.com/symplify/smart-file-system/tree/10.0.19"
+                "source": "https://github.com/symplify/smart-file-system/tree/10.1.1"
             },
             "funding": [
                 {
@@ -7497,7 +7393,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-26T01:19:23+00:00"
+            "time": "2022-03-03T17:22:38+00:00"
         },
         {
             "name": "symplify/symplify-kernel",
@@ -7505,51 +7401,47 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symplify/symplify-kernel.git",
-                "reference": "c5617696372c13c600f9cb7951751b845c22189d"
+                "reference": "7f22537b4bacc4fe16f79100e569ac2ea219e3bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/c5617696372c13c600f9cb7951751b845c22189d",
-                "reference": "c5617696372c13c600f9cb7951751b845c22189d",
+                "url": "https://api.github.com/repos/symplify/symplify-kernel/zipball/7f22537b4bacc4fe16f79100e569ac2ea219e3bd",
+                "reference": "7f22537b4bacc4fe16f79100e569ac2ea219e3bd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "symfony/console": "^5.4|^6.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
-                "symplify/autowire-array-parameter": "^10.1",
-                "symplify/composer-json-manipulator": "^10.1",
-                "symplify/package-builder": "^10.1",
-                "symplify/smart-file-system": "^10.1",
+                "symplify/autowire-array-parameter": "^10.2",
+                "symplify/composer-json-manipulator": "^10.2",
+                "symplify/package-builder": "^10.2",
+                "symplify/smart-file-system": "^10.2",
                 "webmozart/assert": "^1.10"
             },
             "conflict": {
-                "symplify/amnesia": "<10.0.19",
-                "symplify/astral": "<10.0.19",
-                "symplify/coding-standard": "<10.0.19",
-                "symplify/config-transformer": "<10.0.19",
-                "symplify/console-color-diff": "<10.0.19",
-                "symplify/easy-ci": "<10.0.19",
-                "symplify/easy-coding-standard": "<10.0.19",
-                "symplify/easy-parallel": "<10.0.19",
-                "symplify/easy-testing": "<10.0.19",
-                "symplify/git-wrapper": "<10.0.19",
-                "symplify/latte-phpstan-compiler": "<10.0.19",
-                "symplify/markdown-diff": "<10.0.19",
-                "symplify/monorepo-builder": "<10.0.19",
-                "symplify/neon-config-dumper": "<10.0.19",
-                "symplify/php-config-printer": "<10.0.19",
-                "symplify/phpstan-extensions": "<10.0.19",
-                "symplify/phpstan-latte-rules": "<10.0.19",
-                "symplify/phpstan-rules": "<10.0.19",
-                "symplify/rule-doc-generator": "<10.0.19",
-                "symplify/rule-doc-generator-contracts": "<10.0.19",
-                "symplify/simple-php-doc-parser": "<10.0.19",
-                "symplify/skipper": "<10.0.19",
-                "symplify/symfony-php-config": "<10.0.19",
-                "symplify/symfony-static-dumper": "<10.0.19",
-                "symplify/template-phpstan-compiler": "<10.0.19",
-                "symplify/vendor-patches": "<10.0.19"
+                "symplify/amnesia": "<10.1.1",
+                "symplify/astral": "<10.1.1",
+                "symplify/coding-standard": "<10.1.1",
+                "symplify/config-transformer": "<10.1.1",
+                "symplify/easy-ci": "<10.1.1",
+                "symplify/easy-coding-standard": "<10.1.1",
+                "symplify/easy-parallel": "<10.1.1",
+                "symplify/easy-testing": "<10.1.1",
+                "symplify/git-wrapper": "<10.1.1",
+                "symplify/latte-phpstan-compiler": "<10.1.1",
+                "symplify/monorepo-builder": "<10.1.1",
+                "symplify/neon-config-dumper": "<10.1.1",
+                "symplify/php-config-printer": "<10.1.1",
+                "symplify/phpstan-extensions": "<10.1.1",
+                "symplify/phpstan-latte-rules": "<10.1.1",
+                "symplify/phpstan-rules": "<10.1.1",
+                "symplify/rule-doc-generator": "<10.1.1",
+                "symplify/rule-doc-generator-contracts": "<10.1.1",
+                "symplify/skipper": "<10.1.1",
+                "symplify/symfony-static-dumper": "<10.1.1",
+                "symplify/template-phpstan-compiler": "<10.1.1",
+                "symplify/vendor-patches": "<10.1.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -7558,7 +7450,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -7574,7 +7466,7 @@
             "support": {
                 "source": "https://github.com/symplify/symplify-kernel/tree/main"
             },
-            "time": "2022-01-26T01:22:34+00:00"
+            "time": "2022-03-03T17:27:53+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpstan.neon.dist
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/phpstan.neon.dist
@@ -28,6 +28,10 @@ parameters:
         -
             message: '#^Access to property \$post on an unknown class WP_Block_Editor_Context\.$#'
             path: src/Services/CustomPostTypes/AbstractCustomPostType.php
+        # PHPStan bug!?
+        -
+            message: '#^Anonymous function should return (.*) but returns non-empty-string\.$#'
+            path: src/ContentProcessors/AbstractContentParser.php
     # bootstrapFiles:
     #     - graphql-api.php
     level: 8

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/SkipDowngradeTestPathsDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/SkipDowngradeTestPathsDataSource.php
@@ -37,16 +37,21 @@ class SkipDowngradeTestPathsDataSource
     protected function getSkipDowngradeTestVendorPaths(): array
     {
         return [
-            'vendor/symfony/polyfill-ctype/bootstrap80.php',
-            'vendor/symfony/polyfill-intl-grapheme/bootstrap80.php',
-            'vendor/symfony/polyfill-intl-idn/bootstrap80.php',
-            'vendor/symfony/polyfill-intl-normalizer/bootstrap80.php',
-            'vendor/symfony/polyfill-mbstring/bootstrap80.php',
+            'vendor/michelf/php-markdown/test/',
+            'vendor/nikic/fast-route/test/',
+            'vendor/psr/log/Psr/Log/Test/',
             'vendor/symfony/cache/DataCollector/CacheDataCollector.php',
             'vendor/symfony/cache/DoctrineProvider.php',
             'vendor/symfony/cache/Messenger/EarlyExpirationHandler.php',
             'vendor/symfony/dotenv/Command/DebugCommand.php',
             'vendor/symfony/dotenv/Command/DotenvDumpCommand.php',
+            'vendor/symfony/http-foundation/Test/',
+            'vendor/symfony/polyfill-ctype/bootstrap80.php',
+            'vendor/symfony/polyfill-intl-grapheme/bootstrap80.php',
+            'vendor/symfony/polyfill-intl-idn/bootstrap80.php',
+            'vendor/symfony/polyfill-intl-normalizer/bootstrap80.php',
+            'vendor/symfony/polyfill-mbstring/bootstrap80.php',
+            'vendor/symfony/service-contracts/Test/',
             'vendor/symfony/string/Slugger/AsciiSlugger.php',
         ];
     }


### PR DESCRIPTION
Updated all dependencies, and removed the patchers for PHP-Scoper to undo the namespacing of `parent` and `self`, which was fixed on v0.17: https://github.com/humbug/php-scoper/issues/542