### PR TITLE
Pass array values as JSON-encoded to REST endpoints

### DIFF
--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/ModifyCPTBlockAttributesWebserverRequestTestCaseTrait.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/ModifyCPTBlockAttributesWebserverRequestTestCaseTrait.php
@@ -134,7 +134,7 @@ trait ModifyCPTBlockAttributesWebserverRequestTestCaseTrait
          * In that case, pass an empty string instead of an empty array,
          * then it works!
          */
-        $options['query'][Params::BLOCK_ATTRIBUTE_VALUES] = $value === [] ? '' : $value;
+        $options['query'][Params::JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES] = json_encode($value);
         $response = $client->post(
             $endpointURL,
             $options,

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/ModifyPluginSettingsWebserverRequestTestCaseTrait.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/ModifyPluginSettingsWebserverRequestTestCaseTrait.php
@@ -128,18 +128,9 @@ trait ModifyPluginSettingsWebserverRequestTestCaseTrait
             $this->getModuleID($dataName),
         );
         $options = $this->getRESTEndpointRequestOptions();
-        $options['query'][Params::OPTION_VALUES] = [
-            /**
-             * For some reason, passing an empty array doesn't work,
-             * it doesn't append it to the "query". Eg:
-             *
-             *   ["entries" => []] (for User Meta entries)
-             *
-             * In that case, pass an empty string instead of an empty array,
-             * then it works!
-             */
-            $this->getSettingsKey() => $value === [] ? '' : $value,
-        ];
+        $options['query'][Params::JSON_ENCODED_OPTION_VALUES] = json_encode([
+            $this->getSettingsKey() => $value,
+        ]);
         $response = $client->post(
             $endpointURL,
             $options,

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -8,7 +8,7 @@ class Params
 {
     final public const STATE = 'state';
     final public const MODULE_ID = 'moduleID';
-    final public const OPTION_VALUES = 'optionValues';
+    final public const JSON_ENCODED_OPTION_VALUES = 'jsonEncodedOptionValues';
     final public const CUSTOM_POST_ID = 'customPostID';
     final public const BLOCK_NAMESPACE = 'blockNamespace';
     final public const BLOCK_ID = 'blockID';

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Constants/Params.php
@@ -12,5 +12,5 @@ class Params
     final public const CUSTOM_POST_ID = 'customPostID';
     final public const BLOCK_NAMESPACE = 'blockNamespace';
     final public const BLOCK_ID = 'blockID';
-    final public const BLOCK_ATTRIBUTE_VALUES = 'blockAttributeValues';
+    final public const JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES = 'jsonEncodedBlockAttributeValues';
 }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -446,7 +446,25 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
             $customPostID = (int)$params[Params::CUSTOM_POST_ID];
             $blockNamespace = $params[Params::BLOCK_NAMESPACE];
             $blockID = $params[Params::BLOCK_ID];
-            $blockAttributeValues = json_decode($params[Params::JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES], true);
+            $jsonEncodedBlockAttributeValues = $params[Params::JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES];
+            $blockAttributeValues = json_decode($jsonEncodedBlockAttributeValues, true);
+            if ($blockAttributeValues === null) {
+                return new WP_Error(
+                    '1',
+                    sprintf(
+                        __('Property \'%s\' is not JSON-encoded properly', 'graphql-api-testing'),
+                        Params::JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES,
+                    ),
+                    [
+                        Params::STATE => [
+                            Params::CUSTOM_POST_ID => $customPostID,
+                            Params::BLOCK_NAMESPACE => $blockNamespace,
+                            Params::BLOCK_ID => $blockID,
+                            Params::JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES => $jsonEncodedBlockAttributeValues,
+                        ],
+                    ]
+                );
+            }
             /** @var WP_Post */
             $customPost = $this->getCustomPost($customPostID);
             $blocks = \parse_blocks($customPost->post_content);

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -39,7 +39,7 @@ use function serialize_blocks;
  *   --user "admin:{applicationPassword}" \
  *   -X POST \
  *   -H "Content-Type: application/json" \
- *   -d '{"blockAttributeValues": {"mutationScheme": "nested"}}' \
+ *   -d '{"jsonEncodedBlockAttributeValues": "{\"mutationScheme\":\"nested\"}"}' \
  *   https://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/cpt-block-attributes/191/graphql-api/schema-config-mutation-scheme
  * ```
  */

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/CPTBlockAttributesAdminRESTController.php
@@ -99,18 +99,9 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
                         Params::CUSTOM_POST_ID => $this->getCustomPostIDParamArgs(),
                         Params::BLOCK_NAMESPACE => $this->getBlockNamespaceParamArgs(),
                         Params::BLOCK_ID => $this->getBlockIDParamArgs(),
-                        Params::BLOCK_ATTRIBUTE_VALUES => [
-                            'description' => __('Array of [\'block attribute\' => \'value\']', 'graphql-api-testing'),
-                            'type' => 'object',
-                            // 'properties' => [
-                            //     'attribute'  => [
-                            //         'type' => 'string',
-                            //         'required' => true,
-                            //     ],
-                            //     'value' => [
-                            //         'required' => true,
-                            //     ],
-                            // ],
+                        Params::JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES => [
+                            'description' => __('JSON-encoded array of [\'block attribute\' => \'value\']', 'graphql-api-testing'),
+                            'type' => 'string',
                             'required' => true,
                         ],
                     ],
@@ -455,7 +446,7 @@ class CPTBlockAttributesAdminRESTController extends AbstractAdminRESTController
             $customPostID = (int)$params[Params::CUSTOM_POST_ID];
             $blockNamespace = $params[Params::BLOCK_NAMESPACE];
             $blockID = $params[Params::BLOCK_ID];
-            $blockAttributeValues = $params[Params::BLOCK_ATTRIBUTE_VALUES];
+            $blockAttributeValues = json_decode($params[Params::JSON_ENCODED_BLOCK_ATTRIBUTE_VALUES], true);
             /** @var WP_Post */
             $customPost = $this->getCustomPost($customPostID);
             $blocks = \parse_blocks($customPost->post_content);

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
@@ -31,7 +31,7 @@ use function rest_url;
  *   --user "admin:{applicationPassword}" \
  *   -X POST \
  *   -H "Content-Type: application/json" \
- *   -d '{"optionValues": {"path": "/anotherGraphiQL/"}}' \
+ *   -d '{"jsonEncodedOptionValues": "{\"path\":\"/anotherGraphiQL/\"}"}' \
  *   https://graphql-api.lndo.site/wp-json/graphql-api/v1/admin/module-settings/graphqlapi_graphqlapi_graphiql-for-single-endpoint/
  * ```
  */

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
@@ -110,6 +110,21 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
     ): bool|WP_Error {
         $optionValues = json_decode($jsonEncodedOptionValues, true);
         $moduleID = $request->get_param(Params::MODULE_ID);
+        if ($optionValues === null) {
+            return new WP_Error(
+                '1',
+                sprintf(
+                    __('Property \'%s\' is not JSON-encoded properly', 'graphql-api-testing'),
+                    Params::JSON_ENCODED_OPTION_VALUES,
+                ),
+                [
+                    Params::STATE => [
+                        Params::MODULE_ID => $moduleID,
+                        Params::JSON_ENCODED_OPTION_VALUES => $jsonEncodedOptionValues,
+                    ],
+                ]
+            );
+        }
         $module = $this->getModuleByID($moduleID);
         if ($module === null) {
             /**

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
@@ -80,9 +80,9 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
                     'permission_callback' => $this->checkAdminPermission(...),
                     'args' => [
                         Params::MODULE_ID => $this->getModuleIDParamArgs(),
-                        Params::OPTION_VALUES => [
-                            'description' => __('Array of [\'option\' (also called \'input\' in the settings) => \'value\']. Different modules can receive different options', 'graphql-api-testing'),
-                            'type' => 'object',
+                        Params::JSON_ENCODED_OPTION_VALUES => [
+                            'description' => __('JSON-encoded array of [\'option\' (also called \'input\' in the settings) => \'value\']. Different modules can receive different options', 'graphql-api-testing'),
+                            'type' => 'string',
                             // 'properties' => [
                             //     'option'  => [
                             //         'type' => 'string',
@@ -105,9 +105,10 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
      * Validate the module has the given option
      */
     protected function validateOptions(
-        array $optionValues,
+        string $jsonEncodedOptionValues,
         WP_REST_Request $request,
     ): bool|WP_Error {
+        $optionValues = json_decode($jsonEncodedOptionValues, true);
         $moduleID = $request->get_param(Params::MODULE_ID);
         $module = $this->getModuleByID($moduleID);
         if ($module === null) {
@@ -140,7 +141,7 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
                     ),
                     [
                         Params::MODULE_ID => $moduleID,
-                        Params::OPTION_VALUES => [$option => $value],
+                        Params::JSON_ENCODED_OPTION_VALUES => $jsonEncodedOptionValues,
                     ]
                 );
             }
@@ -257,7 +258,7 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
         try {
             $params = $request->get_params();
             $moduleID = $params[Params::MODULE_ID];
-            $optionValues = $params[Params::OPTION_VALUES];
+            $optionValues = json_decode($params[Params::JSON_ENCODED_OPTION_VALUES], true);
             $module = $this->getModuleByID($moduleID);
 
             // Normalize the values


### PR DESCRIPTION
Because there is no schema associated with some inputs (`optionValues` for Settings, and `blockAttributeValues` for CPT blocks), when passing an array with these values, all values within are treated as `string`, which throws errors with PHP strict typing when expecting an `int` or something else.

To simplify (as a hack!), simply provide the JSON-encoded value in the input, converting it from `object` to `string`