### PR TITLE
Use `App::addAction` instead of `add_action` in `-wp` packages

### DIFF
--- a/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/AbstractEndpointHandler.php
+++ b/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/AbstractEndpointHandler.php
@@ -27,7 +27,7 @@ abstract class AbstractEndpointHandler extends UpstreamAbstractEndpointHandler
                 'init',
                 $this->addRewriteEndpoints(...)
             );
-            \add_filter(
+            App::addFilter(
                 'query_vars',
                 $this->addQueryVar(...),
                 10,
@@ -40,7 +40,7 @@ abstract class AbstractEndpointHandler extends UpstreamAbstractEndpointHandler
 
             // // If it is a partial endpoint, we must add all the combinations of routes to Cortex
             // if (!$this->doesEndpointMatchWholeURL()) {
-            //     \add_filter(
+            //     App::addFilter(
             //         'route-endpoints',
             //         $this->getRouteEndpoints(...),
             //         10,

--- a/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/AbstractEndpointHandler.php
+++ b/layers/API/packages/api-endpoints-for-wp/src/EndpointHandlers/AbstractEndpointHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPAPI\APIEndpointsForWP\EndpointHandlers;
 
+use PoP\ComponentModel\App;
 use PoPAPI\APIEndpoints\AbstractEndpointHandler as UpstreamAbstractEndpointHandler;
 
 abstract class AbstractEndpointHandler extends UpstreamAbstractEndpointHandler
@@ -22,7 +23,7 @@ abstract class AbstractEndpointHandler extends UpstreamAbstractEndpointHandler
             /**
              * Register the endpoints
              */
-            \add_action(
+            App::addAction(
                 'init',
                 $this->addRewriteEndpoints(...)
             );
@@ -32,7 +33,7 @@ abstract class AbstractEndpointHandler extends UpstreamAbstractEndpointHandler
                 10,
                 1
             );
-            \add_action(
+            App::addAction(
                 'parse_request',
                 $this->parseRequest(...)
             );

--- a/layers/CMSSchema/packages/menus-wp/phpstan.neon.dist
+++ b/layers/CMSSchema/packages/menus-wp/phpstan.neon.dist
@@ -2,7 +2,3 @@ parameters:
 	level: 8
 	paths:
 		- src
-	ignoreErrors:
-		-
-			message: '#^Function apply_filters invoked with 3 parameters, 2 required\.$#'
-			path: src/TypeAPIs/MenuTypeAPI.php

--- a/layers/CMSSchema/packages/menus-wp/src/TypeAPIs/MenuTypeAPI.php
+++ b/layers/CMSSchema/packages/menus-wp/src/TypeAPIs/MenuTypeAPI.php
@@ -46,11 +46,11 @@ class MenuTypeAPI implements MenuTypeAPIInterface
                     $menuItem->ID,
                     $menuItem->object_id,
                     $menuItem->menu_item_parent === "0" ? null : $menuItem->menu_item_parent,
-                    \apply_filters('the_title', $menuItem->title, $menuItem->object_id),
+                    App::applyFilters('the_title', $menuItem->title, $menuItem->object_id),
                     $menuItem->attr_title,
                     $menuItem->url,
                     $menuItem->description,
-                    \apply_filters('menuitem:classes', array_filter($menuItem->classes), $menuItem),
+                    App::applyFilters('menuitem:classes', array_filter($menuItem->classes), $menuItem),
                     $menuItem->target,
                     $menuItem->xfn,
                 );

--- a/layers/CMSSchema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/CMSSchema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -84,7 +84,7 @@ class UserTypeAPI extends AbstractUserTypeAPI
 
         // Remove the hook
         if ($filterByEmails) {
-            remove_action('pre_user_query', $this->enableMultipleEmails(...));
+            App::removeAction('pre_user_query', $this->enableMultipleEmails(...));
         }
         return $ret;
     }
@@ -110,7 +110,7 @@ class UserTypeAPI extends AbstractUserTypeAPI
 
         // Remove the hook
         if ($filterByEmails) {
-            remove_action('pre_user_query', $this->enableMultipleEmails(...));
+            App::removeAction('pre_user_query', $this->enableMultipleEmails(...));
         }
         return $ret;
     }

--- a/layers/CMSSchema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/CMSSchema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -71,7 +71,7 @@ class UserTypeAPI extends AbstractUserTypeAPI
         // 4. Remove hook
         $filterByEmails = $this->filterByEmails($query);
         if ($filterByEmails) {
-            add_action('pre_user_query', $this->enableMultipleEmails(...));
+            App::addAction('pre_user_query', $this->enableMultipleEmails(...));
         }
 
         // Execute the query. Original solution from:
@@ -102,7 +102,7 @@ class UserTypeAPI extends AbstractUserTypeAPI
         // 4. Remove hook
         $filterByEmails = $this->filterByEmails($query);
         if ($filterByEmails) {
-            add_action('pre_user_query', $this->enableMultipleEmails(...));
+            App::addAction('pre_user_query', $this->enableMultipleEmails(...));
         }
 
         // Execute the query

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractClient.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/AbstractClient.php
@@ -48,7 +48,7 @@ abstract class AbstractClient extends AbstractEndpointHandler
          *
          * @see https://github.com/leoloso/PoP/issues/710
          */
-        \add_action('init', function (): void {
+        App::addAction('init', function (): void {
             if (!$this->isClientDisabled()) {
                 parent::initialize();
             }


### PR DESCRIPTION
So that there's no need to mock those functions in PHPUnit tests.