### PR TITLE
Execute integration tests against InstaWP, using Nightly Link

### DIFF
--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -1,4 +1,4 @@
-name: PHP Coding Standards
+name: PHP coding standards
 on:
     push:
         branches:

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -20,7 +20,7 @@
 # - Upload the .zip file as an artifact to the action (this step is possibly optional)
 # - Upload the .zip file as a release, for download
 ####################################################################################
-name: Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Release Asset
+name: Generate plugins
 on:
     release:
         types: [published]

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,103 +1,101 @@
 name: Integration tests
 on:
-  workflow_run:
-    workflows: ["Generate plugins"]
-    types:
-      - completed
-    branches:
-      - '**'
+    workflow_run:
+        workflows: ["Generate plugins"]
+        types:
+            - completed
 env:
     CHECKOUT_SUBMODULES: ""
 
 jobs:
-  retrieve-artifact-url:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: Retrieve the artifact URL
-    runs-on: ubuntu-latest
-    steps:
-      - name: Retrieve artifact URLs from GitHub workflow
-        uses: actions/github-script@v6
-        id: artifact-url
-        with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let artifactURLs = allArtifacts.data.artifacts.map((artifact) => {
-              return artifact.url.replace('https://api.github.com', 'https://nightly.link')
-            });
-            let artifactURL = artifactURLs.concat(',');
-            return artifactURL;
-          result-encoding: string
+    retrieve-artifact-url:
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        name: Retrieve the artifact URL
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Retrieve artifact URLs from GitHub workflow
+                uses: actions/github-script@v6
+                id: artifact-url
+                with:
+                    script: |
+                        let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            run_id: context.payload.workflow_run.id,
+                        });
+                        let artifactURLs = allArtifacts.data.artifacts.map((artifact) => {
+                            return artifact.url.replace('https://api.github.com', 'https://nightly.link')
+                        });
+                        let artifactURL = artifactURLs.concat(',');
+                        return artifactURL;
+                    result-encoding: string
 
-      - name: Artifact URL for InstaWP
-        run: echo "Artifact URL for InstaWP - ${{ steps.artifact-url.outputs.result }}"
-        shell: bash
+            -   name: Artifact URL for InstaWP
+                run: echo "Artifact URL for InstaWP - ${{ steps.artifact-url.outputs.result }}"
+                shell: bash
 
-    outputs:
-      artifact-url: ${{ steps.artifact-url.outputs.result }}
+        outputs:
+            artifact-url: ${{ steps.artifact-url.outputs.result }}
 
-  launch-instawp-instance:
-    needs: retrieve-artifact-url
-    name: Launch InstaWP instance
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create InstaWP instance
-        uses: instawp/wordpress-testing-automation@main
-        id: create-instawp
-        with:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
-          INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
-          INSTAWP_TEMPLATE_SLUG: graphql-api-integration-tests
-          INSTAWP_ACTION: create-site-template
-          ARTIFACT_URL: ${{ needs.retrieve-artifact-url.outputs.artifact-url }}
+    launch-instawp-instance:
+        needs: retrieve-artifact-url
+        name: Launch InstaWP instance
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Create InstaWP instance
+                uses: instawp/wordpress-testing-automation@main
+                id: create-instawp
+                with:
+                    GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+                    INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
+                    INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
+                    INSTAWP_TEMPLATE_SLUG: graphql-api-integration-tests
+                    INSTAWP_ACTION: create-site-template
+                    ARTIFACT_URL: ${{ needs.retrieve-artifact-url.outputs.artifact-url }}
 
-      - name: InstaWP instance URL
-        run: echo "InstaWP instance URL - ${{ steps.create-instawp.outputs.instawp_url }}"
-        shell: bash        
+            -   name: InstaWP instance URL
+                run: echo "InstaWP instance URL - ${{ steps.create-instawp.outputs.instawp_url }}"
+                shell: bash
 
-    outputs:    
-      instawp-url: ${{ steps.create-instawp.outputs.instawp_url }}
+        outputs:
+            instawp-url: ${{ steps.create-instawp.outputs.instawp_url }}
 
