### PR TITLE
No need to always add the "id" data field

### DIFF
--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -782,9 +782,8 @@ class Engine implements EngineInterface
             'idsDataFields' => [],
         ];
         foreach ($ids as $id) {
-            $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'] ??= $this->getDBObjectMandatoryFields();
             $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'] = array_values(array_unique(array_merge(
-                $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'],
+                $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'] ?? $this->getDBObjectMandatoryFields(),
                 $data_fields
             )));
             // The conditional data fields have the condition data fields, as key, and the list of conditional data fields to load if the condition one is successful, as value

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -782,8 +782,7 @@ class Engine implements EngineInterface
             'idsDataFields' => [],
         ];
         foreach ($ids as $id) {
-            // Make sure to always add the 'id' data-field, since that's the key for the dbobject in the client database
-            $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'] ??= ['id'];
+            $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'] ??= $this->getDBObjectMandatoryFields();
             $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'] = array_values(array_unique(array_merge(
                 $relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'],
                 $data_fields
@@ -797,6 +796,15 @@ class Engine implements EngineInterface
                 );
             }
         }
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getDBObjectMandatoryFields(): array
+    {
+        // Make sure to always add the 'id' data-field, since that's the key for the dbobject in the client database
+        return ['id'];
     }
 
     private function doAddDatasetToDatabase(

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -799,12 +799,14 @@ class Engine implements EngineInterface
     }
 
     /**
+     * If any field must be retrieved always (eg: the object ID
+     * must always be displayed in the client) then add it here.
+     *
      * @return string[]
      */
     protected function getDBObjectMandatoryFields(): array
     {
-        // Make sure to always add the 'id' data-field, since that's the key for the dbobject in the client database
-        return ['id'];
+        return [];
     }
 
     private function doAddDatasetToDatabase(

--- a/layers/SiteBuilder/packages/component-model-configuration/src/Engine/Engine.php
+++ b/layers/SiteBuilder/packages/component-model-configuration/src/Engine/Engine.php
@@ -199,4 +199,16 @@ class Engine extends UpstreamEngine implements EngineInterface
             $meta
         );
     }
+
+    /**
+     * @return string[]
+     */
+    protected function getDBObjectMandatoryFields(): array
+    {
+        // Make sure to always add the 'id' data-field, since that's the key for the dbobject in the client database
+        return [
+            ...parent::getDBObjectMandatoryFields(),
+            'id',
+        ];
+    }
 }


### PR DESCRIPTION
Retrieving the `id` data field is not actually needed for GraphQL.

So moved the code below to `ConfigurationComponentModel`, under the new function `getDBObjectMandatoryFields`:

```php
// Make sure to always add the 'id' data-field, since that's the key for the dbobject in the client database
$relationalTypeOutputDBKeyIDsDataFields[$relationalTypeOutputDBKey]['idsDataFields'][(string)$id]['direct'] ??= ['id'];
```