### PR TITLE
Added GraphQL validation "5.5.1.2": Fragment spread type existence

### DIFF
--- a/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php
+++ b/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\ExtendedSpec\Execution;
+
+use PoP\ComponentModel\Registries\TypeRegistryInterface;
+use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
+use PoP\GraphQLParser\ExtendedSpec\Execution\AbstractExecutableDocument;
+use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
+use PoP\GraphQLParser\StaticHelpers\LocationHelper;
+use PoP\Root\Facades\Instances\InstanceManagerFacade;
+use PoP\Root\Feedback\FeedbackItemResolution;
+
+class ExecutableDocument extends AbstractExecutableDocument
+{
+    private ?TypeRegistryInterface $typeRegistry = null;
+
+    final protected function getTypeRegistry(): TypeRegistryInterface
+    {
+        return $this->typeRegistry ??= InstanceManagerFacade::getInstance()->getInstance(TypeRegistryInterface::class);
+    }
+
+    /**
+     * @throws InvalidRequestException
+     */
+    protected function assertFragmentSpreadTypesExistInSchema(): void
+    {
+        foreach ($this->document->getFragments() as $fragment) {
+            $fragmentModel = $fragment->getModel();
+            if (false/*in_array($fragmentModel, $fragmentNames)*/) {
+                throw new InvalidRequestException(
+                    new FeedbackItemResolution(
+                        GraphQLSpecErrorFeedbackItemProvider::class,
+                        GraphQLSpecErrorFeedbackItemProvider::E_5_5_1_2,
+                        [
+                            $fragmentModel,
+                        ]
+                    ),
+                    LocationHelper::getNonSpecificLocation()
+                );
+            }
+        }
+    }
+}

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/DynamicVariables/AbstractDynamicVariablesTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/DynamicVariables/AbstractDynamicVariablesTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Upstream\GraphQLParser\ExtendedSpec\Execution\DynamicVariables;
 
+use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
-use PoP\GraphQLParser\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\ArgumentValue\DynamicVariableReference;
 use PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/MultipleQueryExecution/AbstractMultipleQueryExecutionTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/MultipleQueryExecution/AbstractMultipleQueryExecutionTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PoP\GraphQLParser\ExtendedSpec\Execution\MultipleQueryExecution;
+namespace PoP\ComponentModel\Upstream\GraphQLParser\ExtendedSpec\Execution\MultipleQueryExecution;
 
+use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
-use PoP\GraphQLParser\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/MultipleQueryExecution/MultipleQueryExecutionDisabledTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/MultipleQueryExecution/MultipleQueryExecutionDisabledTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoP\GraphQLParser\ExtendedSpec\Execution\MultipleQueryExecution;
+namespace PoP\ComponentModel\Upstream\GraphQLParser\ExtendedSpec\Execution\MultipleQueryExecution;
 
 class MultipleQueryExecutionDisabledTest extends AbstractMultipleQueryExecutionTest
 {

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/MultipleQueryExecution/MultipleQueryExecutionEnabledTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/MultipleQueryExecution/MultipleQueryExecutionEnabledTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoP\GraphQLParser\ExtendedSpec\Execution\MultipleQueryExecution;
+namespace PoP\ComponentModel\Upstream\GraphQLParser\ExtendedSpec\Execution\MultipleQueryExecution;
 
 class MultipleQueryExecutionEnabledTest extends AbstractMultipleQueryExecutionTest
 {

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ResolvedFieldVariableReferences/AbstractResolvedFieldVariableReferencesTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ResolvedFieldVariableReferences/AbstractResolvedFieldVariableReferencesTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Upstream\GraphQLParser\ExtendedSpec\Execution\ResolvedFieldVariableReferences;
 
-use PoP\GraphQLParser\ExtendedSpec\Execution\ExecutableDocument;
+use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\ArgumentValue\DynamicVariableReference;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\ArgumentValue\ResolvedFieldVariableReference;
 use PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface;

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Execution/AbstractExecutableDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Execution/AbstractExecutableDocument.php
@@ -9,11 +9,11 @@ use PoP\GraphQLParser\ComponentConfiguration;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\ArgumentValue\DynamicVariableReference;
 use PoP\GraphQLParser\Facades\Query\QueryAugmenterServiceFacade;
 use PoP\GraphQLParser\Spec\Execution\Context;
-use PoP\GraphQLParser\Spec\Execution\ExecutableDocument as UpstreamExecutableDocument;
+use PoP\GraphQLParser\Spec\Execution\AbstractExecutableDocument as UpstreamAbstractExecutableDocument;
 use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\Root\App;
 
-class ExecutableDocument extends UpstreamExecutableDocument
+abstract class AbstractExecutableDocument extends UpstreamAbstractExecutableDocument
 {
     /**
      * Override to support the "multiple query execution" feature:

--- a/layers/Engine/packages/graphql-parser/src/FeedbackItemProviders/GraphQLSpecErrorFeedbackItemProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/FeedbackItemProviders/GraphQLSpecErrorFeedbackItemProvider.php
@@ -117,7 +117,7 @@ class GraphQLSpecErrorFeedbackItemProvider extends AbstractFeedbackItemProvider
             self::E_5_4_2 => $this->__('Argument \'%s\' is duplicated', 'graphql-server'),
             self::E_5_4_2_1 => 'TODO: satisfy',
             self::E_5_5_1_1 => $this->__('Fragment name \'%s\' is duplicated', 'graphql-server'),
-            self::E_5_5_1_2 => 'TODO: satisfy',
+            self::E_5_5_1_2 => $this->__('Fragment spread type \'%s\' is not defined in the schema', 'graphql-server'),
             self::E_5_5_1_3 => 'TODO: satisfy',
             self::E_5_5_1_4 => $this->__('Fragment \'%s\' is not used', 'graphql-server'),
             self::E_5_5_2_1 => $this->__('Fragment \'%s\' is not defined in document', 'graphql-server'),

--- a/layers/Engine/packages/graphql-parser/src/Spec/Execution/AbstractExecutableDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Execution/AbstractExecutableDocument.php
@@ -13,7 +13,7 @@ use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\GraphQLParser\StaticHelpers\LocationHelper;
 use PoP\Root\Services\StandaloneServiceTrait;
 
-class ExecutableDocument implements ExecutableDocumentInterface
+abstract class AbstractExecutableDocument implements ExecutableDocumentInterface
 {
     use StandaloneServiceTrait;
 
@@ -44,6 +44,7 @@ class ExecutableDocument implements ExecutableDocumentInterface
 
         $this->document->validate();
         $this->assertAllMandatoryVariablesHaveValue();
+        $this->assertFragmentSpreadTypesExistInSchema();
 
         // Obtain the operations that must be executed
         $this->requestedOperations = $this->assertAndGetRequestedOperations();
@@ -151,6 +152,14 @@ class ExecutableDocument implements ExecutableDocumentInterface
             }
         }
     }
+
+    /**
+     * Function to be satisfied at the ComponentModel level,
+     * where we access to the schema.
+     *
+     * @throws InvalidRequestException
+     */
+    abstract protected function assertFragmentSpreadTypesExistInSchema(): void;
 
     protected function propagateContext(OperationInterface $operation, ?Context $context): void
     {


### PR DESCRIPTION
Perform validation [5.5.1.2: Fragment spread type existence](https://spec.graphql.org/draft/#sec-Fragment-Spread-Type-Existence) on the GraphQL query