### PR TITLE
Support: Fragment spread can be applied on unions

### DIFF
--- a/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php
+++ b/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php
@@ -44,7 +44,7 @@ class ExecutableDocument extends UpstreamExecutableDocument
             $context
         );
         $this->typeResolvers = [
-            ...$this->getTypeRegistry()->getObjectTypeResolvers(),
+            ...$this->getTypeRegistry()->getRelationalTypeResolvers(),
             ...$this->getTypeRegistry()->getInterfaceTypeResolvers()
         ];
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
@@ -41,7 +41,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
             'typeName',
             'namespace',
             'qualifiedTypeName',
-            'isType',
+            'isObjectType',
             'implements',
             'isTypeOrImplements',
             'isTypeOrImplementsAll',
@@ -54,7 +54,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
             'typeName' => $this->getStringScalarTypeResolver(),
             'namespace' => $this->getStringScalarTypeResolver(),
             'qualifiedTypeName' => $this->getStringScalarTypeResolver(),
-            'isType' => $this->getBooleanScalarTypeResolver(),
+            'isObjectType' => $this->getBooleanScalarTypeResolver(),
             'implements' => $this->getBooleanScalarTypeResolver(),
             'isTypeOrImplements' => $this->getBooleanScalarTypeResolver(),
             'isTypeOrImplementsAll' => $this->getBooleanScalarTypeResolver(),
@@ -68,7 +68,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
             'typeName',
             'namespace',
             'qualifiedTypeName',
-            'isType',
+            'isObjectType',
             'implements',
             'isTypeOrImplements',
             'isTypeOrImplementsAll'
@@ -84,7 +84,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
             'typeName' => $this->__('The object\'s type', 'component-model'),
             'namespace' => $this->__('The object\'s namespace', 'component-model'),
             'qualifiedTypeName' => $this->__('The object\'s namespace + type', 'component-model'),
-            'isType' => $this->__('Indicate if the object is of a given type', 'component-model'),
+            'isObjectType' => $this->__('Indicate if the object is of a given type', 'component-model'),
             'implements' => $this->__('Indicate if the object implements a given interface', 'component-model'),
             'isTypeOrImplements' => $this->__('Indicate if the object is of a given type or implements a given interface', 'component-model'),
             'isTypeOrImplementsAll' => $this->__('Indicate if the object is all of the given types or interfaces', 'component-model'),
