### PR TITLE
Add ancestor to every AST element

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/AbstractOperation.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/AbstractOperation.php
@@ -12,6 +12,8 @@ abstract class AbstractOperation extends AbstractAst implements OperationInterfa
     use WithDirectivesTrait;
     use WithFieldsOrFragmentBondsTrait;
 
+    protected Document $parent;
+    
     public function __construct(
         protected string $name,
         /** @var Variable[] */
@@ -80,6 +82,11 @@ abstract class AbstractOperation extends AbstractAst implements OperationInterfa
             $operationDefinition !== '' ? sprintf(' %s ', $operationDefinition) : ' ',
             $strOperationFieldsOrFragmentBonds,
         );
+    }
+
+    public function setParent(Document $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getName(): string

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/AbstractOperation.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/AbstractOperation.php
@@ -13,7 +13,7 @@ abstract class AbstractOperation extends AbstractAst implements OperationInterfa
     use WithFieldsOrFragmentBondsTrait;
 
     protected Document $parent;
-    
+
     public function __construct(
         protected string $name,
         /** @var Variable[] */

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Argument.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Argument.php
@@ -8,6 +8,8 @@ use PoP\GraphQLParser\Spec\Parser\Location;
 
 class Argument extends AbstractAst
 {
+    protected FieldInterface|Directive $parent;
+
     public function __construct(
         protected string $name,
         protected WithValueInterface $value,
@@ -23,6 +25,11 @@ class Argument extends AbstractAst
             $this->name,
             $this->value->asQueryString()
         );
+    }
+
+    public function setParent(FieldInterface|Directive $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getName(): string

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Enum.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Enum.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
 
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Location;
 
 class Enum extends AbstractAst implements WithValueInterface
 {
+    protected InputList|InputObject|Argument $parent;
+
     public function __construct(
         protected string $enumValue,
         Location $location
@@ -20,6 +23,11 @@ class Enum extends AbstractAst implements WithValueInterface
     public function asQueryString(): string
     {
         return $this->enumValue;
+    }
+
+    public function setParent(InputList|InputObject|Argument $parent): void
+    {
+        $this->parent = $parent;
     }
 
     /**

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputList.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputList.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
 
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithAstValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Location;
 
 class InputList extends AbstractAst implements WithValueInterface, WithAstValueInterface
 {
+    protected InputList|InputObject|Argument $parent;
+    
     /**
      * @param mixed[] $list
      */
@@ -24,6 +27,11 @@ class InputList extends AbstractAst implements WithValueInterface, WithAstValueI
     public function asQueryString(): string
     {
         return $this->getGraphQLQueryStringFormatter()->getListAsQueryString($this->list);
+    }
+
+    public function setParent(InputList|InputObject|Argument $parent): void
+    {
+        $this->parent = $parent;
     }
 
     /**

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputList.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputList.php
@@ -13,7 +13,7 @@ use PoP\GraphQLParser\Spec\Parser\Location;
 class InputList extends AbstractAst implements WithValueInterface, WithAstValueInterface
 {
     protected InputList|InputObject|Argument $parent;
-    
+
     /**
      * @param mixed[] $list
      */

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputObject.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputObject.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
 
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithAstValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Location;
@@ -12,6 +13,8 @@ use stdClass;
 
 class InputObject extends AbstractAst implements WithValueInterface, WithAstValueInterface
 {
+    protected InputList|InputObject|Argument $parent;
+
     public function __construct(
         protected stdClass $object,
         Location $location,
@@ -22,6 +25,11 @@ class InputObject extends AbstractAst implements WithValueInterface, WithAstValu
     public function asQueryString(): string
     {
         return $this->getGraphQLQueryStringFormatter()->getObjectAsQueryString($this->object);
+    }
+
+    public function setParent(InputList|InputObject|Argument $parent): void
+    {
+        $this->parent = $parent;
     }
 
     /**

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Literal.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Literal.php
@@ -12,7 +12,7 @@ use PoP\GraphQLParser\Spec\Parser\Location;
 class Literal extends AbstractAst implements WithValueInterface
 {
     protected InputList|InputObject|Argument $parent;
-    
+
     public function __construct(
         protected string|int|float|bool|null $value,
         Location $location

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Literal.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Literal.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
 
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Location;
 
 class Literal extends AbstractAst implements WithValueInterface
 {
+    protected InputList|InputObject|Argument $parent;
+    
     public function __construct(
         protected string|int|float|bool|null $value,
         Location $location
@@ -20,6 +23,11 @@ class Literal extends AbstractAst implements WithValueInterface
     public function asQueryString(): string
     {
         return $this->getGraphQLQueryStringFormatter()->getLiteralAsQueryString($this->value);
+    }
+
+    public function setParent(InputList|InputObject|Argument $parent): void
+    {
+        $this->parent = $parent;
     }
 
     /**

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Variable.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Variable.php
@@ -10,6 +10,7 @@ use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Enum;
+use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\WithValueInterface;
 use PoP\GraphQLParser\Spec\Parser\Location;
 use PoP\Root\Feedback\FeedbackItemResolution;
@@ -25,6 +26,8 @@ class Variable extends AbstractAst implements WithValueInterface
     protected bool $hasDefaultValue = false;
 
     protected InputList|InputObject|Literal|Enum|null $defaultValue = null;
+
+    protected OperationInterface $parent;
 
     public function __construct(
         protected string $name,
@@ -55,6 +58,11 @@ class Variable extends AbstractAst implements WithValueInterface
             $strType,
             $this->hasDefaultValue ? sprintf(' = %s', $this->defaultValue) : ''
         );
+    }
+
+    public function setParent(OperationInterface $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function setContext(?Context $context): void

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue;
 
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Spec\Parser\Ast\AbstractAst;
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Location;
+use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\Root\Services\StandaloneServiceTrait;
 
 class VariableReference extends AbstractAst implements VariableReferenceInterface
 {
     use StandaloneServiceTrait;
+
+    protected InputList|InputObject|Argument $parent;
 
     public function __construct(
         protected string $name,
@@ -29,6 +32,11 @@ class VariableReference extends AbstractAst implements VariableReferenceInterfac
             '$%s',
             $this->name
         );
+    }
+
+    public function setParent(InputList|InputObject|Argument $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getVariable(): ?Variable

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Directive.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Directive.php
@@ -10,6 +10,8 @@ class Directive extends AbstractAst
 {
     use WithArgumentsTrait;
 
+    protected FieldInterface|OperationInterface|Fragment|InlineFragment $parent;
+    
     /**
      * @param Argument[] $arguments
      */
@@ -40,6 +42,11 @@ class Directive extends AbstractAst
             $this->name,
             $strDirectiveArguments
         );
+    }
+
+    public function setParent(FieldInterface|OperationInterface|Fragment|InlineFragment $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getName(): string

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Directive.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Directive.php
@@ -11,7 +11,7 @@ class Directive extends AbstractAst
     use WithArgumentsTrait;
 
     protected FieldInterface|OperationInterface|Fragment|InlineFragment $parent;
-    
+
     /**
      * @param Argument[] $arguments
      */

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php
@@ -666,7 +666,7 @@ class Document implements DocumentInterface
      * This enables them to re-create the path to them,
      * from the root of the document.
      */
-    public function setAncestorsInAST(): void
+    public function setAncestorsInAST(): self
     {
         foreach ($this->operations as $operation) {
             $operation->setParent($this);
@@ -676,6 +676,7 @@ class Document implements DocumentInterface
             $fragment->setParent($this);
             $this->setAncestorsUnderFragment($fragment);
         }
+        return $this;
     }
 
     private function setAncestorsUnderOperation(OperationInterface $operation): void

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/DocumentInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/DocumentInterface.php
@@ -19,4 +19,10 @@ interface DocumentInterface
      */
     public function getVariableReferencesInOperation(OperationInterface $operation): array;
     public function asDocumentString(): string;
+    /**
+     * For all elements in the AST, inject them their parent.
+     * This enables them to re-create the path to them,
+     * from the root of the document.
+     */
+    public function setAncestorsInAST(): void;
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/DocumentInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/DocumentInterface.php
@@ -24,5 +24,5 @@ interface DocumentInterface
      * This enables them to re-create the path to them,
      * from the root of the document.
      */
-    public function setAncestorsInAST(): void;
+    public function setAncestorsInAST(): self;
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FieldInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FieldInterface.php
@@ -16,4 +16,6 @@ interface FieldInterface extends AstInterface, LocatableInterface, WithDirective
     public function getArguments(): array;
 
     public function getArgument(string $name): ?Argument;
+
+    public function setParent(RelationalField|Fragment|InlineFragment|OperationInterface $parent): void;
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Fragment.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Fragment.php
@@ -11,6 +11,8 @@ class Fragment extends AbstractAst implements WithDirectivesInterface, WithField
     use WithDirectivesTrait;
     use WithFieldsOrFragmentBondsTrait;
 
+    protected Document $parent;
+
     /**
      * @param Directive[] $directives
      * @param FieldInterface[]|FragmentBondInterface[] $fieldsOrFragmentBonds
@@ -61,6 +63,11 @@ class Fragment extends AbstractAst implements WithDirectivesInterface, WithField
             $strFragmentDirectives,
             $strFragmentFieldsOrFragmentBonds,
         );
+    }
+
+    public function setParent(Document $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getName(): string

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FragmentBondInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FragmentBondInterface.php
@@ -9,4 +9,5 @@ namespace PoP\GraphQLParser\Spec\Parser\Ast;
  */
 interface FragmentBondInterface extends AstInterface
 {
+    public function setParent(RelationalField|Fragment|InlineFragment|OperationInterface $parent): void;
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FragmentReference.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FragmentReference.php
@@ -8,7 +8,7 @@ use PoP\GraphQLParser\Spec\Parser\Location;
 
 class FragmentReference extends AbstractAst implements FragmentBondInterface
 {
-    protected RelationalField|Fragment|InlineFragment $parent;
+    protected RelationalField|Fragment|InlineFragment|OperationInterface $parent;
 
     public function __construct(
         protected string $name,
@@ -25,7 +25,7 @@ class FragmentReference extends AbstractAst implements FragmentBondInterface
         );
     }
 
-    public function setParent(RelationalField|Fragment|InlineFragment $parent): void
+    public function setParent(RelationalField|Fragment|InlineFragment|OperationInterface $parent): void
     {
         $this->parent = $parent;
     }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FragmentReference.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/FragmentReference.php
@@ -8,6 +8,8 @@ use PoP\GraphQLParser\Spec\Parser\Location;
 
 class FragmentReference extends AbstractAst implements FragmentBondInterface
 {
+    protected RelationalField|Fragment|InlineFragment $parent;
+
     public function __construct(
         protected string $name,
         Location $location,
@@ -21,6 +23,11 @@ class FragmentReference extends AbstractAst implements FragmentBondInterface
             '...%s',
             $this->name
         );
+    }
+
+    public function setParent(RelationalField|Fragment|InlineFragment $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getName(): string

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/InlineFragment.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/InlineFragment.php
@@ -11,6 +11,8 @@ class InlineFragment extends AbstractAst implements FragmentBondInterface, WithD
     use WithDirectivesTrait;
     use WithFieldsOrFragmentBondsTrait;
 
+    protected RelationalField|Fragment|InlineFragment $parent;
+
     /**
      * @param FieldInterface[]|FragmentBondInterface[] $fieldsOrFragmentBonds
      * @param Directive[] $directives
@@ -59,6 +61,11 @@ class InlineFragment extends AbstractAst implements FragmentBondInterface, WithD
             $strInlineFragmentDirectives,
             $strInlineFragmentFieldsOrFragmentBonds,
         );
+    }
+
+    public function setParent(RelationalField|Fragment|InlineFragment $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getTypeName(): string

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/InlineFragment.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/InlineFragment.php
@@ -11,7 +11,7 @@ class InlineFragment extends AbstractAst implements FragmentBondInterface, WithD
     use WithDirectivesTrait;
     use WithFieldsOrFragmentBondsTrait;
 
-    protected RelationalField|Fragment|InlineFragment $parent;
+    protected RelationalField|Fragment|InlineFragment|OperationInterface $parent;
 
     /**
      * @param FieldInterface[]|FragmentBondInterface[] $fieldsOrFragmentBonds
@@ -63,7 +63,7 @@ class InlineFragment extends AbstractAst implements FragmentBondInterface, WithD
         );
     }
 
-    public function setParent(RelationalField|Fragment|InlineFragment $parent): void
+    public function setParent(RelationalField|Fragment|InlineFragment|OperationInterface $parent): void
     {
         $this->parent = $parent;
     }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/LeafField.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/LeafField.php
@@ -11,6 +11,8 @@ class LeafField extends AbstractAst implements FieldInterface
     use WithArgumentsTrait;
     use WithDirectivesTrait;
 
+    protected RelationalField|Fragment|InlineFragment|OperationInterface $parent;
+
     /**
      * @param Argument[] $arguments
      * @param Directive[] $directives
@@ -61,6 +63,11 @@ class LeafField extends AbstractAst implements FieldInterface
             $strFieldArguments,
             $strFieldDirectives,
         );
+    }
+
+    public function setParent(RelationalField|Fragment|InlineFragment|OperationInterface $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getName(): string

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/OperationInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/OperationInterface.php
@@ -15,4 +15,5 @@ interface OperationInterface extends AstInterface, LocatableInterface, WithDirec
      * @return Variable[]
      */
     public function getVariables(): array;
+    public function setParent(Document $parent): void;
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/RelationalField.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/RelationalField.php
@@ -12,6 +12,8 @@ class RelationalField extends AbstractAst implements FieldInterface, WithFieldsO
     use WithDirectivesTrait;
     use WithFieldsOrFragmentBondsTrait;
 
+    protected RelationalField|Fragment|InlineFragment|OperationInterface $parent;
+
     /**
      * @param Argument[] $arguments
      * @param FieldInterface[]|FragmentBondInterface[] $fieldsOrFragmentBonds
@@ -79,6 +81,11 @@ class RelationalField extends AbstractAst implements FieldInterface, WithFieldsO
             $strFieldDirectives,
             $strFieldFieldsOrFragmentBonds,
         );
+    }
+
+    public function setParent(RelationalField|Fragment|InlineFragment|OperationInterface $parent): void
+    {
+        $this->parent = $parent;
     }
 
     public function getName(): string


### PR DESCRIPTION
In preparation to print the `path` to the element in the GraphQL query where an error was produced:

```json
{
  "errors": [
    {
      "message": "...",
      "path": "MyOperation.posts.author(limit:)"
    }
  ]
}
```

In order to re-create this path, every element in the AST is now injected its parent AST element. This is done by calling method `setAncestorsInAST` from `Document`.