### PR TITLE
Use the syntax for "dynamic variables" also for "expressions"

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1564,11 +1564,11 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         // Expressions: allow to pass a field argument "key:%input%", which is passed when executing the directive through $expressions
 
         /**
-         * Switched from "%{...}%" to "$_..."
+         * Switched from "%{...}%" to "$__..."
          */
         // // Trim it so that "%{ self }%" is equivalent to "%{self}%". This is needed to set expressions through Symfony's DependencyInjection component (since %...% is reserved for its own parameters!)
         // $expressionName = trim(substr($fieldArgValue, strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING), strlen($fieldArgValue) - strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING) - strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)));
-        $expressionName = substr($fieldArgValue, 2);
+        $expressionName = substr($fieldArgValue, strlen('$__'));
         if (!isset($expressions[$expressionName])) {
             // If the expression is not set, then show the error under entry "expressionErrors"
             $objectTypeFieldResolutionFeedbackStore->addError(

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1565,6 +1565,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
 
         /**
          * Switched from "%{...}%" to "$__..."
+         * @todo Convert expressions from "$__" to "$"
          */
         // // Trim it so that "%{ self }%" is equivalent to "%{self}%". This is needed to set expressions through Symfony's DependencyInjection component (since %...% is reserved for its own parameters!)
         // $expressionName = trim(substr($fieldArgValue, strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING), strlen($fieldArgValue) - strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING) - strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)));

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -1562,8 +1562,13 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
         // Expressions: allow to pass a field argument "key:%input%", which is passed when executing the directive through $expressions
-        // Trim it so that "%{ self }%" is equivalent to "%{self}%". This is needed to set expressions through Symfony's DependencyInjection component (since %...% is reserved for its own parameters!)
-        $expressionName = trim(substr($fieldArgValue, strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING), strlen($fieldArgValue) - strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING) - strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)));
+
+        /**
+         * Switched from "%{...}%" to "$_..."
+         */
+        // // Trim it so that "%{ self }%" is equivalent to "%{self}%". This is needed to set expressions through Symfony's DependencyInjection component (since %...% is reserved for its own parameters!)
+        // $expressionName = trim(substr($fieldArgValue, strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING), strlen($fieldArgValue) - strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING) - strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)));
+        $expressionName = substr($fieldArgValue, 2);
         if (!isset($expressions[$expressionName])) {
             // If the expression is not set, then show the error under entry "expressionErrors"
             $objectTypeFieldResolutionFeedbackStore->addError(

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -255,7 +255,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
     public function isFieldArgumentValueAnExpression(mixed $fieldArgValue): bool
     {
         /**
-         * Switched from "%{...}%" to "$_..."
+         * Switched from "%{...}%" to "$__..."
          */
         // // If it starts with "%{" and ends with "}%", it is an expression
         // return
@@ -271,7 +271,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
         //     ) == QuerySyntax::SYMBOL_EXPRESSION_CLOSING;
 
         // If it starts with "$_", it is a dynamic variable
-        return is_string($fieldArgValue) && str_starts_with($fieldArgValue, '$_');
+        return is_string($fieldArgValue) && str_starts_with($fieldArgValue, '$__');
     }
 
     public function isFieldArgumentValueAVariable(mixed $fieldArgValue): bool
@@ -283,7 +283,8 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                 $fieldArgValue,
                 0,
                 strlen(QuerySyntax::SYMBOL_VARIABLE_PREFIX)
-            ) == QuerySyntax::SYMBOL_VARIABLE_PREFIX;
+            ) == QuerySyntax::SYMBOL_VARIABLE_PREFIX
+            && !$this->$this->isFieldArgumentValueAnExpression($fieldArgValue);
     }
 
     public function isFieldArgumentValueDynamic(mixed $fieldArgValue): bool

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -286,7 +286,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                 strlen(QuerySyntax::SYMBOL_VARIABLE_PREFIX)
             ) == QuerySyntax::SYMBOL_VARIABLE_PREFIX
             // If it starts with "$__", it is an expression, not a variable
