### PR TITLE
Integrate REST API for enabling/disabling modules, for integration tests

### DIFF
--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PHPUnitForGraphQLAPI\GraphQLAPI\Integration;
 
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\ModulesAdminRESTController;
 use PHPUnitForGraphQLAPI\WebserverRequests\AbstractClientWebserverRequestTestCase;
 use PHPUnitForGraphQLAPI\WebserverRequests\RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait;
 
@@ -86,16 +87,16 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
         bool $clientEnabled
     ): void {
         $client = static::getClient();
-        $restEndpointPlaceholder = 'wp-json/graphql-api/v1/admin/settings/?name=%s&value=%s';
+        $restEndpointPlaceholder = 'wp-json/graphql-api/v1/admin/modules/%s/?state=%s';
         $endpointURLPlaceholder = static::getWebserverHomeURL() . '/' . $restEndpointPlaceholder;
-        $settingsNames = [
-            'single-endpoint-graphiql' => 'graphiql-client-isEnabled',
-            'single-endpoint-voyager' => 'voyager-client-isEnabled',
+        $moduleIDs = [
+            'single-endpoint-graphiql' => 'graphqlapi_graphqlapi_graphiql-for-single-endpoint',
+            'single-endpoint-voyager' => 'graphqlapi_graphqlapi_interactive-schema-for-single-endpoint',
         ];
         $endpointURL = sprintf(
             $endpointURLPlaceholder,
-            $settingsNames[$dataName],
-            $clientEnabled ? '1' : '0'
+            $moduleIDs[$dataName],
+            $clientEnabled ? ModulesAdminRESTController::MODULE_STATE_ENABLED : ModulesAdminRESTController::MODULE_STATE_DISABLED
         );
         $response = $client->post(
             $endpointURL,

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
@@ -58,8 +58,12 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
     }
 
     /**
-     * Disable the clients for the single endpoint
-     * before the "disabled" test
+     * The single endpoint clients (GraphiQL and Voyager)
+     * are by default enabled.
+     *
+     * To test their disabled state works well, first execute
+     * a REST API call to disable the client, and then re-enable
+     * it afterwards.
      */
     protected function beforeFixtureClientRequest(
         string $dataName,

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
@@ -16,7 +16,7 @@ use PoP\Root\Exception\ShouldNotHappenException;
 class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
 {
     use RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait;
-    
+
     /**
      * @return array<string,string[]>
      */

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PHPUnitForGraphQLAPI\GraphQLAPI\Integration;
 
-use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\ModulesAdminRESTController;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ParamValues;
 use PHPUnitForGraphQLAPI\WebserverRequests\AbstractClientWebserverRequestTestCase;
 use PHPUnitForGraphQLAPI\WebserverRequests\RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait;
 
@@ -96,7 +96,7 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
         $endpointURL = sprintf(
             $endpointURLPlaceholder,
             $moduleIDs[$dataName],
-            $clientEnabled ? ModulesAdminRESTController::MODULE_STATE_ENABLED : ModulesAdminRESTController::MODULE_STATE_DISABLED
+            $clientEnabled ? ParamValues::ENABLED : ParamValues::DISABLED
         );
         $response = $client->post(
             $endpointURL,

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
@@ -61,7 +61,7 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
      * Disable the clients for the single endpoint
      * before the "disabled" test
      */
-    protected function beforeRunningTest(
+    protected function beforeFixtureClientRequest(
         string $dataName,
         string $clientEndpoint,
         bool $enabled,
@@ -69,7 +69,7 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
         if (!$enabled && str_starts_with($dataName, 'single-endpoint-')) {
             $this->executeRESTEndpointToEnableOrDisableClient($dataName, $clientEndpoint, false);
         }
-        parent::beforeRunningTest(
+        parent::beforeFixtureClientRequest(
             $dataName,
             $clientEndpoint,
             $enabled,
@@ -103,7 +103,7 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
      * Re-enable the clients for the single endpoint
      * after the "disabled" test
      */
-    protected function afterRunningTest(
+    protected function afterFixtureClientRequest(
         string $dataName,
         string $clientEndpoint,
         bool $enabled,
@@ -111,7 +111,7 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
         if (!$enabled && str_starts_with($dataName, 'single-endpoint-')) {
             $this->executeRESTEndpointToEnableOrDisableClient($dataName, $clientEndpoint, true);
         }
-        parent::afterRunningTest(
+        parent::afterFixtureClientRequest(
             $dataName,
             $clientEndpoint,
             $enabled,

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/ClientWebserverRequestTest.php
@@ -7,6 +7,7 @@ namespace PHPUnitForGraphQLAPI\GraphQLAPI\Integration;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ParamValues;
 use PHPUnitForGraphQLAPI\WebserverRequests\AbstractClientWebserverRequestTestCase;
 use PHPUnitForGraphQLAPI\WebserverRequests\RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait;
+use PoP\Root\Exception\ShouldNotHappenException;
 
 /**
  * Test that enabling/disabling clients (GraphiQL/Voyager)
@@ -89,19 +90,34 @@ class ClientWebserverRequestTest extends AbstractClientWebserverRequestTestCase
         $client = static::getClient();
         $restEndpointPlaceholder = 'wp-json/graphql-api/v1/admin/modules/%s/?state=%s';
         $endpointURLPlaceholder = static::getWebserverHomeURL() . '/' . $restEndpointPlaceholder;
-        $moduleIDs = [
-            'single-endpoint-graphiql' => 'graphqlapi_graphqlapi_graphiql-for-single-endpoint',
-            'single-endpoint-voyager' => 'graphqlapi_graphqlapi_interactive-schema-for-single-endpoint',
-        ];
         $endpointURL = sprintf(
             $endpointURLPlaceholder,
-            $moduleIDs[$dataName],
+            $this->getModuleID($dataName),
             $clientEnabled ? ParamValues::ENABLED : ParamValues::DISABLED
         );
         $response = $client->post(
             $endpointURL,
             static::getRESTEndpointRequestOptions()
         );
+    }
+
+    /**
+     * To visualize the list of all the modules, and find the "moduleID":
+     *
+     * @see http://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/modules
+     */
+    protected function getModuleID(string $dataName): string
+    {
+        return match ($dataName) {
+            'single-endpoint-graphiql' => 'graphqlapi_graphqlapi_graphiql-for-single-endpoint',
+            'single-endpoint-voyager' => 'graphqlapi_graphqlapi_interactive-schema-for-single-endpoint',
+            default => throw new ShouldNotHappenException(
+                sprintf(
+                    'There is no moduleID configured for $dataName \'%s\'',
+                    $dataName
+                )
+            )
+        };
     }
 
     /**

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractClientWebserverRequestTestCase.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractClientWebserverRequestTestCase.php
@@ -30,12 +30,53 @@ abstract class AbstractClientWebserverRequestTestCase extends AbstractWebserverR
         string $clientEndpoint,
         bool $enabled
     ): void {
+        $dataName = $this->dataName();
+        /**
+         * Allow to execute a REST endpoint against the webserver
+         * before running the test
+         */
+        $this->beforeRunningTest($dataName, $clientEndpoint, $enabled);
+
         $client = static::getClient();
         $clientEndpointURL = static::getWebserverHomeURL() . '/' . $clientEndpoint;
-        $response = $client->get($clientEndpointURL);
+        $options = [
+            'verify' => false,
+        ];
+        $response = $client->get($clientEndpointURL, $options);
+
+        /**
+         * Allow to execute a REST endpoint against the webserver
+         * after running the test
+         */
+        $this->afterRunningTest($dataName, $clientEndpoint, $enabled);
+
         $this->assertEquals(200, $response->getStatusCode());
         $hasCustomHeader = $response->hasHeader(CustomHeaders::CLIENT_ENDPOINT);
         $this->assertTrue($enabled ? $hasCustomHeader : !$hasCustomHeader);
+    }
+
+    /**
+     * Allow to execute a REST endpoint against the webserver
+     * before running the test
+     */
+    protected function beforeRunningTest(
+        string $dataName,
+        string $clientEndpoint,
+        bool $enabled,
+    ): void {
+        // Override if needed
+    }
+
+    /**
+     * Allow to execute a REST endpoint against the webserver
+     * after running the test
+     */
+    protected function afterRunningTest(
+        string $dataName,
+        string $clientEndpoint,
+        bool $enabled,
+    ): void {
+        // Override if needed
     }
 
     /**

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractClientWebserverRequestTestCase.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractClientWebserverRequestTestCase.php
@@ -35,7 +35,7 @@ abstract class AbstractClientWebserverRequestTestCase extends AbstractWebserverR
          * Allow to execute a REST endpoint against the webserver
          * before running the test
          */
-        $this->beforeRunningTest($dataName, $clientEndpoint, $enabled);
+        $this->beforeFixtureClientRequest($dataName, $clientEndpoint, $enabled);
 
         $client = static::getClient();
         $clientEndpointURL = static::getWebserverHomeURL() . '/' . $clientEndpoint;
@@ -48,7 +48,7 @@ abstract class AbstractClientWebserverRequestTestCase extends AbstractWebserverR
          * Allow to execute a REST endpoint against the webserver
          * after running the test
          */
-        $this->afterRunningTest($dataName, $clientEndpoint, $enabled);
+        $this->afterFixtureClientRequest($dataName, $clientEndpoint, $enabled);
 
         $this->assertEquals(200, $response->getStatusCode());
         $hasCustomHeader = $response->hasHeader(CustomHeaders::CLIENT_ENDPOINT);
@@ -59,7 +59,7 @@ abstract class AbstractClientWebserverRequestTestCase extends AbstractWebserverR
      * Allow to execute a REST endpoint against the webserver
      * before running the test
      */
-    protected function beforeRunningTest(
+    protected function beforeFixtureClientRequest(
         string $dataName,
         string $clientEndpoint,
         bool $enabled,
@@ -71,7 +71,7 @@ abstract class AbstractClientWebserverRequestTestCase extends AbstractWebserverR
      * Allow to execute a REST endpoint against the webserver
      * after running the test
      */
-    protected function afterRunningTest(
+    protected function afterFixtureClientRequest(
         string $dataName,
         string $clientEndpoint,
         bool $enabled,

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractEndpointWebserverRequestTestCase.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractEndpointWebserverRequestTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPUnitForGraphQLAPI\WebserverRequests;
 
 use Exception;
+
 // use GuzzleHttp\Exception\ClientException;
 
 abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserverRequestTestCase
@@ -62,7 +63,7 @@ abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserve
         }
         if ($exception !== null) {
             throw $exception;
-        }        
+        }
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($expectedContentType, $response->getHeaderLine('content-type'));

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractEndpointWebserverRequestTestCase.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractEndpointWebserverRequestTestCase.php
@@ -21,11 +21,12 @@ abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserve
         string $operationName = '',
         ?string $method = null,
     ): void {
+        $dataName = $this->dataName();
         /**
          * Allow to execute a REST endpoint against the webserver
          * before running the test
          */
-        $this->beforeRunningTest($this->dataName());
+        $this->beforeRunningTest($dataName);
 
         $client = static::getClient();
         $endpointURL = static::getWebserverHomeURL() . '/' . $endpoint;
@@ -58,17 +59,17 @@ abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserve
             $this->fail($e->getMessage());
         }
 
+        /**
+         * Allow to execute a REST endpoint against the webserver
+         * after running the test
+         */
+        $this->afterRunningTest($dataName);
+
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($expectedContentType, $response->getHeaderLine('content-type'));
         if ($expectedResponseBody !== null) {
             $this->assertJsonStringEqualsJsonString($expectedResponseBody, $response->getBody()->__toString());
         }
-
-        /**
-         * Allow to execute a REST endpoint against the webserver
-         * after running the test
-         */
-        $this->afterRunningTest($this->dataName());
     }
 
     /**

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractEndpointWebserverRequestTestCase.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractEndpointWebserverRequestTestCase.php
@@ -26,7 +26,7 @@ abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserve
          * Allow to execute a REST endpoint against the webserver
          * before running the test
          */
-        $this->beforeRunningTest($dataName);
+        $this->beforeFixtureClientRequest($dataName);
 
         $client = static::getClient();
         $endpointURL = static::getWebserverHomeURL() . '/' . $endpoint;
@@ -63,7 +63,7 @@ abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserve
          * Allow to execute a REST endpoint against the webserver
          * after running the test
          */
-        $this->afterRunningTest($dataName);
+        $this->afterFixtureClientRequest($dataName);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($expectedContentType, $response->getHeaderLine('content-type'));
@@ -96,7 +96,7 @@ abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserve
      * Allow to execute a REST endpoint against the webserver
      * before running the test
      */
-    protected function beforeRunningTest(string $dataName): void
+    protected function beforeFixtureClientRequest(string $dataName): void
     {
         // Override if needed
     }
@@ -105,7 +105,7 @@ abstract class AbstractEndpointWebserverRequestTestCase extends AbstractWebserve
      * Allow to execute a REST endpoint against the webserver
      * after running the test
      */
-    protected function afterRunningTest(string $dataName): void
+    protected function afterFixtureClientRequest(string $dataName): void
     {
         // Override if needed
     }

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTest.php
@@ -49,12 +49,12 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
     /**
      * Disable the plugin before executing the ":disabled" test
      */
-    protected function beforeRunningTest(string $dataName): void
+    protected function beforeFixtureClientRequest(string $dataName): void
     {
         if (str_ends_with($dataName, ':disabled')) {
             $this->executeRESTEndpointToEnableOrDisablePlugin($dataName, 'inactive');
         }
-        parent::beforeRunningTest($dataName);
+        parent::beforeFixtureClientRequest($dataName);
     }
 
     /**
@@ -79,11 +79,11 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
     /**
      * Re-enable the plugin after executing the ":disabled" test
      */
-    protected function afterRunningTest(string $dataName): void
+    protected function afterFixtureClientRequest(string $dataName): void
     {
         if (str_ends_with($dataName, ':disabled')) {
             $this->executeRESTEndpointToEnableOrDisablePlugin($dataName, 'active');
         }
-        parent::afterRunningTest($dataName);
+        parent::afterFixtureClientRequest($dataName);
     }
 }

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTest.php
@@ -13,12 +13,7 @@ namespace PHPUnitForGraphQLAPI\WebserverRequests;
  */
 abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTest extends AbstractEndpointWebserverRequestTestCase
 {
-    use WordPressAuthenticatedUserWebserverRequestTestCaseTrait;
-
-    protected static function useSSL(): bool
-    {
-        return true;
-    }
+    use RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait;
 
     /**
      * @return array<string,array<mixed>>
@@ -70,7 +65,6 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
         $client = static::getClient();
         $restEndpointPlaceholder = 'wp-json/wp/v2/plugins/%s/?status=%s';
         $endpointURLPlaceholder = static::getWebserverHomeURL() . '/' . $restEndpointPlaceholder;
-        $options = static::getRESTEndpointRequestOptions();
         $pluginName = substr($dataName, 0, strlen($dataName) - strlen(':disabled'));
         $client->post(
             sprintf(
@@ -78,20 +72,8 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
                 $pluginName,
                 $status
             ),
-            $options
+            static::getRESTEndpointRequestOptions()
         );
-    }
-
-    /**
-     * Must add the X-WP-Nonce header for the authenticated user.
-     *
-     * @see https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/
-     */
-    protected function getRESTEndpointRequestOptions(): array
-    {
-        $options = static::getRequestBasicOptions();
-        $options['headers']['X-WP-Nonce'] = static::$wpRESTNonce;
-        return $options;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\WebserverRequests;
+
+/**
+ * Tests that require to call the REST API to perform some action
+ * before/after running the test.
+ *
+ * That's why these tests are done with the authenticated user
+ * in WordPress, so the user can execute operations via the REST endpoint.
+ */
+trait RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait
+{
+    use WordPressAuthenticatedUserWebserverRequestTestCaseTrait;
+
+    protected static function useSSL(): bool
+    {
+        return true;
+    }
+
+    abstract protected static function getRequestBasicOptions(): array;
+
+    /**
+     * Must add the X-WP-Nonce header for the authenticated user.
+     *
+     * @see https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/
+     */
+    protected function getRESTEndpointRequestOptions(): array
+    {
+        $options = static::getRequestBasicOptions();
+        $options['headers']['X-WP-Nonce'] = static::$wpRESTNonce;
+        return $options;
+    }
+}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
@@ -13,9 +13,8 @@ Text Domain: graphql-api-testing
 Domain Path: /languages
 */
 
-use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Endpoints\AdminRESTAPIEndpointManager;
-use PHPUnitForGraphQLAPI\GraphQLAPITesting\Utilities\CustomHeaderAppender;
-use GraphQLAPI\GraphQLAPI\Plugin;
+use GraphQLAPI\GraphQLAPI\Plugin as GraphQLAPIMainPlugin;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\Plugin;
 use PoP\Root\Environment as RootEnvironment;
 
 use function add_action;
@@ -29,7 +28,7 @@ add_action(
     'plugins_loaded',
     function(): void {
         // Validate the GraphQL API plugin is installed, or exit
-        if (!class_exists(Plugin::class)) {
+        if (!class_exists(GraphQLAPIMainPlugin::class)) {
             return;
         }
 
@@ -40,15 +39,8 @@ add_action(
         
         // Load Composer’s autoloader
         require_once(__DIR__ . '/vendor/autoload.php');
-        
-        /**
-         * Send custom headers needed for development
-         */
-        new CustomHeaderAppender();
-        
-        /**
-         * Initialize REST endpoints
-         */
-        new AdminRESTAPIEndpointManager();
+
+        // Initialize the plugin
+        (new Plugin())->initialize();
     }
 );

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
@@ -15,21 +15,34 @@ Domain Path: /languages
 
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Endpoints\AdminRESTAPIEndpointManager;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\Utilities\CustomHeaderAppender;
+use GraphQLAPI\GraphQLAPI\Plugin;
+
+use function add_action;
 
 // Exit if accessed directly
 if (!defined('ABSPATH')) {
     exit;
 }
 
-// Load Composer’s autoloader
-require_once(__DIR__ . '/vendor/autoload.php');
-
-/**
- * Send custom headers needed for development
- */
-new CustomHeaderAppender();
-
-/**
- * Initialize REST endpoints
- */
-new AdminRESTAPIEndpointManager();
+add_action(
+    'plugins_loaded',
+    function(): void {
+        // Validate the GraphQL API plugin is installed, or exit
+        if (!class_exists(Plugin::class)) {
+            return;
+        }
+        
+        // Load Composer’s autoloader
+        require_once(__DIR__ . '/vendor/autoload.php');
+        
+        /**
+         * Send custom headers needed for development
+         */
+        new CustomHeaderAppender();
+        
+        /**
+         * Initialize REST endpoints
+         */
+        new AdminRESTAPIEndpointManager();
+    }
+);

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
@@ -16,6 +16,7 @@ Domain Path: /languages
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Endpoints\AdminRESTAPIEndpointManager;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\Utilities\CustomHeaderAppender;
 use GraphQLAPI\GraphQLAPI\Plugin;
+use PoP\Root\Environment as RootEnvironment;
 
 use function add_action;
 
@@ -29,6 +30,11 @@ add_action(
     function(): void {
         // Validate the GraphQL API plugin is installed, or exit
         if (!class_exists(Plugin::class)) {
+            return;
+        }
+
+        // Validate we are in the DEV environment
+        if (!RootEnvironment::isApplicationEnvironmentDev()) {
             return;
         }
         

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPITesting;
+
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Endpoints\AdminRESTAPIEndpointManager;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\Utilities\CustomHeaderAppender;
+
+class Plugin
+{
+    public function initialize(): void
+    {
+        /**
+         * Send custom headers needed for development
+         */
+        new CustomHeaderAppender();
+        
+        /**
+         * Initialize REST endpoints
+         */
+        new AdminRESTAPIEndpointManager();
+    }
+}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
@@ -15,7 +15,7 @@ class Plugin
          * Send custom headers needed for development
          */
         new CustomHeaderAppender();
-        
+
         /**
          * Initialize REST endpoints
          */

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Authentication/RESTAuthentication.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Authentication/RESTAuthentication.php
@@ -12,38 +12,39 @@ use function wp_create_nonce;
 
 class RESTAuthentication
 {
-	protected ?string $restNonce = null;
-	protected ?int $currentUserID = null;
+    protected ?string $restNonce = null;
+    protected ?int $currentUserID = null;
 
-	public function __construct() {
-		add_action(
-			'rest_authentication_errors',
-			$this->retrieveLoggedInUserData(...),
-			PHP_INT_MAX
-		);
-	}
+    public function __construct()
+    {
+        add_action(
+            'rest_authentication_errors',
+            $this->retrieveLoggedInUserData(...),
+            PHP_INT_MAX
+        );
+    }
 
-	public function retrieveLoggedInUserData(?WP_Error $maybeError): ?WP_Error
-	{
-		if ($maybeError !== null) {
-			return $maybeError;
-		}
+    public function retrieveLoggedInUserData(?WP_Error $maybeError): ?WP_Error
+    {
+        if ($maybeError !== null) {
+            return $maybeError;
+        }
 
-		if (is_user_logged_in()) {
-			$this->restNonce = wp_create_nonce('wp_rest');
-			$this->currentUserID = get_current_user_id();
-		}
+        if (is_user_logged_in()) {
+            $this->restNonce = wp_create_nonce('wp_rest');
+            $this->currentUserID = get_current_user_id();
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	public function getRESTNonce(): ?string
-	{
-		return $this->restNonce;
-	}
+    public function getRESTNonce(): ?string
+    {
+        return $this->restNonce;
+    }
 
-	public function getCurrentUserID(): ?int
-	{
-		return $this->currentUserID;
-	}
+    public function getCurrentUserID(): ?int
+    {
+        return $this->currentUserID;
+    }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/ParamValues.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/ParamValues.php
@@ -6,6 +6,6 @@ namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants;
 
 class ParamValues
 {
-	final public const ENABLED = 'enabled';
-	final public const DISABLED = 'disabled';
+    final public const ENABLED = 'enabled';
+    final public const DISABLED = 'disabled';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/ParamValues.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/ParamValues.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants;
+
+class ParamValues
+{
+	final public const ENABLED = 'enabled';
+	final public const DISABLED = 'disabled';
+}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants;
+
+class Params
+{
+	final public const STATE = 'state';
+}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -6,5 +6,5 @@ namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants;
 
 class Params
 {
-	final public const STATE = 'state';
+    final public const STATE = 'state';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/ResponseStatus.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/ResponseStatus.php
@@ -6,6 +6,6 @@ namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants;
 
 class ResponseStatus
 {
-	public const SUCCESS = 'success';	
-	public const ERROR = 'error';	
+    public const SUCCESS = 'success';
+    public const ERROR = 'error';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Roles.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Roles.php
@@ -6,5 +6,5 @@ namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants;
 
 class Roles
 {
-	public const ADMINISTRATOR = 'administrator';	
+    public const ADMINISTRATOR = 'administrator';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractAdminRESTController.php
@@ -10,16 +10,16 @@ use function current_user_can;
 
 abstract class AbstractAdminRESTController extends AbstractRESTController
 {
-	protected function getControllerNamespace(): string
-	{
-		return 'admin';
-	}
+    protected function getControllerNamespace(): string
+    {
+        return 'admin';
+    }
 
-	/**
-	 * Validate the user is the admin.
-	 */
-	public function checkAdminPermission(): bool
-	{
-		return current_user_can(Roles::ADMINISTRATOR);
-	}
+    /**
+     * Validate the user is the admin.
+     */
+    public function checkAdminPermission(): bool
+    {
+        return current_user_can(Roles::ADMINISTRATOR);
+    }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
@@ -24,34 +24,45 @@ abstract class AbstractRESTController extends WP_REST_Controller
 			return;
 		}
 
+		$namespace = $this->getNamespace();
 		foreach ($routeOptions as $route => $routeOptions) {
-			$namespace = sprintf(
-				'%s/%s',
-				$this->getPluginNamespace(),
-				$this->getVersion(),
-			);
-			$controllerNamespace = $this->getControllerNamespace();
-			if ($controllerNamespace !== '') {
-				$namespace = sprintf(
-					'%s/%s',
-					$namespace,
-					$controllerNamespace
-				);
-			}
-			$routeBase = $this->getRouteBase();
-			if ($routeBase !== '') {
-				$route = sprintf(
-					'%s/%s',
-					$routeBase,
-					$route
-				);
-			}
 			register_rest_route(
 				$namespace,
-				$route,
+				$this->getRoute($route),
 				$routeOptions
 			);
 		}
+	}
+
+	final protected function getNamespace(): string
+	{
+		$namespace = sprintf(
+			'%s/%s',
+			$this->getPluginNamespace(),
+			$this->getVersion(),
+		);
+		$controllerNamespace = $this->getControllerNamespace();
+		if ($controllerNamespace !== '') {
+			$namespace = sprintf(
+				'%s/%s',
+				$namespace,
+				$controllerNamespace
+			);
+		}
+		return $namespace;
+	}
+
+	final protected function getRoute(string $route): string
+	{
+		$routeBase = $this->getRouteBase();
+		if ($routeBase !== '') {
+			$route = sprintf(
+				'%s/%s',
+				$routeBase,
+				$route
+			);
+		}
+		return $route;
 	}
 
 	/**
@@ -94,5 +105,26 @@ abstract class AbstractRESTController extends WP_REST_Controller
 	{
 		echo wp_json_encode( $result->get_data() );
 		die;
+	}
+
+	protected function getRouteFromNamespacedRoute(string $namespacedRoute): string
+	{
+		return $this->getRouteFromCompleteRoute(
+			$this->getCompleteRouteFromNamespacedRoute($namespacedRoute)
+		);
+	}
+
+	protected function getCompleteRouteFromNamespacedRoute(string $namespacedRoute): string
+	{
+		return substr($namespacedRoute, strlen('/' . $this->getNamespace() . '/'));
+	}
+
+	protected function getRouteFromCompleteRoute(string $completeRoute): string
+	{
+		$routeBase = $this->getRouteBase();
+		if ($routeBase === '') {
+			return $completeRoute;
+		}
+		return substr($completeRoute, strlen($routeBase . '/'));
 	}
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
@@ -28,7 +28,7 @@ abstract class AbstractRESTController extends WP_REST_Controller
 		foreach ($routeOptions as $route => $routeOptions) {
 			register_rest_route(
 				$namespace,
-				$this->getRoute($route),
+				$route,
 				$routeOptions
 			);
 		}
@@ -52,19 +52,6 @@ abstract class AbstractRESTController extends WP_REST_Controller
 		return $namespace;
 	}
 
-	final protected function getRoute(string $route): string
-	{
-		$routeBase = $this->getRouteBase();
-		if ($routeBase !== '') {
-			$route = sprintf(
-				'%s/%s',
-				$routeBase,
-				$route
-			);
-		}
-		return $route;
-	}
-
 	/**
 	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
 	 */
@@ -81,11 +68,6 @@ abstract class AbstractRESTController extends WP_REST_Controller
 	}
 
 	protected function getControllerNamespace(): string
-	{
-		return '';
-	}
-
-	protected function getRouteBase(): string
 	{
 		return '';
 	}
@@ -109,22 +91,6 @@ abstract class AbstractRESTController extends WP_REST_Controller
 
 	protected function getRouteFromNamespacedRoute(string $namespacedRoute): string
 	{
-		return $this->getRouteFromCompleteRoute(
-			$this->getCompleteRouteFromNamespacedRoute($namespacedRoute)
-		);
-	}
-
-	protected function getCompleteRouteFromNamespacedRoute(string $namespacedRoute): string
-	{
 		return substr($namespacedRoute, strlen('/' . $this->getNamespace() . '/'));
-	}
-
-	protected function getRouteFromCompleteRoute(string $completeRoute): string
-	{
-		$routeBase = $this->getRouteBase();
-		if ($routeBase === '') {
-			return $completeRoute;
-		}
-		return substr($completeRoute, strlen($routeBase . '/'));
 	}
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
@@ -66,7 +66,7 @@ abstract class AbstractRESTController extends WP_REST_Controller
 	}
 
 	/**
-	 * @return array<string,array<string,mixed>> Array of [$route => $options]
+	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
 	 */
 	abstract protected function getRouteOptions(): array;
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/AbstractRESTController.php
@@ -14,83 +14,83 @@ use function rest_ensure_response;
 
 abstract class AbstractRESTController extends WP_REST_Controller
 {
-	/**
+    /**
 	 * phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-	 */
-	public function register_routes(): void
-	{
-		$routeOptions = $this->getRouteOptions();
-		if ($routeOptions === []) {
-			return;
-		}
+     */
+    public function register_routes(): void
+    {
+        $routeOptions = $this->getRouteOptions();
+        if ($routeOptions === []) {
+            return;
+        }
 
-		$namespace = $this->getNamespace();
-		foreach ($routeOptions as $route => $routeOptions) {
-			register_rest_route(
-				$namespace,
-				$route,
-				$routeOptions
-			);
-		}
-	}
+        $namespace = $this->getNamespace();
+        foreach ($routeOptions as $route => $routeOptions) {
+            register_rest_route(
+                $namespace,
+                $route,
+                $routeOptions
+            );
+        }
+    }
 
-	final protected function getNamespace(): string
-	{
-		$namespace = sprintf(
-			'%s/%s',
-			$this->getPluginNamespace(),
-			$this->getVersion(),
-		);
-		$controllerNamespace = $this->getControllerNamespace();
-		if ($controllerNamespace !== '') {
-			$namespace = sprintf(
-				'%s/%s',
-				$namespace,
-				$controllerNamespace
-			);
-		}
-		return $namespace;
-	}
+    final protected function getNamespace(): string
+    {
+        $namespace = sprintf(
+            '%s/%s',
+            $this->getPluginNamespace(),
+            $this->getVersion(),
+        );
+        $controllerNamespace = $this->getControllerNamespace();
+        if ($controllerNamespace !== '') {
+            $namespace = sprintf(
+                '%s/%s',
+                $namespace,
+                $controllerNamespace
+            );
+        }
+        return $namespace;
+    }
 
-	/**
-	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
-	 */
-	abstract protected function getRouteOptions(): array;
+    /**
+     * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
+     */
+    abstract protected function getRouteOptions(): array;
 
-	final protected function getPluginNamespace(): string
-	{
-		return 'graphql-api';
-	}
+    final protected function getPluginNamespace(): string
+    {
+        return 'graphql-api';
+    }
 
-	protected function getVersion(): string
-	{
-		return 'v1';
-	}
+    protected function getVersion(): string
+    {
+        return 'v1';
+    }
 
-	protected function getControllerNamespace(): string
-	{
-		return '';
-	}
+    protected function getControllerNamespace(): string
+    {
+        return '';
+    }
 
-	public function ensureResponse(array $data): WP_REST_Response|WP_Error
-	{
-		add_filter(
-			'rest_pre_serve_request',
-			fn (bool $served, WP_REST_Response $result) => $this->printResponse($result),
-			10,
-			2
-		);
-		return rest_ensure_response($data);
-	}
+    public function ensureResponse(array $data): WP_REST_Response|WP_Error
+    {
+        add_filter(
+            'rest_pre_serve_request',
+            fn (bool $served, WP_REST_Response $result) => $this->printResponse($result),
+            10,
+            2
+        );
+        return rest_ensure_response($data);
+    }
 
-	public function printResponse(WP_REST_Response $result): never
-	{
-		echo wp_json_encode( $result->get_data() );
-		die;
-	}
+    public function printResponse(WP_REST_Response $result): never
+    {
+        echo wp_json_encode($result->get_data());
+        die;
+    }
 
-	protected function getRouteFromNamespacedRoute(string $namespacedRoute): string
-	{
-		return substr($namespacedRoute, strlen('/' . $this->getNamespace() . '/'));
-	}
+    protected function getRouteFromNamespacedRoute(string $namespacedRoute): string
+    {
+        return substr($namespacedRoute, strlen('/' . $this->getNamespace() . '/'));
+    }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -7,20 +7,22 @@ namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers;
 use Exception;
 use function rest_ensure_response;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleRegistryFacade;
-use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleTypeRegistryFacade;
+use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ResponseStatus;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\RESTResponse;
-use WP_Error;
 
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
 class ModulesAdminRESTController extends AbstractAdminRESTController
 {
+	final public const MODULE_STATE_ENABLED = 'enabled';
+	final public const MODULE_STATE_DISABLED = 'disabled';
 	final public const MODULE_STATES = [
-		'enabled',
-		'disabled',
+		self::MODULE_STATE_ENABLED,
+		self::MODULE_STATE_DISABLED,
 	];
 	final public const PARAM_STATE = 'state';
 
@@ -153,8 +155,10 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 			$params = $request->get_params();
 			$moduleState = $params[self::PARAM_STATE];
 
-			// @todo Remove this temporary code
-			$response->data->moduleState = $moduleState;
+			$moduleIDValues = [
+				$moduleID => $moduleState === self::MODULE_STATE_ENABLED,
+			];
+			UserSettingsManagerFacade::getInstance()->setModulesEnabled($moduleIDValues);
 
 			// Success!
 			$response->status = ResponseStatus::SUCCESS;

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -30,6 +30,16 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 	protected function getRouteOptions(): array
 	{
 		return [
+			$this->restBase => [
+				[
+					'methods' => [
+						WP_REST_Server::READABLE,
+						WP_REST_Server::CREATABLE,
+					],
+					'callback' => $this->retrieveAllItems(...),
+					'permission_callback' => $this->checkAdminPermission(...),
+				],
+			],
 			$this->restBase . '/(?P<module>[a-zA-Z_-]+)' => [
 				[
 					'methods' => [
@@ -71,6 +81,12 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 		return true;
 	}
 
+	public function retrieveAllItems(WP_REST_Request $request): WP_REST_Response|WP_Error
+	{
+		$modules = ['a', 'zzzzonga'];
+		return rest_ensure_response($modules);
+	}
+
 	public function enableOrDisableModule(WP_REST_Request $request): WP_REST_Response|WP_Error
 	{
 		$response = new RESTResponse();
@@ -98,5 +114,5 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 		}
 
 		return rest_ensure_response($response);
-	}	
+	}
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -5,28 +5,26 @@ declare(strict_types=1);
 namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers;
 
 use Exception;
-use function rest_ensure_response;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\Params;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ParamValues;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ResponseStatus;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\RESTResponse;
-
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
+use function rest_ensure_response;
+
 class ModulesAdminRESTController extends AbstractAdminRESTController
 {
-	final public const MODULE_STATE_ENABLED = 'enabled';
-	final public const MODULE_STATE_DISABLED = 'disabled';
 	final public const MODULE_STATES = [
-		self::MODULE_STATE_ENABLED,
-		self::MODULE_STATE_DISABLED,
+		ParamValues::ENABLED,
+		ParamValues::DISABLED,
 	];
 	
-	final public const PARAM_STATE = 'state';
-
 	protected string $restBase = 'modules';
 
 	/**
@@ -51,7 +49,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 					'callback' => $this->enableOrDisableModule(...),
 					'permission_callback' => $this->checkAdminPermission(...),
 					'args' => [
-						self::PARAM_STATE => [
+						Params::STATE => [
 							'required' => true,
 							'validate_callback' => $this->validateState(...),
 						],
@@ -77,7 +75,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 					implode(__('\', \'', 'graphql-api'), self::MODULE_STATES)
 				),
 				[
-					self::PARAM_STATE => $value,
+					Params::STATE => $value,
 				]
 			);
 		}
@@ -154,10 +152,10 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 			$module = $this->getModuleByID($moduleID);
 
 			$params = $request->get_params();
-			$moduleState = $params[self::PARAM_STATE];
+			$moduleState = $params[Params::STATE];
 
 			$moduleIDValues = [
-				$moduleID => $moduleState === self::MODULE_STATE_ENABLED,
+				$moduleID => $moduleState === ParamValues::ENABLED,
 			];
 			UserSettingsManagerFacade::getInstance()->setModulesEnabled($moduleIDValues);
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -35,13 +35,21 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 		return [
 			'(?P<module>[a-zA-Z_-]+)' => [
 				[
-					'methods' => WP_REST_Server::CREATABLE,
+					'methods' => [
+						WP_REST_Server::READABLE,
+						WP_REST_Server::CREATABLE,
+					],
 					'callback' => $this->enableOrDisableModule(...),
 					'permission_callback' => $this->checkAdminPermission(...),
 					'args' => [
 						self::PARAM_STATE => [
 							'required' => true,
-							'validate_callback' => $this->validateCallback(...)
+							'validate_callback' => $this->validateCallback(...),
+						],
+						'module' => [
+							'description' => __('Module name', 'graphql-api'),
+							'type' => 'string',
+							'required' => true,
 						],
 					],
 				],

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -39,7 +39,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 					'permission_callback' => $this->checkAdminPermission(...),
 				],
 			],
-			$this->restBase . '/(?P<module>[a-zA-Z_-]+)' => [
+			$this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
 				[
 					'methods' => [
 						WP_REST_Server::READABLE,

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -24,6 +24,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 		self::MODULE_STATE_ENABLED,
 		self::MODULE_STATE_DISABLED,
 	];
+	
 	final public const PARAM_STATE = 'state';
 
 	protected string $restBase = 'modules';

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -20,156 +20,156 @@ use function rest_ensure_response;
 
 class ModulesAdminRESTController extends AbstractAdminRESTController
 {
-	final public const MODULE_STATES = [
-		ParamValues::ENABLED,
-		ParamValues::DISABLED,
-	];
-	
-	protected string $restBase = 'modules';
+    final public const MODULE_STATES = [
+        ParamValues::ENABLED,
+        ParamValues::DISABLED,
+    ];
 
-	/**
-	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
-	 */
-	protected function getRouteOptions(): array
-	{
-		return [
-			$this->restBase => [
-				[
-					'methods' => WP_REST_Server::READABLE,
-					'callback' => $this->retrieveAllItems(...),
-					// Allow anyone to read the modules
-					// 'permission_callback' => $this->checkAdminPermission(...),
-				],
-			],
-			$this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
-				[
-					'methods' => WP_REST_Server::CREATABLE,
-					'callback' => $this->enableOrDisableModule(...),
-					// only the Admin can execute the modification
-					'permission_callback' => $this->checkAdminPermission(...),
-					'args' => [
-						Params::STATE => [
-							'required' => true,
-							'validate_callback' => $this->validateState(...),
-						],
-						'moduleID' => [
-							'description' => __('Module ID', 'graphql-api'),
-							'type' => 'string',
-							'required' => true,
-							'validate_callback' => $this->validateModule(...),
-						],
-					],
-				],
-			],
-		];
-	}
+    protected string $restBase = 'modules';
 
-	protected function validateState(string $value): bool|WP_Error
-	{
-		if (!in_array($value, self::MODULE_STATES)) {			
-			return new WP_Error(
-				'1',
-				sprintf(
-					__('Parameter \'state\' can only have one of these values: \'%s\'', 'graphql-api'),
-					implode(__('\', \'', 'graphql-api'), self::MODULE_STATES)
-				),
-				[
-					Params::STATE => $value,
-				]
-			);
-		}
-		return true;
-	}
+    /**
+     * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
+     */
+    protected function getRouteOptions(): array
+    {
+        return [
+            $this->restBase => [
+                [
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => $this->retrieveAllItems(...),
+                    // Allow anyone to read the modules
+                    // 'permission_callback' => $this->checkAdminPermission(...),
+                ],
+            ],
+            $this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
+                [
+                    'methods' => WP_REST_Server::CREATABLE,
+                    'callback' => $this->enableOrDisableModule(...),
+                    // only the Admin can execute the modification
+                    'permission_callback' => $this->checkAdminPermission(...),
+                    'args' => [
+                        Params::STATE => [
+                            'required' => true,
+                            'validate_callback' => $this->validateState(...),
+                        ],
+                        'moduleID' => [
+                            'description' => __('Module ID', 'graphql-api'),
+                            'type' => 'string',
+                            'required' => true,
+                            'validate_callback' => $this->validateModule(...),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 
-	/**
-	 * Validate there is a module with this ID
-	 */
-	protected function validateModule(string $value): bool|WP_Error
-	{
-		$module = $this->getModuleByID($value);
-		if ($module === null) {			
-			return new WP_Error(
-				'2',
-				sprintf(
-					__('There is no module with ID \'%s\'', 'graphql-api'),
-					$value
-				),
-				[
-					'moduleID' => $value,
-				]
-			);
-		}
-		return true;
-	}
+    protected function validateState(string $value): bool|WP_Error
+    {
+        if (!in_array($value, self::MODULE_STATES)) {
+            return new WP_Error(
+                '1',
+                sprintf(
+                    __('Parameter \'state\' can only have one of these values: \'%s\'', 'graphql-api'),
+                    implode(__('\', \'', 'graphql-api'), self::MODULE_STATES)
+                ),
+                [
+                    Params::STATE => $value,
+                ]
+            );
+        }
+        return true;
+    }
 
-	public function getModuleByID(string $moduleID): ?string
-	{
-		$moduleRegistry = ModuleRegistryFacade::getInstance();
+    /**
+     * Validate there is a module with this ID
+     */
+    protected function validateModule(string $value): bool|WP_Error
+    {
+        $module = $this->getModuleByID($value);
+        if ($module === null) {
+            return new WP_Error(
+                '2',
+                sprintf(
+                    __('There is no module with ID \'%s\'', 'graphql-api'),
+                    $value
+                ),
+                [
+                    'moduleID' => $value,
+                ]
+            );
+        }
+        return true;
+    }
+
+    public function getModuleByID(string $moduleID): ?string
+    {
+        $moduleRegistry = ModuleRegistryFacade::getInstance();
         $modules = $moduleRegistry->getAllModules();
         foreach ($modules as $module) {
             $moduleResolver = $moduleRegistry->getModuleResolver($module);
             if ($moduleID === $moduleResolver->getID($module)) {
-				return $module;
-			}
+                return $module;
+            }
         }
         return null;
-	}
+    }
 
-	public function retrieveAllItems(WP_REST_Request $request): WP_REST_Response|WP_Error
-	{
-		$items = [];
+    public function retrieveAllItems(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $items = [];
         $moduleRegistry = ModuleRegistryFacade::getInstance();
         $modules = $moduleRegistry->getAllModules();
         foreach ($modules as $module) {
             $moduleResolver = $moduleRegistry->getModuleResolver($module);
             $isEnabled = $moduleRegistry->isModuleEnabled($module);
-			$items[] = [
-				'module' => $module,
-				'id' => $moduleResolver->getID($module),
-				'isEnabled' => $isEnabled,
-				'canBeDisabled' => $moduleResolver->canBeDisabled($module),
-				'canBeEnabled' => !$isEnabled && $moduleRegistry->canModuleBeEnabled($module),
-				'hasSettings' => $moduleResolver->hasSettings($module),
-				'name' => $moduleResolver->getName($module),
-				'description' => $moduleResolver->getDescription($module),
-				'dependsOn' => $moduleResolver->getDependedModuleLists($module),
-				// 'url' => $moduleResolver->getURL($module),
-				'slug' => $moduleResolver->getSlug($module),
-				'hasDocs' => $moduleResolver->hasDocumentation($module),
-			];
+            $items[] = [
+                'module' => $module,
+                'id' => $moduleResolver->getID($module),
+                'isEnabled' => $isEnabled,
+                'canBeDisabled' => $moduleResolver->canBeDisabled($module),
+                'canBeEnabled' => !$isEnabled && $moduleRegistry->canModuleBeEnabled($module),
+                'hasSettings' => $moduleResolver->hasSettings($module),
+                'name' => $moduleResolver->getName($module),
+                'description' => $moduleResolver->getDescription($module),
+                'dependsOn' => $moduleResolver->getDependedModuleLists($module),
+                // 'url' => $moduleResolver->getURL($module),
+                'slug' => $moduleResolver->getSlug($module),
+                'hasDocs' => $moduleResolver->hasDocumentation($module),
+            ];
         }
         return rest_ensure_response($items);
-	}
+    }
 
-	public function enableOrDisableModule(WP_REST_Request $request): WP_REST_Response|WP_Error
-	{
-		$response = new RESTResponse();
+    public function enableOrDisableModule(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $response = new RESTResponse();
 
-		try {
-			$namespacedRoute = $request->get_route();
-			$moduleID = substr($this->getRouteFromNamespacedRoute($namespacedRoute), strlen($this->restBase . '/'));
-			$module = $this->getModuleByID($moduleID);
+        try {
+            $namespacedRoute = $request->get_route();
+            $moduleID = substr($this->getRouteFromNamespacedRoute($namespacedRoute), strlen($this->restBase . '/'));
+            $module = $this->getModuleByID($moduleID);
 
-			$params = $request->get_params();
-			$moduleState = $params[Params::STATE];
+            $params = $request->get_params();
+            $moduleState = $params[Params::STATE];
 
-			$moduleIDValues = [
-				$moduleID => $moduleState === ParamValues::ENABLED,
-			];
-			UserSettingsManagerFacade::getInstance()->setModulesEnabled($moduleIDValues);
+            $moduleIDValues = [
+                $moduleID => $moduleState === ParamValues::ENABLED,
+            ];
+            UserSettingsManagerFacade::getInstance()->setModulesEnabled($moduleIDValues);
 
-			// Success!
-			$response->status = ResponseStatus::SUCCESS;
-			$response->message = sprintf(
-				__('Module \'%s\' has been updated successfully %s', 'graphql-api'),
-				$module,
-				$moduleState
-			);
-		} catch ( Exception $e ) {
-			$response->status = ResponseStatus::ERROR;
-			$response->message = $e->getMessage();
-		}
+            // Success!
+            $response->status = ResponseStatus::SUCCESS;
+            $response->message = sprintf(
+                __('Module \'%s\' has been updated successfully %s', 'graphql-api'),
+                $module,
+                $moduleState
+            );
+        } catch (Exception $e) {
+            $response->status = ResponseStatus::ERROR;
+            $response->message = $e->getMessage();
+        }
 
-		return rest_ensure_response($response);
-	}
+        return rest_ensure_response($response);
+    }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -22,10 +22,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 	];
 	final public const PARAM_STATE = 'state';
 
-	protected function getRouteBase(): string
-	{
-		return 'modules';
-	}
+	protected string $restBase = 'modules';
 
 	/**
 	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
@@ -33,7 +30,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 	protected function getRouteOptions(): array
 	{
 		return [
-			'(?P<module>[a-zA-Z_-]+)' => [
+			$this->restBase . '/(?P<module>[a-zA-Z_-]+)' => [
 				[
 					'methods' => [
 						WP_REST_Server::READABLE,
@@ -80,7 +77,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 
 		try {
 			$namespacedRoute = $request->get_route();
-			$module = $this->getRouteFromNamespacedRoute($namespacedRoute);
+			$module = substr($this->getRouteFromNamespacedRoute($namespacedRoute), strlen($this->restBase . '/'));
 
 			$params = $request->get_params();
 			$moduleState = $params[self::PARAM_STATE];

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -49,7 +49,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 		];
 	}
 
-	protected function validateCallback(string $value): ?WP_Error
+	protected function validateCallback(string $value): bool|WP_Error
 	{
 		if (!in_array($value, self::MODULE_STATES)) {			
 			return new WP_Error(
@@ -63,7 +63,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 				]
 			);
 		}
-		return null;
+		return true;
 	}
 
 	public function enableOrDisableModule(WP_REST_Request $request): WP_REST_Response|WP_Error

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -37,16 +37,15 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 				[
 					'methods' => WP_REST_Server::READABLE,
 					'callback' => $this->retrieveAllItems(...),
-					'permission_callback' => $this->checkAdminPermission(...),
+					// Allow anyone to read the modules
+					// 'permission_callback' => $this->checkAdminPermission(...),
 				],
 			],
 			$this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
 				[
-					'methods' => [
-						WP_REST_Server::READABLE,
-						WP_REST_Server::CREATABLE,
-					],
+					'methods' => WP_REST_Server::CREATABLE,
 					'callback' => $this->enableOrDisableModule(...),
+					// only the Admin can execute the modification
 					'permission_callback' => $this->checkAdminPermission(...),
 					'args' => [
 						Params::STATE => [

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -28,28 +28,27 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 	}
 
 	/**
-	 * @return array<string,array<string,mixed>> Array of [$route => $options]
+	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
 	 */
 	protected function getRouteOptions(): array
 	{
 		return [
 			'(?P<module>[a-zA-Z_-]+)' => [
-				'methods' => WP_REST_Server::CREATABLE,
-				'callback' => $this->enableOrDisableModule(...),
-				'permission_callback' => $this->checkAdminPermission(...),
-				'args' => [
-					self::PARAM_STATE => [
-						'required' => true,
-						'validate_callback' => $this->validateCallback(...)
+				[
+					'methods' => WP_REST_Server::CREATABLE,
+					'callback' => $this->enableOrDisableModule(...),
+					'permission_callback' => $this->checkAdminPermission(...),
+					'args' => [
+						self::PARAM_STATE => [
+							'required' => true,
+							'validate_callback' => $this->validateCallback(...)
+						],
 					],
-				]
+				],
 			],
 		];
 	}
 
-	/**
-	 * @return array<string,array<string,mixed>> Array of [$route => $options]
-	 */
 	protected function validateCallback(string $value): bool|WP_Error
 	{
 		if (in_array($value, self::MODULE_STATES)) {

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -51,19 +51,19 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 
 	protected function validateCallback(string $value): ?WP_Error
 	{
-		if (in_array($value, self::MODULE_STATES)) {
-			return null;
+		if (!in_array($value, self::MODULE_STATES)) {			
+			return new WP_Error(
+				'1',
+				sprintf(
+					__('Parameter \'state\' can only have one of these values: \'%s\'', 'graphql-api'),
+					implode(__('\', \'', 'graphql-api'), self::MODULE_STATES)
+				),
+				[
+					self::PARAM_STATE => $value,
+				]
+			);
 		}
-		return new WP_Error(
-			'1',
-			sprintf(
-				__('Parameter \'state\' can only have one of these values: \'%s\'', 'graphql-api'),
-				implode(__('\', \'', 'graphql-api'), self::MODULE_STATES)
-			),
-			[
-				self::PARAM_STATE => $value,
-			]
-		);
+		return null;
 	}
 
 	public function enableOrDisableModule(WP_REST_Request $request): WP_REST_Response|WP_Error

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -95,7 +95,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 					$value
 				),
 				[
-					self::PARAM_STATE => $value,
+					'moduleID' => $value,
 				]
 			);
 		}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -49,10 +49,10 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 		];
 	}
 
-	protected function validateCallback(string $value): bool|WP_Error
+	protected function validateCallback(string $value): ?WP_Error
 	{
 		if (in_array($value, self::MODULE_STATES)) {
-			return true;
+			return null;
 		}
 		return new WP_Error(
 			'1',

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -32,10 +32,8 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 	 */
 	protected function getRouteOptions(): array
 	{
-		$routeOptions = [];
-		$modules = ['a', 'b', 'c'];
-		foreach ($modules as $module) {
-			$routeOptions[$module] = [
+		return [
+			'(?P<module>[a-zA-Z_-]+)' => [
 				'methods' => WP_REST_Server::CREATABLE,
 				'callback' => $this->enableOrDisableModule(...),
 				'permission_callback' => $this->checkAdminPermission(...),
@@ -44,10 +42,9 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
 						'required' => true,
 						'validate_callback' => $this->validateCallback(...)
 					],
-				],
-			];
-		}
-		return $routeOptions;
+				]
+			],
+		];
 	}
 
 	/**

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers;
+
+use Exception;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ResponseStatus;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\RESTResponse;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+use function rest_ensure_response;
+
+class ModulesAdminRESTController extends AbstractAdminRESTController
+{
+	final public const MODULE_STATES = [
+		'enabled',
+		'disabled',
+	];
+	final public const PARAM_STATE = 'state';
+
+	protected function getRouteBase(): string
+	{
+		return 'modules';
+	}
+
+	/**
+	 * @return array<string,array<string,mixed>> Array of [$route => $options]
+	 */
+	protected function getRouteOptions(): array
+	{
+		$routeOptions = [];
+		$modules = ['a', 'b', 'c'];
+		foreach ($modules as $module) {
+			$routeOptions[$module] = [
+				'methods' => WP_REST_Server::CREATABLE,
+				'callback' => $this->enableOrDisableModule(...),
+				'permission_callback' => $this->checkAdminPermission(...),
+				'args' => [
+					self::PARAM_STATE => [
+						'required' => true,
+						'validate_callback' => $this->validateCallback(...)
+					],
+				],
+			];
+		}
+		return $routeOptions;
+	}
+
+	/**
+	 * @return array<string,array<string,mixed>> Array of [$route => $options]
+	 */
+	protected function validateCallback(string $value): bool|WP_Error
+	{
+		if (in_array($value, self::MODULE_STATES)) {
+			return true;
+		}
+		return new WP_Error(
+			'1',
+			sprintf(
+				__('Parameter \'state\' can only have one of these values: \'%s\'', 'graphql-api'),
+				implode(__('\', \'', 'graphql-api'), self::MODULE_STATES)
+			),
+			[
+				self::PARAM_STATE => $value,
+			]
+		);
+	}
+
+	public function enableOrDisableModule(WP_REST_Request $request): WP_REST_Response|WP_Error
+	{
+		$response = new RESTResponse();
+
+		try {
+			$namespacedRoute = $request->get_route();
+			$module = $this->getRouteFromNamespacedRoute($namespacedRoute);
+
+			$params = $request->get_params();
+			$moduleState = $params[self::PARAM_STATE];
+
+			// @todo Remove this temporary code
+			$response->data->moduleState = $moduleState;
+
+			// Success!
+			$response->status = ResponseStatus::SUCCESS;
+			$response->message = sprintf(
+				__('Module \'%s\' has been updated successfully %s', 'graphql-api'),
+				$module,
+				$moduleState
+			);
+		} catch ( Exception $e ) {
+			$response->status = ResponseStatus::ERROR;
+			$response->message = $e->getMessage();
+		}
+
+		return rest_ensure_response($response);
+	}	
+}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -17,22 +17,24 @@ use function rest_ensure_response;
 class SettingsAdminRESTController extends AbstractAdminRESTController
 {
 	/**
-	 * @return array<string,array<string,mixed>> Array of [$route => $options]
+	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
 	 */
 	protected function getRouteOptions(): array
 	{
 		return [
 			'settings' => [
-				'methods' => WP_REST_Server::CREATABLE,
-				'callback' => $this->updateSettings(...),
-				'permission_callback' => $this->checkAdminPermission(...),
-				'args' => [
-					'name' => [
-						'required' => true
-					],
-					'value' => [
-						'required' => true,
-						'sanitize_callback' => fn (string $value) => (bool) $value
+				[
+					'methods' => WP_REST_Server::CREATABLE,
+					'callback' => $this->updateSettings(...),
+					'permission_callback' => $this->checkAdminPermission(...),
+					'args' => [
+						'name' => [
+							'required' => true
+						],
+						'value' => [
+							'required' => true,
+							'sanitize_callback' => fn (string $value) => (bool) $value
+						],
 					],
 				],
 			],

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -16,58 +16,58 @@ use function rest_ensure_response;
 
 class SettingsAdminRESTController extends AbstractAdminRESTController
 {
-	/**
-	 * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
-	 */
-	protected function getRouteOptions(): array
-	{
-		return [
-			'settings' => [
-				[
-					'methods' => [
-						WP_REST_Server::READABLE,
-						WP_REST_Server::CREATABLE,
-					],
-					'callback' => $this->updateSettings(...),
-					'permission_callback' => $this->checkAdminPermission(...),
-					'args' => [
-						'name' => [
-							'required' => true
-						],
-						'value' => [
-							'required' => true,
-							'sanitize_callback' => fn (string $value) => (bool) $value
-						],
-					],
-				],
-			],
-		];
-	}
+    /**
+     * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
+     */
+    protected function getRouteOptions(): array
+    {
+        return [
+            'settings' => [
+                [
+                    'methods' => [
+                        WP_REST_Server::READABLE,
+                        WP_REST_Server::CREATABLE,
+                    ],
+                    'callback' => $this->updateSettings(...),
+                    'permission_callback' => $this->checkAdminPermission(...),
+                    'args' => [
+                        'name' => [
+                            'required' => true
+                        ],
+                        'value' => [
+                            'required' => true,
+                            'sanitize_callback' => fn (string $value) => (bool) $value
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 
-	public function updateSettings(WP_REST_Request $request): WP_REST_Response|WP_Error
-	{
-		$response = new RESTResponse();
+    public function updateSettings(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $response = new RESTResponse();
 
-		try {
-			$params = $request->get_params();
-			$settingsName = $params['name'];
-			$settingsValue = $params['value'];
+        try {
+            $params = $request->get_params();
+            $settingsName = $params['name'];
+            $settingsValue = $params['value'];
 
-			// @todo Remove this temporary code
-			$response->data->settingsName = $settingsName;
-			$response->data->settingsValue = $settingsValue;
+            // @todo Remove this temporary code
+            $response->data->settingsName = $settingsName;
+            $response->data->settingsValue = $settingsValue;
 
-			// Success!
-			$response->status = ResponseStatus::SUCCESS;
-			$response->message = sprintf(
-				__('The settings for \'%s\' have been updated successfully', 'graphql-api'),
-				$settingsName
-			);
-		} catch ( Exception $e ) {
-			$response->status = ResponseStatus::ERROR;
-			$response->message = $e->getMessage();
-		}
+            // Success!
+            $response->status = ResponseStatus::SUCCESS;
+            $response->message = sprintf(
+                __('The settings for \'%s\' have been updated successfully', 'graphql-api'),
+                $settingsName
+            );
+        } catch (Exception $e) {
+            $response->status = ResponseStatus::ERROR;
+            $response->message = $e->getMessage();
+        }
 
-		return rest_ensure_response($response);
-	}	
+        return rest_ensure_response($response);
+    }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -24,7 +24,10 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
 		return [
 			'settings' => [
 				[
-					'methods' => WP_REST_Server::CREATABLE,
+					'methods' => [
+						WP_REST_Server::READABLE,
+						WP_REST_Server::CREATABLE,
+					],
 					'callback' => $this->updateSettings(...),
 					'permission_callback' => $this->checkAdminPermission(...),
 					'args' => [

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -12,7 +12,6 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
-use function esc_html__;
 use function rest_ensure_response;
 
 class SettingsAdminRESTController extends AbstractAdminRESTController
@@ -27,6 +26,15 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
 				'methods' => WP_REST_Server::CREATABLE,
 				'callback' => $this->updateSettings(...),
 				'permission_callback' => $this->checkAdminPermission(...),
+				'args' => [
+					'name' => [
+						'required' => true
+					],
+					'value' => [
+						'required' => true,
+						'sanitize_callback' => fn (string $value) => (bool) $value
+					],
+				],
 			],
 		];
 	}
@@ -37,18 +45,8 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
 
 		try {
 			$params = $request->get_params();
-			$settingsName = $params['name'] ?? null;
-			if ($settingsName === null) {
-				throw new Exception(
-					__('The settings name has not been provided', 'graphql-api')
-				);
-			}
-			if (!array_key_exists('value', $params)) {
-				throw new Exception(
-					__('The value has not been provided', 'graphql-api')
-				);
-			}
-			$settingsValue = (bool) $params['value'];
+			$settingsName = $params['name'];
+			$settingsValue = $params['value'];
 
 			// @todo Remove this temporary code
 			$response->data->settingsName = $settingsName;

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AbstractRESTAPIEndpointManager.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AbstractRESTAPIEndpointManager.php
@@ -10,29 +10,29 @@ use function add_action;
 
 abstract class AbstractRESTAPIEndpointManager
 {
-	public function __construct()
-	{
-		$this->initialize();
-	}
+    public function __construct()
+    {
+        $this->initialize();
+    }
 
-	public function initialize()
-	{
-		if (!class_exists('WP_REST_Server')) {
-			return;
-		}
+    public function initialize()
+    {
+        if (!class_exists('WP_REST_Server')) {
+            return;
+        }
 
-		add_action('rest_api_init', $this->registerRoutes(...));
-	}
+        add_action('rest_api_init', $this->registerRoutes(...));
+    }
 
-	public function registerRoutes(): void
-	{
-		foreach ($this->getControllers() as $controller) {
-			$controller->register_routes();
-		}
-	}
+    public function registerRoutes(): void
+    {
+        foreach ($this->getControllers() as $controller) {
+            $controller->register_routes();
+        }
+    }
 
-	/**
-	 * @return AbstractRESTController[]
-	 */
-	abstract protected function getControllers(): array;
+    /**
+     * @return AbstractRESTController[]
+     */
+    abstract protected function getControllers(): array;
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
@@ -10,14 +10,14 @@ use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\SettingsAdminREST
 
 class AdminRESTAPIEndpointManager extends AbstractRESTAPIEndpointManager
 {
-	/**
-	 * @return AbstractRESTController[]
-	 */
-	protected function getControllers(): array
-	{
-		return [
-			new SettingsAdminRESTController(),
-			new ModulesAdminRESTController(),
-		];
-	}
+    /**
+     * @return AbstractRESTController[]
+     */
+    protected function getControllers(): array
+    {
+        return [
+            new SettingsAdminRESTController(),
+            new ModulesAdminRESTController(),
+        ];
+    }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Endpoints;
 
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\AbstractRESTController;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\ModulesAdminRESTController;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\SettingsAdminRESTController;
 
 class AdminRESTAPIEndpointManager extends AbstractRESTAPIEndpointManager
@@ -16,6 +17,7 @@ class AdminRESTAPIEndpointManager extends AbstractRESTAPIEndpointManager
 	{
 		return [
 			new SettingsAdminRESTController(),
+			new ModulesAdminRESTController(),
 		];
 	}
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/RESTResponse.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/RESTResponse.php
@@ -8,13 +8,13 @@ use stdClass;
 
 class RESTResponse
 {
-	public function __construct(
-		public string $status = '',
-		public string $message = '',
-		/**
-		 * Extra data
-		 */
-		public stdClass $data = new stdClass(),
-	) {
-	}
+    public function __construct(
+        public string $status = '',
+        public string $message = '',
+        /**
+         * Extra data
+         */
+        public stdClass $data = new stdClass(),
+    ) {
+    }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Utilities/CustomHeaderAppender.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Utilities/CustomHeaderAppender.php
@@ -31,7 +31,7 @@ class CustomHeaderAppender
         if (!is_user_logged_in()) {
             return;
         }
-        
+
         header(sprintf(
             '%s: %s',
             CustomHeaders::WP_REST_NONCE,

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/AbstractGraphQLServerTestCase.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/AbstractGraphQLServerTestCase.php
@@ -101,9 +101,7 @@ abstract class AbstractGraphQLServerTestCase extends TestCase
             $variablesFile,
             $operationName,
         );
-
         $response = self::getGraphQLServer()->execute($graphQLQuery, $graphQLVariables, $operationName);
-        
         /**
          * Perform additional assertions, such as macking sure
          * that there are no mock Responses left in the queue.

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/AbstractGraphQLServerTestCase.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/AbstractGraphQLServerTestCase.php
@@ -103,17 +103,18 @@ abstract class AbstractGraphQLServerTestCase extends TestCase
         );
 
         $response = self::getGraphQLServer()->execute($graphQLQuery, $graphQLVariables, $operationName);
-        $this->assertJsonStringEqualsJsonFile(
-            $expectedResponseFile,
-            $response->getContent()
-        );
-
+        
         /**
          * Perform additional assertions, such as macking sure
          * that there are no mock Responses left in the queue.
          */
         $this->afterFixtureGraphQLQueryExecution(
             $dataName,
+        );
+
+        $this->assertJsonStringEqualsJsonFile(
+            $expectedResponseFile,
+            $response->getContent()
         );
     }
 


### PR DESCRIPTION
Added REST API endpoints to enable/disable modules:

- `http://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/modules`
- `http://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/modules/(?P<moduleID>[a-zA-Z_-]+)`

Now, in the integration test `ClientWebserverRequestTest`, it can:

- Disable the "GraphiQL client for the single endpoint" module
- Test requesting the client returns an error
- Re-enable the "GraphiQL client for the single endpoint" module