### PR TITLE
Make applyFunction work with GraphQL query

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4602,16 +4602,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.4.7",
+            "version": "1.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "15087679960d72ae56bfcbf0d728d19941d3f7c2"
+                "reference": "898c479c39caa727bedf4311dd294a8f4e250e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/15087679960d72ae56bfcbf0d728d19941d3f7c2",
-                "reference": "15087679960d72ae56bfcbf0d728d19941d3f7c2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/898c479c39caa727bedf4311dd294a8f4e250e72",
+                "reference": "898c479c39caa727bedf4311dd294a8f4e250e72",
                 "shasum": ""
             },
             "require": {
@@ -4625,11 +4625,6 @@
                 "phpstan.phar"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "bootstrap.php"
@@ -4642,7 +4637,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.4.7"
+                "source": "https://github.com/phpstan/phpstan/tree/1.4.10"
             },
             "funding": [
                 {
@@ -4662,7 +4657,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-02T16:04:01+00:00"
+            "time": "2022-03-14T10:25:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
+++ b/layers/API/packages/api/src/Schema/FieldQueryConvertor.php
@@ -1021,20 +1021,6 @@ class FieldQueryConvertor implements FieldQueryConvertorInterface
             );
         }
 
-        // --------------------------------------------------------
-        // Validate correctness of order of elements: ...(...)[...]<...>
-        // (0. field name, 1. field args, 2. bookmarks, 3. skip output if null?, 4. field directives)
-        // --------------------------------------------------------
-        if ($fieldArgsOpeningSymbolPos !== false) {
-            if ($fieldArgsOpeningSymbolPos == 0) {
-                return sprintf(
-                    $this->__('Name is missing in property \'%s\'. %s', 'api'),
-                    $property,
-                    $errorMessageEnd
-                );
-            }
-        }
-
         // After the ")", it must be either the end, "@", "[", "?" or "<"
         $aliasSymbolPos = QueryHelpers::findFieldAliasSymbolPosition($property);
         $skipOutputIfNullSymbolPos = QueryHelpers::findSkipOutputIfNullSymbolPosition($property);

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -472,7 +472,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     {
         return array_merge(
             $this->getExpressionsForObject($id, $variables, $messages),
-            $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string) $id][$fieldOutputKey] ?? []
+            $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string)$id][$fieldOutputKey] ?? []
         );
     }
 
@@ -484,12 +484,17 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     protected function addExpressionForObjectAndField(int | string $id, string $fieldOutputKey, string $key, mixed $value, array &$messages): void
     {
         $this->addExpressionForObject($id, $key, $value, $messages);
-        $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string) $id][$fieldOutputKey][$key] = $value;
+        $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string)$id][$fieldOutputKey][$key] = $value;
     }
 
     protected function getExpressionForObject(int | string $id, string $key, array &$messages): mixed
     {
         return $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT][(string)$id][$key] ?? null;
+    }
+
+    protected function getExpressionForObjectAndField(int | string $id, string $fieldOutputKey, string $key, array &$messages): mixed
+    {
+        return $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string)$id][$fieldOutputKey][$key] ?? $this->getExpressionForObject($id, $key, $messages);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -194,7 +194,9 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         );
 
         // Store the args, they may be used in `resolveDirective`