-  execute-integration-tests:
-    needs: launch-instawp-instance
-    name: Execute integration tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: ${{ env.CHECKOUT_SUBMODULES }}
+    execute-integration-tests:
+        needs: launch-instawp-instance
+        name: Execute integration tests
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+                with:
+                    submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
-      - name: Set-up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.1
-          coverage: none
-        env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Set-up PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.1
+                    coverage: none
+                env:
+                    COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+            -   name: Install Composer dependencies
+                uses: "ramsey/composer-install@v1"
 
-      - name: Run tests
-        run: INTEGRATION_TESTS_WEBSERVER_DOMAIN=${{ needs.launch-instawp-instance.outputs.instawp-url }} vendor/bin/phpunit --filter=Integration/
+            -   name: Run tests
+                run: INTEGRATION_TESTS_WEBSERVER_DOMAIN=${{ needs.launch-instawp-instance.outputs.instawp-url }} vendor/bin/phpunit --filter=Integration/
 
-  destroy-instawp-after-testing:
-    needs: execute-integration-tests
-    if: ${{ always() }}
-    name: Destroy InstaWP instance
-    runs-on: ubuntu-latest
-    steps:
-      - uses: instawp/wordpress-testing-automation@main
-        if: github.event.action == 'closed' || github.event.action == 'merged'
-        id: detroy-instawp
-        with:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
-          INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
-          INSTAWP_TEMPLATE_SLUG: graphql-api-integration-tests
-          INSTAWP_ACTION: destroy-site
+    destroy-instawp-after-testing:
+        needs: execute-integration-tests
+        if: ${{ always() }}
+        name: Destroy InstaWP instance
+        runs-on: ubuntu-latest
+        steps:
+            - uses: instawp/wordpress-testing-automation@main
+                if: github.event.action == 'closed' || github.event.action == 'merged'
+                id: detroy-instawp
+                with:
+                    GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+                    INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
+                    INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
+                    INSTAWP_TEMPLATE_SLUG: graphql-api-integration-tests
+                    INSTAWP_ACTION: destroy-site

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,7 +4,6 @@ on:
     workflows: [Generate plugins]
     types:
       - completed
-    branches: [*]
 env:
     CHECKOUT_SUBMODULES: ""
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,7 +30,7 @@ jobs:
           result-encoding: string
 
       - name: Artifact URL for InstaWP
-        run: echo "Artifact URL for InstaWP: ${{ steps.artifact-url.outputs.result }}"
+        run: echo "Artifact URL for InstaWP - ${{ steps.artifact-url.outputs.result }}"
         shell: bash
 
     outputs:
@@ -54,7 +54,7 @@ jobs:
           ARTIFACT_URL: ${{ needs.retrieve-artifact-url.outputs.artifact-url }}
 
       - name: InstaWP instance URL
-        run: echo "InstaWP instance URL: ${{ steps.create-instawp.outputs.instawp_url }}"
+        run: echo "InstaWP instance URL - ${{ steps.create-instawp.outputs.instawp_url }}"
         shell: bash
     outputs:
     

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,7 +1,7 @@
 name: Integration tests
 on:
   workflow_run:
-    workflows: ["Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Release Asset"]
+    workflows: [Generate plugins]
     types:
       - completed
 env:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,7 +49,7 @@ jobs:
 
   execute-integration-tests:
     needs: launch-instawp-instance
-    name: Execute Integration tests
+    name: Execute integration tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -86,6 +86,7 @@ jobs:
 
   destroy-instawp-after-testing:
     needs: execute-integration-tests
+    if: ${{ always() }}
     name: Destroy InstaWP instance
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -44,8 +44,34 @@ jobs:
       - name: Echo InstaWP instance URL
         run: echo InstaWP instance URL ${{ steps.create-instawp.outputs.instawp_url }}
         shell: bash
+    outputs:
+      instawp-url: ${{ steps.create-instawp.outputs.instawp_url }}
 
