### PR TITLE
Nest multiple query execution operations by wrapping them on `self`

### DIFF
--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -20,10 +20,8 @@ use PoP\GraphQLParser\Spec\Parser\Ast\FragmentBondInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
 use PoP\GraphQLParser\Spec\Parser\Ast\InlineFragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
-use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\StaticHelpers\LocationHelper;
-use SplObjectStorage;
 
 abstract class AbstractRelationalFieldQueryDataComponentProcessor extends AbstractQueryDataComponentProcessor
 {

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -133,10 +133,58 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
         $fragments = $executableDocument->getDocument()->getFragments();
         $fieldFragmentModelsTuples = [];
         $requestedOperations = $executableDocument->getRequestedOperations();
+
         /**
          * Multiple Query Execution: In order to have the fields
-         * of the operations be resolved in the same order as the
-         * operations, wrap them on a "self" field.
+         * of the subsequent operations be resolved in the same
+         * order as the operations (which is necessary for `@export`
+         * to work), then wrap them on a "self" field.
+         *
+         * For instance, in the following GraphQL query:
+         *
+         *     query One {
+         *       user(by: {id: 1}) {
+         *         name @export(as: "_name")
+         *       }
+         *     }
+         *
+         *     query Two {
+         *       firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
+         *     }
+         *
+         *     query Three {
+         *       secondEcho: echo(value: $_ucName)
+         *     }
+         * 
+         * `firstEcho` is normally resolved on the first iteration for `Root`,
+         * that is before `name @export(as: "_name")` is resolved on the
+         * second iteration on `User`.
+         *
+         * For that reason, the fields are wrapped in `self`, and the query
+         * above is converted to:
+         *
+         *     query One {
+         *       user(by: {id: 1}) {
+         *         name @export(as: "_name")
+         *       }
+         *     }
+         *
+         *     query Two {
+         *       self {
+         *         firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
+         *       }
+         *     }
+         *
+         *     query Three {
+         *       self {
+         *         self {
+         *           secondEcho: echo(value: $_ucName)
+         *         }
+         *       }
+         *     }
+         *
+         * Now, `firstEcho` is resolved on the third iteration (second on `Root`),
+         * which is after `name @export(as: "_name")`.
          */
         $requestedOperationsCount = count($requestedOperations);
         for ($operationOrder = 0; $operationOrder < $requestedOperationsCount; $operationOrder++) {

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -146,7 +146,16 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
             $operation = $requestedOperations[$operationOrder];
             $fieldOrFragmentBonds = $operation->getFieldsOrFragmentBonds();
             for ($i = 0; $i < $operationOrder; $i++) {
-
+                $fieldOrFragmentBonds = [
+                    new RelationalField(
+                        'self',
+                        null,
+                        [],
+                        $fieldOrFragmentBonds,
+                        [],
+                        LocationHelper::getNonSpecificLocation()
+                    ),
+                ];
             }
             $operationFieldOrFragmentBonds[$operation] = $fieldOrFragmentBonds;
         }

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -137,10 +137,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
          * Multiple Query Execution: In order to have the fields
          * of the operations be resolved in the same order as the
          * operations, wrap them on a "self" field.
-         *
-         * @var SplObjectStorage<OperationInterface,FieldInterface[]|FragmentBondInterface[]>
          */
-        $operationFieldOrFragmentBonds = new SplObjectStorage();
         $requestedOperationsCount = count($requestedOperations);
         for ($operationOrder = 0; $operationOrder < $requestedOperationsCount; $operationOrder++) {
             $operation = $requestedOperations[$operationOrder];
@@ -157,10 +154,6 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
                     ),
                 ];
             }
-            $operationFieldOrFragmentBonds[$operation] = $fieldOrFragmentBonds;
-        }
-        foreach ($requestedOperations as $operation) {
-            $fieldOrFragmentBonds = $operationFieldOrFragmentBonds[$operation];
             $fieldFragmentModelsTuples = array_merge(
                 $fieldFragmentModelsTuples,
                 $this->getAllFieldFragmentModelsTuplesFromFieldsOrFragmentBonds(

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -130,7 +130,8 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
     ): array {
         $fragments = $executableDocument->getDocument()->getFragments();
         $fieldFragmentModelsTuples = [];
-        foreach ($executableDocument->getRequestedOperations() as $operation) {
+        $requestedOperations = $executableDocument->getRequestedOperations();
+        foreach ($requestedOperations as $operation) {
             $fieldFragmentModelsTuples = array_merge(
                 $fieldFragmentModelsTuples,
                 $this->getAllFieldFragmentModelsTuplesFromFieldsOrFragmentBonds(

--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -153,7 +153,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
          *     query Three {
          *       secondEcho: echo(value: $_ucName)
          *     }
-         * 
+         *
          * `firstEcho` is normally resolved on the first iteration for `Root`,
          * that is before `name @export(as: "_name")` is resolved on the
          * second iteration on `User`.


### PR DESCRIPTION
Multiple Query Execution: In order to have the fields of the subsequent operations be resolved in the same order as the operations (which is necessary for `@export` to work), then wrap them on a `self` field.

For instance, in the following GraphQL query:

```graphql
query One {
  user(by: {id: 1}) {
    name @export(as: "_name")
  }
}

query Two {
  firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
}

query Three {
  secondEcho: echo(value: $_ucName)
}
```

`firstEcho` is normally resolved on the first iteration for `Root`, that is before `name @export(as: "_name")` is resolved on the second iteration on `User`.

For that reason, the fields are wrapped in `self`, and the query above is converted to:

```graphql
query One {
  user(by: {id: 1}) {
    name @export(as: "_name")
  }
}

query Two {
  self {
    firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
  }
}

query Three {
  self {
    self {
      secondEcho: echo(value: $_ucName)
    }
  }
}
```

Now, `firstEcho` is resolved on the third iteration (second on `Root`), which is after `name @export(as: "_name")`.
