### PR TITLE
Removed functions from FieldQueryInterpreter

### DIFF
--- a/layers/API/packages/api-mirrorquery/src/DataStructureFormatters/MirrorQueryDataStructureFormatter.php
+++ b/layers/API/packages/api-mirrorquery/src/DataStructureFormatters/MirrorQueryDataStructureFormatter.php
@@ -138,7 +138,6 @@ class MirrorQueryDataStructureFormatter extends AbstractJSONDataStructureFormatt
         foreach ($propertyFields as $propertyField) {
             // Only if the property has been set (in case of dbError it is not set)
             $propertyFieldOutputKey = $this->getFieldQueryInterpreter()->getFieldOutputKey($propertyField);
-            $uniquePropertyFieldOutputKey = $this->getFieldQueryInterpreter()->getUniqueFieldOutputKeyByTypeOutputKey($typeOutputKey, $propertyField);
 
             // @todo Re-do this logic, by passing the FieldInterface directly
             /** @var FieldInterface|null */
@@ -146,7 +145,7 @@ class MirrorQueryDataStructureFormatter extends AbstractJSONDataStructureFormatt
             /** @var FieldInterface[] */
             $resolvedObjectFields = iterator_to_array($resolvedObject);
             foreach ($resolvedObjectFields as $resolvedObjectField) {
-                if ($resolvedObjectField->getOutputKey() === $uniquePropertyFieldOutputKey) {
+                if ($resolvedObjectField->getOutputKey() === $propertyFieldOutputKey) {
                     $propertyFieldInstance = $resolvedObjectField;
                     break;
                 }
@@ -160,7 +159,7 @@ class MirrorQueryDataStructureFormatter extends AbstractJSONDataStructureFormatt
         // Add the nested levels
         foreach ($nestedFields as $nestedField => $nestedPropertyFields) {
             $nestedFieldOutputKey = $this->getFieldQueryInterpreter()->getFieldOutputKey($nestedField);
-            $uniqueNestedFieldOutputKey = $this->getFieldQueryInterpreter()->getUniqueFieldOutputKeyByTypeOutputKey($typeOutputKey, $nestedField);
+        
 
             // @todo Re-do this logic, by passing the FieldInterface directly
             /** @var FieldInterface|null */
@@ -168,7 +167,7 @@ class MirrorQueryDataStructureFormatter extends AbstractJSONDataStructureFormatt
             /** @var FieldInterface[] */
             $resolvedObjectFields = iterator_to_array($resolvedObject);
             foreach ($resolvedObjectFields as $resolvedObjectField) {
-                if ($resolvedObjectField->getOutputKey() === $uniqueNestedFieldOutputKey) {
+                if ($resolvedObjectField->getOutputKey() === $nestedFieldOutputKey) {
                     $nestedFieldInstance = $resolvedObjectField;
                     break;
                 }
@@ -195,7 +194,7 @@ class MirrorQueryDataStructureFormatter extends AbstractJSONDataStructureFormatt
             }
 
             // The first field, "id", needs not be concatenated. All the others do need
-            $nextField = ($concatenateField ? $objectKeyPath . '.' : '') . $uniqueNestedFieldOutputKey;
+            $nextField = ($concatenateField ? $objectKeyPath . '.' : '') . $nestedFieldOutputKey;
 
             // The type with ID may be stored under $unionTypeOutputKeyIDs
             $unionTypeOutputKeyID = $unionTypeOutputKeyIDs[$typeOutputKey][$objectID][$nestedFieldInstance] ?? null;

--- a/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
+++ b/layers/Engine/packages/component-model/src/ComponentProcessors/AbstractComponentProcessor.php
@@ -661,10 +661,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                 if ($typeResolver === null) {
                     continue;
                 }
-                // @todo: Check if it should use `getUniqueFieldOutputKeyByTypeResolverClass`, or pass some $object to `getUniqueFieldOutputKey`, or what
-                // @see https://github.com/leoloso/PoP/issues/1050
-                $subcomponent_data_field = $relationalComponentFieldNode->getField()->asFieldOutputQueryString();
-                $ret[$relationalComponentFieldNode->getField()] = $this->getFieldQueryInterpreter()->getTargetObjectTypeUniqueFieldOutputKeys($relationalTypeResolver, $subcomponent_data_field);
+                $ret[$relationalComponentFieldNode->getField()] = $this->getFieldQueryInterpreter()->getTargetObjectTypeUniqueFieldOutputKeys($relationalTypeResolver, $relationalComponentFieldNode->getField());
             }
             foreach ($this->getConditionalRelationalComponentFieldNodes($component) as $conditionalRelationalComponentFieldNode) {
                 foreach ($conditionalRelationalComponentFieldNode->getRelationalComponentFieldNodes() as $relationalComponentFieldNode) {
@@ -673,9 +670,7 @@ abstract class AbstractComponentProcessor implements ComponentProcessorInterface
                     if ($typeResolver === null) {
                         continue;
                     }
-                    // @todo: Check if it should use `getUniqueFieldOutputKeyByTypeResolverClass`, or pass some $object to `getUniqueFieldOutputKey`, or what
-                    // @see https://github.com/leoloso/PoP/issues/1050
-                    $ret[$relationalComponentFieldNode->getField()] = $this->getFieldQueryInterpreter()->getTargetObjectTypeUniqueFieldOutputKeys($relationalTypeResolver, $relationalComponentFieldNode->getField()->asFieldOutputQueryString());
+                    $ret[$relationalComponentFieldNode->getField()] = $this->getFieldQueryInterpreter()->getTargetObjectTypeUniqueFieldOutputKeys($relationalTypeResolver, $relationalComponentFieldNode->getField());
                 }
             }
         }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -116,7 +116,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
      */
     final public function getTargetObjectTypeUniqueFieldOutputKeys(
         RelationalTypeResolverInterface $relationalTypeResolver,
-        string $field,
+        FieldInterface $field,
     ): array {
         $uniqueFieldOutputKeys = [];
         /** @var ObjectTypeResolverInterface[] */
@@ -125,7 +125,7 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             : [$relationalTypeResolver];
 
         foreach ($targetObjectTypeResolvers as $targetObjectTypeResolver) {
-            $uniqueFieldOutputKeys[$targetObjectTypeResolver->getTypeName()] = $this->getFieldOutputKey($field);
+            $uniqueFieldOutputKeys[$targetObjectTypeResolver->getTypeName()] = $field->getOutputKey();
         }
         return $uniqueFieldOutputKeys;
     }

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -125,19 +125,9 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
             : [$relationalTypeResolver];
 
         foreach ($targetObjectTypeResolvers as $targetObjectTypeResolver) {
-            $uniqueFieldOutputKeys[$targetObjectTypeResolver->getTypeName()] = $this->getUniqueFieldOutputKeyByObjectTypeResolver(
-                $targetObjectTypeResolver,
-                $field
-            );
+            $uniqueFieldOutputKeys[$targetObjectTypeResolver->getTypeName()] = $this->getFieldOutputKey($field);
         }
         return $uniqueFieldOutputKeys;
-    }
-
-    final public function getUniqueFieldOutputKeyByObjectTypeResolver(
-        ObjectTypeResolverInterface $objectTypeResolver,
-        string $field,
-    ): string {
-        return $this->getFieldOutputKey($field);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php
@@ -105,43 +105,6 @@ class FieldQueryInterpreter extends UpstreamFieldQueryInterpreter implements Fie
     }
 
     /**
-     * If two different fields for the same type have the same fieldOutputKey, then
-     * add a counter to the second one, so each of them is unique.
-     * That is to avoid overriding the previous value, as when doing:
-     *
-     *   ?query=posts.title|self.excerpt@title
-     *
-     * In this case, the value of the excerpt would override the value of the title,
-     * since they both have fieldOutputKey "title".
-     *
-     * If the TypeResolver is of Union type, because the data for the object
-     * is stored under the target ObjectTypeResolver, then the unique field name
-     * must be retrieved against the target ObjectTypeResolver
-     */
-    final public function getUniqueFieldOutputKey(
-        RelationalTypeResolverInterface $relationalTypeResolver,
-        string $field,
-        object $object,
-    ): string {
-        if ($relationalTypeResolver instanceof UnionTypeResolverInterface) {
-            $targetObjectTypeResolver = $relationalTypeResolver->getTargetObjectTypeResolver($object);
-            if ($targetObjectTypeResolver === null) {
-                throw new SchemaReferenceException(
-                    sprintf(
-                        $this->__('The Union Type \'%s\' does not provide a target ObjectTypeResolver for the object', 'component-model'),
-                        $relationalTypeResolver->getMaybeNamespacedTypeName()
-                    )
-                );
-            }
-            return $this->getUniqueFieldOutputKeyByObjectTypeResolver(
-                $targetObjectTypeResolver,
-                $field
-            );
-        }
-        return $this->getFieldOutputKey($field);
-    }
-
-    /**
      * If the TypeResolver is of Union type, and we don't have the object
      * (eg: when printing the configuration), then generate a list of the
      * unique field outputs for all the target ObjectTypeResolvers.

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -28,10 +28,6 @@ interface FieldQueryInterpreterInterface extends UpstreamFieldQueryInterpreterIn
         RelationalTypeResolverInterface $relationalTypeResolver,
         string $field,
     ): array;
-    public function getUniqueFieldOutputKeyByObjectTypeResolver(
-        ObjectTypeResolverInterface $objectTypeResolver,
-        string $field,
-    ): string;
     /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop
      */

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -15,25 +15,6 @@ use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 interface FieldQueryInterpreterInterface extends UpstreamFieldQueryInterpreterInterface
 {
     /**
-     * If two different fields for the same type have the same fieldOutputKey, then
-     * add a counter to the second one, so each of them is unique.
-     * That is to avoid overriding the previous value, as when doing:
-     *
-     *   ?query=posts.title|self.excerpt@title
-     *
-     * In this case, the value of the excerpt would override the value of the title,
-     * since they both have fieldOutputKey "title".
-     *
-     * If the TypeResolver is of Union type, because the data for the object
-     * is stored under the target ObjectTypeResolver, then the unique field name
-     * must be retrieved against the target ObjectTypeResolver
-     */
-    public function getUniqueFieldOutputKey(
-        RelationalTypeResolverInterface $relationalTypeResolver,
-        string $field,
-        object $object,
-    ): string;
-    /**
      * If the TypeResolver is of Union type, and we don't have the object
      * (eg: when printing the configuration), then generate a list of the
      * unique field outputs for all the target ObjectTypeResolvers.

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -26,7 +26,7 @@ interface FieldQueryInterpreterInterface extends UpstreamFieldQueryInterpreterIn
      */
     public function getTargetObjectTypeUniqueFieldOutputKeys(
         RelationalTypeResolverInterface $relationalTypeResolver,
-        string $field,
+        FieldInterface $field,
     ): array;
     /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop

--- a/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreterInterface.php
@@ -51,7 +51,6 @@ interface FieldQueryInterpreterInterface extends UpstreamFieldQueryInterpreterIn
         ObjectTypeResolverInterface $objectTypeResolver,
         string $field,
     ): string;
-    public function getUniqueFieldOutputKeyByTypeOutputKey(string $typeOutputKey, string $field): string;
     /**
      * Extract field args without using the schema. It is needed to find out which fieldResolver will process a field, where we can't depend on the schema since this one needs to know who the fieldResolver is, creating an infitine loop
      */

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/avatar-postauthors-layoutsbase.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/avatar-postauthors-layoutsbase.php
@@ -51,7 +51,7 @@ abstract class PoP_Module_Processor_PostAuthorAvatarLayoutsBase extends PoPEngin
         $ret['avatar'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $avatar_field
+                $avatar_field // @todo Fix: pass LeafField
             ),
             'size' => $avatar_size
         );

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/useravatarlayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-avatar-processors/library/processors/abstract-classes/layouts/useravatarlayouts-base.php
@@ -46,7 +46,7 @@ abstract class PoP_Module_Processor_UserAvatarLayoutsBase extends PoPEngine_Quer
         $ret['avatar'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $avatar_field
+                $avatar_field // @todo Fix: pass LeafField
             ),
         );
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/abstract-classes/formcomponents/typeaheads/user-selectabletypeaheadalert-formcomponents-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-bootstrapcollection-processors/library/processors/abstract-classes/formcomponents/typeaheads/user-selectabletypeaheadalert-formcomponents-base.php
@@ -14,7 +14,7 @@ abstract class PoP_Module_Processor_UserSelectableTypeaheadAlertFormComponentsBa
             $ret['avatar'] = array(
                 'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                     $this->getProp($component, $props, 'succeeding-typeResolver'),
-                    $avatar_field
+                    $avatar_field // @todo Fix: pass LeafField
                 ),
                 'size' => $avatar_size
             );

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/post-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/post-card-base.php
@@ -50,7 +50,7 @@ abstract class PoP_Module_Processor_PostCardLayoutsBase extends PoPEngine_QueryD
         $ret['thumb'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $this->getThumbField($component, $props)
+                $this->getThumbField($component, $props) // @todo Fix: pass LeafField
             ),
         );
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
@@ -69,8 +69,6 @@ abstract class PoP_Module_Processor_UserCardLayoutsBase extends PoPEngine_QueryD
     {
         $ret = parent::getImmutableConfiguration($component, $props);
 
-        $componentprocessor_manager = ComponentProcessorManagerFacade::getInstance();
-
         if (PoP_Application_ConfigurationUtils::useUseravatar()) {
             $avatar_size = $this->getAvatarSize($component, $props);
             $avatar_field = PoP_AvatarFoundationManagerFactory::getInstance()->getAvatarField($avatar_size);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/cards/user-card-base.php
@@ -78,7 +78,7 @@ abstract class PoP_Module_Processor_UserCardLayoutsBase extends PoPEngine_QueryD
             $ret['avatar'] = array(
                 'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                     $this->getProp($component, $props, 'succeeding-typeResolver'),
-                    $avatar_field
+                    $avatar_field // @todo Fix: pass LeafField
                 ),
                 'size' => $avatar_size
             );

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postthumblayouts-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/postthumblayouts-base.php
@@ -102,7 +102,7 @@ abstract class PoP_Module_Processor_PostThumbLayoutsBase extends PoPEngine_Query
         $ret['thumb'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $this->getThumbField($component, $props))
+                $this->getThumbField($component, $props)) // @todo Fix: pass LeafField
         );
         if ($target = $this->getLinktarget($component, $props)) {
             $ret['link-target'] = $target;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/post-typeahead-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/post-typeahead-component-base.php
@@ -32,7 +32,8 @@ abstract class PoP_Module_Processor_PostTypeaheadComponentLayoutsBase extends Po
         $ret['thumb'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $thumb),
+                $thumb // @todo Fix: pass LeafField
+            ),
         );
         
         return $ret;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-mention-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-mention-component-base.php
