### PR TITLE
Cache object type resolved values

### DIFF
--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -141,6 +141,7 @@ class EngineState
 
     protected function getDataHash(array $data): string
     {
-        return (string)hash('crc32', json_encode($data));
+        return json_encode($data);
+        // return (string)hash('crc32', json_encode($data));
     }
 }

--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -87,17 +87,19 @@ class EngineState
 
     public function hasRelationalTypeResolvedValue(
         RelationalTypeResolverInterface $relationalTypeResolver,
-        string|int $objectID,
+        object $object,
         string $field
     ): bool {
+        $objectID = $relationalTypeResolver->getID($object);
         return array_key_exists($field, $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID] ?? []);
     }
 
     public function getRelationalTypeResolvedValue(
         RelationalTypeResolverInterface $relationalTypeResolver,
-        string|int $objectID,
+        object $object,
         string $field
     ): mixed {
+        $objectID = $relationalTypeResolver->getID($object);
         return $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID][$field];
     }
 }

--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Engine;
 
-use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 
 class EngineState
 {
@@ -79,37 +79,37 @@ class EngineState
          * @todo Check if caching by $objectID and $field is enough; $variables? $options? $feedbackStore?
          * @todo Check how this plays out for mutations; should they be executed more than once? If so, when/how?
          *
-         * @var array<string|id,array<string,mixed>> Multidimensional array of [$relationalTypeResolverNamespacedName][$objectID][$field] => $value
+         * @var array<string|id,array<string,mixed>> Multidimensional array of [$objectTypeResolverNamespacedName][$objectID][$field] => $value
          */
-        protected array $relationalTypeResolvedValuesCache = [],
+        protected array $objectTypeResolvedValuesCache = [],
     ) {
     }
 
-    public function hasRelationalTypeResolvedValue(
-        RelationalTypeResolverInterface $relationalTypeResolver,
+    public function hasObjectTypeResolvedValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
         object $object,
         string $field,
     ): bool {
-        $objectID = $relationalTypeResolver->getID($object);
-        return array_key_exists($field, $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID] ?? []);
+        $objectID = $objectTypeResolver->getID($object);
+        return array_key_exists($field, $this->objectTypeResolvedValuesCache[$objectTypeResolver->getNamespacedTypeName()][$objectID] ?? []);
     }
 
-    public function getRelationalTypeResolvedValue(
-        RelationalTypeResolverInterface $relationalTypeResolver,
+    public function getObjectTypeResolvedValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
         object $object,
         string $field,
     ): mixed {
-        $objectID = $relationalTypeResolver->getID($object);
-        return $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID][$field];
+        $objectID = $objectTypeResolver->getID($object);
+        return $this->objectTypeResolvedValuesCache[$objectTypeResolver->getNamespacedTypeName()][$objectID][$field];
     }
 
-    public function setRelationalTypeResolvedValue(
-        RelationalTypeResolverInterface $relationalTypeResolver,
+    public function setObjectTypeResolvedValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
         object $object,
         string $field,
         mixed $value,
     ): void {
-        $objectID = $relationalTypeResolver->getID($object);
-        $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID][$field] = $value;
+        $objectID = $objectTypeResolver->getID($object);
+        $this->objectTypeResolvedValuesCache[$objectTypeResolver->getNamespacedTypeName()][$objectID][$field] = $value;
     }
 }

--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -76,7 +76,6 @@ class EngineState
          * But the 2nd AST must not be recalculated.
          *
          * @todo Incorporate with AST to compare against the Field->getLocation(), to make sure 2 fields are indeed the same
-         * @todo Check if can avoid caching by $variables and $expressions
          * @todo Check if caching by $feedbackStore is also needed
          * @todo Check if caching by $options is also needed
          * @todo Check how this plays out for mutations; should they be executed more than once? If so, when/how?

--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -88,7 +88,7 @@ class EngineState
     public function hasRelationalTypeResolvedValue(
         RelationalTypeResolverInterface $relationalTypeResolver,
         object $object,
-        string $field
+        string $field,
     ): bool {
         $objectID = $relationalTypeResolver->getID($object);
         return array_key_exists($field, $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID] ?? []);
@@ -97,9 +97,19 @@ class EngineState
     public function getRelationalTypeResolvedValue(
         RelationalTypeResolverInterface $relationalTypeResolver,
         object $object,
-        string $field
+        string $field,
     ): mixed {
         $objectID = $relationalTypeResolver->getID($object);
         return $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID][$field];
+    }
+
+    public function setRelationalTypeResolvedValue(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        object $object,
+        string $field,
+        mixed $value,
+    ): void {
+        $objectID = $relationalTypeResolver->getID($object);
+        $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID][$field] = $value;
     }
 }

--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Engine;
 