-        $this->directiveArgsForSchema = $directiveArgs;
+        if ($directiveArgs !== null) {
+            $this->directiveArgsForSchema = $directiveArgs;
+        }
 
         return [
             $validDirective,

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -481,7 +481,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      * They can communicate passing data across,
      * because with `getExpressionsForObjectAndField`
      * they operate on the same expressions set by both ID and field:
-     * 
+     *
      * ```graphql
      *   userPostData: getSelfProp(self: "%{self}%", property: "userData")
      *     @forEach(affectDirectivesUnderPos: [1, 2])

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -468,6 +468,48 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     }
 
     /**
+     * This function is needed to use in combination with @forEach
+     * and inner nested directives. @forEach works by
+     * setting all entries in the array under distinct fields
+     * (["userPostData.0", "userPostData.1", "userPostData.2", etc]).
+     *
+     * Then, directives can target the value of an expression
+     * to their nested directives, without fear of that value being overriden.
+     *
+     * Eg: in this query, the 1st @applyFunction is exporting the value
+     * of `userLang` as an expression, to be read by the 2nd @applyFunction.
+     * They can communicate passing data across,
+     * because with `getExpressionsForObjectAndField`
+     * they operate on the same expressions set by both ID and field:
+     * 
+     * ```graphql
+     *   userPostData: getSelfProp(self: "%{self}%", property: "userData")
+     *     @forEach(affectDirectivesUnderPos: [1, 2])
+     *       @applyFunction(
+     *         name: "extract",
+     *         arguments: {
+     *           object: "%{value}%",
+     *           path: "lang",
+     *         },
+     *         target: "userLang",
+     *         targetType: EXPRESSION
+     *       )
+     *       @applyFunction(
+     *         name: "sprintf",
+     *         arguments: {
+     *           string: "postContent-%s",
+     *           values: ["%{userLang}%"]
+     *         },
+     *         target: "userPostContentKey",
+     *         targetType: EXPRESSION
+     *       )
+     * ```
+     *
+     * If using `getExpressionsForObject` instead, each element in the array
+     * traversed by @forEach would override the value of `userLang`, and so
+     * only the value of the last item in the array will be made available as
+     * `userLang` to ALL entries in the next @applyFunction.
+     *
      * @return mixed[]
      */
     protected function getExpressionsForObjectAndField(int | string $id, string $fieldOutputKey, array $variables, array $messages): array

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -47,8 +47,8 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     use BasicServiceTrait;
     use CheckDangerouslyDynamicScalarFieldOrDirectiveResolverTrait;
 
-    public const MESSAGE_EXPRESSIONS = 'expressions';
-    public const EXPRESSION_ID_FIELD_SEPARATOR = '|';
+    private const MESSAGE_EXPRESSIONS_FOR_OBJECT = 'expressionsForObject';
+    private const MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD = 'expressionsForObjectAndField';
 
     protected string $directive;
     /** @var array<string, array<string, InputTypeResolverInterface>> */
@@ -461,7 +461,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         // Otherwise it can't, since the fieldResolver doesn't have access to either $dbItems
         return array_merge(
             $variables,
-            $messages[self::MESSAGE_EXPRESSIONS][(string)$id] ?? []
+            $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT][(string)$id] ?? []
         );
     }
 
@@ -472,24 +472,24 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     {
         return array_merge(
             $this->getExpressionsForObject($id, $variables, $messages),
-            $messages[self::MESSAGE_EXPRESSIONS][((string)$id) . self::EXPRESSION_ID_FIELD_SEPARATOR . $fieldOutputKey] ?? []
+            $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string) $id][$fieldOutputKey] ?? []
         );
     }
 
     protected function addExpressionForObject(int | string $id, string $key, mixed $value, array &$messages): void
     {
-        $messages[self::MESSAGE_EXPRESSIONS][(string)$id][$key] = $value;
+        $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT][(string)$id][$key] = $value;
     }
 
     protected function addExpressionForObjectAndField(int | string $id, string $fieldOutputKey, string $key, mixed $value, array &$messages): void
     {
         $this->addExpressionForObject($id, $key, $value, $messages);
-        $messages[self::MESSAGE_EXPRESSIONS][((string)$id) . self::EXPRESSION_ID_FIELD_SEPARATOR . $fieldOutputKey][$key] = $value;
+        $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string) $id][$fieldOutputKey][$key] = $value;
     }
 
     protected function getExpressionForObject(int | string $id, string $key, array &$messages): mixed
     {
-        return $messages[self::MESSAGE_EXPRESSIONS][(string)$id][$key] ?? null;
+        return $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT][(string)$id][$key] ?? null;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -454,7 +454,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     /**
      * @return mixed[]
      */
-    protected function getExpressionsForObject(int | string $id, array &$variables, array &$messages): array
+    protected function getExpressionsForObject(int | string $id, array $variables, array $messages): array
     {
         // Create a custom $variables containing all the properties from $dbItems for this object
         // This way, when encountering $propName in a fieldArg in a fieldResolver, it can resolve that value
@@ -468,7 +468,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     /**
      * @return mixed[]
      */
-    protected function getExpressionsForObjectAndField(int | string $id, string $fieldOutputKey, array &$variables, array &$messages): array
+    protected function getExpressionsForObjectAndField(int | string $id, string $fieldOutputKey, array $variables, array $messages): array
     {
         return array_merge(
             $this->getExpressionsForObject($id, $variables, $messages),
@@ -487,12 +487,12 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string)$id][$fieldOutputKey][$key] = $value;
     }
 
-    protected function getExpressionForObject(int | string $id, string $key, array &$messages): mixed
+    protected function getExpressionForObject(int | string $id, string $key, array $messages): mixed
     {
         return $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT][(string)$id][$key] ?? null;
     }
 
-    protected function getExpressionForObjectAndField(int | string $id, string $fieldOutputKey, string $key, array &$messages): mixed
+    protected function getExpressionForObjectAndField(int | string $id, string $fieldOutputKey, string $key, array $messages): mixed
     {
         return $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][(string)$id][$fieldOutputKey][$key] ?? $this->getExpressionForObject($id, $key, $messages);
     }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -47,7 +47,8 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     use BasicServiceTrait;
     use CheckDangerouslyDynamicScalarFieldOrDirectiveResolverTrait;
 
-    const MESSAGE_EXPRESSIONS = 'expressions';
+    public const MESSAGE_EXPRESSIONS = 'expressions';
+    public const EXPRESSION_ID_FIELD_SEPARATOR = '|';
 
     protected string $directive;
     /** @var array<string, array<string, InputTypeResolverInterface>> */
@@ -464,9 +465,26 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         );
     }
 
+    /**
+     * @return mixed[]
+     */
+    protected function getExpressionsForObjectAndField(int | string $id, string $fieldOutputKey, array &$variables, array &$messages): array
+    {
+        return array_merge(
+            $this->getExpressionsForObject($id, $variables, $messages),
+            $messages[self::MESSAGE_EXPRESSIONS][((string)$id) . self::EXPRESSION_ID_FIELD_SEPARATOR . $fieldOutputKey] ?? []
+        );
+    }
+
     protected function addExpressionForObject(int | string $id, string $key, mixed $value, array &$messages): void
     {
         $messages[self::MESSAGE_EXPRESSIONS][(string)$id][$key] = $value;
+    }
+
+    protected function addExpressionForObjectAndField(int | string $id, string $fieldOutputKey, string $key, mixed $value, array &$messages): void
+    {
+        $this->addExpressionForObject($id, $key, $value, $messages);
+        $messages[self::MESSAGE_EXPRESSIONS][((string)$id) . self::EXPRESSION_ID_FIELD_SEPARATOR . $fieldOutputKey][$key] = $value;
     }
 
     protected function getExpressionForObject(int | string $id, string $key, array &$messages): mixed

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -208,6 +208,7 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
             $relationalTypeResolver,
             $field,
             $id,
+            $this->directive
         );
 
         // 3. Add the output in the DB

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesInDBItemsDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesInDBItemsDirectiveResolver.php
@@ -84,7 +84,8 @@ final class SerializeLeafOutputTypeValuesInDBItemsDirectiveResolver extends Abst
                     $separateObjectTypeFieldResolutionFeedbackStore,
                     $targetObjectTypeResolver,
                     $field,
-                    $id
+                    $id,
+                    $this->directive
                 );
                 if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
                     continue;
@@ -110,7 +111,8 @@ final class SerializeLeafOutputTypeValuesInDBItemsDirectiveResolver extends Abst
                     $separateObjectTypeFieldResolutionFeedbackStore,
                     $targetObjectTypeResolver,
                     $field,
-                    $id
+                    $id,
+                    $this->directive
                 );
                 if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
                     continue;

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -755,7 +755,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         $separateObjectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
         $fieldArgs = $this->extractFieldOrDirectiveArgumentsForObject($objectTypeResolver, $object, $fieldArgs, $fieldOutputKey, $variables, $expressions, $separateObjectTypeFieldResolutionFeedbackStore);
         // Cast the values to their appropriate type. If casting fails, the value returns as null
-        $fieldArgs = $this->castAndValidateFieldArgumentsForObject($objectTypeResolver, $field, $fieldArgs, $objectTypeFieldResolutionFeedbackStore);
+        $fieldArgs = $this->castAndValidateFieldArgumentsForObject($objectTypeResolver, $field, $fieldArgs, $separateObjectTypeFieldResolutionFeedbackStore);
         $objectTypeFieldResolutionFeedbackStore->incorporate($separateObjectTypeFieldResolutionFeedbackStore);
         if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
             $validAndResolvedField = null;

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1524,25 +1524,12 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         if ($this->isFieldArgumentValueAnExpression($fieldArgValue)) {
             // Expressions: allow to pass a field argument "key:%input%", which is passed when executing the directive through $expressions
             // Trim it so that "%{ self }%" is equivalent to "%{self}%". This is needed to set expressions through Symfony's DependencyInjection component (since %...% is reserved for its own parameters!)
-            $expressionName = trim(substr($fieldArgValue, strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING), strlen($fieldArgValue) - strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING) - strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)));
-            if (!isset($expressions[$expressionName])) {
-                // If the expression is not set, then show the error under entry "expressionErrors"
-                $objectTypeFieldResolutionFeedbackStore->addError(
-                    new ObjectTypeFieldResolutionFeedback(
-                        new FeedbackItemResolution(
-                            ErrorFeedbackItemProvider::class,
-                            ErrorFeedbackItemProvider::E14,
-                            [
-                                $expressionName,
-                            ]
-                        ),
-                        LocationHelper::getNonSpecificLocation(),
-                        $relationalTypeResolver,
-                    )
-                );
-                return null;
-            }
-            return $expressions[$expressionName];
+            return $this->resolveExpression(
+                $relationalTypeResolver,
+                $fieldArgValue,
+                $expressions,
+                $objectTypeFieldResolutionFeedbackStore,
+            );
         }
         if ($this->isFieldArgumentValueAField($fieldArgValue)) {
             // Execute as field
@@ -1566,6 +1553,35 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         }
 
         return $fieldArgValue;
+    }
+
+    public function resolveExpression(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        mixed $fieldArgValue,
+        ?array $expressions,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        // Expressions: allow to pass a field argument "key:%input%", which is passed when executing the directive through $expressions
+        // Trim it so that "%{ self }%" is equivalent to "%{self}%". This is needed to set expressions through Symfony's DependencyInjection component (since %...% is reserved for its own parameters!)
+        $expressionName = trim(substr($fieldArgValue, strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING), strlen($fieldArgValue) - strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING) - strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)));
+        if (!isset($expressions[$expressionName])) {
+            // If the expression is not set, then show the error under entry "expressionErrors"
+            $objectTypeFieldResolutionFeedbackStore->addError(
+                new ObjectTypeFieldResolutionFeedback(
+                    new FeedbackItemResolution(
+                        ErrorFeedbackItemProvider::class,
+                        ErrorFeedbackItemProvider::E14,
+                        [
+                            $expressionName,
+                        ]
+                    ),
+                    LocationHelper::getNonSpecificLocation(),
+                    $relationalTypeResolver,
+                )
+            );
+            return null;
+        }
+        return $expressions[$expressionName];
     }
 
     protected function collectFieldArgumentValueErrorQualifiedEntriesForSchema(

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -107,4 +107,10 @@ interface FieldQueryInterpreterInterface extends UpstreamFieldQueryInterpreterIn
     ): array;
     public function maybeConvertFieldArgumentValue(mixed $fieldArgValue, ?array $variables = null): mixed;
     public function maybeConvertFieldArgumentArrayOrObjectValue(mixed $fieldArgValue, ?array $variables = null): mixed;
+    public function resolveExpression(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        mixed $fieldArgValue,
+        ?array $expressions,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed;
 }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -466,11 +466,9 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
         if ($if === null) {
             return $array;
         }
-        if (!$this->getFieldQueryInterpreter()->isFieldArgumentValueDynamic($if)) {
+        if (!$this->getFieldQueryInterpreter()->isFieldArgumentValueAField($if)) {
             return $if ? $array : [];
         }
-        $isFieldArgumentValueAField = $this->getFieldQueryInterpreter()->isFieldArgumentValueAField($if);
-        $isFieldArgumentValueAnExpression = $this->getFieldQueryInterpreter()->isFieldArgumentValueAnExpression($if);
         // If it is a field, execute the function against all the values in the array
         // Those that satisfy the condition stay, the others are filtered out
         // We must add each item in the array as expression `%{value}%`, over which the if function can be evaluated
@@ -483,23 +481,14 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
             $this->addExpressionForObjectAndField($id, $fieldOutputKey, Expressions::NAME_VALUE, $value, $messages);
             $expressions = $this->getExpressionsForObject($id, $variables, $messages);
             $objectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
-            if ($isFieldArgumentValueAField) {
-                $resolvedValue = $relationalTypeResolver->resolveValue(
-                    $objectIDItems[(string)$id],
-                    $if,
-                    $variables,
-                    $expressions,
-                    $objectTypeFieldResolutionFeedbackStore,
-                    $options
-                );
-            } elseif ($isFieldArgumentValueAnExpression) {
-                $resolvedValue = $this->getFieldQueryInterpreter()->resolveExpression(
-                    $relationalTypeResolver,
-                    $if,
-                    $expressions,
-                    $objectTypeFieldResolutionFeedbackStore
-                );
-            }
+            $resolvedValue = $relationalTypeResolver->resolveValue(
+                $objectIDItems[(string)$id],
+                $if,
+                $variables,
+                $expressions,
+                $objectTypeFieldResolutionFeedbackStore,
+                $options
+            );
             $this->maybeNestDirectiveFeedback(
                 $relationalTypeResolver,
                 $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -244,20 +244,19 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
 
                 // The value is an array or an stdClass. Unpack all the elements into their own property
                 $array = (array) $value;
-                if (
-                    $arrayItems = $this->getArrayItems(
-                        $array,
-                        $id,
-                        $field,
-                        $relationalTypeResolver,
-                        $objectIDItems,
-                        $previousDBItems,
-                        $dbItems,
-                        $variables,
-                        $messages,
-                        $engineIterationFeedbackStore,
-                    )
-                ) {
+                $arrayItems = $this->getArrayItems(
+                    $array,
+                    $id,
+                    $field,
+                    $relationalTypeResolver,
+                    $objectIDItems,
+                    $previousDBItems,
+                    $dbItems,
+                    $variables,
+                    $messages,
+                    $engineIterationFeedbackStore,
+                );
+                if ($arrayItems !== []) {
                     $execute = true;
                     foreach ($arrayItems as $key => &$value) {
                         // Add into the $idsDataFields object for the array items

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -266,6 +266,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                 $array = (array) $value;
                 $arrayItems = $this->getArrayItems(
                     $array,
+                    $object,
                     $id,
                     $field,
                     $relationalTypeResolver,
@@ -276,21 +277,6 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                     $messages,
                     $engineIterationFeedbackStore,
                 );
-                if ($this->addIfDirectiveArgument()) {
-                    $arrayItems = $this->filterIfArrayItems(
-                        $arrayItems,
-                        $object,
-                        $id,
-                        $field,
-                        $relationalTypeResolver,
-                        $objectIDItems,
-                        $previousDBItems,
-                        $dbItems,
-                        $variables,
-                        $messages,
-                        $engineIterationFeedbackStore,
-                    );
-                }
                 if ($arrayItems !== []) {
                     $execute = true;
                     foreach ($arrayItems as $key => &$value) {
@@ -403,6 +389,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                     $array = (array) $value;
                     $arrayItems = $this->getArrayItems(
                         $array,
+                        $object,
                         $id,
                         $field,
                         $relationalTypeResolver,
@@ -437,6 +424,49 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
     }
 
     abstract protected function addIfDirectiveArgument(): bool;
+
+    final protected function getArrayItems(
+        array &$array,
+        object $object,
+        int | string $id,
+        string $field,
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        array $objectIDItems,
+        array $previousDBItems,
+        array &$dbItems,
+        array &$variables,
+        array &$messages,
+        EngineIterationFeedbackStore $engineIterationFeedbackStore,
+    ): array {
+        $arrayItems = $this->doGetArrayItems(
+            $array,
+            $id,
+            $field,
+            $relationalTypeResolver,
+            $objectIDItems,
+            $previousDBItems,
+            $dbItems,
+            $variables,
+            $messages,
+            $engineIterationFeedbackStore,
+        );
+        if ($this->addIfDirectiveArgument()) {
+            $arrayItems = $this->filterIfArrayItems(
+                $arrayItems,
+                $object,
+                $id,
+                $field,
+                $relationalTypeResolver,
+                $objectIDItems,
+                $previousDBItems,
+                $dbItems,
+                $variables,
+                $messages,
+                $engineIterationFeedbackStore,
+            );
+        }
+        return $arrayItems;
+    }
 
     final protected function filterIfArrayItems(
         array &$array,
@@ -535,7 +565,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
     /**
      * Return the items to iterate on
      */
-    abstract protected function getArrayItems(
+    abstract protected function doGetArrayItems(
         array &$array,
         int | string $id,
         string $field,

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -499,6 +499,12 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                         $relationalTypeResolver,
                         $objectTypeFieldResolutionFeedbackStore,
                     );
+                    $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
+                        $objectTypeFieldResolutionFeedbackStore,
+                        $relationalTypeResolver,
+                        $field,
+                        $id
+                    );
                     if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
                         continue;
                     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -529,6 +529,12 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                         $relationalTypeResolver,
                         $objectTypeFieldResolutionFeedbackStore,
                     );
+                    $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
+                        $objectTypeFieldResolutionFeedbackStore,
+                        $relationalTypeResolver,
+                        $field,
+                        $id
+                    );
                     if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
                         continue;
                     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -499,6 +499,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
         if (!$this->getFieldQueryInterpreter()->isFieldArgumentValueAField($if)) {
             return $if ? $array : [];
         }
+        // @todo Together with removing `isFieldArgumentValueAField`, all the code below should be removed!
         // If it is a field, execute the function against all the values in the array
         // Those that satisfy the condition stay, the others are filtered out
         // We must add each item in the array as expression `%{value}%`, over which the if function can be evaluated

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -587,8 +587,8 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
             $value = $isValueInDBItems ?
                 $dbItems[(string)$id][$fieldOutputKey] :
                 $previousDBItems[$dbKey][(string)$id][$fieldOutputKey];
-            $this->addExpressionForObject($id, Expressions::NAME_VALUE, $value, $messages);
-            $expressions = $this->getExpressionsForObject($id, $variables, $messages);
+            $this->addExpressionForObjectAndField($id, $fieldOutputKey, Expressions::NAME_VALUE, $value, $messages);
+            $expressions = $this->getExpressionsForObjectAndField($id, $fieldOutputKey, $variables, $messages);
 
             $options = [
                 AbstractRelationalTypeResolver::OPTION_VALIDATE_SCHEMA_ON_RESULT_ITEM => true,

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -651,6 +651,29 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                         continue;
                     }
                     $existingValue[] = $resolvedValue;
+                } elseif ($this->getFieldQueryInterpreter()->isFieldArgumentValueAnExpression($value)) {
+                    $objectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
+                    $resolvedValue = $this->getFieldQueryInterpreter()->resolveExpression(
+                        $relationalTypeResolver,
+                        $value,
+                        $expressions,
+                        $objectTypeFieldResolutionFeedbackStore
+                    );
+                    $this->maybeNestDirectiveFeedback(
+                        $relationalTypeResolver,
+                        $objectTypeFieldResolutionFeedbackStore,
+                    );
+                    $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
+                        $objectTypeFieldResolutionFeedbackStore,
+                        $relationalTypeResolver,
+                        $field,
+                        $id,
+                        $this->directive
+                    );
+                    if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+                        continue;
+                    }
+                    $existingValue[] = $resolvedValue;
                 }
                 $this->addExpressionForObject($id, (string) $key, $existingValue, $messages);
             }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -9,12 +9,12 @@ use PoP\ComponentModel\ComponentConfiguration as ComponentModelComponentConfigur
 use PoP\ComponentModel\DirectivePipeline\DirectivePipelineServiceInterface;
 use PoP\ComponentModel\DirectiveResolvers\AbstractGlobalMetaDirectiveResolver;
 use PoP\ComponentModel\Feedback\EngineIterationFeedbackStore;
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\ComponentModel\Feedback\ObjectFeedback;
 use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\Feedback\SchemaFeedback;
 use PoP\ComponentModel\TypeResolvers\AbstractRelationalTypeResolver;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
 use PoP\Engine\Component;
 use PoP\Engine\ComponentConfiguration;
 use PoP\Engine\Dataloading\Expressions;
@@ -24,6 +24,7 @@ use PoP\FieldQuery\QueryHelpers;
 use PoP\FieldQuery\QuerySyntax;
 use PoP\GraphQLParser\StaticHelpers\LocationHelper;
 use PoP\Root\App;
+use PoP\Root\Feedback\FeedbackItemResolution;
 use stdClass;
 
 abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver extends AbstractGlobalMetaDirectiveResolver
@@ -37,6 +38,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
 
     private ?DirectivePipelineServiceInterface $directivePipelineService = null;
     private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
 
     final public function setDirectivePipelineService(DirectivePipelineServiceInterface $directivePipelineService): void
     {
@@ -54,6 +56,14 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
     {
         return $this->jsonObjectScalarTypeResolver ??= $this->instanceManager->getInstance(JSONObjectScalarTypeResolver::class);
     }
+    final public function setBooleanScalarTypeResolver(BooleanScalarTypeResolver $booleanScalarTypeResolver): void
+    {
+        $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        return $this->booleanScalarTypeResolver ??= $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+    }
 
     public function getDirectiveArgNameTypeResolvers(RelationalTypeResolverInterface $relationalTypeResolver): array
     {
@@ -65,6 +75,9 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
         }
         return array_merge(
             $directiveArgNameTypeResolvers,
+            $this->addIfDirectiveArgument() ? [
+                'if' => $this->getBooleanScalarTypeResolver(),
+            ] : [],
             [
                 'addExpressions' => $this->getJSONObjectScalarTypeResolver(),
                 'appendExpressions' => $this->getJSONObjectScalarTypeResolver(),
@@ -75,6 +88,7 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
     public function getDirectiveArgDescription(RelationalTypeResolverInterface $relationalTypeResolver, string $directiveArgName): ?string
     {
         return match ($directiveArgName) {
+            'if' => $this->__('If provided, iterate only those items that satisfy this condition `%s`', 'component-model'),
             'addExpressions' => sprintf(
                 $this->__('Expressions to inject to the composed directive. The value of the affected field can be provided under special expression `%s`', 'component-model'),
                 QueryHelpers::getExpressionQuery(Expressions::NAME_VALUE)
@@ -89,6 +103,12 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
 
     public function getDirectiveExpressions(RelationalTypeResolverInterface $relationalTypeResolver): array
     {
+        if ($this->addIfDirectiveArgument()) {
+            return [
+                Expressions::NAME_KEY => $this->__('Key of the array element from the current iteration', 'component-model'),
+                Expressions::NAME_VALUE => $this->__('Value of the array element from the current iteration', 'component-model'),
+            ];
+        }
         return [
             Expressions::NAME_VALUE => sprintf(
                 $this->__('Value of the array element from the current iteration, available for params \'%s\' and \'%s\'', 'component-model'),
@@ -256,6 +276,20 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                     $messages,
                     $engineIterationFeedbackStore,
                 );
+                if ($this->addIfDirectiveArgument()) {
+                    $arrayItems = $this->filterIfArrayItems(
+                        $arrayItems,
+                        $id,
+                        $field,
+                        $relationalTypeResolver,
+                        $objectIDItems,
+                        $previousDBItems,
+                        $dbItems,
+                        $variables,
+                        $messages,
+                        $engineIterationFeedbackStore,
+                    );
+                }
                 if ($arrayItems !== []) {
                     $execute = true;
                     foreach ($arrayItems as $key => &$value) {
@@ -399,6 +433,70 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                 }
             }
         }
+    }
+
+    abstract protected function addIfDirectiveArgument(): bool;
+
+    final protected function filterIfArrayItems(
+        array &$array,
+        int | string $id,
+        string $field,
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        array $objectIDItems,
+        array $previousDBItems,
+        array &$dbItems,
+        array &$variables,
+        array &$messages,
+        EngineIterationFeedbackStore $engineIterationFeedbackStore,
+    ): ?array {
+        $if = $this->directiveArgsForSchema['if'] ?? null;
+        if ($if === null) {
+            return $array;
+        }
+        if (!$this->getFieldQueryInterpreter()->isFieldArgumentValueAField($if)) {
+            return $if ? $array : [];
+        }
+        // If it is a field, execute the function against all the values in the array
+        // Those that satisfy the condition stay, the others are filtered out
+        // We must add each item in the array as expression `%{value}%`, over which the if function can be evaluated
+        $arrayItems = [];
+        $options = [
+            AbstractRelationalTypeResolver::OPTION_VALIDATE_SCHEMA_ON_RESULT_ITEM => true,
+        ];
+        foreach ($array as $key => $value) {
+            $this->addExpressionForObject($id, Expressions::NAME_KEY, $key, $messages);
+            $this->addExpressionForObject($id, Expressions::NAME_VALUE, $value, $messages);
+            $expressions = $this->getExpressionsForObject($id, $variables, $messages);
+            $objectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
+            $resolvedValue = $relationalTypeResolver->resolveValue(
+                $objectIDItems[(string)$id],
+                $if,
+                $variables,
+                $expressions,
+                $objectTypeFieldResolutionFeedbackStore,
+                $options
+            );
+            $this->maybeNestDirectiveFeedback(
+                $relationalTypeResolver,
+                $objectTypeFieldResolutionFeedbackStore,
+            );
+            $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
+                $objectTypeFieldResolutionFeedbackStore,
+                $relationalTypeResolver,
+                $field,
+                $id,
+                $this->directive
+            );
+            if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+                continue;
+            }
+            // Evaluate it
+            if (!$resolvedValue) {
+                continue;
+            }
+            $arrayItems[$key] = $value;
+        }
+        return $arrayItems;
     }
     /**
      * Place the result for the array in the original property

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -451,7 +451,8 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array {
-        $expressions = $this->getExpressionsForObject($id, $variables, $messages);
+        $fieldOutputKey = $this->getFieldQueryInterpreter()->getUniqueFieldOutputKey($relationalTypeResolver, $field, $object);
+        $expressions = $this->getExpressionsForObjectAndField($id, $fieldOutputKey, $variables, $messages);
         list(
             $objectValidDirective,
             $objectDirectiveName,
@@ -476,8 +477,8 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
             AbstractRelationalTypeResolver::OPTION_VALIDATE_SCHEMA_ON_RESULT_ITEM => true,
         ];
         foreach ($array as $key => $value) {
-            $this->addExpressionForObject($id, Expressions::NAME_KEY, $key, $messages);
-            $this->addExpressionForObject($id, Expressions::NAME_VALUE, $value, $messages);
+            $this->addExpressionForObjectAndField($id, $fieldOutputKey, Expressions::NAME_KEY, $key, $messages);
+            $this->addExpressionForObjectAndField($id, $fieldOutputKey, Expressions::NAME_VALUE, $value, $messages);
             $expressions = $this->getExpressionsForObject($id, $variables, $messages);
             $objectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
             $resolvedValue = $relationalTypeResolver->resolveValue(

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolver.php
@@ -503,7 +503,8 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                         $objectTypeFieldResolutionFeedbackStore,
                         $relationalTypeResolver,
                         $field,
-                        $id
+                        $id,
+                        $this->directive
                     );
                     if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
                         continue;
@@ -533,7 +534,8 @@ abstract class AbstractApplyNestedDirectivesOnArrayOrObjectItemsDirectiveResolve
                         $objectTypeFieldResolutionFeedbackStore,
                         $relationalTypeResolver,
                         $field,
-                        $id
+                        $id,
+                        $this->directive
                     );
                     if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
                         continue;

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/InvokeRelationalTypeResolverDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/InvokeRelationalTypeResolverDirectiveResolverTrait.php
@@ -19,6 +19,8 @@ trait InvokeRelationalTypeResolverDirectiveResolverTrait
         RelationalTypeResolverInterface $relationalTypeResolver,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void {
+        // @todo Display the nested errors in the output, currently they are not
+        return;
         // If there was an error, add it as nested
         $errors = $objectTypeFieldResolutionFeedbackStore->getErrors();
         if ($errors !== []) {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/InvokeRelationalTypeResolverDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/InvokeRelationalTypeResolverDirectiveResolverTrait.php
@@ -23,10 +23,12 @@ trait InvokeRelationalTypeResolverDirectiveResolverTrait
         // @todo Also integrate it with "why" in errors:
         // @see https://github.com/graphql/graphql-spec/issues/893
         $disabled = true;
+        /** @phpstan-ignore-next-line */
         if ($disabled) {
             return;
         }
         // If there was an error, add it as nested
+        /** @phpstan-ignore-next-line */
         $errors = $objectTypeFieldResolutionFeedbackStore->getErrors();
         if ($errors !== []) {
             $objectTypeFieldResolutionFeedbackStore->setErrors([]);

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/InvokeRelationalTypeResolverDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/InvokeRelationalTypeResolverDirectiveResolverTrait.php
@@ -19,8 +19,13 @@ trait InvokeRelationalTypeResolverDirectiveResolverTrait
         RelationalTypeResolverInterface $relationalTypeResolver,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void {
-        // @todo Display the nested errors in the output, currently they are not
-        return;
+        // @todo Display the nested errors in the output, currently they are not!
+        // @todo Also integrate it with "why" in errors:
+        // @see https://github.com/graphql/graphql-spec/issues/893
+        $disabled = true;
+        if ($disabled) {
+            return;
+        }
         // If there was an error, add it as nested
         $errors = $objectTypeFieldResolutionFeedbackStore->getErrors();
         if ($errors !== []) {

--- a/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/engine/src/FieldResolvers/ObjectType/OperatorGlobalObjectTypeFieldResolver.php
@@ -263,7 +263,7 @@ class OperatorGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFiel
             case 'extract':
                 try {
                     $array = (array) $fieldArgs['object'];
-                    $pointerToArrayItemUnderPath = $this->getArrayTraversionHelperService()->getPointerToArrayItemUnderPath($array, $fieldArgs['path']);
+                    $pointerToArrayItemUnderPath = $this->getArrayTraversionHelperService()->getPointerToElementItemUnderPath($array, $fieldArgs['path']);
                 } catch (RuntimeOperationException $e) {
                     $objectTypeFieldResolutionFeedbackStore->addError(
                         new ObjectTypeFieldResolutionFeedback(

--- a/layers/Engine/packages/engine/src/HelperServices/ArrayTraversionHelperService.php
+++ b/layers/Engine/packages/engine/src/HelperServices/ArrayTraversionHelperService.php
@@ -29,6 +29,20 @@ class ArrayTraversionHelperService implements ArrayTraversionHelperServiceInterf
      */
     public function &getPointerToArrayItemUnderPath(array &$data, string $path): array
     {
+        $dataPointer = $this->getPointerToElementItemUnderPath($data, $path);
+
+        if (!is_array($dataPointer)) {
+            $this->throwItemUnderPathIsNotArrayException($dataPointer, $path);
+        }
+
+        return $dataPointer;
+    }
+
+    /**
+     * @throws RuntimeOperationException If the path cannot be reached under the array
+     */
+    public function &getPointerToElementItemUnderPath(array &$data, string $path): mixed
+    {
         $dataPointer = &$data;
 
         // Iterate the data array to the provided path.
@@ -53,10 +67,6 @@ class ArrayTraversionHelperService implements ArrayTraversionHelperServiceInterf
             // We are accessing a level that doesn't exist
             // If we reached the end of the array and can't keep going down any level more, then it's an error
             $this->throwNoArrayItemUnderPathException($data, $path);
-        }
-
-        if (!is_array($dataPointer)) {
-            $this->throwItemUnderPathIsNotArrayException($dataPointer, $path);
         }
 
         return $dataPointer;

--- a/layers/Engine/packages/engine/src/HelperServices/ArrayTraversionHelperServiceInterface.php
+++ b/layers/Engine/packages/engine/src/HelperServices/ArrayTraversionHelperServiceInterface.php
@@ -15,5 +15,9 @@ interface ArrayTraversionHelperServiceInterface
     /**
      * @throws RuntimeOperationException If the path cannot be reached under the array
      */
+    public function &getPointerToElementItemUnderPath(array &$data, string $path): mixed;
+    /**
+     * @throws RuntimeOperationException If the path cannot be reached under the array
+     */
     public function setValueToArrayItemUnderPath(array &$data, string $path, mixed $value): void;
 }

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
@@ -290,19 +290,30 @@ class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
          * If the value is of type InputList, then resolve the array with its variables (under `getValue`)
          */
         if ($value instanceof InputList) {
-            return array_map(
-                [$this, 'convertArgumentValue'],
-                $value->getValue()
-            );
+            $array = [];
+            foreach ($value->getAstValue() as $key => $value) {
+                $array[$key] = $this->convertArgumentValue($value);
+            }
+            return $array;
+            // return array_map(
+            //     [$this, 'convertArgumentValue'],
+            //     $value->getValue()
+            // );
         }
 
         if ($value instanceof InputObject) {
-            // Convert from array back to stdClass
-            return (object) array_map(
-                [$this, 'convertArgumentValue'],
-                // Convert from stdClass to array
-                (array) $value->getValue()
-            );
+            // Copied from `InputObject->getValue`
+            $object = new stdClass();
+            foreach ((array) $value->getAstValue() as $key => $value) {
+                $object->$key = $this->convertArgumentValue($value);
+            }
+            return $object;
+            // // Convert from array back to stdClass
+            // return (object) array_map(
+            //     [$this, 'convertArgumentValue'],
+            //     // Convert from stdClass to array
+            //     (array) $value->getValue()
+            // );
         }
 
         // Otherwise it may be a scalar value

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Standalone/IntrospectionQueryGraphQLServerTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Standalone/IntrospectionQueryGraphQLServerTest.php
@@ -1482,16 +1482,16 @@ class IntrospectionQueryGraphQLServerTest extends AbstractGraphQLServerTestCase
                                 "enumValues" => null,
                                 "possibleTypes" => null
                             ],
-                            // [
-                            //     "kind" => "SCALAR",
-                            //     "name" => "DangerouslyDynamic",
-                            //     "description" => "Special scalar type which is not coerced or validated. In particular, it does not need to validate if it is an array or not, as GraphQL requires based on the applied WrappingType (such as `[String]`).",
-                            //     "fields" => null,
-                            //     "inputFields" => null,
-                            //     "interfaces" => null,
-                            //     "enumValues" => null,
-                            //     "possibleTypes" => null
-                            // ],
+                            [
+                                "kind" => "SCALAR",
+                                "name" => "DangerouslyDynamic",
+                                "description" => "Special scalar type which is not coerced or validated. In particular, it does not need to validate if it is an array or not, as GraphQL requires based on the applied WrappingType (such as `[String]`).",
+                                "fields" => null,
+                                "inputFields" => null,
+                                "interfaces" => null,
+                                "enumValues" => null,
+                                "possibleTypes" => null
+                            ],
                             [
                                 "kind" => "SCALAR",
                                 "name" => "ID",
@@ -1510,6 +1510,16 @@ class IntrospectionQueryGraphQLServerTest extends AbstractGraphQLServerTestCase
                                 "inputFields" => null,
                                 "interfaces" => null,
                                 "enumValues" => null,
+                                "possibleTypes" => null
+                            ],
+                            [
+                                "description" => "Custom scalar representing a JSON Object of unrestricted shape",
+                                "enumValues" => null,
+                                "fields" => null,
+                                "inputFields" => null,
+                                "interfaces" => null,
+                                "kind" => "SCALAR",
+                                "name" => "JSONObject",
                                 "possibleTypes" => null
                             ],
                             [
@@ -1551,16 +1561,6 @@ class IntrospectionQueryGraphQLServerTest extends AbstractGraphQLServerTestCase
                                     [
                                         "kind" => "OBJECT",
                                         "name" => "Root",
-                                        "ofType" => null
-                                    ],
-                                    [
-                                        "kind" => "OBJECT",
-                                        "name" => "MutationRoot",
-                                        "ofType" => null
-                                    ],
-                                    [
-                                        "kind" => "OBJECT",
-                                        "name" => "QueryRoot",
                                         "ofType" => null
                                     ],
                                     [
@@ -1621,6 +1621,16 @@ class IntrospectionQueryGraphQLServerTest extends AbstractGraphQLServerTestCase
                                     [
                                         "kind" => "OBJECT",
                                         "name" => "_DirectiveExtensions",
+                                        "ofType" => null
+                                    ],
+                                    [
+                                        "kind" => "OBJECT",
+                                        "name" => "MutationRoot",
+                                        "ofType" => null
+                                    ],
+                                    [
+                                        "kind" => "OBJECT",
+                                        "name" => "QueryRoot",
                                         "ofType" => null
                                     ]
                                 ]


### PR DESCRIPTION
PQL queries are now completely supported using the GraphQL query syntax.

The [newsletter query](https://graphql-by-pop.com/guides/localized-newsletter.html) can be executed like this:

```graphql
# Query fields in Post
query Step_1($postId: ID!) {
  post(by: {id: $postId}) {
    content
    date: dateStr(format: "d/m/Y")
  }
}

# Copy the fields from Post to Root
query Step_2($postId: ID!) {
  post(by: {id: $postId}) @copyRelationalResults(
    copyFromFields: ["content", "date"],
    copyToFields: ["postContent", "postDate"]
  ) {
    id
  }
}

# Produce the User Data, by manipulating the list of results from the REST API endpoint
query Step_3 {
  userList: getJSON(
    url: "https://newapi.getpop.org/wp-json/newsletter/v1/subscriptions"
  ) @skip(if: true)

  userListLang: extract(
    object: $_userList,
    path: "lang"
  ) @skip(if: true)

  userLangs: arrayUnique(
    array: $_userListLang
  )
    # @skip(if: true)
    @export(as: "_userLangs")

  userEmails: extract(
    object: $_userList,
    path: "email"
  ) @skip(if: true)

  joinedUserEmailsTemp: arrayJoin(
    array: $_userEmails,
    separator: "&emails[]="
  ) @skip(if: true)

  joinedUserEmails: arrayAddItem(
    array: [],
    value: $_joinedUserEmailsTemp
  ) @skip(if: true)

  userEndpoint: sprintf(
    string: "https://newapi.getpop.org/users/api/rest/?query=name|email&emails[]=%s",
    values: $_joinedUserEmails
  ) @skip(if: true)

  userEndpointData: getJSON(
    url: $_userEndpoint
  ) @skip(if: true)

  userData: arrayFill(
    source: $_userEndpointData,
    target: $_userList,
    index: "email"
  ) @export(as: "_userData")
}

query Step_4 {
  ##########################################
  # Should be able to execute the commented field below,
  # but it returns error "No value has been exported for dynamic variable '_userLangs'"
  # so added Temp steps
  ##########################################
  # translateToLangs: arrayDiff(
  #   arrays: [$_userLangs, ["en"]]
  # )
  translateToLangsTemp1: arrayAddItem(
    array: [],
    value: $_userLangs
  ) @skip(if: true)
  translateToLangsTemp2: arrayAddItem(
    array: $_translateToLangsTemp1,
    value: ["en"]
  ) @skip(if: true)
  translateToLangs: arrayDiff(
    arrays: $_translateToLangsTemp2
  ) @skip(if: true)
  ##########################################

  postContent: getSelfProp(self: "%{self}%", property: "postContent")
    @translateMultiple(
      from: "en",
      to: $_translateToLangs
    )
    @renameProperty(to: "postContent-en")
  
  userPostData: getSelfProp(self: "%{self}%", property: "userData")
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4])
      @applyFunction(
        name: "extract",
        arguments: {
          object: "%{value}%",
          path: "lang",
        },
        target: "userLang",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "sprintf",
        arguments: {
          string: "postContent-%s",
          values: ["%{userLang}%"]
        },
        target: "userPostContentKey",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "getSelfProp",
        arguments: {
          self: "%{self}%",
          property: "%{userPostContentKey}%",
        },
        target: "userPostContent",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: "%{value}%",
          key: "postContent",
          value: "%{userPostContent}%"
        }
      )
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4])
      @applyFunction(
        name: "extract",
        arguments: {
          object: "%{value}%",
          path: "name",
        },
        target: "userName",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "getSelfProp",
        arguments: {
          self: "%{self}%",
          property: "postDate",
        },
        target: "postDate",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "sprintf",
        arguments: {
          string: "<p>Hi %s, we published this post on %s, enjoy!</p>",
          values: ["%{userName}%", "%{postDate}%"]
        },
        target: "header",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: "%{value}%",
          key: "header",
          value: "%{header}%"
        }
      )
    @export(as: "_userPostData")
}