@@ -41,7 +41,7 @@ abstract class PoP_Module_Processor_UserMentionComponentLayoutsBase extends PoPE
             $ret['avatar'] = array(
                 'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                     $this->getProp($component, $props, 'succeeding-typeResolver'),
-                    $avatar_field
+                    $avatar_field // @todo Fix: pass LeafField
                 ),
                 'size' => $avatar_size
             );

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-typeahead-component-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/layouts/typeaheads/user-typeahead-component-base.php
@@ -44,8 +44,9 @@ abstract class PoP_Module_Processor_UserTypeaheadComponentLayoutsBase extends Po
 
             $ret['avatar'] = array(
                 'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
-                $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $avatar_field),
+                    $this->getProp($component, $props, 'succeeding-typeResolver'),
+                    $avatar_field // @todo Fix: pass LeafField
+                ),
                 'size' => $avatar_size
             );
         }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
@@ -49,8 +49,6 @@ abstract class PoP_Module_Processor_SocialMediaItemsBase extends PoPEngine_Query
 
     public function getImmutableConfiguration(\PoP\ComponentModel\Component\Component $component, array &$props): array
     {
-        $componentprocessor_manager = ComponentProcessorManagerFacade::getInstance();
-
         $ret = parent::getImmutableConfiguration($component, $props);
 
         $title = sprintf(TranslationAPIFacade::getInstance()->__('Share on %s', 'pop-coreprocessors'), $this->getName($component));

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/socialmedia/socialmedia-items-base.php
@@ -62,7 +62,7 @@ abstract class PoP_Module_Processor_SocialMediaItemsBase extends PoPEngine_Query
         
         $ret['shareurl-field'] = FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
             $this->getProp($component, $props, 'succeeding-typeResolver'),
-            $this->getShareurlField($component, $props)
+            $this->getShareurlField($component, $props) // @todo Fix: pass LeafField
         );
 
         if ($provider = $this->getProvider($component)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/post-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/post-headers-base.php
@@ -65,7 +65,8 @@ abstract class PoP_Module_Processor_PostViewComponentHeadersBase extends PoPEngi
         $ret['thumb'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $this->getThumbField($component, $props))
+                $this->getThumbField($component, $props) // @todo Fix: pass LeafField
+            )
         );
         
         return $ret;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/user-headers-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-coreprocessors/pop-library/processors/abstract-classes/viewcomponents/user-headers-base.php