-  destroy-wp-after-testing:
+  execute-integration-tests:
+    needs: launch-instawp-instance
+    name: Execute Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: ${{ env.CHECKOUT_SUBMODULES }}
+
+      - name: Set-up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          coverage: none
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
+
+      - name: Run tests
+        run: INTEGRATION_TESTS_WEBSERVER_DOMAIN=${{ needs.launch-instawp-instance.outputs.instawp-url }} vendor/bin/phpunit --filter=Integration/
+
+  destroy-instawp-after-testing:
     runs-on: ubuntu-latest
     steps:
       - uses: instawp/wordpress-testing-automation@main

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,7 +8,7 @@ env:
     CHECKOUT_SUBMODULES: ""
 
 jobs:
-  launch-instawp-instance:
+  retrieve-artifact-url:
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve artifact URLs from GitHub workflow
@@ -27,9 +27,18 @@ jobs:
             let artifactURL = artifactURLs.concat(',');
             return artifactURL;
           result-encoding: string
-      - name: Echo Artifact URL for InstaWP
+
+      - name: Artifact URL for InstaWP
         run: echo Artifact URL for InstaWP: ${{ steps.artifact-url.outputs.result }}
         shell: bash
+
+    outputs:
+      artifact-url: ${{ steps.artifact-url.outputs.result }}
+
+  launch-instawp-instance:
+    needs: retrieve-artifact-url
+    runs-on: ubuntu-latest
+    steps:
       - name: Create InstaWP instance
         uses: instawp/wordpress-testing-automation@main
         id: create-instawp
@@ -40,11 +49,13 @@ jobs:
           INSTAWP_TEMPLATE_SLUG: vendor
           REPO_ID: 4
           INSTAWP_ACTION: create-site-template
-          ARTIFACT_URL: ${{steps.artifact-url.outputs.result}}
-      - name: Echo InstaWP instance URL
+          ARTIFACT_URL: ${{ needs.retrieve-artifact-url.outputs.artifact-url }}
+
+      - name: InstaWP instance URL
         run: echo InstaWP instance URL ${{ steps.create-instawp.outputs.instawp_url }}
         shell: bash
     outputs:
+    
       instawp-url: ${{ steps.create-instawp.outputs.instawp_url }}
 
   execute-integration-tests:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,7 +1,7 @@
 name: Integration tests
 on:
   workflow_run:
-    workflows: [Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Release Asset]
+    workflows: ["Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Release Asset"]
     types:
       - completed
 env:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,6 +4,7 @@ on:
     workflows: [Generate plugins]
     types:
       - completed
+    branches: [*]
 env:
     CHECKOUT_SUBMODULES: ""
 
@@ -56,7 +57,7 @@ jobs:
       - name: InstaWP instance URL
         run: echo "InstaWP instance URL - ${{ steps.create-instawp.outputs.instawp_url }}"
         shell: bash        
-        
+
     outputs:    
       instawp-url: ${{ steps.create-instawp.outputs.instawp_url }}
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,57 @@
+name: Integration tests
+on:
+  workflow_run:
+    workflows: [Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Release Asset]
+    types:
+      - completed
+env:
+    CHECKOUT_SUBMODULES: ""
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrieve artifact URLs
+        uses: actions/github-script@v6
+        id: artifact-url
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let artifactURLs = allArtifacts.data.artifacts.map((artifact) => {
+              return artifact.url.replace('https://api.github.com', 'https://nightly.link')
+            });
+            let artifactURL = artifactURLs.concat(',');
+            return artifactURL;
+          result-encoding: string
+      - name: InstaWP URL
+        run: echo InstaWP URL: ${{ steps.artifact-url.outputs.result }}
+        shell: bash
+      - name: Create InstaWP instance
+        uses: instawp/wordpress-testing-automation@main
+        id: create-instawp
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
+          INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
+          INSTAWP_TEMPLATE_SLUG: vendor
+          REPO_ID: 4
+          INSTAWP_ACTION: create-site-template
+          ARTIFACT_URL: ${{steps.artifact-url.outputs.result}}
+
+  destroy-wp-after-testing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: instawp/wordpress-testing-automation@main
+        if: github.event.action == 'closed' || github.event.action == 'merged'
+        id: detroy-instawp
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
+          INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
+          INSTAWP_TEMPLATE_SLUG: vendor
+          REPO_ID: 4
+          INSTAWP_ACTION: destroy-site

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,8 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
           INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
