### PR TITLE
Renamed `getDataFields` and other 3 functions

### DIFF
--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -204,7 +204,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         if (App::getState('does-api-query-have-errors')) {
             return [];

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -149,7 +149,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
     /**
      * @return LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         if (App::getState('does-api-query-have-errors')) {
             return [];

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -306,7 +306,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
      *
      * @todo Remove all commented code below this function
      */
-    public function getConditionalOnDataFieldSubcomponents(array $component): array
+    public function getConditionalLeafComponentFields(array $component): array
     {
         if (App::getState('does-api-query-have-errors')) {
             return [];
@@ -417,7 +417,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
     // /**
     //  * @return ConditionalLeafComponentField[]
     //  */
-    // public function getConditionalOnDataFieldSubcomponents(array $component): array
+    // public function getConditionalLeafComponentFields(array $component): array
     // {
     //     $componentAtts = $component[2] ?? null;
     //     if (!$this->ignoreConditionalFields($componentAtts)) {

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -290,7 +290,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
      * Watch out! This function loads both leaf fields (eg: "date") and
      * relational fields (eg: "author").
      *
-     * Using `getConditionalOnDataFieldRelationalSubcomponents` to
+     * Using `getConditionalRelationalComponentFields` to
      * load relational fields does not work, because the component to
      * process entry "author" is added twice
      * (once "ignoreConditionalFields" => true, once => false) and both
@@ -479,7 +479,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
     // /**
     //  * @return ConditionalRelationalComponentField[]
     //  */
-    // public function getConditionalOnDataFieldRelationalSubcomponents(array $component): array
+    // public function getConditionalRelationalComponentFields(array $component): array
     // {
     //     $componentAtts = $component[2] ?? null;
     //     if (!$this->ignoreConditionalFields($componentAtts)) {

--- a/layers/Engine/packages/component-model/README.md
+++ b/layers/Engine/packages/component-model/README.md
@@ -1400,12 +1400,12 @@ Consider the image below: Starting from the object type "post", and moving down 
 
 ![Changing the DB object from one domain to another](https://uploads.getpop.org/wp-content/uploads/2018/12/loading-data-at-intervals-relational.jpg)
 
-Switching domins is accomplished through function `getRelationalSubcomponents`. It must return an array, in which each key is the property, or "data-field", containing the ID of the object to switch to, and its value is another array, in which the key is the [Dataloader](#dataloader) to use to load this object, and its values are the components to use:
+Switching domins is accomplished through function `getRelationalComponentFields`. It must return an array, in which each key is the property, or "data-field", containing the ID of the object to switch to, and its value is another array, in which the key is the [Dataloader](#dataloader) to use to load this object, and its values are the components to use:
 
 ```php
-function getRelationalSubcomponents($component) 
+function getRelationalComponentFields($component) 
 {
-  $ret = parent::getRelationalSubcomponents($component);
+  $ret = parent::getRelationalComponentFields($component);
 
   switch ($component[1]) {
     case self::COMPONENT_AUTHORARTICLES:
@@ -1432,9 +1432,9 @@ function getRelationalSubcomponents($component)
 Alternatively, instead of explicitly defining the name of the dataloader, we can also select the default dataloader defined for that field through constant `POP_CONSTANT_SUBCOMPONENTDATALOADER_DEFAULTFROMFIELD`, which are defined through the [ObjectTypeFieldResolver](#ObjectTypeFieldResolver). In the example below, the default dataloaders for fields `"author"` and `"comments"` will be automatically selected:
 
 ```php
-function getRelationalSubcomponents($component) 
+function getRelationalComponentFields($component) 
 {
-  $ret = parent::getRelationalSubcomponents($component);
+  $ret = parent::getRelationalComponentFields($component);
 
   switch ($component[1]) {
     case self::COMPONENT_AUTHORARTICLES:
@@ -1645,7 +1645,7 @@ class ObjectTypeFieldResolver_Posts extends \PoP\Engine\AbstractObjectTypeFieldR
 }
 ```
 
-The ObjectTypeFieldResolver also allows to select the default dataloader to process a specific field through function `getFieldDefaultDataloader`. This feature is required for [switching domain](#Switching-domain-to-a-relational-object) through function `getRelationalSubcomponents` and deciding to not explicitly indicate the dataloader to use to load relationships, but use the default one for that field instead. For instance, for the fieldprocessor for posts, it is implemented like this:
+The ObjectTypeFieldResolver also allows to select the default dataloader to process a specific field through function `getFieldDefaultDataloader`. This feature is required for [switching domain](#Switching-domain-to-a-relational-object) through function `getRelationalComponentFields` and deciding to not explicitly indicate the dataloader to use to load relationships, but use the default one for that field instead. For instance, for the fieldprocessor for posts, it is implemented like this:
 
 ```php
 function getFieldDefaultDataloader($field) 

--- a/layers/Engine/packages/component-model/README.md
+++ b/layers/Engine/packages/component-model/README.md
@@ -1372,12 +1372,12 @@ Starting from a dataloading component, and including itself, any descendant comp
 
 ##### Defining the Data-Fields
 
-"Data fields", which are the properties to be required from the loaded database object, are defined through function `getDataFields`:
+"Data fields", which are the properties to be required from the loaded database object, are defined through function `getLeafComponentFields`:
 
 ```php
-function getDataFields($component, $props) 
+function getLeafComponentFields($component, $props) 
 {
-  $ret = parent::getDataFields($component, $props);
+  $ret = parent::getLeafComponentFields($component, $props);
 
   switch ($component[1]) {
     case self::COMPONENT_AUTHORARTICLES:

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
@@ -268,7 +268,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                     }
                 }
             }
-            foreach ($this->getConditionalOnDataFieldSubcomponents($component) as $conditionalLeafComponentField) {
+            foreach ($this->getConditionalLeafComponentFields($component) as $conditionalLeafComponentField) {
                 foreach ($conditionalLeafComponentField->getConditionalNestedComponents() as $conditionalSubcomponent) {
                     $this->setProp($conditionalSubcomponent, $props, 'succeeding-typeResolver', $relationalTypeResolver);
                 }
@@ -755,7 +755,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
     /**
      * @return ConditionalLeafComponentField[]
      */
-    public function getConditionalOnDataFieldSubcomponents(array $component): array
+    public function getConditionalLeafComponentFields(array $component): array
     {
         return [];
     }
@@ -819,7 +819,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                 array_merge(
                     $this->getLeafComponentFields($component, $props),
                     $this->getRelationalComponentFields($component),
-                    $this->getConditionalOnDataFieldSubcomponents($component),
+                    $this->getConditionalLeafComponentFields($component),
                     $this->getConditionalOnDataFieldRelationalSubcomponents($component),
                 )
             )
@@ -1117,7 +1117,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
         if ($subComponents = $this->getComponentsToPropagateDataProperties($component)) {
             // Calculate in 2 steps:
             // First step: The conditional-on-data-field-subcomponents must have their data-fields added under entry "conditional-data-fields"
-            $conditionalLeafComponentFields = $this->getConditionalOnDataFieldSubcomponents($component);
+            $conditionalLeafComponentFields = $this->getConditionalLeafComponentFields($component);
             $conditionalRelationalComponentFields = $this->getConditionalOnDataFieldRelationalSubcomponents($component);
             if ($conditionalLeafComponentFields !== [] || $conditionalRelationalComponentFields !== []) {
                 $directSubcomponents = $this->getSubcomponents($component);
@@ -1348,7 +1348,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
 
         if (in_array(self::COMPONENTELEMENT_CONDITIONALONDATAFIELDSUBCOMPONENTS, $elements)) {
             // Modules are arrays, comparing them through the default SORT_STRING fails
-            foreach ($this->getConditionalOnDataFieldSubcomponents($component) as $conditionalLeafComponentField) {
+            foreach ($this->getConditionalLeafComponentFields($component) as $conditionalLeafComponentField) {
                 $ret = array_unique(
                     array_merge(
                         $ret,

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
@@ -259,7 +259,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
             foreach ($this->getSubcomponents($component) as $subComponent) {
                 $this->setProp($subComponent, $props, 'succeeding-typeResolver', $relationalTypeResolver);
             }
-            foreach ($this->getRelationalSubcomponents($component) as $relationalComponentField) {
+            foreach ($this->getRelationalComponentFields($component) as $relationalComponentField) {
                 // @todo Pass the ComponentField directly, do not convert to string first
                 $subcomponent_data_field = $relationalComponentField->asFieldOutputQueryString();
                 if ($subcomponent_typeResolver = $this->getDataloadHelperService()->getTypeResolverFromSubcomponentDataField($relationalTypeResolver, $subcomponent_data_field)) {
@@ -570,7 +570,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
 
         // This prop is set for both dataloading and non-dataloading components
         if ($relationalTypeResolver = $this->getProp($component, $props, 'succeeding-typeResolver')) {
-            foreach ($this->getRelationalSubcomponents($component) as $relationalComponentField) {
+            foreach ($this->getRelationalComponentFields($component) as $relationalComponentField) {
                 // @todo Pass the ComponentField directly, do not convert to string first
                 $subcomponent_data_field = $relationalComponentField->asFieldOutputQueryString();
                 // If passing a subcomponent fieldname that doesn't exist to the API, then $subcomponent_typeResolver_class will be empty
@@ -641,7 +641,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
 
         if ($relationalTypeResolver = $this->getProp($component, $props, 'succeeding-typeResolver')) {
             $this->getComponentFilterManager()->prepareForPropagation($component, $props);
-            foreach ($this->getRelationalSubcomponents($component) as $relationalComponentField) {
+            foreach ($this->getRelationalComponentFields($component) as $relationalComponentField) {
                 // @todo Pass the ComponentField directly, do not convert to string first
                 $subcomponent_data_field = $relationalComponentField->asFieldOutputQueryString();
                 // @todo: Check if it should use `getUniqueFieldOutputKeyByTypeResolverClass`, or pass some $object to `getUniqueFieldOutputKey`, or what
@@ -747,7 +747,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         return [];
     }
@@ -818,7 +818,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
             $astComponentFields = array_unique(
                 array_merge(
                     $this->getLeafComponentFields($component, $props),
-                    $this->getRelationalSubcomponents($component),
+                    $this->getRelationalComponentFields($component),
                     $this->getConditionalOnDataFieldSubcomponents($component),
                     $this->getConditionalOnDataFieldRelationalSubcomponents($component),
                 )
@@ -1222,7 +1222,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
 
         // Combine the direct and conditionalOnDataField components all together to iterate below
         $relationalSubcomponents = [];
-        foreach ($this->getRelationalSubcomponents($component) as $relationalComponentField) {
+        foreach ($this->getRelationalComponentFields($component) as $relationalComponentField) {
             // @todo Pass the ComponentField directly, do not convert to string first
             $subcomponent_data_field = $relationalComponentField->asFieldOutputQueryString();
             $relationalSubcomponents[$subcomponent_data_field] = $relationalComponentField->getNestedComponents();
@@ -1335,7 +1335,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
         }
 
         if (in_array(self::COMPONENTELEMENT_RELATIONALSUBCOMPONENTS, $elements)) {
-            foreach ($this->getRelationalSubcomponents($component) as $relationalComponentField) {
+            foreach ($this->getRelationalComponentFields($component) as $relationalComponentField) {
                 $ret = array_values(array_unique(
                     array_merge(
                         $relationalComponentField->getNestedComponents(),

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
@@ -274,7 +274,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                 }
             }
             foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
-                foreach ($conditionalRelationalComponentField->getConditionalRelationalComponentFields() as $relationalComponentField) {
+                foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                     if ($subcomponentTypeResolver = $this->getDataloadHelperService()->getTypeResolverFromSubcomponentDataField($relationalTypeResolver, $conditionalDataField)) {
                         foreach ($relationalComponentField->getNestedComponents() as $conditionalSubcomponent) {
@@ -583,7 +583,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                 }
             }
             foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
-                foreach ($conditionalRelationalComponentField->getConditionalRelationalComponentFields() as $relationalComponentField) {
+                foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                     // If passing a subcomponent fieldname that doesn't exist to the API, then $subcomponentTypeResolverClass will be empty
                     if ($subcomponent_typeResolver = $this->getDataloadHelperService()->getTypeResolverFromSubcomponentDataField($relationalTypeResolver, $conditionalDataField)) {
@@ -659,7 +659,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                 }
             }
             foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
-                foreach ($conditionalRelationalComponentField->getConditionalRelationalComponentFields() as $relationalComponentField) {
+                foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                     // @todo: Check if it should use `getUniqueFieldOutputKeyByTypeResolverClass`, or pass some $object to `getUniqueFieldOutputKey`, or what
                     // @see https://github.com/leoloso/PoP/issues/1050
@@ -1131,7 +1131,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                 foreach ($conditionalRelationalComponentFields as $conditionalRelationalComponentField) {
                     $conditionDataField = $conditionalRelationalComponentField->asFieldOutputQueryString();
                     $conditionalComponentFields[$conditionDataField] = [];
-                    foreach ($conditionalRelationalComponentField->getConditionalRelationalComponentFields() as $subConditionalRelationalComponentField) {
+                    foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $subConditionalRelationalComponentField) {
                         $conditionalSubcomponents = $subConditionalRelationalComponentField->getNestedComponents();
                         $conditionalComponentFields[$conditionDataField] = array_merge(
                             $conditionalComponentFields[$conditionDataField],
@@ -1228,7 +1228,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
             $relationalSubcomponents[$subcomponent_data_field] = $relationalComponentField->getNestedComponents();
         }
         foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
-            foreach ($conditionalRelationalComponentField->getConditionalRelationalComponentFields() as $relationalComponentField) {
+            foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                 $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                 $relationalSubcomponents[$conditionalDataField] = array_values(array_unique(array_merge(
                     $relationalSubcomponents[$conditionalDataField] ?? [],
@@ -1361,7 +1361,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
 
         if (in_array(self::COMPONENTELEMENT_CONDITIONALONDATAFIELDRELATIONALSUBCOMPONENTS, $elements)) {
             foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
-                foreach ($conditionalRelationalComponentField->getConditionalRelationalComponentFields() as $relationalComponentField) {
+                foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $ret = array_values(
                         array_unique(
                             array_merge(

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
@@ -702,7 +702,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
     public function getDatasource(array $component, array &$props): string
     {
         // Each component can only return one piece of data, and it must be indicated if it static or mutableonrequest
-        // Retrieving only 1 piece is needed so that its children do not get confused what data their getDataFields applies to
+        // Retrieving only 1 piece is needed so that its children do not get confused what data their getLeafComponentFields applies to
         return DataSources::MUTABLEONREQUEST;
     }
 
@@ -739,7 +739,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
     /**
      * @return LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return [];
     }
@@ -817,7 +817,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
             /** @var ComponentFieldInterface[] */
             $astComponentFields = array_unique(
                 array_merge(
-                    $this->getDataFields($component, $props),
+                    $this->getLeafComponentFields($component, $props),
                     $this->getRelationalSubcomponents($component),
                     $this->getConditionalOnDataFieldSubcomponents($component),
                     $this->getConditionalOnDataFieldRelationalSubcomponents($component),

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
@@ -273,7 +273,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                     $this->setProp($conditionalSubcomponent, $props, 'succeeding-typeResolver', $relationalTypeResolver);
                 }
             }
-            foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
+            foreach ($this->getConditionalRelationalComponentFields($component) as $conditionalRelationalComponentField) {
                 foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                     if ($subcomponentTypeResolver = $this->getDataloadHelperService()->getTypeResolverFromSubcomponentDataField($relationalTypeResolver, $conditionalDataField)) {
@@ -582,7 +582,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                     $ret[$subcomponent_data_field_outputkey] = $this->getFieldQueryInterpreter()->getTargetObjectTypeUniqueFieldOutputKeys($relationalTypeResolver, $subcomponent_data_field);
                 }
             }
-            foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
+            foreach ($this->getConditionalRelationalComponentFields($component) as $conditionalRelationalComponentField) {
                 foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                     // If passing a subcomponent fieldname that doesn't exist to the API, then $subcomponentTypeResolverClass will be empty
@@ -658,7 +658,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                     $this->getComponentProcessorManager()->getProcessor($subcomponent_component)->addToDatasetDatabaseKeys($subcomponent_component, $props[$componentFullName][Props::SUBCOMPONENTS], array_merge($path, [$subcomponent_data_field_outputkey]), $ret);
                 }
             }
-            foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
+            foreach ($this->getConditionalRelationalComponentFields($component) as $conditionalRelationalComponentField) {
                 foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                     // @todo: Check if it should use `getUniqueFieldOutputKeyByTypeResolverClass`, or pass some $object to `getUniqueFieldOutputKey`, or what
@@ -763,7 +763,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
     /**
      * @return ConditionalRelationalComponentField[]
      */
-    public function getConditionalOnDataFieldRelationalSubcomponents(array $component): array
+    public function getConditionalRelationalComponentFields(array $component): array
     {
         return [];
     }
@@ -820,7 +820,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                     $this->getLeafComponentFields($component, $props),
                     $this->getRelationalComponentFields($component),
                     $this->getConditionalLeafComponentFields($component),
-                    $this->getConditionalOnDataFieldRelationalSubcomponents($component),
+                    $this->getConditionalRelationalComponentFields($component),
                 )
             )
         ) {
@@ -1118,7 +1118,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
             // Calculate in 2 steps:
             // First step: The conditional-on-data-field-subcomponents must have their data-fields added under entry "conditional-data-fields"
             $conditionalLeafComponentFields = $this->getConditionalLeafComponentFields($component);
-            $conditionalRelationalComponentFields = $this->getConditionalOnDataFieldRelationalSubcomponents($component);
+            $conditionalRelationalComponentFields = $this->getConditionalRelationalComponentFields($component);
             if ($conditionalLeafComponentFields !== [] || $conditionalRelationalComponentFields !== []) {
                 $directSubcomponents = $this->getSubcomponents($component);
                 $conditionalComponentFields = [];
@@ -1227,7 +1227,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
             $subcomponent_data_field = $relationalComponentField->asFieldOutputQueryString();
             $relationalSubcomponents[$subcomponent_data_field] = $relationalComponentField->getNestedComponents();
         }
-        foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
+        foreach ($this->getConditionalRelationalComponentFields($component) as $conditionalRelationalComponentField) {
             foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                 $conditionalDataField = $relationalComponentField->asFieldOutputQueryString();
                 $relationalSubcomponents[$conditionalDataField] = array_values(array_unique(array_merge(
@@ -1360,7 +1360,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
         }
 
         if (in_array(self::COMPONENTELEMENT_CONDITIONALONDATAFIELDRELATIONALSUBCOMPONENTS, $elements)) {
-            foreach ($this->getConditionalOnDataFieldRelationalSubcomponents($component) as $conditionalRelationalComponentField) {
+            foreach ($this->getConditionalRelationalComponentFields($component) as $conditionalRelationalComponentField) {
                 foreach ($conditionalRelationalComponentField->getRelationalComponentFields() as $relationalComponentField) {
                     $ret = array_values(
                         array_unique(

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
@@ -52,7 +52,7 @@ interface ComponentProcessorInterface
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array;
+    public function getRelationalComponentFields(array $component): array;
     /**
      * @return ConditionalLeafComponentField[]
      */

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
@@ -56,7 +56,7 @@ interface ComponentProcessorInterface
     /**
      * @return ConditionalLeafComponentField[]
      */
-    public function getConditionalOnDataFieldSubcomponents(array $component): array;
+    public function getConditionalLeafComponentFields(array $component): array;
     /**
      * @return ConditionalRelationalComponentField[]
      */

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
@@ -48,7 +48,7 @@ interface ComponentProcessorInterface
     /**
      * @return LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array;
+    public function getLeafComponentFields(array $component, array &$props): array;
     /**
      * @return RelationalComponentField[]
      */

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/ComponentProcessorInterface.php
@@ -60,7 +60,7 @@ interface ComponentProcessorInterface
     /**
      * @return ConditionalRelationalComponentField[]
      */
-    public function getConditionalOnDataFieldRelationalSubcomponents(array $component): array;
+    public function getConditionalRelationalComponentFields(array $component): array;
     public function getImmutableDataPropertiesDatasetcomponentTree(array $component, array &$props): array;
     public function getImmutableDataPropertiesDatasetcomponentTreeFullsection(array $component, array &$props): array;
     public function getDatasetcomponentTreeSectionFlattenedDataFields(array $component, array &$props): array;

--- a/layers/Engine/packages/component-model/src/GraphQLEngine/Model/ComponentModelSpec/ConditionalRelationalComponentField.php
+++ b/layers/Engine/packages/component-model/src/GraphQLEngine/Model/ComponentModelSpec/ConditionalRelationalComponentField.php
@@ -19,13 +19,13 @@ class ConditionalRelationalComponentField extends LeafField implements Component
      * When the value of the field is `true`, load the conditional
      * domain switching fields.
      *
-     * @param RelationalComponentField[] $conditionalRelationalComponentFields
+     * @param RelationalComponentField[] $relationalComponentFields
      * @param Argument[] $arguments
      * @param Directive[] $directives
      */
     public function __construct(
         string $name,
-        protected array $conditionalRelationalComponentFields,
+        protected array $relationalComponentFields,
         ?string $alias = null,
         array $arguments = [],
         array $directives = [],
@@ -43,8 +43,8 @@ class ConditionalRelationalComponentField extends LeafField implements Component
     /**
      * @return RelationalComponentField[]
      */
-    public function getConditionalRelationalComponentFields(): array
+    public function getRelationalComponentFields(): array
     {
-        return $this->conditionalRelationalComponentFields;
+        return $this->relationalComponentFields;
     }
 }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks-processors/library/processors/abstract-classes/layouts/linkframes-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-addpostlinks-processors/library/processors/abstract-classes/layouts/linkframes-base.php
@@ -30,9 +30,9 @@ abstract class PoP_AddPostLinks_Module_Processor_LinkFrameLayoutsBase extends Po
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret[] = 'link';
         $ret[] = 'isLinkEmbeddable';

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/processors/abstract-classes/layouts/volunteertag-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application-processors/pop-library/processors/abstract-classes/layouts/volunteertag-base.php
@@ -14,7 +14,7 @@ abstract class PoP_Module_Processor_VolunteerTagLayoutsBase extends PoPEngine_Qu
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('volunteersNeeded');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/avatar-postauthors-layoutsbase.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/avatar-postauthors-layoutsbase.php
@@ -23,9 +23,9 @@ abstract class PoP_Module_Processor_PostAuthorAvatarLayoutsBase extends PoPEngin
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
     
         $url_field = $this->getUrlField($component, $props);
         $avatar_size = $this->getAvatarSize($component, $props);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/useravatarlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/useravatarlayouts-base.php
@@ -18,7 +18,7 @@ abstract class PoP_Module_Processor_UserAvatarLayoutsBase extends PoPEngine_Quer
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $avatar_size = $this->getAvatarSize($component);
         $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/userphoto-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/userphoto-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_UserPhotoLayoutsBase extends PoPEngine_Query
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('userphoto', 'displayName');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles-processors/library/processors/abstract-classes/layouts/layouts-individuals-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles-processors/library/processors/abstract-classes/layouts/layouts-individuals-base.php
@@ -13,7 +13,7 @@ abstract class GD_URE_Custom_Module_Processor_ProfileIndividualLayoutsBase exten
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('individualInterestsByName');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles-processors/library/processors/abstract-classes/layouts/layouts-organizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles-processors/library/processors/abstract-classes/layouts/layouts-organizations-base.php
@@ -13,7 +13,7 @@ abstract class GD_URE_Custom_Module_Processor_ProfileOrganizationLayoutsBase ext
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('organizationTypesByName', 'organizationCategoriesByName', 'contactPerson', 'contactNumber');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation-processors/pop-library/processors/abstract-classes/forminputs/featuredimageinner-forminputs-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentcreation-processors/pop-library/processors/abstract-classes/forminputs/featuredimageinner-forminputs-base.php
@@ -60,9 +60,9 @@ abstract class PoP_Module_Processor_FeaturedImageInnerFormInputsBase extends PoP
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
         $ret[] = 'featuredImageAttrs';
         return $ret;
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks-processors/library/processors/abstract-classes/layouts/link-access-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks-processors/library/processors/abstract-classes/layouts/link-access-base.php
@@ -12,7 +12,7 @@ abstract class Wassup_Module_Processor_LinkAccessLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('linkAccessByName');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/buttons/buttoninners-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/buttons/buttoninners-base.php
@@ -48,7 +48,7 @@ abstract class PoP_Module_Processor_ButtonInnersBase extends PoPEngine_QueryData
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $ret = array();
         if ($text_field = $this->getTextField($component, $props)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/buttons/buttons-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/buttons/buttons-base.php
@@ -22,7 +22,7 @@ abstract class PoP_Module_Processor_ButtonsBase extends PoPEngine_QueryDataCompo
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $ret = array();
         if ($url = $this->getUrlField($component)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/elements/condition-wrappers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/elements/condition-wrappers-base.php
@@ -12,9 +12,9 @@ abstract class PoP_Module_Processor_ConditionWrapperBase extends PoPEngine_Query
     /**
      * @return ConditionalLeafComponentField[]
      */
-    public function getConditionalOnDataFieldSubcomponents(array $component): array
+    public function getConditionalLeafComponentFields(array $component): array
     {
-        $ret = parent::getConditionalOnDataFieldSubcomponents($component);
+        $ret = parent::getConditionalLeafComponentFields($component);
 
         if ($conditionDataField = $this->getConditionField($component)) {
             if ($layouts = $this->getConditionSucceededSubcomponents($component)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/elements/condition-wrappers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/elements/condition-wrappers-base.php
@@ -57,7 +57,7 @@ abstract class PoP_Module_Processor_ConditionWrapperBase extends PoPEngine_Query
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $ret = [];
         if ($conditionDataField = $this->getConditionField($component)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/formcomponents/formcomponentvalue-triggerlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/formcomponents/formcomponentvalue-triggerlayouts-base.php
@@ -126,9 +126,9 @@ abstract class PoP_Module_Processor_TriggerLayoutFormComponentValuesBase extends
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
         $this->addMetaFormcomponentDataFields($ret, $component, $props);
         return $ret;
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/formcomponents/formcomponentvalue-triggerlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/formcomponents/formcomponentvalue-triggerlayouts-base.php
@@ -152,7 +152,7 @@ abstract class PoP_Module_Processor_TriggerLayoutFormComponentValuesBase extends
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         if ($field = $this->getDbobjectField($component)) {
             return [
@@ -165,7 +165,7 @@ abstract class PoP_Module_Processor_TriggerLayoutFormComponentValuesBase extends
             ];
         }
 
-        return parent::getRelationalSubcomponents($component);
+        return parent::getRelationalComponentFields($component);
     }
 
     public function getMutableonrequestConfiguration(array $component, array &$props): array

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/formcomponents/typeaheads/fetchlinktypeahead-formcomponents-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/formcomponents/typeaheads/fetchlinktypeahead-formcomponents-base.php
@@ -25,9 +25,9 @@ abstract class PoP_Module_Processor_FetchlinkTypeaheadFormComponentsBase extends
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         // Add the 'URL' since that's where it will go upon selection of the typeahead value
         $ret[] = 'url';

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/forminputs/forminputs-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/forminputs/forminputs-base.php
@@ -97,9 +97,9 @@ abstract class PoP_Module_Processor_FormInputsBase extends PoPEngine_QueryDataCo
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
         $this->addMetaFormcomponentDataFields($ret, $component, $props);
         return $ret;
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/authorcontact-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/authorcontact-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_AuthorContactLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('contact');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/authorcontents-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/authorcontents-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_AuthorContentLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('displayName', 'descriptionFormatted', 'shortDescriptionFormatted');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/comment-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/comment-card-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_CommentCardLayoutsBase extends PoPEngine_Que
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('contentClipped');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/post-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/post-card-base.php
@@ -37,7 +37,7 @@ abstract class PoP_Module_Processor_PostCardLayoutsBase extends PoPEngine_QueryD
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $thumb = $this->getThumbField($component, $props);
         return array('id', $thumb, 'title', 'url');

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
@@ -33,9 +33,9 @@ abstract class PoP_Module_Processor_UserCardLayoutsBase extends PoPEngine_QueryD
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         // Important: the TYPEAHEAD_COMPONENT should not have data-fields, because it doesn't apply to {{blockSettings.dataset}}
         // but it applies to Twitter Typeahead, which doesn't need these parameters, however these, here, upset the whole getDatasetcomponentTreeSectionFlattenedDataFields

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/categories-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/categories-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_CategoriesLayoutsBase extends PoPEngine_Quer
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array(
             $this->getCategoriesField($component, $props),

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/appendcomment-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/appendcomment-base.php
@@ -15,9 +15,9 @@ abstract class PoP_Module_Processor_AppendCommentLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret[] = 'customPostID';
         $ret[] = 'parent';

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/commentlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/commentlayouts-base.php
@@ -90,9 +90,9 @@ abstract class PoP_Module_Processor_CommentLayoutsBase extends PoPEngine_QueryDa
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret = array_merge(
             $ret,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/commentlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/comments/commentlayouts-base.php
@@ -58,9 +58,9 @@ abstract class PoP_Module_Processor_CommentLayoutsBase extends PoPEngine_QueryDa
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
-        $ret = parent::getRelationalSubcomponents($component);
+        $ret = parent::getRelationalComponentFields($component);
 
         $components = array(
             $this->getAuthornameComponent($component),

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/content-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/content-layouts-base.php
@@ -27,10 +27,10 @@ abstract class PoP_Module_Processor_ContentLayoutsBase extends PoPEngine_QueryDa
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array(
                 'content',
             )

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/embedpreviews-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/embedpreviews-base.php
@@ -49,9 +49,9 @@ abstract class PoP_Module_Processor_EmbedPreviewLayoutsBase extends PoPEngine_Qu
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
     
         if ($src_field = $this->getFrameSrcField($component, $props)) {
             $ret[] = $src_field;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/fullobjectlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/fullobjectlayouts-base.php
@@ -18,10 +18,10 @@ abstract class PoP_Module_Processor_FullObjectLayoutsBase extends PoPEngine_Quer
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array('url')
         );
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/fullobjecttitle-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/fullobjecttitle-layouts-base.php
@@ -13,10 +13,10 @@ abstract class PoP_Module_Processor_FullObjectTitleLayoutsBase extends PoPEngine
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array(
                 $this->getTitleConditionField($component, $props),
                 $this->getUrlField($component, $props),

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/linkcontent-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/linkcontent-layouts-base.php
@@ -12,10 +12,10 @@ abstract class PoP_Module_Processor_LinkContentLayoutsBase extends PoPEngine_Que
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array(
                 'linkcontent',
             )

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/menus/dropdown-menus-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/menus/dropdown-menus-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_DropdownMenuLayoutsBase extends PoPEngine_Qu
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'itemDataEntries(flat:true)@itemDataEntries');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/menus/indent-menus-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/menus/indent-menus-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_IndentMenuLayoutsBase extends PoPEngine_Quer
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'itemDataEntries(flat:true)@itemDataEntries');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/menus/menulayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/menus/menulayouts-base.php
@@ -7,7 +7,7 @@ abstract class PoP_Module_Processor_MenuLayoutsBase extends PoPEngine_QueryDataC
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'itemDataEntries(flat:true)@itemDataEntries');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/multiplelayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/multiplelayouts-base.php
@@ -33,9 +33,9 @@ abstract class PoP_Module_Processor_MultipleLayoutsBase extends PoPEngine_QueryD
     /**
      * @return ConditionalLeafComponentField[]
      */
-    public function getConditionalOnDataFieldSubcomponents(array $component): array
+    public function getConditionalLeafComponentFields(array $component): array
     {
-        $ret = parent::getConditionalOnDataFieldSubcomponents($component);
+        $ret = parent::getConditionalLeafComponentFields($component);
 
         // The function below returns an array with value => $subComponent.
         // It must be converted to value => [$subComponent]

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postadditionals-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postadditionals-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_PostAdditionalLayoutsBase extends PoPEngine_
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('multilayoutKeys');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postauthors/name-postauthors-layoutsbase.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postauthors/name-postauthors-layoutsbase.php
@@ -22,9 +22,9 @@ abstract class PoP_Module_Processor_PostAuthorNameLayoutsBase extends PoPEngine_
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
     
         $ret[] = $this->getUrlField($component, $props);
         $ret[] = 'displayName';

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postdates-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postdates-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_PostDateLayoutsBase extends PoPEngine_QueryD
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('date');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/posts/fullviewlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/posts/fullviewlayouts-base.php
@@ -16,10 +16,10 @@ abstract class PoP_Module_Processor_FullViewLayoutsBase extends PoP_Module_Proce
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array('catSlugs')
         );
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/posts/previewpostlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/posts/previewpostlayouts-base.php
@@ -73,9 +73,9 @@ abstract class PoP_Module_Processor_PreviewPostLayoutsBase extends PoP_Module_Pr
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
-        $ret = parent::getRelationalSubcomponents($component);
+        $ret = parent::getRelationalComponentFields($component);
 
         $components = [];
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/posts/previewpostlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/posts/previewpostlayouts-base.php
@@ -106,9 +106,9 @@ abstract class PoP_Module_Processor_PreviewPostLayoutsBase extends PoP_Module_Pr
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret[] = 'customPostType';
         $ret[] = 'catSlugs';

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/poststatus-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/poststatus-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_PostStatusLayoutsBase extends PoPEngine_Quer
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('status');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postthumblayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postthumblayouts-base.php
@@ -37,9 +37,9 @@ abstract class PoP_Module_Processor_PostThumbLayoutsBase extends PoPEngine_Query
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret[] = $this->getThumbField($component, $props);
         $ret[] = $this->getUrlField($component);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/previewobjectlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/previewobjectlayouts-base.php
@@ -52,9 +52,9 @@ abstract class PoP_Module_Processor_PreviewObjectLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret[] = $this->getUrlField($component);
         if ($this->showExcerpt($component)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/published-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/published-base.php
@@ -14,7 +14,7 @@ abstract class PoP_Module_Processor_PostStatusDateLayoutsBase extends PoPEngine_
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('date', 'status');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/scripts/latestcount-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/scripts/latestcount-layouts-base.php
@@ -12,10 +12,10 @@ abstract class PoP_Module_Processor_LatestCountScriptsLayoutsBase extends PoPEng
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array('latestcountsTriggerValues', 'authors', 'tags', 'references')
         );
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/subcomponents/subcomponents-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/subcomponents/subcomponents-base.php
@@ -22,7 +22,7 @@ abstract class PoP_Module_Processor_SubcomponentLayoutsBase extends PoPEngine_Qu
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         return [
             new RelationalComponentField(

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/taginfo-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/taginfo-base.php
@@ -13,7 +13,7 @@ abstract class PoP_Module_Processor_TagInfoLayoutsBase extends PoPEngine_QueryDa
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('count');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/tags-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/tags-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_TagLayoutsBase extends PoPEngine_QueryDataCo
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('url', 'symbolnamedescription');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/post-typeahead-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/post-typeahead-component-base.php
@@ -18,7 +18,7 @@ abstract class PoP_Module_Processor_PostTypeaheadComponentLayoutsBase extends Po
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $thumb = $this->getThumbField($component, $props);
         return array('id', $thumb, 'title', 'url');

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/tag-mention-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/tag-mention-component-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_TagMentionComponentLayoutsBase extends PoPEn
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('mentionQueryby', 'namedescription', 'symbolnamedescription');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/tag-typeahead-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/tag-typeahead-component-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_TagTypeaheadComponentLayoutsBase extends PoP
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('symbolnamedescription');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-mention-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-mention-component-base.php
@@ -13,7 +13,7 @@ abstract class PoP_Module_Processor_UserMentionComponentLayoutsBase extends PoPE
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         // Can't use "user-nicename", because @Mentions plugin does not store the "-" in the html attribute, so it would
         // save the entry as data-usernicename. To avoid conflicts, just remove the "-"

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-typeahead-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-typeahead-component-base.php
@@ -13,7 +13,7 @@ abstract class PoP_Module_Processor_UserTypeaheadComponentLayoutsBase extends Po
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
     
         /* FIX THIS: 'url' */

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/userquicklinks-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/userquicklinks-base.php
@@ -13,7 +13,7 @@ abstract class PoP_Module_Processor_UserQuickLinkLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('contactSmall');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/users/fulluserlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/users/fulluserlayouts-base.php
@@ -15,10 +15,10 @@ abstract class PoP_Module_Processor_FullUserLayoutsBase extends PoP_Module_Proce
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array('shortDescriptionFormatted', 'descriptionFormatted')
         );
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/users/previewuserlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/users/previewuserlayouts-base.php
@@ -13,10 +13,10 @@ abstract class PoP_Module_Processor_PreviewUserLayoutsBase extends PoP_Module_Pr
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $ret = array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             array('displayName', 'isProfile')
         );
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
@@ -37,7 +37,7 @@ abstract class PoP_Module_Processor_SocialMediaItemsBase extends PoPEngine_Query
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $ret = array(
             $this->getShareurlField($component, $props),

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/comment-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/comment-headers-base.php
@@ -17,7 +17,7 @@ abstract class PoP_Module_Processor_CommentViewComponentHeadersBase extends PoPE
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         if ($header = $this->getHeaderSubcomponent($component)) {
             return [
@@ -30,7 +30,7 @@ abstract class PoP_Module_Processor_CommentViewComponentHeadersBase extends PoPE
             ];
         }
 
-        return parent::getRelationalSubcomponents($component);
+        return parent::getRelationalComponentFields($component);
     }
 
     public function headerShowUrl(array $component, array &$props)

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/commentclipped-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/commentclipped-headers-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_CommentClippedViewComponentHeadersBase exten
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('contentClipped');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/post-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/post-headers-base.php
@@ -13,7 +13,7 @@ abstract class PoP_Module_Processor_PostViewComponentHeadersBase extends PoPEngi
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $thumb = $this->getThumbField($component, $props);
         $data_fields = array('id', 'title', $thumb);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/preloadtargetdata-buttons-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/preloadtargetdata-buttons-base.php
@@ -20,9 +20,9 @@ abstract class PoP_Module_Processor_PreloadTargetDataButtonsBase extends PoP_Mod
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
-        $ret = parent::getRelationalSubcomponents($component);
+        $ret = parent::getRelationalComponentFields($component);
 
         // We need to load the data needed by the datum, so that when executing `triggerSelect` in function `renderDBObjectLayoutFromURLParam`
         // the data has already been preloaded

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/tag-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/tag-headers-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_TagViewComponentHeadersBase extends PoPEngin
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $data_fields = array('id', 'symbolnamedescription');
         if ($this->headerShowUrl($component, $props)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/user-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/user-headers-base.php
@@ -18,7 +18,7 @@ abstract class PoP_Module_Processor_UserViewComponentHeadersBase extends PoPEngi
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $data_fields = array('id', 'displayName');
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/layouts/segmentedbuttonlayouts-menus.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/layouts/segmentedbuttonlayouts-menus.php
@@ -32,7 +32,7 @@ class PoP_Module_Processor_SegmentedButtonMenuLayouts extends PoP_Module_Process
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         switch ($component[1]) {
             case self::COMPONENT_LAYOUT_MENU_SEGMENTEDBUTTON:
@@ -40,7 +40,7 @@ class PoP_Module_Processor_SegmentedButtonMenuLayouts extends PoP_Module_Process
                 return array('id', 'itemDataEntries(flat:true)@itemDataEntries');
         }
 
-        return parent::getDataFields($component, $props);
+        return parent::getLeafComponentFields($component, $props);
     }
 
     public function getSegmentedbuttonSubcomponents(array $component)

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-htmlcssplatform/kernel/componentprocessors/pop-componentprocessor.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-engine-htmlcssplatform/kernel/componentprocessors/pop-componentprocessor.php
@@ -74,9 +74,9 @@ abstract class PoP_HTMLCSSPlatformQueryDataComponentProcessorBase extends Abstra
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         if ($dbobject_params = $this->getProp($component, $props, 'dbobject-params')) {
             $ret = array_merge(

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/datetime-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/datetime-layouts-base.php
@@ -61,7 +61,7 @@ abstract class GD_EM_Module_Processor_DateTimeLayoutsBase extends PoPEngine_Quer
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('dates', 'times');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/layout-carousel-indicators-eventdate-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/layout-carousel-indicators-eventdate-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_EventDateCarouselIndicatorLayoutsBase extend
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('startDateReadable');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/layoutcalendar-content-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/layoutcalendar-content-base.php
@@ -12,9 +12,9 @@ abstract class PoP_Module_Processor_CalendarContentLayoutsBase extends PoPEngine
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
         $ret[] = 'volunteersNeeded';
         $ret[] = 'url';
         if ($this->getProp($component, $props, 'show-title')) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/layoutevent-tablecol-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/layouts/layoutevent-tablecol-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_EventDateAndTimeLayoutsBase extends PoPEngin
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('dates', 'times');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/structures/calendars/calendarinners-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-events-processors/library/processors/abstract-classes/structures/calendars/calendarinners-base.php
@@ -12,9 +12,9 @@ abstract class PoP_Module_Processor_CalendarInnersBase extends PoP_Module_Proces
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret = array_merge(
             $ret,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/dataloads.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/dataloads.php
@@ -114,9 +114,9 @@ class ComponentProcessor_Dataloads extends AbstractDataloadComponentProcessor
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
-        $ret = parent::getRelationalSubcomponents($component);
+        $ret = parent::getRelationalComponentFields($component);
 
         switch ($component[1]) {
             case self::COMPONENT_EXAMPLE_SINGLE:

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/dataloads.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/dataloads.php
@@ -146,7 +146,7 @@ class ComponentProcessor_Dataloads extends AbstractDataloadComponentProcessor
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $data_fields = array(
             self::COMPONENT_EXAMPLE_LATESTPOSTS => array('title', 'content', 'url'),
@@ -157,7 +157,7 @@ class ComponentProcessor_Dataloads extends AbstractDataloadComponentProcessor
             self::COMPONENT_EXAMPLE_HOMESTATICPAGE => array('title', 'content', 'date'),
         );
         return array_merge(
-            parent::getDataFields($component, $props),
+            parent::getLeafComponentFields($component, $props),
             $data_fields[$component[1]] ?? array()
         );
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/layouts.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/layouts.php
@@ -28,9 +28,9 @@ class ComponentProcessor_Layouts extends AbstractComponentProcessor
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         switch ($component[1]) {
             case self::COMPONENT_EXAMPLE_COMMENT:

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/layouts.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-examplemodules/library/processors/layouts.php
@@ -58,9 +58,9 @@ class ComponentProcessor_Layouts extends AbstractComponentProcessor
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
-        $ret = parent::getRelationalSubcomponents($component);
+        $ret = parent::getRelationalComponentFields($component);
 
         switch ($component[1]) {
             case self::COMPONENT_EXAMPLE_COMMENT:

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/layout-locationaddress-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/layout-locationaddress-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_LocationAddressLayoutsBase extends PoPEngine
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('address');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/layout-locationname-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/layout-locationname-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_LocationNameLayoutsBase extends PoPEngine_Qu
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('name');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/layout-locations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/layout-locations-base.php
@@ -12,7 +12,7 @@ abstract class GD_EM_Module_Processor_LocationLayoutsBase extends PoPEngine_Quer
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'name', 'address', 'coordinates');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/locations/location-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/locations/location-card-base.php
@@ -12,7 +12,7 @@ abstract class GD_EM_Module_Processor_LocationTypeaheadsSelectedLayoutsBase exte
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'name', 'address', 'coordinates'); // Coordinates: needed for drawing the selected location on the Google Map, so keep even if it doesn't show in the .tmpl
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/locations/location-triggertypeaheadselect-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/locations/location-triggertypeaheadselect-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_TriggerLocationTypeaheadScriptLayoutsBase ex
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'name', 'address', 'coordinates');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/locations/location-typeahead-components-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/layouts/locations/location-typeahead-components-base.php
@@ -12,7 +12,7 @@ abstract class GD_EM_Module_Processor_LocationTypeaheadsComponentLayoutsBase ext
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'name', 'address', 'coordinates'); // Coordinates: needed for drawing the selected location on the Google Map, so keep even if it doesn't show in the .tmpl
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-script-markers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-script-markers-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_MapMarkerScriptsBase extends PoPEngine_Query
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('id', 'coordinates', 'name', 'address');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-scripts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-scripts-base.php
@@ -28,7 +28,7 @@ abstract class PoP_Module_Processor_MapScriptsBase extends PoPEngine_QueryDataCo
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         return [
             new RelationalComponentField(

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-staticimage-locations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-staticimage-locations-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_MapStaticImageLocationsBase extends PoPEngin
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         $urlparam = $this->getUrlparamSubcomponent($component);
         return [

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-staticimage-urlparams-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/map-staticimage-urlparams-base.php
@@ -12,7 +12,7 @@ abstract class PoP_Module_Processor_MapStaticImageURLParamsBase extends PoPEngin
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('coordinates');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
@@ -38,7 +38,7 @@ abstract class PoP_Module_Processor_PostMapScriptCustomizationsBase extends PoP_
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         if ($authors_component = $this->getAuthorsComponent($component)) {
             return [
@@ -51,7 +51,7 @@ abstract class PoP_Module_Processor_PostMapScriptCustomizationsBase extends PoP_
             ];
         }
 
-        return parent::getRelationalSubcomponents($component);
+        return parent::getRelationalComponentFields($component);
     }
 
     public function getThumbField(array $component, array &$props)

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
@@ -83,7 +83,7 @@ abstract class PoP_Module_Processor_PostMapScriptCustomizationsBase extends PoP_
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $thumb = $this->getThumbField($component, $props);
         return array('id', 'title', $thumb, 'url');

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/user-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/user-map-scriptcustomizations-base.php
@@ -23,7 +23,7 @@ abstract class PoP_Module_Processor_UserMapScriptCustomizationsBase extends PoP_
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         $data_fields = array('id', 'displayName', 'url', 'shortDescriptionFormatted');
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/viewcomponents/location-buttoninners-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/viewcomponents/location-buttoninners-base.php
@@ -42,7 +42,7 @@ abstract class PoP_Module_Processor_LocationViewComponentButtonInnersBase extend
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         if ($location_component = $this->getLocationComponent($component)) {
             return [
@@ -54,6 +54,6 @@ abstract class PoP_Module_Processor_LocationViewComponentButtonInnersBase extend
                 ),
             ];
         }
-        return parent::getRelationalSubcomponents($component);
+        return parent::getRelationalComponentFields($component);
     }
 }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/viewcomponents/location-buttons-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/viewcomponents/location-buttons-base.php
@@ -49,7 +49,7 @@ abstract class PoP_Module_Processor_LocationViewComponentButtonsBase extends PoP
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
         if ($this->showEachLocation($component)) {
             $components = [];
@@ -70,7 +70,7 @@ abstract class PoP_Module_Processor_LocationViewComponentButtonsBase extends PoP
             }
         }
 
-        return parent::getRelationalSubcomponents($component);
+        return parent::getRelationalComponentFields($component);
     }
 
     public function getUrlField(array $component)

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/notificationicon-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/notificationicon-base.php
@@ -12,9 +12,9 @@ abstract class PoP_Module_Processor_NotificationActionIconLayoutsBase extends Po
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         // $ret[] = 'action';
         $ret[] = 'icon';

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/notificationtimelayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/notificationtimelayouts-base.php
@@ -12,9 +12,9 @@ abstract class PoP_Module_Processor_NotificationTimeLayoutsBase extends PoPEngin
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         $ret[] = 'histTimeNogmt';
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/previewnotificationlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/previewnotificationlayouts-base.php
@@ -127,9 +127,9 @@ abstract class PoP_Module_Processor_PreviewNotificationLayoutsBase extends PoPEn
     /**
      * @return ConditionalLeafComponentField[]
      */
-    public function getConditionalOnDataFieldSubcomponents(array $component): array
+    public function getConditionalLeafComponentFields(array $component): array
     {
-        $ret = parent::getConditionalOnDataFieldSubcomponents($component);
+        $ret = parent::getConditionalLeafComponentFields($component);
 
         return array_merge(
             $ret,

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/previewnotificationlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/previewnotificationlayouts-base.php
@@ -91,9 +91,9 @@ abstract class PoP_Module_Processor_PreviewNotificationLayoutsBase extends PoPEn
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         // From the combination of object_type and action, we obtain the layout to use for the notification
         // $ret[] = 'objectType';

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/previewnotificationlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/abstract-classes/layouts/previewnotificationlayouts-base.php
@@ -58,9 +58,9 @@ abstract class PoP_Module_Processor_PreviewNotificationLayoutsBase extends PoPEn
     /**
      * @return RelationalComponentField[]
      */
-    public function getRelationalSubcomponents(array $component): array
+    public function getRelationalComponentFields(array $component): array
     {
-        $ret = parent::getRelationalSubcomponents($component);
+        $ret = parent::getRelationalComponentFields($component);
 
         $components = array();
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/functions/structures/contents/contentmultipleinners.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/functions/structures/contents/contentmultipleinners.php
@@ -61,9 +61,9 @@ class GD_AAL_Module_Processor_FunctionsContentMultipleInners extends PoP_Module_
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         switch ($component[1]) {
             case self::COMPONENT_CONTENTINNER_MARKNOTIFICATIONASREAD:

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/layouts/notifications/multicomponents.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-notifications-processors/library/processors/layouts/notifications/multicomponents.php
@@ -16,9 +16,9 @@ class PoP_Module_Processor_MultipleComponentLayouts extends PoP_Module_Processor
     /**
      * @return ConditionalLeafComponentField[]
      */
-    public function getConditionalOnDataFieldSubcomponents(array $component): array
+    public function getConditionalLeafComponentFields(array $component): array
     {
-        $ret = parent::getConditionalOnDataFieldSubcomponents($component);
+        $ret = parent::getConditionalLeafComponentFields($component);
 
         switch ($component[1]) {
             case self::COMPONENT_AAL_MULTICOMPONENT_QUICKLINKGROUP_BOTTOM:

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-ssr/library/processors/pop-dynamicdatamoduledecoratorprocessor.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-ssr/library/processors/pop-dynamicdatamoduledecoratorprocessor.php
@@ -170,7 +170,7 @@ class PoP_DynamicDataModuleDecoratorProcessor extends AbstractModuleDecoratorPro
         $processor = $this->getDecoratedcomponentProcessor($component);
         $modulefilter_manager = ComponentFilterManagerFacade::getInstance();
         $modulefilter_manager->prepareForPropagation($component, $props);
-        foreach ($processor->getRelationalSubcomponents($component) as $relationalComponentField) {
+        foreach ($processor->getRelationalComponentFields($component) as $relationalComponentField) {
             // @todo Pass the ComponentField directly, do not convert to string first
             $subcomponent_data_field = $relationalComponentField->asFieldOutputQueryString();
             $subcomponent_components_data_properties = array(

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar-processors/library/processors/abstract-classes/forminputs/fileupload-pictures-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar-processors/library/processors/abstract-classes/forminputs/fileupload-pictures-base.php
@@ -97,7 +97,7 @@ abstract class PoP_Module_Processor_FileUploadPicturesBase extends PoPEngine_Que
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array(
             'fileUploadPictureURL',

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/abstract-classes/layouts/memberprivileges-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/abstract-classes/layouts/memberprivileges-layouts-base.php
@@ -12,7 +12,7 @@ abstract class GD_URE_Module_Processor_MemberPrivilegesLayoutsBase extends PoPEn
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('memberPrivilegesByName');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/abstract-classes/layouts/memberstatus-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/abstract-classes/layouts/memberstatus-layouts-base.php
@@ -12,7 +12,7 @@ abstract class GD_URE_Module_Processor_MemberStatusLayoutsBase extends PoPEngine
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('memberStatusByName');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/abstract-classes/layouts/membertags-layouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities-processors/library/processors/abstract-classes/layouts/membertags-layouts-base.php
@@ -12,7 +12,7 @@ abstract class GD_URE_Module_Processor_MemberTagsLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('memberTagsByName');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/processors/abstract-classes/layouts/stance.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/processors/abstract-classes/layouts/stance.php
@@ -13,7 +13,7 @@ abstract class UserStance_Module_Processor_StanceLayoutsBase extends PoPEngine_Q
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
         return array('catName');
     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/processors/buttons/post-buttons.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userstance-processors/library/processors/buttons/post-buttons.php
@@ -21,9 +21,9 @@ class UserStance_Module_Processor_PostButtons extends PoP_Module_Processor_Prelo
      *
      * @return \PoP\ComponentModel\GraphQLEngine\Model\ComponentModelSpec\LeafComponentField[]
      */
-    public function getDataFields(array $component, array &$props): array
+    public function getLeafComponentFields(array $component, array &$props): array
     {
-        $ret = parent::getDataFields($component, $props);
+        $ret = parent::getLeafComponentFields($component, $props);
 
         switch ($component[1]) {
             case self::COMPONENT_LAZYBUTTON_STANCE_CREATEORUPDATE:


### PR DESCRIPTION
Renamed from:

```php
    /**
     * @return LeafComponentField[]
     */
    public function getDataFields(array $component, array &$props): array;
    /**
     * @return RelationalComponentField[]
     */
    public function getRelationalSubcomponents(array $component): array;
    /**
     * @return ConditionalLeafComponentField[]
     */
    public function getConditionalOnDataFieldSubcomponents(array $component): array;
    /**
     * @return ConditionalRelationalComponentField[]
     */
    public function getConditionalOnDataFieldRelationalSubcomponents(array $component): array;
```

to:

```php
    /**
     * @return LeafComponentField[]
     */
    public function getLeafComponentFields(array $component, array &$props): array;
    /**
     * @return RelationalComponentField[]
     */
    public function getRelationalComponentFields(array $component): array;
    /**
     * @return ConditionalLeafComponentField[]
     */
    public function getConditionalLeafComponentFields(array $component): array;
    /**
     * @return ConditionalRelationalComponentField[]
     */
    public function getConditionalRelationalComponentFields(array $component): array;
```