### PR TITLE
Added REST endpoints modifying value inside CPT blocks

### DIFF
--- a/layers/Engine/packages/root/src/Container/Loader/ServiceYamlFileLoaderTrait.php
+++ b/layers/Engine/packages/root/src/Container/Loader/ServiceYamlFileLoaderTrait.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\Root\Container\Loader;
 
-use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-
 /**
  * Trait to help override the Symfony class, to:
  *

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -10,6 +10,7 @@ class Params
     final public const MODULE_ID = 'moduleID';
     final public const OPTION_VALUES = 'optionValues';
     final public const CUSTOM_POST_ID = 'customPostID';
+    final public const BLOCK_NAMESPACE = 'blockNamespace';
     final public const BLOCK_ID = 'blockID';
     final public const BLOCK_ATTRIBUTE_VALUES = 'blockAttributeValues';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -11,4 +11,5 @@ class Params
     final public const OPTION_VALUES = 'optionValues';
     final public const CUSTOM_POST_ID = 'customPostID';
     final public const BLOCK_ID = 'blockID';
+    final public const BLOCK_ATTRIBUTE_VALUES = 'blockAttributeValues';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -9,4 +9,6 @@ class Params
     final public const STATE = 'state';
     final public const MODULE_ID = 'moduleID';
     final public const OPTION_VALUES = 'optionValues';
+    final public const CUSTOM_POST_ID = 'customPostID';
+    final public const BLOCK_ID = 'blockID';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -159,7 +159,9 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                 'rest_post_invalid_id',
                 __('Invalid custom post ID', 'graphql-api-testing'),
                 [
-                    Params::STATE => $customPostID,
+                    Params::STATE => [
+                        Params::CUSTOM_POST_ID => $customPostID,
+                    ],
                 ]
             );
 		}
@@ -173,7 +175,9 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     $customPostID
                 ),
                 [
-                    Params::STATE => $customPostID,
+                    Params::STATE => [
+                        Params::CUSTOM_POST_ID => $customPostID,
+                    ],
                 ]
             );
 		}
@@ -191,7 +195,9 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     )
                 ),
                 [
-                    Params::STATE => $customPostID,
+                    Params::STATE => [
+                        Params::CUSTOM_POST_ID => $customPostID,
+                    ],
                 ]
             );
 		}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -480,10 +480,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                 }
                 // Found the block
                 $found = true;
-                $block['attrs'] = array_merge(
-                    $block['attrs'] ?? [],
-                    $blockAttributeValues
-                );
+                $block['attrs'] = $blockAttributeValues;
                 break;
             }
             if (!$found) {

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -258,12 +258,23 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
 
     public function retrieveAllItems(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $items = [];
         $params = $request->get_params();
         $customPostID = (int)$params[Params::CUSTOM_POST_ID];
         /** @var WP_Post */
         $customPost = $this->getCustomPost($customPostID);
         $blocks = \parse_blocks($customPost->post_content);
