### PR TITLE
Modules and settings in REST API: Add READABLE endpoint for single item

### DIFF
--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/RequestRESTAPIWordPressAuthenticatedUserWebserverRequestTestTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPUnitForGraphQLAPI\WebserverRequests;
 
 use function getenv;
+
 use PoP\ComponentModel\Constants\FrameworkParams;
 
 /**

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -8,6 +8,5 @@ class Params
 {
     final public const STATE = 'state';
     final public const MODULE_ID = 'moduleID';
-    final public const OPTION = 'option';
-    final public const VALUE = 'value';
+    final public const OPTION_VALUES = 'optionValues';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -69,19 +69,6 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
             ],
         ];
     }
-    
-    /**
-     * @return array<string,mixed>
-     */
-    protected function getModuleIDParamArgs(): array
-    {
-        return [
-            'description' => __('Module ID', 'graphql-api-testing'),
-            'type' => 'string',
-            'required' => true,
-            'validate_callback' => $this->validateModule(...),
-        ];
-    }
 
     protected function validateState(string $value): bool|WP_Error
     {

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -54,8 +54,6 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
                         Params::MODULE_ID => $this->getModuleIDParamArgs(),
                     ],
                 ],
-            ],
-            $this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
                 [
                     'methods' => WP_REST_Server::CREATABLE,
                     'callback' => $this->updateModule(...),

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -46,6 +46,17 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
             ],
             $this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
                 [
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => $this->retrieveModule(...),
+                    // Allow anyone to read the modules
+                    // 'permission_callback' => $this->checkAdminPermission(...),
+                    'args' => [
+                        Params::MODULE_ID => $this->getModuleIDParamArgs(),
+                    ],
+                ],
+            ],
+            $this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
+                [
                     'methods' => WP_REST_Server::CREATABLE,
                     'callback' => $this->updateModule(...),
                     // only the Admin can execute the modification
@@ -55,15 +66,23 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
                             'required' => true,
                             'validate_callback' => $this->validateState(...),
                         ],
-                        Params::MODULE_ID => [
-                            'description' => __('Module ID', 'graphql-api-testing'),
-                            'type' => 'string',
-                            'required' => true,
-                            'validate_callback' => $this->validateModule(...),
-                        ],
+                        Params::MODULE_ID => $this->getModuleIDParamArgs(),
                     ],
                 ],
             ],
+        ];
+    }
+    
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getModuleIDParamArgs(): array
+    {
+        return [
+            'description' => __('Module ID', 'graphql-api-testing'),
+            'type' => 'string',
+            'required' => true,
+            'validate_callback' => $this->validateModule(...),
         ];
     }
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -154,17 +154,17 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
         return $this->prepareItemForResponse($module);
     }
 