@@ -55,7 +55,7 @@ abstract class PoP_Module_Processor_UserViewComponentHeadersBase extends PoPEngi
             $ret['avatar'] = array(
                 'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                     $this->getProp($component, $props, 'succeeding-typeResolver'),
-                    $avatar_field
+                    $avatar_field // @todo Fix: pass LeafField
                 ),
                 'size' => $avatar_size
             );

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
@@ -109,7 +109,8 @@ abstract class PoP_Module_Processor_PostMapScriptCustomizationsBase extends PoP_
         $ret['thumb'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),
-                $this->getThumbField($component, $props)),
+                $this->getThumbField($component, $props) // @todo Fix: pass LeafField
+            ),
         );
 
         if ($authors_component = $this->getAuthorsComponent($component)) {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/post-map-scriptcustomizations-base.php
@@ -104,8 +104,6 @@ abstract class PoP_Module_Processor_PostMapScriptCustomizationsBase extends PoP_
     {
         $ret = parent::getImmutableConfiguration($component, $props);
 
-        $componentprocessor_manager = ComponentProcessorManagerFacade::getInstance();
-
         $ret['thumb'] = array(
             'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                 $this->getProp($component, $props, 'succeeding-typeResolver'),

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/user-map-scriptcustomizations-base.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-locations-processors/library/processors/abstract-classes/maps/user-map-scriptcustomizations-base.php
@@ -53,14 +53,14 @@ abstract class PoP_Module_Processor_UserMapScriptCustomizationsBase extends PoP_
                 'sm' => array(
                     'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                         $this->getProp($component, $props, 'succeeding-typeResolver'),
-                        $avatar_field_sm
+                        $avatar_field_sm // @todo Fix: pass LeafField
                     ),
                     'size' => $avatar_size_sm
                 ),
                 'md' => array(
                     'name' => FieldQueryInterpreterFacade::getInstance()->getTargetObjectTypeUniqueFieldOutputKeys(
                         $this->getProp($component, $props, 'succeeding-typeResolver'),
-                        $avatar_field_md
+                        $avatar_field_md // @todo Fix: pass LeafField
                     ),
                     'size' => $avatar_size_md
                 )


### PR DESCRIPTION
Removed:

- `getUniqueFieldOutputKey`
- `getUniqueFieldOutputKeyByObjectTypeResolver`
- `getUniqueFieldOutputKeyByTypeOutputKey`

Pass `FieldInterface` instead of `string` to:

- `getTargetObjectTypeUniqueFieldOutputKeys`