### PR TITLE
Create Enum AST from Literal

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Enum.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Enum.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
+
+use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
+use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
+use PoP\GraphQLParser\Spec\Parser\Location;
+
+class Enum extends AbstractAst implements WithValueInterface
+{
+    public function __construct(
+        protected string $enumValue,
+        Location $location
+    ) {
+        parent::__construct($location);
+    }
+
+    public function asQueryString(): string
+    {
+        return $this->enumValue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): mixed
+    {
+        return $this->enumValue;
+    }
+
+    /**
+     * @param string $enumValue
+     */
+    public function setValue(mixed $enumValue): void
+    {
+        $this->enumValue = $enumValue;
+    }
+}

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Variable.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Variable.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
 
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\FeedbackItemProviders\FeedbackItemProvider;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
+use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Enum;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Location;
+use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\Root\Services\StandaloneServiceTrait;
 
 class Variable extends AbstractAst implements WithValueInterface
@@ -23,7 +24,7 @@ class Variable extends AbstractAst implements WithValueInterface
 
     protected bool $hasDefaultValue = false;
 
-    protected InputList|InputObject|Literal|null $defaultValue = null;
+    protected InputList|InputObject|Literal|Enum|null $defaultValue = null;
 
     public function __construct(
         protected string $name,
@@ -106,12 +107,12 @@ class Variable extends AbstractAst implements WithValueInterface
         return $this->hasDefaultValue;
     }
 
-    public function getDefaultValue(): InputList|InputObject|Literal|null
+    public function getDefaultValue(): InputList|InputObject|Literal|Enum|null
     {
         return $this->defaultValue;
     }
 
-    public function setDefaultValue(InputList|InputObject|Literal|null $defaultValue): void
+    public function setDefaultValue(InputList|InputObject|Literal|Enum|null $defaultValue): void
     {
         $this->hasDefaultValue = true;
         $this->defaultValue = $defaultValue;
@@ -130,7 +131,7 @@ class Variable extends AbstractAst implements WithValueInterface
     /**
      * Get the value from the context or from the variable
      *
-     * @return InputList|InputObject|Literal|null
+     * @return InputList|InputObject|Literal|Enum|null
      * @throws InvalidRequestException
      */
     public function getValue(): mixed

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -560,7 +560,7 @@ class Parser extends Tokenizer implements ParserInterface
             case Token::TYPE_FALSE:
                 $token = $this->lex();
                 return $this->createLiteral($token->getData(), $this->getTokenLocation($token));
-            
+
             case Token::TYPE_IDENTIFIER:
                 $token = $this->lex();
                 return $this->createEnum($token->getData(), $this->getTokenLocation($token));

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLParserErrorFeedbackItemProvider;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
+use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Enum;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\InputList;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\InputObject;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
@@ -27,6 +27,7 @@ use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\QueryOperation;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
+use PoP\Root\Feedback\FeedbackItemResolution;
 use stdClass;
 
 class Parser extends Tokenizer implements ParserInterface
@@ -540,7 +541,7 @@ class Parser extends Tokenizer implements ParserInterface
     /**
      * @throws SyntaxErrorException
      */
-    protected function parseValue(): array|InputList|InputObject|Literal|VariableReference
+    protected function parseValue(): array|InputList|InputObject|Literal|Enum|VariableReference
     {
         switch ($this->lookAhead->getType()) {
             case Token::TYPE_LSQUARE_BRACE:
@@ -554,13 +555,15 @@ class Parser extends Tokenizer implements ParserInterface
 
             case Token::TYPE_NUMBER:
             case Token::TYPE_STRING:
-            case Token::TYPE_IDENTIFIER:
             case Token::TYPE_NULL:
             case Token::TYPE_TRUE:
             case Token::TYPE_FALSE:
                 $token = $this->lex();
-
                 return $this->createLiteral($token->getData(), $this->getTokenLocation($token));
+            
+            case Token::TYPE_IDENTIFIER:
+                $token = $this->lex();
+                return $this->createEnum($token->getData(), $this->getTokenLocation($token));
         }
 
         throw $this->createUnexpectedException($this->lookAhead);
@@ -571,6 +574,13 @@ class Parser extends Tokenizer implements ParserInterface
         Location $location
     ): Literal {
         return new Literal($value, $location);
+    }
+
+    public function createEnum(
+        string $enumValue,
+        Location $location
+    ): Enum {
+        return new Enum($enumValue, $location);
     }
 
     protected function parseList(bool $createType): InputList|array

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/ParserInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/ParserInterface.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
-use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
 use PoP\GraphQLParser\Spec\Parser\Ast\Document;
 
 interface ParserInterface
 {
     public function parse(string $source): Document;
-
-    public function createLiteral(
-        string|int|float|bool|null $value,
-        Location $location
-    ): Literal;
 }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser;
 
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLParserErrorFeedbackItemProvider;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
+use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Enum;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\InputList;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\InputObject;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
@@ -26,6 +26,7 @@ use PoP\GraphQLParser\Spec\Parser\Ast\QueryOperation;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\Spec\Parser\ParserInterface;
 use PoP\Root\AbstractTestCase;
+use PoP\Root\Feedback\FeedbackItemResolution;
 use stdClass;
 
 class ParserTest extends AbstractTestCase
@@ -721,7 +722,7 @@ GRAPHQL;
                     [
                         new QueryOperation('CheckTypeOfLuke', [], [], [
                             new RelationalField('hero', null, [
-                                new Argument('episode', new Literal('EMPIRE', new Location(2, 33)), new Location(2, 24)),
+                                new Argument('episode', new Enum('EMPIRE', new Location(2, 33)), new Location(2, 24)),
                             ], [
                                 new LeafField('__typename', null, [], [], new Location(3, 21)),
                                 new LeafField('name', null, [], [], new Location(4, 21)),
@@ -729,8 +730,7 @@ GRAPHQL;
                         ], new Location(1, 7))
                     ]
                 ),
-                // @todo Fix: it should be `EMPIRE`, not `"EMPIRE"`, but ENUM is currently not mapped in the AST!
-                'query CheckTypeOfLuke { hero(episode: "EMPIRE") { __typename name } }',
+                'query CheckTypeOfLuke { hero(episode: EMPIRE) { __typename name } }',
             ],
             [
                 '{ test { __typename, id } }',


### PR DESCRIPTION
When parsing this query:

```graphql
query CheckTypeOfLuke {
  hero(episode: EMPIRE) {
    __typename
    name
  }
}
```

...enum `EMPIRE` was identified by the parser as a `Literal`. As a consequence, function `asQueryString` printed it as `"EMPIRE"`.

Now, there is a new `Enum` class, and the enum is printed as `EMPIRE` (without quotes)