### PR TITLE
Remove duplicate setting fields in `$already_loaded_id_fields`

### DIFF
--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -1754,26 +1754,6 @@ class Engine implements EngineInterface
              * thus caching most of the website even for logged-in users
              */
             if ($iterationResolvedIDFieldValues) {
-                /**
-                 * Conditional data fields: Store the loaded IDs/fields in an object,
-                 * to avoid fetching them again in later iterations on the same typeResolver
-                 * To find out if they were loaded, validate against the DBObject,
-                 * to see if it has those properties
-                 */
-                foreach ($idFieldSet as $id => $fieldSet) {
-                    // If it failed to load the item, it will be null
-                    $iterationResolvedFieldValues = $iterationResolvedIDFieldValues[$id] ?? null;
-                    if ($iterationResolvedFieldValues === null) {
-                        continue;
-                    }
-                    /** @var FieldInterface[] */
-                    $resolvedDirectFields = iterator_to_array($iterationResolvedFieldValues);
-                    $already_loaded_id_fields[$relationalTypeOutputKey][$id] = array_merge(
-                        $already_loaded_id_fields[$relationalTypeOutputKey][$id] ?? [],
-                        $resolvedDirectFields
-                    );
-                }
-
                 // If the type is union, then add the type corresponding to each object on its ID
                 $resolvedIDFieldValues = $this->moveEntriesWithIDUnderDBName($iterationResolvedIDFieldValues, $relationalTypeResolver);
                 foreach ($resolvedIDFieldValues as $dbName => $entries) {


### PR DESCRIPTION
Setting direct fields in `$already_loaded_id_fields` was already done here:

```php
// Store the loaded IDs/fields in an object, to avoid fetching them again in later iterations on the same typeResolver
$already_loaded_id_fields[$relationalTypeOutputKey] ??= [];
foreach ($idFieldSet as $id => $fieldSet) {
    $already_loaded_id_fields[$relationalTypeOutputKey][$id] = array_merge(
        $already_loaded_id_fields[$relationalTypeOutputKey][$id] ?? [],
        $fieldSet->fields,
        // Conditional items must also be in direct, so no need to check to cache them
        // iterator_to_array($fieldSet->conditionalFields)
    );
}
```

So this logic was applied twice, and can be safely removed.

The removed logic seemed to have sense only for conditional fields, however after the migration to AST it seems to not be needed anymore:

```php
        // Conditional items must also be in direct, so no need to check to cache them
        // iterator_to_array($fieldSet->conditionalFields)
```

So directly remove