+        return rest_ensure_response(
+            $this->prepareBlocksForResponse($customPostID, $blocks)
+        );
+    }
+
+    /**
+     * @param array<array<string,mixed>> $blocks
+     * @return array<string,mixed>
+     */
+    protected function prepareBlocksForResponse(int $customPostID, array $blocks): array
+    {
+        $items = [];
         foreach ($blocks as $block) {
             if (empty($block['blockName'])) {
                 continue;
@@ -272,7 +283,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                 $this->prepareItemForResponse($customPostID, $block)
             );
         }
-        return rest_ensure_response($items);
+        return $items;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -9,12 +9,10 @@ use GraphQLAPI\GraphQLAPI\Constants\ModuleSettingOptions;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleRegistryFacade;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\GraphQLAPI\ModuleSettings\Properties;
-use GraphQLAPI\GraphQLAPI\Settings\SettingsNormalizerInterface;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\Params;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ResponseStatus;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Response\ResponseKeys;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\RESTResponse;
-use PoP\Root\Facades\Instances\InstanceManagerFacade;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -37,13 +35,6 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
     use WithFlushRewriteRulesRESTControllerTrait;
 
     protected string $restBase = 'cpt-block-attributes';
-
-    private ?SettingsNormalizerInterface $settingsNormalizer = null;
-
-    final protected function getSettingsNormalizer(): SettingsNormalizerInterface
-    {
-        return $this->settingsNormalizer ??= InstanceManagerFacade::getInstance()->getInstance(SettingsNormalizerInterface::class);
-    }
 
     /**
      * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
@@ -303,8 +294,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
             $optionValues = $params[Params::OPTION_VALUES];
             $module = $this->getModuleByID($moduleID);
 
-            // Normalize the values
-            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeModuleSettings($module, $optionValues);
+            $normalizedOptionValues = $optionValues;
 
             // Store in the DB
             $userSettingsManager = UserSettingsManagerFacade::getInstance();

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -405,6 +405,16 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     )
                 ),
             ],
+            'collection' => [
+                'href' => rest_url(
+                    sprintf(
+                        '%s/%s/%s',
+                        $this->getNamespace(),
+                        $this->restBase,
+                        $customPostID,
+                    )
+                ),
+            ],
         ];
     }
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers;
+
+use Exception;
+use GraphQLAPI\GraphQLAPI\Constants\ModuleSettingOptions;
+use GraphQLAPI\GraphQLAPI\Facades\Registries\ModuleRegistryFacade;
+use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
+use GraphQLAPI\GraphQLAPI\ModuleSettings\Properties;
+use GraphQLAPI\GraphQLAPI\Settings\SettingsNormalizerInterface;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\Params;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ResponseStatus;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Response\ResponseKeys;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\RESTResponse;
+use PoP\Root\Facades\Instances\InstanceManagerFacade;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+use function rest_ensure_response;
+use function rest_url;
+
+/**
+ * Visualize and modify the attributes of a block inside a custom post, including:
+ *
+ * - Schema Configurators
+ * - Custom Endpoints
+ * - Persisted Queries
+ * - ACLs
+ * - CCLs
+ */
+class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
+{
+    use WithFlushRewriteRulesRESTControllerTrait;
+
+    protected string $restBase = 'cpt-block-attributes';
+
+    private ?SettingsNormalizerInterface $settingsNormalizer = null;
+
+    final protected function getSettingsNormalizer(): SettingsNormalizerInterface
+    {
+        return $this->settingsNormalizer ??= InstanceManagerFacade::getInstance()->getInstance(SettingsNormalizerInterface::class);
+    }
+
+    /**
+     * @return array<string,array<array<string,mixed>>> Array of [$route => [$options]]
+     */
+    protected function getRouteOptions(): array
+    {
+        return [
+            $this->restBase => [
+                [
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => $this->retrieveAllItems(...),
+                    // Allow anyone to read the modules
+                    'permission_callback' => '__return_true',
+                ],
+            ],
+            $this->restBase . '/(?P<moduleID>[a-zA-Z_-]+)' => [
+                [
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => $this->retrieveItem(...),
+                    // Allow anyone to read the modules
+                    'permission_callback' => '__return_true',
+                    'args' => [
+                        Params::MODULE_ID => $this->getModuleIDParamArgs(),
+                    ],
+                ],
+                [
+                    'methods' => WP_REST_Server::CREATABLE,
+                    'callback' => $this->updateItem(...),
+                    // only the Admin can execute the modification
+                    'permission_callback' => $this->checkAdminPermission(...),
+                    'args' => [
+                        Params::MODULE_ID => $this->getModuleIDParamArgs(),
+                        Params::OPTION_VALUES => [
+                            'description' => __('Array of [\'option\' (also called \'input\' in the settings) => \'value\']. Different modules can receive different options', 'graphql-api-testing'),
+                            'type' => 'object',
+                            // 'properties' => [
+                            //     'option'  => [
+                            //         'type' => 'string',
+                            //         'required' => true,
+                            //     ],
+                            //     'value' => [
+                            //         'required' => true,
+                            //     ],
+                            // ],
+                            'required' => true,
+                            'validate_callback' => $this->validateOptions(...),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Validate the module has the given option
+     */
+    protected function validateOptions(
+        array $optionValues,
+        WP_REST_Request $request,
+    ): bool|WP_Error {
+        $moduleID = $request->get_param(Params::MODULE_ID);
+        $module = $this->getModuleByID($moduleID);
+        if ($module === null) {
+            /**
+             * No need to provide an error message, since it's already done
+             * when validating the moduleID
+             */
+            return false;
+        }
+
+        $moduleRegistry = ModuleRegistryFacade::getInstance();
+        $moduleResolver = $moduleRegistry->getModuleResolver($module);
+        $moduleSettings = $moduleResolver->getSettings($module);
+        foreach ((array) $optionValues as $option => $value) {
+            $found = false;
+            foreach ($moduleSettings as $moduleSetting) {
+                if ($moduleSetting[Properties::INPUT] === $option) {
+                    $found = true;
+                    break;
+                }
+            }
+            if (!$found) {
+                return new WP_Error(
+                    '1',
+                    sprintf(
+                        __('There is no option \'%s\' for module \'%s\' (with ID \'%s\')', 'graphql-api-testing'),
+                        $option,
+                        $module,
+                        $moduleID
+                    ),
+                    [
+                        Params::MODULE_ID => $moduleID,
+                        Params::OPTION_VALUES => [$option => $value],
+                    ]
+                );
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getModuleIDParamArgs(): array
+    {
+        return [
+            'description' => __('Module ID', 'graphql-api-testing'),
+            'type' => 'string',
+            'required' => true,
+            'validate_callback' => $this->validateModule(...),
+        ];
+    }
+
+    /**
+     * Validate there is a module with this ID
+     */
+    protected function validateModule(string $moduleID): bool|WP_Error
+    {
+        $module = $this->getModuleByID($moduleID);
+        if ($module === null) {
+            return new WP_Error(
+                '1',
+                sprintf(
+                    __('There is no module with ID \'%s\'', 'graphql-api'),
+                    $moduleID
+                ),
+                [
+                    'moduleID' => $moduleID,
+                ]
+            );
+        }
+        return true;
+    }
+
+    public function getModuleByID(string $moduleID): ?string
+    {
+        $moduleRegistry = ModuleRegistryFacade::getInstance();
+        $modules = $moduleRegistry->getAllModules();
+        foreach ($modules as $module) {
+            $moduleResolver = $moduleRegistry->getModuleResolver($module);
+            if ($moduleID === $moduleResolver->getID($module)) {
+                return $module;
+            }
+        }
+        return null;
+    }
+
+    public function retrieveAllItems(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $items = [];
+        $moduleRegistry = ModuleRegistryFacade::getInstance();
+        $modules = $moduleRegistry->getAllModules();
+        foreach ($modules as $module) {
+            $items[] = $this->prepare_response_for_collection(
+                $this->prepareItemForResponse($module)
+            );
+        }
+        return rest_ensure_response($items);
+    }
+
+    protected function prepareItemForResponse(string $module): WP_REST_Response
+    {
+        $item = $this->prepareItem($module);
+        $response = rest_ensure_response($item);
+        $response->add_links($this->prepareLinks($module));
+        return $response;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function prepareItem(string $module): array
+    {
+        $moduleRegistry = ModuleRegistryFacade::getInstance();
+        $moduleResolver = $moduleRegistry->getModuleResolver($module);
+
+        /**
+         * Append the settings value, store in the DB, to the description
+         * of the settings, which is defined by code.
+         */
+        $settings = $moduleResolver->getSettings($module);
+        $userSettingsManager = UserSettingsManagerFacade::getInstance();
+        $editableSettings = [];
+        foreach ($settings as $setting) {
+            // There are non-editable inputs, to show information. Skip those
+            $input = $setting[Properties::INPUT] ?? null;
+            if ($input === null) {
+                continue;
+            }
+            $setting[ResponseKeys::VALUE] = $userSettingsManager->getSetting($module, $input);
+            $editableSettings[] = $setting;
+        }
+        return [
+            ResponseKeys::MODULE => $module,
+            ResponseKeys::ID => $moduleResolver->getID($module),
+            ResponseKeys::SETTINGS => $editableSettings,
+        ];
+    }
+
+    public function retrieveItem(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $params = $request->get_params();
+        $moduleID = $params[Params::MODULE_ID];
+        $module = $this->getModuleByID($moduleID);
+        $item = $this->prepareItemForResponse($module);
+        return rest_ensure_response($item);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function prepareLinks(string $module): array
+    {
+        $moduleRegistry = ModuleRegistryFacade::getInstance();
+        $moduleResolver = $moduleRegistry->getModuleResolver($module);
+        $moduleID = $moduleResolver->getID($module);
+        return [
+            'self' => [
+                'href' => rest_url(
+                    sprintf(
+                        '%s/%s/%s',
+                        $this->getNamespace(),
+                        $this->restBase,
+                        $moduleID,
+                    )
+                ),
+            ],
+            'collection' => [
+                'href' => rest_url(
+                    sprintf(
+                        '%s/%s',
+                        $this->getNamespace(),
+                        $this->restBase,
+                    )
+                ),
+            ],
+            'module' => [
+                'href' => rest_url(
+                    sprintf(
+                        '%s/%s/%s',
+                        $this->getNamespace(),
+                        'modules',
+                        $moduleID,
+                    )
+                ),
+            ],
+        ];
+    }
+
+    public function updateItem(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        $response = new RESTResponse();
+
+        try {
+            $params = $request->get_params();
+            $moduleID = $params[Params::MODULE_ID];
+            $optionValues = $params[Params::OPTION_VALUES];
+            $module = $this->getModuleByID($moduleID);
+
+            // Normalize the values
+            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeModuleSettings($module, $optionValues);
+
+            // Store in the DB
+            $userSettingsManager = UserSettingsManagerFacade::getInstance();
+            $userSettingsManager->setSettings($module, $normalizedOptionValues);
+
+            /**
+             * Flush rewrite rules in the next request.
+             * Eg: after changing the path of the GraphiQL
+             * client for the single endpoint,
+             * accessing the previous path must produce a 404.
+             *
+             * Not all settings need flushing, so check first.
+             */
+            if ($this->shouldFlushRewriteRules($optionValues)) {
+                $this->enqueueFlushRewriteRules();
+            }
+
+            // Success!
+            $response->status = ResponseStatus::SUCCESS;
+            $response->message = sprintf(
+                __('Settings for module \'%s\' (with ID \'%s\') have been updated successfully', 'graphql-api-testing'),
+                $module,
+                $moduleID
+            );
+        } catch (Exception $e) {
+            $response->status = ResponseStatus::ERROR;
+            $response->message = $e->getMessage();
+        }
+
+        return rest_ensure_response($response);
+    }
+
+    /**
+     * Some options need be flushed, others not.
+     * To find out, check the settings inputs.
+     *
+     * Inputs that need flushing (implemented so far):
+     *
+     * - Path (eg: GraphiQL/Voyager clients)
+     *
+     * @param array<string,mixed> $optionValues
+     */
+    protected function shouldFlushRewriteRules(array $optionValues): bool
+    {
+        return array_key_exists(
+            ModuleSettingOptions::PATH,
+            $optionValues
+        );
+    }
+}

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -251,6 +251,9 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
         $customPost = $this->getCustomPost($customPostID);
         $blocks = \parse_blocks($customPost->post_content);
         foreach ($blocks as $block) {
+            if (empty($block['blockName'])) {
+                continue;
+            }
             $items[] = $this->prepare_response_for_collection(
                 $this->prepareItemForResponse($customPostID, $block)
             );

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -64,42 +64,42 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     ],
                 ],
             ],
-            // $this->restBase . '/(?P<customPostID>[\d]+)/(?P<blockID>[a-zA-Z_-]+)' => [
-            //     [
-            //         'methods' => WP_REST_Server::READABLE,
-            //         'callback' => $this->retrieveItem(...),
-            //         // Allow anyone to read the modules
-            //         'permission_callback' => '__return_true',
-            //         'args' => [
-            //             Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
-            //             Params::BLOCK_ID => $this->getBlockIDParamArgs(),
-            //         ],
-            //     ],
-            //     [
-            //         'methods' => WP_REST_Server::CREATABLE,
-            //         'callback' => $this->updateItem(...),
-            //         // only the Admin can execute the modification
-            //         'permission_callback' => $this->checkAdminPermission(...),
-            //         'args' => [
-            //             Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
-            //             Params::BLOCK_ID => $this->getBlockIDParamArgs(),
-            //             Params::BLOCK_ATTRIBUTE_VALUES => [
-            //                 'description' => __('Array of [\'attribute\' => \'value\']. Different blocks can normally contain different attributes', 'graphql-api-testing'),
-            //                 'type' => 'object',
-            //                 // 'properties' => [
-            //                 //     'attribute'  => [
-            //                 //         'type' => 'string',
-            //                 //         'required' => true,
-            //                 //     ],
-            //                 //     'value' => [
-            //                 //         'required' => true,
-            //                 //     ],
-            //                 // ],
-            //                 'required' => true,
-            //             ],
-            //         ],
-            //     ],
-            // ],
+            $this->restBase . '/(?P<customPostID>[\d]+)/(?P<blockID>[a-zA-Z_-]+)' => [
+                [
+                    'methods' => WP_REST_Server::READABLE,
+                    'callback' => $this->retrieveItem(...),
+                    // Allow anyone to read the modules
+                    'permission_callback' => '__return_true',
+                    'args' => [
+                        Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
+                        Params::BLOCK_ID => $this->getBlockIDParamArgs(),
+                    ],
+                ],
+                [
+                    'methods' => WP_REST_Server::CREATABLE,
+                    'callback' => $this->updateItem(...),
+                    // only the Admin can execute the modification
+                    'permission_callback' => $this->checkAdminPermission(...),
+                    'args' => [
+                        Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
+                        Params::BLOCK_ID => $this->getBlockIDParamArgs(),
+                        Params::BLOCK_ATTRIBUTE_VALUES => [
+                            'description' => __('Array of [\'attribute\' => \'value\']. Different blocks can normally contain different attributes', 'graphql-api-testing'),
+                            'type' => 'object',
+                            // 'properties' => [
+                            //     'attribute'  => [
+                            //         'type' => 'string',
+                            //         'required' => true,
+                            //     ],
+                            //     'value' => [
+                            //         'required' => true,
+                            //     ],
+                            // ],
+                            'required' => true,
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -251,7 +251,11 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
         $customPost = $this->getCustomPost($customPostID);
         $blocks = \parse_blocks($customPost->post_content);
         foreach ($blocks as $block) {
-            $items[$block['blockName']] = $block['attrs'];
+            $item = [
+                'blockName' => $block['blockName'],
+                'attrs' => $block['attrs'],
+            ];
+            $items[$block['blockName']] = $item;
         }
         return rest_ensure_response($items);
     }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -7,7 +7,6 @@ namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers;
 use Exception;
 use GraphQLAPI\GraphQLAPI\Constants\ModuleSettingOptions;
 use GraphQLAPI\GraphQLAPI\Facades\Registries\CustomPostTypeRegistryFacade;
-use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\GraphQLAPI\Services\CustomPostTypes\CustomPostTypeInterface;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\Params;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Constants\ResponseStatus;
@@ -47,6 +46,8 @@ use function serialize_blocks;
 class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
 {
     use WithFlushRewriteRulesRESTControllerTrait;
+
+    protected static const BLOCK_ID_SEPARATOR = ':';
 
     protected string $restBase = 'cpt-block-attributes';
     /** @var string[]|null */
@@ -404,7 +405,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
     protected function getBlockNamespacedNameAndPosition(string $blockNamespace, string $blockID): array
     {
         $blockNamespacedID = $blockNamespace . '/' . $blockID;
-        $parts = explode(':', $blockNamespacedID);
+        $parts = explode(self::BLOCK_ID_SEPARATOR, $blockNamespacedID);
         return [$parts[0], (int) ($parts[1] ?? 0)];
     }
 
@@ -447,7 +448,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
         if ($blockPosition === 0) {
             return $blockNamespacedName;
         }
-        return $blockNamespacedName . ':' . $blockPosition;
+        return $blockNamespacedName . self::BLOCK_ID_SEPARATOR . $blockPosition;
     }
 
     public function updateItem(WP_REST_Request $request): WP_REST_Response|WP_Error

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -47,7 +47,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
 {
     use WithFlushRewriteRulesRESTControllerTrait;
 
-    protected static const BLOCK_ID_SEPARATOR = ':';
+    protected const BLOCK_ID_SEPARATOR = ':';
 
     protected string $restBase = 'cpt-block-attributes';
     /** @var string[]|null */

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -72,11 +72,11 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     'args' => [
                         Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
                         Params::BLOCK_ID => $this->getBlockIDParamArgs(),
-                        Params::OPTION_VALUES => [
-                            'description' => __('Array of [\'option\' (also called \'input\' in the settings) => \'value\']. Different modules can receive different options', 'graphql-api-testing'),
+                        Params::BLOCK_ATTRIBUTE_VALUES => [
+                            'description' => __('Array of [\'attribute\' => \'value\']. Different blocks can normally contain different attributes', 'graphql-api-testing'),
                             'type' => 'object',
                             // 'properties' => [
-                            //     'option'  => [
+                            //     'attribute'  => [
                             //         'type' => 'string',
                             //         'required' => true,
                             //     ],
@@ -132,7 +132,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     ),
                     [
                         Params::CUSTOM_POST_ID => $customPostID,
-                        Params::OPTION_VALUES => [$option => $value],
+                        Params::BLOCK_ATTRIBUTE_VALUES => [$option => $value],
                     ]
                 );
             }
@@ -330,7 +330,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
         try {
             $params = $request->get_params();
             $customPostID = $params[Params::CUSTOM_POST_ID];
-            $optionValues = $params[Params::OPTION_VALUES];
+            $optionValues = $params[Params::BLOCK_ATTRIBUTE_VALUES];
             $module = $this->getModuleByID($customPostID);
 
             $normalizedOptionValues = $optionValues;

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -85,59 +85,11 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                             //     ],
                             // ],
                             'required' => true,
-                            'validate_callback' => $this->validateOptions(...),
                         ],
                     ],
                 ],
             ],
         ];
-    }
-
-    /**
-     * Validate the module has the given option
-     */
-    protected function validateOptions(
-        array $optionValues,
-        WP_REST_Request $request,
-    ): bool|WP_Error {
-        $customPostID = $request->get_param(Params::CUSTOM_POST_ID);
-        $module = $this->getModuleByID($customPostID);
-        if ($module === null) {
-            /**
-             * No need to provide an error message, since it's already done
-             * when validating the customPostID
-             */
-            return false;
-        }
-
-        $moduleRegistry = ModuleRegistryFacade::getInstance();
-        $moduleResolver = $moduleRegistry->getModuleResolver($module);
-        $moduleSettings = $moduleResolver->getSettings($module);
-        foreach ((array) $optionValues as $option => $value) {
-            $found = false;
-            foreach ($moduleSettings as $moduleSetting) {
-                if ($moduleSetting[Properties::INPUT] === $option) {
-                    $found = true;
-                    break;
-                }
-            }
-            if (!$found) {
-                return new WP_Error(
-                    '1',
-                    sprintf(
-                        __('There is no option \'%s\' for module \'%s\' (with ID \'%s\')', 'graphql-api-testing'),
-                        $option,
-                        $module,
-                        $customPostID
-                    ),
-                    [
-                        Params::CUSTOM_POST_ID => $customPostID,
-                        Params::BLOCK_ATTRIBUTE_VALUES => [$option => $value],
-                    ]
-                );
-            }
-        }
-        return true;
     }
 
     /**

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -377,9 +377,10 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
         return null;
     }
 
-    protected function getBlockNamespacedNameAndPosition(string $blockID): array
+    protected function getBlockNamespacedNameAndPosition(string $blockNamespace, string $blockID): array
     {
-        $parts = explode(':', $blockID);
+        $blockNamespacedID = $blockNamespace . '/' . $blockID;
+        $parts = explode(':', $blockNamespacedID);
         return [$parts[0], (int) ($parts[1] ?? 0)];
     }
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -64,7 +64,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     ],
                 ],
             ],
-            $this->restBase . '/(?P<customPostID>[\d]+)/(?P<blockID>[a-zA-Z_-]+)' => [
+            $this->restBase . '/(?P<customPostID>[\d]+)/(?P<blockNamespace>[a-zA-Z_-]+)/(?P<blockID>[a-zA-Z_-]+)' => [
                 [
                     'methods' => WP_REST_Server::READABLE,
                     'callback' => $this->retrieveItem(...),
@@ -72,6 +72,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     'permission_callback' => '__return_true',
                     'args' => [
                         Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
+                        Params::BLOCK_NAMESPACE => $this->getBlockNamespaceParamArgs(),
                         Params::BLOCK_ID => $this->getBlockIDParamArgs(),
                     ],
                 ],
@@ -82,6 +83,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     'permission_callback' => $this->checkAdminPermission(...),
                     'args' => [
                         Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
+                        Params::BLOCK_NAMESPACE => $this->getBlockNamespaceParamArgs(),
                         Params::BLOCK_ID => $this->getBlockIDParamArgs(),
                         Params::BLOCK_ATTRIBUTE_VALUES => [
                             'description' => __('Array of [\'attribute\' => \'value\']. Different blocks can normally contain different attributes', 'graphql-api-testing'),
@@ -113,6 +115,18 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
             'type' => 'integer',
             'required' => true,
             'validate_callback' => $this->validateCustomPost(...),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getBlockNamespaceParamArgs(): array
+    {
+        return [
+            'description' => __('Block namespace', 'graphql-api-testing'),
+            'type' => 'string',
+            'required' => true,
         ];
     }
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -320,18 +320,32 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
         $blocks = \parse_blocks($customPost->post_content);
         $block = $this->getBlock($blockNamespace, $blockID, $blocks);
         if ($block === null) {
+            $errorData = [
+                Params::STATE => [
+                    Params::CUSTOM_POST_ID => $customPostID,
+                    Params::BLOCK_NAMESPACE => $blockNamespace,
+                    Params::BLOCK_ID => $blockID,
+                ],
+            ];
+            [$blockNamespacedName, $blockPosition] = $this->getBlockNamespacedNameAndPosition($blockNamespace, $blockID);
+            if ($blockPosition === 0) {
+                return new WP_Error(
+                    '1',
+                    sprintf(
+                        __('There is no block with name \'%s\'', 'graphql-api-testing'),
+                        $blockNamespacedName
+                    ),
+                    $errorData
+                );
+            }
             return new WP_Error(
                 '1',
                 sprintf(
-                    __('There is no block with ID \'%s\'', 'graphql-api-testing'),
-                    $blockID
+                    __('There is no block with name \'%s\' on position \'%s\'', 'graphql-api-testing'),
+                    $blockNamespacedName,
+                    $blockPosition
                 ),
-                [
-                    Params::STATE => [
-                        Params::CUSTOM_POST_ID => $customPostID,
-                        Params::BLOCK_ID => $blockID,
-                    ],
-                ]
+                $errorData
             );
         }
         return $this->prepareItemForResponse($customPostID, $block);

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -86,7 +86,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                         Params::BLOCK_NAMESPACE => $this->getBlockNamespaceParamArgs(),
                         Params::BLOCK_ID => $this->getBlockIDParamArgs(),
                         Params::BLOCK_ATTRIBUTE_VALUES => [
-                            'description' => __('Array of [\'attribute\' => \'value\']. Different blocks can normally contain different attributes', 'graphql-api-testing'),
+                            'description' => __('Array of [\'block attribute\' => \'value\']', 'graphql-api-testing'),
                             'type' => 'object',
                             // 'properties' => [
                             //     'attribute'  => [
@@ -433,11 +433,11 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
         try {
             $params = $request->get_params();
             $customPostID = $params[Params::CUSTOM_POST_ID];
-            $optionValues = $params[Params::BLOCK_ATTRIBUTE_VALUES];
+            $blockAttributeValues = $params[Params::BLOCK_ATTRIBUTE_VALUES];
             // $module = $this->getModuleByID($customPostID);
             $module = $customPostID;
 
-            $normalizedOptionValues = $optionValues;
+            $normalizedOptionValues = $blockAttributeValues;
 
             // Store in the DB
             $userSettingsManager = UserSettingsManagerFacade::getInstance();
@@ -451,7 +451,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
              *
              * Not all settings need flushing, so check first.
              */
-            if ($this->shouldFlushRewriteRules($optionValues)) {
+            if ($this->shouldFlushRewriteRules($blockAttributeValues)) {
                 $this->enqueueFlushRewriteRules();
             }
 
@@ -478,13 +478,13 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
      *
      * - Path (eg: GraphiQL/Voyager clients)
      *
-     * @param array<string,mixed> $optionValues
+     * @param array<string,mixed> $blockAttributeValues
      */
-    protected function shouldFlushRewriteRules(array $optionValues): bool
+    protected function shouldFlushRewriteRules(array $blockAttributeValues): bool
     {
         return array_key_exists(
             ModuleSettingOptions::PATH,
-            $optionValues
+            $blockAttributeValues
         );
     }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -31,6 +31,17 @@ use function rest_url;
  * - Persisted Queries
  * - ACLs
  * - CCLs
+ *
+ * Example to execute a block attribute update:
+ *
+ * ```bash
+ * curl -i --insecure \
+ *   --user "admin:{applicationPassword}" \
+ *   -X POST \
+ *   -H "Content-Type: application/json" \
+ *   -d '{"blockAttributeValues": {"mutationScheme": "nested"}}' \
+ *   https://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/cpt-block-attributes/191/graphql-api/schema-config-mutation-scheme
+ * ```
  */
 class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
 {

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -309,16 +309,6 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
             'self' => [
                 'href' => rest_url(
                     sprintf(
-                        '%s/%s/%s',
-                        $this->getNamespace(),
-                        $this->restBase,
-                        $customPostID,
-                    )
-                ),
-            ],
-            'block' => [
-                'href' => rest_url(
-                    sprintf(
                         '%s/%s/%s/%s',
                         $this->getNamespace(),
                         $this->restBase,

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -168,16 +168,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
     }
 
 	/**
-	 * Get the post, if the ID is valid.
-	 *
-	 * @since 4.7.2
-	 *
-	 * @param int $id Supplied ID.
-	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
-     *
-     * Function copied from WordPress core.
-     *
-     * @see wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+	 * @return WP_Post|WP_Error Custom post object if ID is valid, WP_Error otherwise.
 	 */
 	protected function getCustomPost(int $customPostID): WP_Post|WP_Error
     {
@@ -283,7 +274,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
 
     /**
      * @param array<array<string,mixed>> $blocks
-     * @return array<string,mixed>
+     * @return array<int,mixed>
      */
     protected function prepareItemsForResponse(int $customPostID, array $blocks): array
     {

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -161,18 +161,18 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
     protected function validateCustomPost(string $customPostID): bool|WP_Error
     {
         $post = $this->getCustomPost((int)$customPostID);
-		if (is_wp_error($post)) {
-			return $post;
-		}
+        if (is_wp_error($post)) {
+            return $post;
+        }
         return true;
     }
 
-	/**
-	 * @return WP_Post|WP_Error Custom post object if ID is valid, WP_Error otherwise.
-	 */
-	protected function getCustomPost(int $customPostID): WP_Post|WP_Error
+    /**
+     * @return WP_Post|WP_Error Custom post object if ID is valid, WP_Error otherwise.
+     */
+    protected function getCustomPost(int $customPostID): WP_Post|WP_Error
     {
-		if ($customPostID <= 0) {
+        if ($customPostID <= 0) {
             return new WP_Error(
                 'rest_post_invalid_id',
                 __('Invalid custom post ID', 'graphql-api-testing'),
@@ -182,11 +182,11 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     ],
                 ]
             );
-		}
+        }
 
-		$post = get_post($customPostID);
-		if (empty($post) || empty($post->ID)) {
-			return new WP_Error(
+        $post = get_post($customPostID);
+        if (empty($post) || empty($post->ID)) {
+            return new WP_Error(
                 'rest_post_invalid_id',
                 sprintf(
                     __('There is no custom post with ID \'%s\'', 'graphql-api-testing'),
@@ -198,11 +198,11 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     ],
                 ]
             );
-		}
+        }
 
         $supportedCustomPostTypes = $this->getSupportedCustomPostTypes();
-		if (!in_array($post->post_type, $supportedCustomPostTypes)) {
-			return new WP_Error(
+        if (!in_array($post->post_type, $supportedCustomPostTypes)) {
+            return new WP_Error(
                 'rest_post_invalid_id',
                 sprintf(
                     __('Custom post is of unsupported custom post type \'%s\' (supported custom post types are: \'%s\')', 'graphql-api-testing'),
@@ -218,10 +218,10 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                     ],
                 ]
             );
-		}
+        }
 
-		return $post;
-	}
+        return $post;
+    }
 
     /**
      * Get the CPTs from this plugin
@@ -455,7 +455,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
             /** @var WP_Post */
             $customPost = $this->getCustomPost($customPostID);
             $blocks = \parse_blocks($customPost->post_content);
-            
+
             /**
              * Find the block and update the attributes
              */

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
@@ -19,7 +19,9 @@ class AdminRESTAPIEndpointManager extends AbstractRESTAPIEndpointManager
         return [
             new ModuleSettingsAdminRESTController(),
             new ModulesAdminRESTController(),
-            new CPTBlockAttributesAdminRESTController(),
+            new CPTBlockAttributesAdminRESTController(
+                'GraphQLAPI\GraphQLAPI',
+            ),
         ];
     }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Endpoints/AdminRESTAPIEndpointManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Endpoints;
 
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\AbstractRESTController;
+use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\CPTBlockAttributesAdminRESTController;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\ModulesAdminRESTController;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Controllers\ModuleSettingsAdminRESTController;
 
@@ -18,6 +19,7 @@ class AdminRESTAPIEndpointManager extends AbstractRESTAPIEndpointManager
         return [
             new ModuleSettingsAdminRESTController(),
             new ModulesAdminRESTController(),
+            new CPTBlockAttributesAdminRESTController(),
         ];
     }
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Response/ResponseKeys.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Response/ResponseKeys.php
@@ -10,4 +10,6 @@ class ResponseKeys
     public const ID = 'id';
     public const SETTINGS = 'settings';
     public const VALUE = 'value';
+    public const BLOCK_NAME = 'blockName';
+    public const BLOCK_ATTRS = 'attrs';
 }


### PR DESCRIPTION
Added the REST endpoint `wp-json/graphql-api/v1/admin/cpt-block-attributes` to visualize and modify the attributes of a block inside a custom post, including:

- Schema Configurators
- Custom Endpoints
- Persisted Queries
- ACLs
- CCLs

Endpoints:

- View all attributes for all blocks in the CPT: `GET wp-json/graphql-api/v1/admin/cpt-block-attributes/%customPostID%/`
- View all attributes for some block in the CPT: `GET wp-json/graphql-api/v1/admin/cpt-block-attributes/%customPostID%/%blockNamespace%/%blockName%/`
- Update all attributes for some block in the CPT: `POST wp-json/graphql-api/v1/admin/cpt-block-attributes/%customPostID%/%blockNamespace%/%blockName%/` and pass param `blockAttributeValues` as an array of `attributeName` => `value`

Example to execute a block attribute update:

```bash
curl -i --insecure \
  --user "admin:{applicationPassword}" \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{"blockAttributeValues": {"mutationScheme": "nested"}}' \
  https://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/cpt-block-attributes/191/graphql-api/schema-config-mutation-scheme
```