-          INSTAWP_TEMPLATE_SLUG: vendor
-          REPO_ID: 4
+          INSTAWP_TEMPLATE_SLUG: graphql-api-integration-tests
           INSTAWP_ACTION: create-site-template
           ARTIFACT_URL: ${{ needs.retrieve-artifact-url.outputs.artifact-url }}
 
@@ -97,6 +96,5 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           INSTAWP_TOKEN: ${{secrets.INSTAWP_TOKEN}}
           INSTAWP_DOMAIN: ${{secrets.INSTAWP_DOMAIN}}
-          INSTAWP_TEMPLATE_SLUG: vendor
-          REPO_ID: 4
+          INSTAWP_TEMPLATE_SLUG: graphql-api-integration-tests
           INSTAWP_ACTION: destroy-site

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,7 +4,7 @@ on:
     # workflows: [Generate plugins]
     workflows: [Monorepo validation]
     types:
-      - completed
+      - requested
 env:
     CHECKOUT_SUBMODULES: ""
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   retrieve-artifact-url:
+    name: Retrieve the artifact URL
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve artifact URLs from GitHub workflow
@@ -37,6 +38,7 @@ jobs:
 
   launch-instawp-instance:
     needs: retrieve-artifact-url
+    name: Launch InstaWP instance
     runs-on: ubuntu-latest
     steps:
       - name: Create InstaWP instance
@@ -83,6 +85,8 @@ jobs:
         run: INTEGRATION_TESTS_WEBSERVER_DOMAIN=${{ needs.launch-instawp-instance.outputs.instawp-url }} vendor/bin/phpunit --filter=Integration/
 
   destroy-instawp-after-testing:
+    needs: execute-integration-tests
+    name: Destroy InstaWP instance
     runs-on: ubuntu-latest
     steps:
       - uses: instawp/wordpress-testing-automation@main

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,10 +1,9 @@
 name: Integration tests
 on:
   workflow_run:
-    # workflows: [Generate plugins]
-    workflows: [Monorepo validation]
+    workflows: [Generate plugins]
     types:
-      - requested
+      - completed
 env:
     CHECKOUT_SUBMODULES: ""
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,9 +1,11 @@
 name: Integration tests
 on:
   workflow_run:
-    workflows: [Generate plugins]
+    workflows: ["Generate plugins"]
     types:
       - completed
+    branches:
+      - '**'
 env:
     CHECKOUT_SUBMODULES: ""
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   retrieve-artifact-url:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Retrieve the artifact URL
     runs-on: ubuntu-latest
     steps:
@@ -54,9 +55,9 @@ jobs:
 
       - name: InstaWP instance URL
         run: echo "InstaWP instance URL - ${{ steps.create-instawp.outputs.instawp_url }}"
-        shell: bash
-    outputs:
-    
+        shell: bash        
+        
+    outputs:    
       instawp-url: ${{ steps.create-instawp.outputs.instawp_url }}
 
   execute-integration-tests:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,7 +30,7 @@ jobs:
           result-encoding: string
 
       - name: Artifact URL for InstaWP
-        run: echo Artifact URL for InstaWP: ${{ steps.artifact-url.outputs.result }}
+        run: echo "Artifact URL for InstaWP: ${{ steps.artifact-url.outputs.result }}"
         shell: bash
 
     outputs:
@@ -54,7 +54,7 @@ jobs:
           ARTIFACT_URL: ${{ needs.retrieve-artifact-url.outputs.artifact-url }}
 
       - name: InstaWP instance URL
