### PR TITLE
Test core fields with namespacing

### DIFF
--- a/layers/CMSSchema/packages/customposts-wp/src/Overrides/TypeResolvers/UnionType/CustomPostUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/Overrides/TypeResolvers/UnionType/CustomPostUnionTypeResolver.php
@@ -6,13 +6,11 @@ namespace PoPCMSSchema\CustomPostsWP\Overrides\TypeResolvers\UnionType;
 
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoPCMSSchema\CustomPosts\TypeResolvers\UnionType\CustomPostUnionTypeResolver as UpstreamCustomPostUnionTypeResolver;
+use PoPCMSSchema\SchemaCommonsWP\Overrides\TypeResolvers\OverridingTypeResolverTrait;
 
 class CustomPostUnionTypeResolver extends UpstreamCustomPostUnionTypeResolver
 {
-    protected function getClassToNamespace(): string
-    {
-        return get_parent_class();
-    }
+    use OverridingTypeResolverTrait;
 
     /**
      * Overriding function to provide optimization:

--- a/layers/CMSSchema/packages/customposts-wp/src/Overrides/TypeResolvers/UnionType/CustomPostUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/Overrides/TypeResolvers/UnionType/CustomPostUnionTypeResolver.php
@@ -9,6 +9,11 @@ use PoPCMSSchema\CustomPosts\TypeResolvers\UnionType\CustomPostUnionTypeResolver
 
 class CustomPostUnionTypeResolver extends UpstreamCustomPostUnionTypeResolver
 {
+    protected function getClassToNamespace(): string
+    {
+        return get_parent_class();
+    }
+
     /**
      * Overriding function to provide optimization:
      * instead of calling ->isIDOfType on each object (as in parent function),

--- a/layers/CMSSchema/packages/schema-commons-wp/src/Overrides/TypeResolvers/OverridingTypeResolverTrait.php
+++ b/layers/CMSSchema/packages/schema-commons-wp/src/Overrides/TypeResolvers/OverridingTypeResolverTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\SchemaCommonsWP\Overrides\TypeResolvers;
+
+trait OverridingTypeResolverTrait
+{
+    protected function getClassToNamespace(): string
+    {
+        return get_parent_class();
+    }
+}

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractTypeResolver.php
@@ -50,7 +50,12 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
 
     public function getNamespace(): string
     {
-        return $this->getSchemaNamespacingService()->getSchemaNamespace(get_called_class());
+        return $this->getSchemaNamespacingService()->getSchemaNamespace($this->getClassToNamespace());
+    }
+
+    protected function getClassToNamespace(): string
+    {
+        return get_called_class();
     }
 
     final public function getNamespacedTypeName(): string

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/AbstractNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/AbstractNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPI\Unit\Faker;
+
+use GraphQLByPoP\GraphQLServer\Unit\EnabledDisabledFixtureQueryExecutionGraphQLServerTestCaseTrait;
+use PHPUnitForGraphQLAPI\WPFakerSchema\Unit\AbstractWPFakerFixtureQueryExecutionGraphQLServerTest;
+
+abstract class AbstractNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest extends AbstractWPFakerFixtureQueryExecutionGraphQLServerTest
+{
+    use EnabledDisabledFixtureQueryExecutionGraphQLServerTestCaseTrait;
+
+    /**
+     * Directory under the fixture files are placed
+     */
+    protected function getFixtureFolder(): string
+    {
+        return __DIR__ . '/fixture-namespacing';
+    }
+
+    /**
+     * @return string[]
+     */
+    protected static function getGraphQLServerComponentClasses(): array
+    {
+        return [
+            ...parent::getGraphQLServerComponentClasses(),
+            ...[
+                \PoPWPSchema\Users\Component::class,
+                \PoPWPSchema\Posts\Component::class,
+            ]
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected static function getGraphQLServerComponentClassConfiguration(): array
+    {
+        return [
+            ...parent::getGraphQLServerComponentClassConfiguration(),
+            ...[
+                \PoP\ComponentModel\Component::class => [
+                    \PoP\ComponentModel\Environment::NAMESPACE_TYPES_AND_INTERFACES => static::isEnabled(),
+                ],
+            ]
+        ];
+    }
+}

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/DisabledNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/DisabledNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPI\Unit\Faker;
+
+use GraphQLByPoP\GraphQLServer\Unit\EnabledFixtureQueryExecutionGraphQLServerTestCaseTrait;
+
+class DisabledNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest extends AbstractNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest
+{
+    use EnabledFixtureQueryExecutionGraphQLServerTestCaseTrait;
+}

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/EnabledNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/EnabledNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPI\Unit\Faker;
+
+use GraphQLByPoP\GraphQLServer\Unit\EnabledFixtureQueryExecutionGraphQLServerTestCaseTrait;
+
+class EnabledNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest extends AbstractNamespacingWPFakerFixtureQueryExecutionGraphQLServerTest
+{
+    use EnabledFixtureQueryExecutionGraphQLServerTestCaseTrait;
+}

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields.gql
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields.gql
@@ -7,10 +7,13 @@
     __typename
     isObjectTypeWithNamespacing: isObjectType(type: "PoPCMSSchema_Posts_Post")
     isObjectTypeWithoutNamespacing: isObjectType(type: "Post")
+    isObjectTypeWithWrongNamespacing: isObjectType(type: "NonExisting_PoPCMSSchema_Posts_Post")
     implementsWithNamespacing: implements(interface: "PoPCMSSchema_CustomPosts_IsCustomPost")
     implementsWithoutNamespacing: implements(interface: "IsCustomPost")
+    implementsWithWrongNamespacing: implements(interface: "NonExisting_PoPCMSSchema_CustomPosts_IsCustomPost")
     isInUnionTypeWithNamespacing: isInUnionType(type: "PoPCMSSchema_CustomPosts_CustomPostUnion")
     isInUnionTypeWithoutNamespacing: isInUnionType(type: "CustomPostUnion")
+    isInUnionTypeWithWrongNamespacing: isInUnionType(type: "NonExisting_PoPCMSSchema_CustomPosts_CustomPostUnion")
   }
 
   users(
@@ -21,9 +24,12 @@
     __typename
     isObjectTypeWithNamespacing: isObjectType(type: "PoPCMSSchema_Posts_Post")
     isObjectTypeWithoutNamespacing: isObjectType(type: "Post")
+    isObjectTypeWithWrongNamespacing: isObjectType(type: "NonExisting_PoPCMSSchema_Posts_Post")
     implementsWithNamespacing: implements(interface: "PoPCMSSchema_CustomPosts_IsCustomPost")
     implementsWithoutNamespacing: implements(interface: "IsCustomPost")
+    implementsWithWrongNamespacing: implements(interface: "NonExisting_PoPCMSSchema_CustomPosts_IsCustomPost")
     isInUnionTypeWithNamespacing: isInUnionType(type: "PoPCMSSchema_CustomPosts_CustomPostUnion")
     isInUnionTypeWithoutNamespacing: isInUnionType(type: "CustomPostUnion")
+    isInUnionTypeWithWrongNamespacing: isInUnionType(type: "NonExisting_PoPCMSSchema_CustomPosts_CustomPostUnion")
   }
 }

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields.gql
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields.gql
@@ -1,0 +1,29 @@
+{
+  customPosts(
+    pagination: {
+      limit: 3
+    }
+  ) {
+    __typename
+    isObjectTypeWithNamespacing: isObjectType(type: "PoPCMSSchema_Posts_Post")
+    isObjectTypeWithoutNamespacing: isObjectType(type: "Post")
+    implementsWithNamespacing: implements(interface: "PoPCMSSchema_CustomPosts_IsCustomPost")
+    implementsWithoutNamespacing: implements(interface: "IsCustomPost")
+    isInUnionTypeWithNamespacing: isInUnionType(type: "PoPCMSSchema_CustomPosts_CustomPostUnion")
+    isInUnionTypeWithoutNamespacing: isInUnionType(type: "CustomPostUnion")
+  }
+
+  users(
+    pagination: {
+      limit: 3
+    }
+  ) {
+    __typename
+    isObjectTypeWithNamespacing: isObjectType(type: "PoPCMSSchema_Posts_Post")
+    isObjectTypeWithoutNamespacing: isObjectType(type: "Post")
+    implementsWithNamespacing: implements(interface: "PoPCMSSchema_CustomPosts_IsCustomPost")
+    implementsWithoutNamespacing: implements(interface: "IsCustomPost")
+    isInUnionTypeWithNamespacing: isInUnionType(type: "PoPCMSSchema_CustomPosts_CustomPostUnion")
+    isInUnionTypeWithoutNamespacing: isInUnionType(type: "CustomPostUnion")
+  }
+}

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@disabled.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@disabled.json
@@ -5,28 +5,37 @@
         "__typename": "PoPCMSSchema_Posts_Post",
         "isObjectTypeWithNamespacing": true,
         "isObjectTypeWithoutNamespacing": true,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": true,
         "implementsWithoutNamespacing": true,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": true,