-            && !$this->$this->isFieldArgumentValueAnExpression($fieldArgValue);
+            && !$this->isFieldArgumentValueAnExpression($fieldArgValue);
     }
 
     public function isFieldArgumentValueDynamic(mixed $fieldArgValue): bool

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -254,18 +254,24 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
 
     public function isFieldArgumentValueAnExpression(mixed $fieldArgValue): bool
     {
-        // If it starts and ends with "%", it is an expression
-        return
-            is_string($fieldArgValue)
-            && substr(
-                $fieldArgValue,
-                0,
-                strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING)
-            ) == QuerySyntax::SYMBOL_EXPRESSION_OPENING
-            && substr(
-                $fieldArgValue,
-                -1 * strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)
-            ) == QuerySyntax::SYMBOL_EXPRESSION_CLOSING;
+        /**
+         * Switched from "%{...}%" to "$_..."
+         */
+        // // If it starts with "%{" and ends with "}%", it is an expression
+        // return
+        //     is_string($fieldArgValue)
+        //     && substr(
+        //         $fieldArgValue,
+        //         0,
+        //         strlen(QuerySyntax::SYMBOL_EXPRESSION_OPENING)
+        //     ) == QuerySyntax::SYMBOL_EXPRESSION_OPENING
+        //     && substr(
+        //         $fieldArgValue,
+        //         -1 * strlen(QuerySyntax::SYMBOL_EXPRESSION_CLOSING)
+        //     ) == QuerySyntax::SYMBOL_EXPRESSION_CLOSING;
+
+        // If it starts with "$_", it is a dynamic variable
+        return is_string($fieldArgValue) && str_starts_with($fieldArgValue, '$_');
     }
 
     public function isFieldArgumentValueAVariable(mixed $fieldArgValue): bool

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -285,6 +285,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
                 0,
                 strlen(QuerySyntax::SYMBOL_VARIABLE_PREFIX)
             ) == QuerySyntax::SYMBOL_VARIABLE_PREFIX
+            // If it starts with "$__", it is an expression, not a variable
             && !$this->$this->isFieldArgumentValueAnExpression($fieldArgValue);
     }
 