-        run: echo InstaWP instance URL ${{ steps.create-instawp.outputs.instawp_url }}
+        run: echo "InstaWP instance URL: ${{ steps.create-instawp.outputs.instawp_url }}"
         shell: bash
     outputs:
     

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,7 +1,8 @@
 name: Integration tests
 on:
   workflow_run:
-    workflows: [Generate plugins]
+    # workflows: [Generate plugins]
+    workflows: [Monorepo validation]
     types:
       - completed
 env:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,10 +8,10 @@ env:
     CHECKOUT_SUBMODULES: ""
 
 jobs:
-  download:
+  launch-instawp-instance:
     runs-on: ubuntu-latest
     steps:
-      - name: Retrieve artifact URLs
+      - name: Retrieve artifact URLs from GitHub workflow
         uses: actions/github-script@v6
         id: artifact-url
         with:
@@ -27,8 +27,8 @@ jobs:
             let artifactURL = artifactURLs.concat(',');
             return artifactURL;
           result-encoding: string
-      - name: InstaWP URL
-        run: echo InstaWP URL: ${{ steps.artifact-url.outputs.result }}
+      - name: Echo Artifact URL for InstaWP
+        run: echo Artifact URL for InstaWP: ${{ steps.artifact-url.outputs.result }}
         shell: bash
       - name: Create InstaWP instance
         uses: instawp/wordpress-testing-automation@main
@@ -41,6 +41,9 @@ jobs:
           REPO_ID: 4
           INSTAWP_ACTION: create-site-template
           ARTIFACT_URL: ${{steps.artifact-url.outputs.result}}
+      - name: Echo InstaWP instance URL
+        run: echo InstaWP instance URL ${{ steps.create-instawp.outputs.instawp_url }}
+        shell: bash
 
   destroy-wp-after-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -1,4 +1,4 @@
-name: Split Monorepo Dev-Master
+name: Split monorepo - dev-master
 
 on:
     push:

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -1,4 +1,4 @@
-name: Split Monorepo Tagged
+name: Split monorepo - tagged
 
 on:
     push:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,4 +1,4 @@
-name: PHPUnit tests
+name: Unit tests
 on:
     push:
         branches:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
     main:
-        name: Execute PHPUnit tests
+        name: Execute unit tests
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -16,26 +16,25 @@ class PluginDataSource
     public function getPluginConfigEntries(): array
     {
         return [
-            // @todo Commented temporarily for faster testing; Uncomment!
-            // // GraphQL API for WordPress
-            // [
-            //     'path' => 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp',
-            //     'zip_file' => 'graphql-api',
-            //     'main_file' => 'graphql-api.php',
-            //     'exclude_files' => 'dev-helpers/\* docs/images/\*',
-            //     'dist_repo_organization' => 'GraphQLAPI',
-            //     'dist_repo_name' => 'graphql-api-for-wp-dist',
-            //     'additional_rector_configs' => [
-            //         $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-cacheitem.php',
-            //         $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-mixedtype.php',
-            //         $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-uniontype.php',
-            //     ],
-            //     'rector_downgrade_config' => $this->rootDir . '/config/rector/downgrade/graphql-api/rector.php',
-            //     'scoping' => [
-            //         'phpscoper_config' => $this->rootDir . '/ci/scoping/scoper-graphql-api.inc.php',
-            //         'rector_test_config' => $this->rootDir . '/ci/scoping/rector-test-scoping-graphql-api.php',
-            //     ],
-            // ],
+            // GraphQL API for WordPress
+            [
+                'path' => 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp',
+                'zip_file' => 'graphql-api',
+                'main_file' => 'graphql-api.php',
+                'exclude_files' => 'dev-helpers/\* docs/images/\*',
+                'dist_repo_organization' => 'GraphQLAPI',
+                'dist_repo_name' => 'graphql-api-for-wp-dist',
+                'additional_rector_configs' => [
+                    $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-cacheitem.php',
+                    $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-mixedtype.php',
+                    $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-uniontype.php',
+                ],
+                'rector_downgrade_config' => $this->rootDir . '/config/rector/downgrade/graphql-api/rector.php',
+                'scoping' => [
+                    'phpscoper_config' => $this->rootDir . '/ci/scoping/scoper-graphql-api.inc.php',
+                    'rector_test_config' => $this->rootDir . '/ci/scoping/rector-test-scoping-graphql-api.php',
+                ],
+            ],
             // GraphQL API - Testing <= To run integration tests with InstaWP
             [
                 'path' => 'layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing',

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -16,25 +16,26 @@ class PluginDataSource
     public function getPluginConfigEntries(): array
     {
         return [
-            // GraphQL API for WordPress
-            [
-                'path' => 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp',
-                'zip_file' => 'graphql-api',
-                'main_file' => 'graphql-api.php',
-                'exclude_files' => 'dev-helpers/\* docs/images/\*',
-                'dist_repo_organization' => 'GraphQLAPI',
-                'dist_repo_name' => 'graphql-api-for-wp-dist',
-                'additional_rector_configs' => [
-                    $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-cacheitem.php',
-                    $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-mixedtype.php',
-                    $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-uniontype.php',
-                ],
-                'rector_downgrade_config' => $this->rootDir . '/config/rector/downgrade/graphql-api/rector.php',
-                'scoping' => [
-                    'phpscoper_config' => $this->rootDir . '/ci/scoping/scoper-graphql-api.inc.php',
-                    'rector_test_config' => $this->rootDir . '/ci/scoping/rector-test-scoping-graphql-api.php',
-                ],
-            ],
+            // @todo Commented temporarily for faster testing; Uncomment!
+            // // GraphQL API for WordPress
+            // [
+            //     'path' => 'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp',
+            //     'zip_file' => 'graphql-api',
+            //     'main_file' => 'graphql-api.php',
+            //     'exclude_files' => 'dev-helpers/\* docs/images/\*',
+            //     'dist_repo_organization' => 'GraphQLAPI',
+            //     'dist_repo_name' => 'graphql-api-for-wp-dist',
+            //     'additional_rector_configs' => [
+            //         $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-cacheitem.php',
+            //         $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-mixedtype.php',
+            //         $this->rootDir . '/config/rector/downgrade/graphql-api/chained-rules/rector-arrowfunction-uniontype.php',
+            //     ],
+            //     'rector_downgrade_config' => $this->rootDir . '/config/rector/downgrade/graphql-api/rector.php',
+            //     'scoping' => [
+            //         'phpscoper_config' => $this->rootDir . '/ci/scoping/scoper-graphql-api.inc.php',
+            //         'rector_test_config' => $this->rootDir . '/ci/scoping/rector-test-scoping-graphql-api.php',
+            //     ],
+            // ],
             // GraphQL API - Testing <= To run integration tests with InstaWP
             [
                 'path' => 'layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing',


### PR DESCRIPTION
Used services to execute integration tests:

- [InstaWP](https://instawp.com/): to generate a throwaway WordPress instance against which to execute the integration tests
- [Nightly link](https://nightly.link): to allow to retrieve the artifacts without having to be logged-in to GitHub (which the InstaWP service is not)

The process is the following:

Wait until the "GraphQL API" and "GraphQL API Testing" plugin artifacts have been generated (on workflow with name `"Generate Installable Plugin, Upload as Artifact, and (maybe) Upload as Release Asset"`) and then trigger a new workflow [using the `workflow_run` trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow).

This new workflow will retrieve the URL for the generated artifacts:

- `graphql-api`
- `graphql-api-testing`

These artifact URLs must have their domain changed, from `api.github.com` to `nightly.link`, because the [`actions/upload-artifact` "Artifact download URL only work for registered users"](https://github.com/actions/upload-artifact/issues/51).

Then, we pass these URLs (joined with `,`) under param `ARTIFACT_URL` to the InstaWP action, which will create a new WordPress instance and install these artifacts (i.e. these plugins), and we retrieve the URL of the new InstaWP instance.

Then, we execute the integration tests against the InstaWP instance, and finally destroy it.