-        "isInUnionTypeWithoutNamespacing": true
+        "isInUnionTypeWithoutNamespacing": true,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Posts_Post",
         "isObjectTypeWithNamespacing": true,
         "isObjectTypeWithoutNamespacing": true,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": true,
         "implementsWithoutNamespacing": true,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": true,
-        "isInUnionTypeWithoutNamespacing": true
+        "isInUnionTypeWithoutNamespacing": true,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Posts_Post",
         "isObjectTypeWithNamespacing": true,
         "isObjectTypeWithoutNamespacing": true,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": true,
         "implementsWithoutNamespacing": true,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": true,
-        "isInUnionTypeWithoutNamespacing": true
+        "isInUnionTypeWithoutNamespacing": true,
+        "isInUnionTypeWithWrongNamespacing": false
       }
     ],
     "users": [
@@ -34,28 +43,37 @@
         "__typename": "PoPCMSSchema_Users_User",
         "isObjectTypeWithNamespacing": false,
         "isObjectTypeWithoutNamespacing": false,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": false,
         "implementsWithoutNamespacing": false,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": false,
-        "isInUnionTypeWithoutNamespacing": false
+        "isInUnionTypeWithoutNamespacing": false,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Users_User",
         "isObjectTypeWithNamespacing": false,
         "isObjectTypeWithoutNamespacing": false,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": false,
         "implementsWithoutNamespacing": false,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": false,
-        "isInUnionTypeWithoutNamespacing": false
+        "isInUnionTypeWithoutNamespacing": false,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Users_User",
         "isObjectTypeWithNamespacing": false,
         "isObjectTypeWithoutNamespacing": false,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": false,
         "implementsWithoutNamespacing": false,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": false,
-        "isInUnionTypeWithoutNamespacing": false
+        "isInUnionTypeWithoutNamespacing": false,
+        "isInUnionTypeWithWrongNamespacing": false
       }
     ]
   }

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@disabled.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@disabled.json
@@ -1,0 +1,62 @@
+{
+  "data": {
+    "customPosts": [
+      {
+        "__typename": "PoPCMSSchema_Posts_Post",
+        "isObjectTypeWithNamespacing": true,
+        "isObjectTypeWithoutNamespacing": true,
+        "implementsWithNamespacing": true,
+        "implementsWithoutNamespacing": true,
+        "isInUnionTypeWithNamespacing": true,
+        "isInUnionTypeWithoutNamespacing": true
+      },
+      {
+        "__typename": "PoPCMSSchema_Posts_Post",
+        "isObjectTypeWithNamespacing": true,
+        "isObjectTypeWithoutNamespacing": true,
+        "implementsWithNamespacing": true,
+        "implementsWithoutNamespacing": true,
+        "isInUnionTypeWithNamespacing": true,
+        "isInUnionTypeWithoutNamespacing": true
+      },
+      {
+        "__typename": "PoPCMSSchema_Posts_Post",
+        "isObjectTypeWithNamespacing": true,
+        "isObjectTypeWithoutNamespacing": true,
+        "implementsWithNamespacing": true,
+        "implementsWithoutNamespacing": true,
+        "isInUnionTypeWithNamespacing": true,
+        "isInUnionTypeWithoutNamespacing": true
+      }
+    ],
+    "users": [
+      {
+        "__typename": "PoPCMSSchema_Users_User",
+        "isObjectTypeWithNamespacing": false,
+        "isObjectTypeWithoutNamespacing": false,
+        "implementsWithNamespacing": false,
+        "implementsWithoutNamespacing": false,
+        "isInUnionTypeWithNamespacing": false,
+        "isInUnionTypeWithoutNamespacing": false
+      },
+      {
+        "__typename": "PoPCMSSchema_Users_User",
+        "isObjectTypeWithNamespacing": false,
+        "isObjectTypeWithoutNamespacing": false,
+        "implementsWithNamespacing": false,
+        "implementsWithoutNamespacing": false,
+        "isInUnionTypeWithNamespacing": false,
+        "isInUnionTypeWithoutNamespacing": false
+      },
+      {
+        "__typename": "PoPCMSSchema_Users_User",
+        "isObjectTypeWithNamespacing": false,
+        "isObjectTypeWithoutNamespacing": false,
+        "implementsWithNamespacing": false,
+        "implementsWithoutNamespacing": false,
+        "isInUnionTypeWithNamespacing": false,
+        "isInUnionTypeWithoutNamespacing": false
+      }
+    ]
+  }
+}

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@enabled.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@enabled.json
@@ -5,28 +5,37 @@
         "__typename": "PoPCMSSchema_Posts_Post",
         "isObjectTypeWithNamespacing": true,
         "isObjectTypeWithoutNamespacing": true,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": true,
         "implementsWithoutNamespacing": true,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": true,