--- a/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/field-query/src/FieldQueryInterpreter.php
@@ -256,6 +256,7 @@ class FieldQueryInterpreter implements FieldQueryInterpreterInterface
     {
         /**
          * Switched from "%{...}%" to "$__..."
+         * @todo Convert expressions from "$__" to "$"
          */
         // // If it starts with "%{" and ends with "}%", it is an expression
         // return

--- a/layers/Engine/packages/field-query/src/QueryHelpers.php
+++ b/layers/Engine/packages/field-query/src/QueryHelpers.php
@@ -181,6 +181,7 @@ class QueryHelpers
     {
         /**
          * Switched from "%{...}%" to "$__..."
+         * @todo Convert expressions from "$__" to "$"
          */
         // return QuerySyntax::SYMBOL_EXPRESSION_OPENING . $expressionName . QuerySyntax::SYMBOL_EXPRESSION_CLOSING;
         return '$__' . $expressionName;

--- a/layers/Engine/packages/field-query/src/QueryHelpers.php
+++ b/layers/Engine/packages/field-query/src/QueryHelpers.php
@@ -180,10 +180,10 @@ class QueryHelpers
     public static function getExpressionQuery(string $expressionName): string
     {
         /**
-         * Switched from "%{...}%" to "$_..."
+         * Switched from "%{...}%" to "$__..."
          */
         // return QuerySyntax::SYMBOL_EXPRESSION_OPENING . $expressionName . QuerySyntax::SYMBOL_EXPRESSION_CLOSING;
-        return '$_' . $expressionName;
+        return '$__' . $expressionName;
     }
 
     /**

--- a/layers/Engine/packages/field-query/src/QueryHelpers.php
+++ b/layers/Engine/packages/field-query/src/QueryHelpers.php
@@ -179,7 +179,11 @@ class QueryHelpers
 
     public static function getExpressionQuery(string $expressionName): string
     {
-        return QuerySyntax::SYMBOL_EXPRESSION_OPENING . $expressionName . QuerySyntax::SYMBOL_EXPRESSION_CLOSING;
+        /**
+         * Switched from "%{...}%" to "$_..."
+         */
+        // return QuerySyntax::SYMBOL_EXPRESSION_OPENING . $expressionName . QuerySyntax::SYMBOL_EXPRESSION_CLOSING;
+        return '$_' . $expressionName;
     }
 
     /**

--- a/layers/Engine/packages/field-query/src/QuerySyntax.php
+++ b/layers/Engine/packages/field-query/src/QuerySyntax.php
@@ -25,6 +25,7 @@ class QuerySyntax
     const SYMBOL_FRAGMENT_PREFIX = '--';
     /**
      * Switched from "%{...}%" to "$__..."
+     * @todo Convert expressions from "$__" to "$"
      */
     // const SYMBOL_EXPRESSION_OPENING = '%{';
     // const SYMBOL_EXPRESSION_CLOSING = '}%';

--- a/layers/Engine/packages/field-query/src/QuerySyntax.php
+++ b/layers/Engine/packages/field-query/src/QuerySyntax.php
@@ -24,7 +24,7 @@ class QuerySyntax
     const SYMBOL_VARIABLE_PREFIX = '$';
     const SYMBOL_FRAGMENT_PREFIX = '--';
     /**
-     * Switched from "%{...}%" to "$_..."
+     * Switched from "%{...}%" to "$__..."
      */
     // const SYMBOL_EXPRESSION_OPENING = '%{';
     // const SYMBOL_EXPRESSION_CLOSING = '}%';

--- a/layers/Engine/packages/field-query/src/QuerySyntax.php
+++ b/layers/Engine/packages/field-query/src/QuerySyntax.php
@@ -23,8 +23,11 @@ class QuerySyntax
     const SYMBOL_FIELDARGS_ARGKEYVALUESEPARATOR = ':';
     const SYMBOL_VARIABLE_PREFIX = '$';
     const SYMBOL_FRAGMENT_PREFIX = '--';
-    const SYMBOL_EXPRESSION_OPENING = '%{';
-    const SYMBOL_EXPRESSION_CLOSING = '}%';
+    /**
+     * Switched from "%{...}%" to "$_..."
+     */
+    // const SYMBOL_EXPRESSION_OPENING = '%{';
+    // const SYMBOL_EXPRESSION_CLOSING = '}%';
     const SYMBOL_FIELDARGS_ARGVALUESTRING_OPENING = '"';
     const SYMBOL_FIELDARGS_ARGVALUESTRING_CLOSING = '"';
     const SYMBOL_FIELDARGS_ARGVALUEARRAY_OPENING = '[';

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php
@@ -32,6 +32,19 @@ class DynamicVariableReference extends AbstractDynamicVariableReference
      */
     public function getValue(): mixed
     {
+        /**
+         * @todo Remove this temporary hack to support expressions (until the engine is migrated to AST).
+         *
+         * This temporary logic returns value "$__expressionName",
+         * to be processed as an expression on runtime.
+         *
+         * Switched from "%{...}%" to "$__..."
+         * @todo Convert expressions from "$__" to "$"
+         */
+        if (str_starts_with($this->name, '__')) {
+            return '$' . $this->name;
+        }
+
         if ($this->context === null) {
             throw new InvalidRequestException(
                 new FeedbackItemResolution(

--- a/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
+++ b/layers/GraphQLByPoP/packages/graphql-query/src/Schema/GraphQLQueryConvertor.php
@@ -202,7 +202,13 @@ class GraphQLQueryConvertor implements GraphQLQueryConvertorInterface
      */
     public function treatVariableAsExpression(string $variableName): bool
     {
-        return substr($variableName, 0, strlen(QuerySymbols::VARIABLE_AS_EXPRESSION_NAME_PREFIX)) == QuerySymbols::VARIABLE_AS_EXPRESSION_NAME_PREFIX;
+        return
+            substr($variableName, 0, strlen(QuerySymbols::VARIABLE_AS_EXPRESSION_NAME_PREFIX)) == QuerySymbols::VARIABLE_AS_EXPRESSION_NAME_PREFIX
+            /**
+             * Switched from "%{...}%" to "$__..."
+             * @todo Convert expressions from "$__" to "$"
+             */
+            && !str_starts_with($variableName, '__');
     }
 
     protected function convertArgumentValue($value)


### PR DESCRIPTION
Expressions were converted from using syntax `"%{...}%"` to `$__`, hence they are now fully supported using valid GraphQL syntax.

The [newsletter query](https://graphql-by-pop.com/guides/localized-newsletter.html) is now executed like this:

```graphql
query __ALL { id }

# Query fields in Post
query Step_1($postId: ID!) {
  post(by: {id: $postId}) {
    content
    date: dateStr(format: "d/m/Y")
  }
}

# Copy the fields from Post to Root
query Step_2($postId: ID!) {
  post(by: {id: $postId}) @copyRelationalResults(
    copyFromFields: ["content", "date"],
    copyToFields: ["postContent", "postDate"]
  ) {
    id
  }
}

# Produce the User Data, by manipulating the list of results from the REST API endpoint
query Step_3 {
  userList: getJSON(
    url: "https://newapi.getpop.org/wp-json/newsletter/v1/subscriptions"
  ) @skip(if: true)

  userListLang: extract(
    object: $_userList,
    path: "lang"
  ) @skip(if: true)

  userLangs: arrayUnique(
    array: $_userListLang
  )
    # @skip(if: true)
    @export(as: "_userLangs")

  userEmails: extract(
    object: $_userList,
    path: "email"
  ) @skip(if: true)

  joinedUserEmailsTemp: arrayJoin(
    array: $_userEmails,
    separator: "&emails[]="
  ) @skip(if: true)

  joinedUserEmails: arrayAddItem(
    array: [],
    value: $_joinedUserEmailsTemp
  ) @skip(if: true)

  userEndpoint: sprintf(
    string: "https://newapi.getpop.org/users/api/rest/?query=name|email&emails[]=%s",
    values: $_joinedUserEmails
  ) @skip(if: true)

  userEndpointData: getJSON(
    url: $_userEndpoint
  ) @skip(if: true)

  userData: arrayFill(
    source: $_userEndpointData,
    target: $_userList,
    index: "email"
  ) @export(as: "_userData")
}

query Step_4 {
  ##########################################
  # Should be able to execute the commented field below,
  # but it returns error "No value has been exported for dynamic variable '_userLangs'"
  # so added Temp steps
  ##########################################
  # translateToLangs: arrayDiff(
  #   arrays: [$_userLangs, ["en"]]
  # )
  translateToLangsTemp1: arrayAddItem(
    array: [],
    value: $_userLangs
  ) @skip(if: true)
  translateToLangsTemp2: arrayAddItem(
    array: $_translateToLangsTemp1,
    value: ["en"]
  ) @skip(if: true)
  translateToLangs: arrayDiff(
    arrays: $_translateToLangsTemp2
  ) @skip(if: true)
  ##########################################

  postContent: getSelfProp(self: $__self, property: "postContent")
    @translateMultiple(
      from: "en",
      to: $_translateToLangs
    )
    @renameProperty(to: "postContent-en")
  
  userPostData: getSelfProp(self: $__self, property: "userData")
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4])
      @applyFunction(
        name: "extract",
        arguments: {
          object: $__value,
          path: "lang",
        },
        target: "userLang",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "sprintf",
        arguments: {
          string: "postContent-%s",
          values: [$__userLang]
        },
        target: "userPostContentKey",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "getSelfProp",
        arguments: {
          self: $__self,
          property: $__userPostContentKey,
        },
        target: "userPostContent",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: $__value,
          key: "postContent",
          value: $__userPostContent
        }
      )
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4])
      @applyFunction(
        name: "extract",
        arguments: {
          object: $__value,
          path: "name",
        },
        target: "userName",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "getSelfProp",
        arguments: {
          self: $__self,
          property: "postDate",
        },
        target: "postDate",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "sprintf",
        arguments: {
          string: "<p>Hi %s, we published this post on %s, enjoy!</p>",
          values: [$__userName, $__postDate]
        },
        target: "header",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: $__value,
          key: "header",
          value: $__header
        }
      )
    @export(as: "_userPostData")
}

query Step_5 {
  translatedUserPostProps: echo(value: $_userPostData)
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4])
      @applyFunction(
        name: "extract",
        arguments: {
          object: $__value,
          path: "lang",
        },
        target: "userLang",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "equals",
        arguments: {
          value1: $__userLang,
          value2: "en",
        },
        target: "userLangIsEn",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "not",
        arguments: {
          value: $__userLangIsEn
        },
        target: "userLangIsNotEn",
        targetType: EXPRESSION
      )
      @advancePointerInArrayOrObject(
        if: $__userLangIsNotEn
        path: "header",
        appendExpressions: {
          toLang: $__userLang
        }
      )
        @translateMultiple(
          from: "en",
          to: $__toLang,
          oneLanguagePerField: true,
          override: true
        )
    @export(as: "_translatedUserPostProps")
}

query Step_6 {
  emails: getSelfProp(self: $__self, property: "translatedUserPostProps")
    @forEach(affectDirectivesUnderPos: [1, 2, 3, 4, 5])
      @applyFunction(
        name: "extract",
        arguments: {
          object: $__value,
          path: "header",
        },
        target: "entryHeader",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "extract",
        arguments: {
          object: $__value,
          path: "postContent",
        },
        target: "entryPostContent",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "concat",
        arguments: {
          values: [$__entryHeader, $__entryPostContent],
        },
        target: "entryBody",
        targetType: EXPRESSION
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: $__value,
          key: "emailBody",
          value: $__entryBody
        }
      )
      @applyFunction(
        name: "arrayAddItem",
        arguments: {
          array: $__value,
          key: "emailSubject",
          value: "GraphQL API Newsletter"
        }
      )
      # Having generated all the data, this directive would send the emails
      # @sendByEmail
}

```