@@ -95,7 +95,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
     public function getFieldArgNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): array
     {
         return match ($fieldName) {
-            'isType' => [
+            'isObjectType' => [
                 'type' => $this->getStringScalarTypeResolver(),
             ],
             'implements' => [
@@ -114,7 +114,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
     public function getFieldArgDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): ?string
     {
         return match ([$fieldName => $fieldArgName]) {
-            ['isType' => 'type'] => $this->__('The type name to compare against', 'component-model'),
+            ['isObjectType' => 'type'] => $this->__('The type name to compare against', 'component-model'),
             ['implements' => 'interface'] => $this->__('The interface name to compare against', 'component-model'),
             ['isTypeOrImplements' => 'typeOrInterface'] => $this->__('The type or interface name to compare against', 'component-model'),
             ['isTypeOrImplementsAll' => 'typeOrInterfaces'] => $this->__('The types and interface names to compare against', 'component-model'),
@@ -125,7 +125,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
     public function getFieldArgTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): int
     {
         return match ([$fieldName => $fieldArgName]) {
-            ['isType' => 'type'],
+            ['isObjectType' => 'type'],
             ['implements' => 'interface'],
             ['isTypeOrImplements' => 'typeOrInterface']
                 => SchemaTypeModifiers::MANDATORY,
@@ -162,7 +162,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
             case 'qualifiedTypeName':
                 return $objectTypeResolver->getNamespacedTypeName();
 
-            case 'isType':
+            case 'isObjectType':
                 $typeName = $fieldArgs['type'];
                 // If the provided typeName contains the namespace separator, then compare by qualifiedType
                 if (str_contains($typeName, SchemaDefinitionTokens::NAMESPACE_SEPARATOR)) {
@@ -232,7 +232,7 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
                 $isType = $objectTypeResolver->resolveValue(
                     $object,
                     $this->getFieldQueryInterpreter()->getField(
-                        'isType',
+                        'isObjectType',
                         [
                             'type' => $fieldArgs['typeOrInterface'],
                         ]

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/CoreGlobalObjectTypeFieldResolver.php
@@ -258,7 +258,8 @@ class CoreGlobalObjectTypeFieldResolver extends AbstractGlobalObjectTypeFieldRes
                  */
                 $isNamespacedUnionTypeName = str_contains($unionTypeName, SchemaDefinitionTokens::NAMESPACE_SEPARATOR);
                 foreach ($unionTypeResolvers as $unionTypeResolver) {
-                    if ($unionTypeName === $unionTypeResolver->getTypeName()
+                    if (
+                        $unionTypeName === $unionTypeResolver->getTypeName()
                         || ($isNamespacedUnionTypeName && $unionTypeName === $unionTypeResolver->getNamespacedTypeName())
                     ) {
                         $foundUnionTypeResolver = $unionTypeResolver;

--- a/layers/Engine/packages/component-model/src/Registries/TypeRegistry.php
+++ b/layers/Engine/packages/component-model/src/Registries/TypeRegistry.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterfac
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
 
 class TypeRegistry implements TypeRegistryInterface
 {
@@ -35,6 +36,16 @@ class TypeRegistry implements TypeRegistryInterface
         return array_values(array_filter(
             $this->typeResolvers,
             fn ($typeResolver) => $typeResolver instanceof RelationalTypeResolverInterface
+        ));
+    }
+    /**
+     * @return UnionTypeResolverInterface[]
+     */
+    public function getUnionTypeResolvers(): array
+    {
+        return array_values(array_filter(
+            $this->typeResolvers,
+            fn ($typeResolver) => $typeResolver instanceof UnionTypeResolverInterface
         ));
     }
     /**

--- a/layers/Engine/packages/component-model/src/Registries/TypeRegistryInterface.php
+++ b/layers/Engine/packages/component-model/src/Registries/TypeRegistryInterface.php
@@ -8,6 +8,7 @@ use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterfac
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\TypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
 
 interface TypeRegistryInterface
 {
@@ -20,6 +21,10 @@ interface TypeRegistryInterface
      * @return RelationalTypeResolverInterface[]
      */
     public function getRelationalTypeResolvers(): array;
+    /**
+     * @return UnionTypeResolverInterface[]
+     */
+    public function getUnionTypeResolvers(): array;
     /**
      * @return ObjectTypeResolverInterface[]
      */

--- a/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/ExtendedSpec/Execution/ExecutableDocumentTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/ExtendedSpec/Execution/ExecutableDocumentTest.php
@@ -80,6 +80,26 @@ class ExecutableDocumentTest extends UpstreamExecutableDocumentTest
                 }
                 GRAPHQL,
             ],
+            'union-type-in-fragment' => [
+                <<<GRAPHQL
+                {
+                    customPosts {
+                        __typename
+                        ...CustomPostData
+                    }
+                }
+                
+                fragment CustomPostData on CustomPostUnion {
+                    customPostType
+                    ...PostData
+                }
+                
+                fragment PostData on Post {
+                    id
+                    title
+                }
+                GRAPHQL,
+            ],
             'object-type-in-inline-fragment' => [
                 <<<GRAPHQL
                 {
@@ -101,6 +121,22 @@ class ExecutableDocumentTest extends UpstreamExecutableDocumentTest
                         ...on IsCustomPost {
                             id
                             title
+                        }
+                    }
+                }
+                GRAPHQL,
+            ],
+            'union-type-in-inline-fragment' => [
+                <<<GRAPHQL
+                {
+                    customPosts {
+                        __typename
+                        ...on CustomPostUnion {
+                            customPostType
+                            ...on Post {
+                                id
+                                title
+                            }
                         }
                     }
                 }

--- a/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/fragment.gql
+++ b/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/fragment.gql
@@ -4,18 +4,18 @@
       limit: 3
     }
   ) {
+    __typename
     ...CustomPostData
     ...UserData
   }
 }
 
 fragment CustomPostData on CustomPostUnion {
-  __typename
+  customPostType
   ...CustomPostNodeData
 }
 
 fragment CustomPostNodeData on IsCustomPost {
-  customPostType
   date
   ...PostData
 }

--- a/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/fragment.gql
+++ b/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/fragment.gql
@@ -4,13 +4,18 @@
       limit: 3
     }
   ) {
-    __typename
     ...CustomPostData
     ...UserData
   }
 }
 
-fragment CustomPostData on IsCustomPost {
+fragment CustomPostData on CustomPostUnion {
+  __typename
+  ...CustomPostNodeData
+}
+
+fragment CustomPostNodeData on IsCustomPost {
+  customPostType
   date
   ...PostData
 }

--- a/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/fragment.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/fragment.json
@@ -3,16 +3,19 @@
     "customPosts": [
       {
         "__typename": "Post",
+        "customPostType": "post",
+        "date": "2018-10-20T20:03:48+00:00",
         "id": 1724,
-        "title": "Keyboard navigation",
-        "date": "2018-10-20T20:03:48+00:00"
+        "title": "Keyboard navigation"
       },
       {
         "__typename": "Page",
+        "customPostType": "page",
         "date": "2010-07-25T19:40:01+00:00"
       },
       {
         "__typename": "Page",
+        "customPostType": "page",
         "date": "2007-09-04T09:52:50+00:00"
       }
     ]

--- a/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/inline-fragment.gql
+++ b/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/inline-fragment.gql
@@ -4,11 +4,11 @@
       limit: 3
     }
   ) {
+    __typename
     ... on CustomPostUnion {
-      __typename
+      customPostType
       ... on IsCustomPost {
         date
-        customPostType
         ... on Post {
           id
           title

--- a/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/inline-fragment.gql
+++ b/layers/GraphQLAPIForWP/phpunit-packages/wpfaker-schema/tests/Standalone/Upstream/ComponentModel/Fixture/Success/inline-fragment.gql
@@ -4,13 +4,15 @@
       limit: 3
     }
   ) {
-    __typename
-    ... on IsCustomPost {
-      date
-      customPostType
-      ... on Post {
-        id
-        title
+    ... on CustomPostUnion {
+      __typename
+      ... on IsCustomPost {
+        date
+        customPostType
+        ... on Post {
+          id
+          title
+        }
       }
     }
     ... on User {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addhighlights-processors/library/multilayout-processors/multilayout-processors.php
@@ -21,7 +21,7 @@ class PoP_AddHighlights_Multilayout_Processor extends PoP_Application_Multilayou
                     $highlightTypeResolver = $instanceManager->getInstance(HighlightObjectTypeResolver::class);
                     $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                     $field = $fieldQueryInterpreter->getField(
-                        'isType',
+                        'isObjectType',
                         [
                             'type' => $highlightTypeResolver->getTypeName(),
                         ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/plugins/pop-events/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonautomatedemails-processors/plugins/pop-events/library/multilayout-processors/multilayout-processors.php
@@ -30,7 +30,7 @@ class PoP_CommonAutomatedEmails_Events_Multilayout_Processor extends PoP_Applica
                         $eventObjectTypeResolver = $instanceManager->getInstance(EventObjectTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
-                            'isType',
+                            'isObjectType',
                             [
                                 'type' => $eventObjectTypeResolver->getTypeName(),
                             ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/plugins/pop-application-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/plugins/pop-application-processors/library/multilayout-processors/multilayout-processors.php
@@ -25,7 +25,7 @@ class PoP_Events_Multilayout_Processor extends PoP_Application_Multilayout_Proce
         /** @var RelationalTypeResolverInterface */
         $eventObjectTypeResolver = $instanceManager->getInstance(EventObjectTypeResolver::class);
         $field = $fieldQueryInterpreter->getField(
-            'isType',
+            'isObjectType',
             [
                 'type' => $eventObjectTypeResolver->getTypeName(),
             ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-eventscreation-processors/library/multilayout-processors/multilayout-processors.php
@@ -36,7 +36,7 @@ class PoP_EventsCreation_Multilayout_Processor extends PoP_Application_Multilayo
                         $eventObjectTypeResolver = $instanceManager->getInstance(EventObjectTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
-                            'isType',
+                            'isObjectType',
                             [
                                 'type' => $eventObjectTypeResolver->getTypeName(),
                             ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
@@ -16,7 +16,7 @@ class PoP_LocationPostCategoryLayouts_Multilayout_Processor extends PoP_Applicat
                     $locationPostTypeResolver = $instanceManager->getInstance(LocationPostObjectTypeResolver::class);
                     $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                     $field = $fieldQueryInterpreter->getField(
-                        'isType',
+                        'isObjectType',
                         [
                             'type' => $locationPostTypeResolver->getTypeName(),
                         ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationposts-processors/library/multilayout-processors/multilayout-processors.php
@@ -21,7 +21,7 @@ class PoP_LocationPosts_Multilayout_Processor extends PoP_Application_Multilayou
         $locationPostTypeResolver = $instanceManager->getInstance(LocationPostObjectTypeResolver::class);
         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
         $field = $fieldQueryInterpreter->getField(
-            'isType',
+            'isObjectType',
             [
                 'type' => $locationPostTypeResolver->getTypeName(),
             ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locationpostscreation-processors/library/multilayout-processors/multilayout-processors.php
@@ -23,7 +23,7 @@ class PoP_LocationPostsCreation_Multilayout_Processor extends PoP_Application_Mu
                     $locationPostTypeResolver = $instanceManager->getInstance(LocationPostObjectTypeResolver::class);
                     $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                     $field = $fieldQueryInterpreter->getField(
-                        'isType',
+                        'isObjectType',
                         [
                             'type' => $locationPostTypeResolver->getTypeName(),
                         ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-postcategorylayouts-processors/library/multilayout-processors/multilayout-processors.php
@@ -22,7 +22,7 @@ class PoP_PostCategoryLayouts_Multilayout_Processor extends PoP_Application_Mult
                         $postObjectTypeResolver = $instanceManager->getInstance(PostObjectTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
-                            'isType',
+                            'isObjectType',
                             [
                                 'type' => $postObjectTypeResolver->getTypeName(),
                             ]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/multilayout-processors/multilayout-processors.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/multilayout-processors/multilayout-processors.php
@@ -41,7 +41,7 @@ class PoP_UserStance_Multilayout_Processor extends PoP_Application_Multilayout_P
                         $stanceTypeResolver = $instanceManager->getInstance(StanceObjectTypeResolver::class);
                         $fieldQueryInterpreter = FieldQueryInterpreterFacade::getInstance();
                         $field = $fieldQueryInterpreter->getField(
-                            'isType',
+                            'isObjectType',
                             [
                                 'type' => $stanceTypeResolver->getTypeName(),
                             ]


### PR DESCRIPTION
As defined in the spec on [validation 5.5.1.3](https://spec.graphql.org/October2021/#sec-Fragments-On-Composite-Types):

> The target type of fragment must have kind UNION, INTERFACE, or OBJECT.