-        "isInUnionTypeWithoutNamespacing": true
+        "isInUnionTypeWithoutNamespacing": true,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Posts_Post",
         "isObjectTypeWithNamespacing": true,
         "isObjectTypeWithoutNamespacing": true,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": true,
         "implementsWithoutNamespacing": true,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": true,
-        "isInUnionTypeWithoutNamespacing": true
+        "isInUnionTypeWithoutNamespacing": true,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Posts_Post",
         "isObjectTypeWithNamespacing": true,
         "isObjectTypeWithoutNamespacing": true,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": true,
         "implementsWithoutNamespacing": true,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": true,
-        "isInUnionTypeWithoutNamespacing": true
+        "isInUnionTypeWithoutNamespacing": true,
+        "isInUnionTypeWithWrongNamespacing": false
       }
     ],
     "users": [
@@ -34,28 +43,37 @@
         "__typename": "PoPCMSSchema_Users_User",
         "isObjectTypeWithNamespacing": false,
         "isObjectTypeWithoutNamespacing": false,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": false,
         "implementsWithoutNamespacing": false,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": false,
-        "isInUnionTypeWithoutNamespacing": false
+        "isInUnionTypeWithoutNamespacing": false,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Users_User",
         "isObjectTypeWithNamespacing": false,
         "isObjectTypeWithoutNamespacing": false,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": false,
         "implementsWithoutNamespacing": false,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": false,
-        "isInUnionTypeWithoutNamespacing": false
+        "isInUnionTypeWithoutNamespacing": false,
+        "isInUnionTypeWithWrongNamespacing": false
       },
       {
         "__typename": "PoPCMSSchema_Users_User",
         "isObjectTypeWithNamespacing": false,
         "isObjectTypeWithoutNamespacing": false,
+        "isObjectTypeWithWrongNamespacing": false,
         "implementsWithNamespacing": false,
         "implementsWithoutNamespacing": false,
+        "implementsWithWrongNamespacing": false,
         "isInUnionTypeWithNamespacing": false,
-        "isInUnionTypeWithoutNamespacing": false
+        "isInUnionTypeWithoutNamespacing": false,
+        "isInUnionTypeWithWrongNamespacing": false
       }
     ]
   }

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@enabled.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Unit/Faker/fixture-namespacing/type-fields@enabled.json
@@ -1,0 +1,62 @@
+{
+  "data": {
+    "customPosts": [
+      {
+        "__typename": "PoPCMSSchema_Posts_Post",
+        "isObjectTypeWithNamespacing": true,
+        "isObjectTypeWithoutNamespacing": true,
+        "implementsWithNamespacing": true,
+        "implementsWithoutNamespacing": true,
+        "isInUnionTypeWithNamespacing": true,
+        "isInUnionTypeWithoutNamespacing": true
+      },
+      {
+        "__typename": "PoPCMSSchema_Posts_Post",
+        "isObjectTypeWithNamespacing": true,
+        "isObjectTypeWithoutNamespacing": true,
+        "implementsWithNamespacing": true,
+        "implementsWithoutNamespacing": true,
+        "isInUnionTypeWithNamespacing": true,
+        "isInUnionTypeWithoutNamespacing": true
+      },
+      {
+        "__typename": "PoPCMSSchema_Posts_Post",
+        "isObjectTypeWithNamespacing": true,
+        "isObjectTypeWithoutNamespacing": true,
+        "implementsWithNamespacing": true,
+        "implementsWithoutNamespacing": true,
+        "isInUnionTypeWithNamespacing": true,
+        "isInUnionTypeWithoutNamespacing": true
+      }
+    ],
+    "users": [
+      {
+        "__typename": "PoPCMSSchema_Users_User",
+        "isObjectTypeWithNamespacing": false,
+        "isObjectTypeWithoutNamespacing": false,
+        "implementsWithNamespacing": false,
+        "implementsWithoutNamespacing": false,
+        "isInUnionTypeWithNamespacing": false,
+        "isInUnionTypeWithoutNamespacing": false
+      },
+      {
+        "__typename": "PoPCMSSchema_Users_User",
+        "isObjectTypeWithNamespacing": false,
+        "isObjectTypeWithoutNamespacing": false,
+        "implementsWithNamespacing": false,
+        "implementsWithoutNamespacing": false,
+        "isInUnionTypeWithNamespacing": false,
+        "isInUnionTypeWithoutNamespacing": false
+      },
+      {
+        "__typename": "PoPCMSSchema_Users_User",
+        "isObjectTypeWithNamespacing": false,
+        "isObjectTypeWithoutNamespacing": false,
+        "implementsWithNamespacing": false,
+        "implementsWithoutNamespacing": false,
+        "isInUnionTypeWithNamespacing": false,
+        "isInUnionTypeWithoutNamespacing": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Test fields with/out namespacing:

- `isObjectType`
- `implements`
- `isInUnionType`

Whether `NAMESPACE_TYPES_AND_INTERFACES` is enabled or not, the results are always the same!