query Step_5 {
  translatedUserPostProps: echo(value: $_userPostData)
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4])
      @applyFunction(
        name: "extract",
        arguments: {
          object: "%{value}%",
          path: "lang",
        },
        target: "userLang",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "equals",
        arguments: {
          value1: "%{userLang}%",
          value2: "en",
        },
        target: "userLangIsEn",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "not",
        arguments: {
          value: "%{userLangIsEn}%"
        },
        target: "userLangIsNotEn",
        targetType: EXPRESSION
      )
      @advancePointerInArrayOrObject(
        if: "%{userLangIsNotEn}%"
        path: "header",
        appendExpressions: {
          toLang: "%{userLang}%"
        }
      )
        @translateMultiple(
          from: "en",
          to: "%{toLang}%",
          oneLanguagePerField: true,
          override: true
        )
    @export(as: "_translatedUserPostProps")
}

query Step_6 {
  emails: getSelfProp(self: "%{self}%", property: "translatedUserPostProps")
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4, 5])
      @applyFunction(
        name: "extract",
        arguments: {
          object: "%{value}%",
          path: "header",
        },
        target: "entryHeader",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "extract",
        arguments: {
          object: "%{value}%",
          path: "postContent",
        },
        target: "entryPostContent",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "concat",
        arguments: {
          values: ["%{entryHeader}%", "%{entryPostContent}%"],
        },
        target: "entryBody",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: "%{value}%",
          key: "emailBody",
          value: "%{entryBody}%"
        }
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: "%{value}%",
          key: "emailSubject",
          value: "GraphQL API Newsletter"
        }
      )
      # Having generated all the data, this directive would send the emails
      # @sendByEmail
}

query __ALL { id }
```

Next steps will be to integrate dynamic variables and expressions, so that we can pass input `$_value` instead of `"%{value}%"`.

Once that is done, the migration to GraphQL syntax for all advanced functionality (previously supported using the [PQL syntax](https://graphql-by-pop.com/docs/extended/pql.html) only) will be complete.