### PR TITLE
MonorepoBuilder: Stick to version `10.2.2`, to avoid incompatible MBConfig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.6",
         "symfony/var-dumper": "^6.0",
-        "symplify/monorepo-builder": "^10.0",
+        "symplify/monorepo-builder": "10.2.2",
         "szepeviktor/phpstan-wordpress": "^1.0"
     },
     "autoload": {

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/DataToAppendAndRemoveDataSource.php
@@ -14,7 +14,13 @@ class DataToAppendAndRemoveDataSource
         // Install also the monorepo-builder! So it can be used in CI
         return [
             'require-dev' => [
-                'symplify/monorepo-builder' => '^10.0',
+                /**
+                 * Last working version of the MonorepoBuilder before upgraded to using MBConfig
+                 * (after which the library can't be used directly from source anymore).
+                 *
+                 * @see https://github.com/symplify/symplify/issues/4184
+                 */                
+                'symplify/monorepo-builder' => '10.2.2',
                 'friendsofphp/php-cs-fixer' => '^3.5',
                 'slevomat/coding-standard' => '^7.0',
             ],


### PR DESCRIPTION
This PR makes the repo use the last working version of the MonorepoBuilder (as forked under [`leoloso/monorepo-builder`](https://github.com/leoloso/monorepo-builder)) before it was upgraded to using `MBConfig`: version `10.2.2`.

After this version, the library can't be used directly from source anymore, and the downgraded library does not allow for extensibility (eg: can't extend `AbstractSymplifyCommand`, as it is namespaced).

I asked the MonorepoBuilder's maintainer to [ask in Symfony to merge the needed patch](https://github.com/symplify/symplify/issues/4184) so the library could still be used from source, but he won't do it.

Then, it's better to not update the MonorepoBuilder to its newer releases anymore, unless this issue is solved.