-	/**
-	 * @return array<string,mixed>
-	 */
-	protected function prepareLinks(string $module): array
+    /**
+     * @return array<string,mixed>
+     */
+    protected function prepareLinks(string $module): array
     {
         $moduleRegistry = ModuleRegistryFacade::getInstance();
         $moduleResolver = $moduleRegistry->getModuleResolver($module);
         $moduleID = $moduleResolver->getID($module);
-		return [
-			'self' => [
-				'href' => rest_url(
+        return [
+            'self' => [
+                'href' => rest_url(
                     sprintf(
                         '%s/%s/%s',
                         $this->getNamespace(),
@@ -173,8 +173,8 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
                     )
                 ),
             ],
-			'collection' => [
-				'href' => rest_url(
+            'collection' => [
+                'href' => rest_url(
                     sprintf(
                         '%s/%s',
                         $this->getNamespace(),
@@ -182,8 +182,8 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
                     )
                 ),
             ],
-			'settings' => [
-				'href' => rest_url(
+            'settings' => [
+                'href' => rest_url(
                     sprintf(
                         '%s/%s/%s',
                         $this->getNamespace(),
@@ -193,7 +193,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
                 ),
             ],
         ];
-	}
+    }
 
     public function updateItem(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
@@ -229,7 +229,7 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
                     $module
                 );
             }
-            
+
             // Success!
             $response->status = ResponseStatus::SUCCESS;
             $response->message = $successMessage;

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -18,6 +18,18 @@ use WP_REST_Server;
 
 use function rest_ensure_response;
 
+/**
+ * Example to enable/disable a module
+ *
+ * ```bash
+ * curl -i --insecure \
+ *   --user "admin:{applicationPassword}" \
+ *   -X POST \
+ *   -H "Content-Type: application/json" \
+ *   -d '{"state": "enabled"}' \
+ *   https://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/modules/graphqlapi_graphqlapi_graphiql-for-single-endpoint/
+ * ```
+ */
 class ModulesAdminRESTController extends AbstractAdminRESTController
 {
     use WithModuleParamRESTControllerTrait;

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModulesAdminRESTController.php
@@ -173,6 +173,15 @@ class ModulesAdminRESTController extends AbstractAdminRESTController
                     )
                 ),
             ],
+			'collection' => [
+				'href' => rest_url(
+                    sprintf(
+                        '%s/%s',
+                        $this->getNamespace(),
+                        $this->restBase,
+                    )
+                ),
+            ],
 			'settings' => [
 				'href' => rest_url(
                     sprintf(

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -45,7 +45,7 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
                     'methods' => WP_REST_Server::READABLE,
                     'callback' => $this->retrieveAllItems(...),
                     // Allow anyone to read the modules
-                    // 'permission_callback' => $this->checkAdminPermission(...),
+                    'permission_callback' => '__return_true',
                 ],
             ],
             $this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)/(?P<option>[a-zA-Z_-]+)' => [

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -219,7 +219,16 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
                         '%s/%s/%s',
                         $this->getNamespace(),
                         $this->restBase,
-                        $moduleID
+                        $moduleID,
+                    )
+                ),
+            ],
+			'collection' => [
+				'href' => rest_url(
+                    sprintf(
+                        '%s/%s',
+                        $this->getNamespace(),
+                        $this->restBase,
                     )
                 ),
             ],
@@ -229,7 +238,7 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
                         '%s/%s/%s',
                         $this->getNamespace(),
                         'modules',
-                        $moduleID
+                        $moduleID,
                     )
                 ),
             ],

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -51,16 +51,11 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
             $this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)/(?P<option>[a-zA-Z_-]+)' => [
                 [
                     'methods' => WP_REST_Server::CREATABLE,
-                    'callback' => $this->updateSettings(...),
+                    'callback' => $this->updateItem(...),
                     // only the Admin can execute the modification
                     'permission_callback' => $this->checkAdminPermission(...),
                     'args' => [
-                        Params::MODULE_ID => [
-                            'description' => __('Module ID', 'graphql-api-testing'),
-                            'type' => 'string',
-                            'required' => true,
-                            'validate_callback' => $this->validateModule(...),
-                        ],
+                        Params::MODULE_ID => $this->getModuleIDParamArgs(),
                         Params::OPTION => [
                             'description' => __('Option (also called \'input\' in the settings)', 'graphql-api-testing'),
                             'type' => 'string',
@@ -138,7 +133,7 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
         return rest_ensure_response($items);
     }
 
-    public function updateSettings(WP_REST_Request $request): WP_REST_Response|WP_Error
+    public function updateItem(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         $response = new RESTResponse();
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -25,7 +25,7 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
     use WithModuleParamRESTControllerTrait;
     use WithFlushRewriteRulesRESTControllerTrait;
 
-    protected string $restBase = 'settings';
+    protected string $restBase = 'module-settings';
 
     private ?SettingsNormalizerInterface $settingsNormalizer = null;
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -13,7 +13,6 @@ use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\Params;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ResponseStatus;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\RESTResponse;
 use PoP\Root\Facades\Instances\InstanceManagerFacade;
-use stdClass;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -21,6 +20,18 @@ use WP_REST_Server;
 
 use function rest_ensure_response;
 
+/**
+ * Example to execute a Settings update:
+ *
+ * ```bash
+ * curl -i --insecure \
+ *   --user "admin:{applicationPassword}" \
+ *   -X POST \
+ *   -H "Content-Type: application/json" \
+ *   -d '{"optionValues": {"path": "/anotherGraphiQL/"}}' \
+ *   https://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/module-settings/graphqlapi_graphqlapi_graphiql-for-single-endpoint/
+ * ```
+ */
 class SettingsAdminRESTController extends AbstractAdminRESTController
 {
     use WithModuleParamRESTControllerTrait;

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -160,7 +160,12 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
         $settings = $moduleResolver->getSettings($module);
         $userSettingsManager = UserSettingsManagerFacade::getInstance();
         foreach ($settings as &$setting) {
-            $setting['value'] = $userSettingsManager->getSetting($module, $setting['input']);
+            // There are non-editable inputs, to show information. Skip those
+            $input = $setting['input'] ?? null;
+            if ($input === null) {
+                continue;
+            }
+            $setting['value'] = $userSettingsManager->getSetting($module, $input);
         }
         return [
             'module' => $module,

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/SettingsAdminRESTController.php
@@ -86,7 +86,7 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
                             //         'required' => true,
                             //     ],
                             //     'value' => [
-                            //         'required' => true,     
+                            //         'required' => true,
                             //     ],
                             // ],
                             'required' => true,
@@ -204,17 +204,17 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
         return rest_ensure_response($item);
     }
 
-	/**
-	 * @return array<string,mixed>
-	 */
-	protected function prepareLinks(string $module): array
+    /**
+     * @return array<string,mixed>
+     */
+    protected function prepareLinks(string $module): array
     {
         $moduleRegistry = ModuleRegistryFacade::getInstance();
         $moduleResolver = $moduleRegistry->getModuleResolver($module);
         $moduleID = $moduleResolver->getID($module);
-		return [
-			'self' => [
-				'href' => rest_url(
+        return [
+            'self' => [
+                'href' => rest_url(
                     sprintf(
                         '%s/%s/%s',
                         $this->getNamespace(),
@@ -223,8 +223,8 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
                     )
                 ),
             ],
-			'collection' => [
-				'href' => rest_url(
+            'collection' => [
+                'href' => rest_url(
                     sprintf(
                         '%s/%s',
                         $this->getNamespace(),
@@ -232,8 +232,8 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
                     )
                 ),
             ],
-			'module' => [
-				'href' => rest_url(
+            'module' => [
+                'href' => rest_url(
                     sprintf(
                         '%s/%s/%s',
                         $this->getNamespace(),
@@ -243,7 +243,7 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
                 ),
             ],
         ];
-	}
+    }
 
     public function updateItem(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
@@ -257,7 +257,7 @@ class SettingsAdminRESTController extends AbstractAdminRESTController
 
             // Normalize the values
             $optionValues = $this->getSettingsNormalizer()->normalizeModuleSettings($module, (array)$optionValues);
-            
+
             // Store in the DB
             $userSettingsManager = UserSettingsManagerFacade::getInstance();
             $userSettingsManager->setSettings($module, $optionValues);

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/WithModuleParamRESTControllerTrait.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/WithModuleParamRESTControllerTrait.php
@@ -8,7 +8,20 @@ use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleRegistryFacade;
 use WP_Error;
 
 trait WithModuleParamRESTControllerTrait
-{
+{    
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getModuleIDParamArgs(): array
+    {
+        return [
+            'description' => __('Module ID', 'graphql-api-testing'),
+            'type' => 'string',
+            'required' => true,
+            'validate_callback' => $this->validateModule(...),
+        ];
+    }
+
     /**
      * Validate there is a module with this ID
      */
@@ -19,7 +32,7 @@ trait WithModuleParamRESTControllerTrait
             return new WP_Error(
                 '1',
                 sprintf(
-                    __('There is no module with ID \'%s\'', 'graphql-api-testing'),
+                    __('There is no module with ID \'%s\'', 'graphql-api'),
                     $moduleID
                 ),
                 [

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/WithModuleParamRESTControllerTrait.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/WithModuleParamRESTControllerTrait.php
@@ -8,7 +8,7 @@ use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleRegistryFacade;
 use WP_Error;
 
 trait WithModuleParamRESTControllerTrait
-{    
+{
     /**
      * @return array<string,mixed>
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
@@ -12,10 +12,17 @@ interface SettingsNormalizerInterface
      * - If the input is empty, replace with the default
      * - Convert from string to int/bool
      *
-     * @param array<string, string> $value All values submitted, each under its optionName as key
+     * @param array<string, string> $values All values submitted, each under its optionName as key
      * @return array<string, mixed> Normalized values
      */
-    public function normalizeSettings(array $value): array;
+    public function normalizeSettings(array $values): array;
+    /**
+     * Normalize the form values for a specific module
+     *
+     * @param array<string, string> $values All values submitted, each under its optionName as key
+     * @return array<string, mixed> Normalized values
+     */
+    public function normalizeModuleSettings(string $module, array $values): array;
     /**
      * Return all the modules with settings
      *

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
@@ -131,6 +131,23 @@ class UserSettingsManager implements UserSettingsManagerInterface
         $this->setOptionItem(Options::SETTINGS, $item, $value);
     }
 
+    /**
+     * @param array<string,mixed> $optionValues
+     */
+    public function setSettings(string $module, array $optionValues): void
+    {
+        $moduleRegistry = SystemModuleRegistryFacade::getInstance();
+        $moduleResolver = $moduleRegistry->getModuleResolver($module);
+
+        $itemValues = [];
+        foreach ($optionValues as $option => $value) {
+            $item = $moduleResolver->getSettingOptionName($module, $option);
+            $itemValues[$item] = $value;
+        }
+
+        $this->setOptionItems(Options::SETTINGS, $itemValues);
+    }
+
     public function hasSetModuleEnabled(string $moduleID): bool
     {
         return $this->hasItem(Options::MODULES, $moduleID);
@@ -146,9 +163,20 @@ class UserSettingsManager implements UserSettingsManagerInterface
         $this->setOptionItem(Options::MODULES, $moduleID, $isEnabled);
     }
 
-    public function setOptionItem(string $optionName, string $item, mixed $value): void
+    protected function setOptionItem(string $optionName, string $item, mixed $value): void
     {
         $this->storeItem($optionName, $item, $value);
+
+        // Update the timestamp
+        $this->storeContainerTimestamp();
+    }
+
+    /**
+     * @param array<string,mixed> $itemValues
+     */
+    protected function setOptionItems(string $optionName, array $itemValues): void
+    {
+        $this->storeItems($optionName, $itemValues);
 
         // Update the timestamp
         $this->storeContainerTimestamp();

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManagerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManagerInterface.php
@@ -37,6 +37,10 @@ interface UserSettingsManagerInterface
     public function hasSetting(string $module, string $option): bool;
     public function getSetting(string $module, string $option): mixed;
     public function setSetting(string $module, string $option, mixed $value): void;
+    /**
+     * @param array<string,mixed> $optionValues
+     */
+    public function setSettings(string $module, array $optionValues): void;
     public function hasSetModuleEnabled(string $moduleID): bool;
     public function isModuleEnabled(string $moduleID): bool;
     public function setModuleEnabled(string $moduleID, bool $isEnabled): void;


### PR DESCRIPTION
Added GET endpoints to retrieve data for a single module/settings.

Format:

- `wp-json/graphql-api/v1/admin/modules/{moduleID}`
- `wp-json/graphql-api/v1/admin/module-settings/{moduleID}`

Eg:

```bash
curl -i \
  -H "Content-Type: application/json" \
  http://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/modules/graphqlapi_graphqlapi_graphiql-for-single-endpoint/
```

Or:

```bash
curl -i \
  -H "Content-Type: application/json" \
  http://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/module-settings/graphqlapi_graphqlapi_graphiql-for-single-endpoint/
```