+use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
+
 class EngineState
 {
     public function __construct(
@@ -54,6 +56,48 @@ class EngineState
          * @var array<string,array<string,mixed>>
          */
         public array $relationalTypeOutputDBKeyIDsDataFields = [],
+
+        /**
+         * After executing `resolveValue` on the Object/UnionTypeResolver,
+         * store the results to re-use for subsequent calls for same object/field.
+         *
+         * This is mandatory due to the "Resolved Field Variable References",
+         * which re-create the same field in the AST.
+         *
+         * For instance, in this query, the `id` field is created twice in the AST:
+         *
+         * ```graphql
+         * {
+         *   id
+         *   echo(value: $_id)
+         * }
+         * ```
+         *
+         * But the 2nd AST must not be recalculated.
+         *
+         * @todo Incorporate with AST to compare against the Field->getLocation(), to make sure 2 fields are indeed the same
+         * @todo Check if caching by $objectID and $field is enough; $variables? $options? $feedbackStore?
+         * @todo Check how this plays out for mutations; should they be executed more than once? If so, when/how?
+         *
+         * @var array<string|id,array<string,mixed>> Multidimensional array of [$relationalTypeResolverNamespacedName][$objectID][$field] => $value
+         */
+        protected array $relationalTypeResolvedValuesCache = [],
     ) {
+    }
+
+    public function hasRelationalTypeResolvedValue(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        string|int $objectID,
+        string $field
+    ): bool {
+        return array_key_exists($field, $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID] ?? []);
+    }
+
+    public function getRelationalTypeResolvedValue(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        string|int $objectID,
+        string $field
+    ): mixed {
+        return $this->relationalTypeResolvedValuesCache[$relationalTypeResolver->getNamespacedTypeName()][$objectID][$field];
     }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -386,7 +386,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
          * @todo Check how this plays out for mutations; should they be executed more than once? If so, when/how?
          */
         $engineState = App::getEngineState();
-        if (!$engineState->hasRelationalTypeResolvedValue($this, $object, $field)) {
+        if (!$engineState->hasObjectTypeResolvedValue($this, $object, $field)) {
             $value = $this->doResolveValue(
                 $object,
                 $field,
@@ -395,9 +395,9 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
                 $objectTypeFieldResolutionFeedbackStore,
                 $options,
             );
-            $engineState->setRelationalTypeResolvedValue($this, $object, $field, $value);
+            $engineState->setObjectTypeResolvedValue($this, $object, $field, $value);
         }        
-        return $engineState->getRelationalTypeResolvedValue($this, $object, $field);
+        return $engineState->getObjectTypeResolvedValue($this, $object, $field);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -386,7 +386,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
          * @todo Check how this plays out for mutations; should they be executed more than once? If so, when/how?
          */
         $engineState = App::getEngineState();
-        if (!$engineState->hasObjectTypeResolvedValue($this, $object, $field)) {
+        if (!$engineState->hasObjectTypeResolvedValue($this, $object, $field, $variables, $expressions)) {
             $value = $this->doResolveValue(
                 $object,
                 $field,
@@ -395,9 +395,9 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
                 $objectTypeFieldResolutionFeedbackStore,
                 $options,
             );
-            $engineState->setObjectTypeResolvedValue($this, $object, $field, $value);
+            $engineState->setObjectTypeResolvedValue($this, $object, $field, $variables, $expressions, $value);
         }        
-        return $engineState->getObjectTypeResolvedValue($this, $object, $field);
+        return $engineState->getObjectTypeResolvedValue($this, $object, $field, $variables, $expressions);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -363,28 +363,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = []
     ): mixed {
-        /**
-         * If the same field has already been resolved for this object,
-         * retrieve it from the cache.
-         *
-         * This is mandatory due to the "Resolved Field Variable References",
-         * which re-create the same field in the AST.
-         *
-         * For instance, in this query, the `id` field is created twice in the AST:
-         *
-         * ```graphql
-         * {
-         *   id
-         *   echo(value: $_id)
-         * }
-         * ```
-         *
-         * But the 2nd AST must not be recalculated.
-         *
-         * @todo Incorporate with AST to compare against the Field->getLocation(), to make sure 2 fields are indeed the same
-         * @todo Check if caching by $objectID and $field is enough; $variables? $options? $feedbackStore?
-         * @todo Check how this plays out for mutations; should they be executed more than once? If so, when/how?
-         */
         $engineState = App::getEngineState();
         if (!$engineState->hasObjectTypeResolvedValue($this, $object, $field, $variables, $expressions)) {
             $value = $this->doResolveValue(


### PR DESCRIPTION
After executing `resolveValue` on the Object/UnionTypeResolver, store the results to re-use for subsequent calls for same object/field.

This is mandatory due to the "Resolved Field Variable References", which re-create the same field in the AST.

For instance, in this query, the `id` field is created twice in the AST:

```graphql
{
  id
  echo(value: $_id)
}
```

But the 2nd AST must not be recalculated.