### PR TITLE
Remove $variables from everywhere

### DIFF
--- a/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
+++ b/layers/Engine/packages/cache-control/src/DirectiveResolvers/AbstractCacheControlDirectiveResolver.php
@@ -144,7 +144,6 @@ abstract class AbstractCacheControlDirectiveResolver extends AbstractGlobalDirec
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineDecorator.php
+++ b/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineDecorator.php
@@ -47,7 +47,6 @@ class DirectivePipelineDecorator
                 $pipelineIDFieldSet,
                 $pipelineFieldDataAccessProviders,
                 $resolvedIDFieldValues,
-                $variables,
                 $messages,
                 $engineIterationFeedbackStore,
             )
@@ -64,7 +63,6 @@ class DirectivePipelineDecorator
             $pipelineFieldDataAccessProviders,
             /** @var array<string|int,SplObjectStorage<FieldInterface,mixed>> */
             $resolvedIDFieldValues,
-            $variables,
             $messages,
             $engineIterationFeedbackStore,
         ) = DirectivePipelineUtils::extractArgumentsFromPayload($payload);

--- a/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineDecorator.php
+++ b/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineDecorator.php
@@ -34,7 +34,6 @@ class DirectivePipelineDecorator
         array $unionTypeOutputKeyIDs,
         array $previouslyResolvedIDFieldValues,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineUtils.php
+++ b/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineUtils.php
@@ -56,7 +56,6 @@ class DirectivePipelineUtils
             &$payload['pipelineIDFieldSet'],
             &$payload['pipelineFieldDataAccessProviders'],
             &$payload['resolvedIDFieldValues'],
-            &$payload['variables'],
             &$payload['messages'],
             &$payload['engineIterationFeedbackStore'],
         ];

--- a/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineUtils.php
+++ b/layers/Engine/packages/component-model/src/DirectivePipeline/DirectivePipelineUtils.php
@@ -28,7 +28,6 @@ class DirectivePipelineUtils
         array &$pipelineIDFieldSet,
         array &$pipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array {
@@ -41,7 +40,6 @@ class DirectivePipelineUtils
             'pipelineIDFieldSet' => &$pipelineIDFieldSet,
             'pipelineFieldDataAccessProviders' => &$pipelineFieldDataAccessProviders,
             'resolvedIDFieldValues' => &$resolvedIDFieldValues,
-            'variables' => &$variables,
             'messages' => &$messages,
             'engineIterationFeedbackStore' => &$engineIterationFeedbackStore,
         ];

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1198,7 +1198,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
                     $pipelineIDFieldSet,
                     $pipelineFieldDataAccessProviders,
                     $resolvedIDFieldValues,
-                    $variables,
                     $messages,
                     $engineIterationFeedbackStore,
                 );

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -648,15 +648,9 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     /**
      * @return mixed[]
      */
-    protected function getExpressionsForObject(int|string $id, array $variables, array $messages): array
+    protected function getExpressionsForObject(int|string $id, array $messages): array
     {
-        // Create a custom $variables containing all the properties from $resolvedIDFieldValues for this object
-        // This way, when encountering $propName in a fieldArg in a fieldResolver, it can resolve that value
-        // Otherwise it can't, since the fieldResolver doesn't have access to either $resolvedIDFieldValues
-        return array_merge(
-            $variables,
-            $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT][$id] ?? []
-        );
+        return $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT][$id] ?? [];
     }
 
     /**
@@ -704,10 +698,10 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      *
      * @return mixed[]
      */
-    protected function getExpressionsForObjectAndField(int|string $id, FieldInterface $field, array $variables, array $messages): array
+    protected function getExpressionsForObjectAndField(int|string $id, FieldInterface $field, array $messages): array
     {
         return array_merge(
-            $this->getExpressionsForObject($id, $variables, $messages),
+            $this->getExpressionsForObject($id, $messages),
             $messages[self::MESSAGE_EXPRESSIONS_FOR_OBJECT_AND_FIELD][$id][$field->getOutputKey()] ?? []
         );
     }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -207,12 +207,10 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      * were not provided in the query.
      *
      * @param FieldInterface[] $fields
-     * @param array<string,mixed> $variables
      */
     public function prepareDirective(
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $fields,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
         $directiveData = $this->getDirectiveData(
@@ -1138,7 +1136,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             $pipelineIDFieldSet,
             $pipelineFieldDataAccessProviders,
             $resolvedIDFieldValues,
-            $variables,
             $messages,
             /** @var EngineIterationFeedbackStore */
             $engineIterationFeedbackStore,
@@ -1168,7 +1165,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         //     $idObjects,
         //     $resolvedIDFieldValues,
         //     $previouslyResolvedIDFieldValues,
-        //     $variables,
         //     $messages,
         // );
 
@@ -1277,7 +1273,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
             $pipelineIDFieldSet,
             $pipelineFieldDataAccessProviders,
             $resolvedIDFieldValues,
-            $variables,
             $messages,
             $engineIterationFeedbackStore,
         );

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractMetaDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractMetaDirectiveResolver.php
@@ -39,18 +39,15 @@ abstract class AbstractMetaDirectiveResolver extends AbstractDirectiveResolver i
      * If it has nestedDirectives, extract them and validate them
      *
      * @param FieldInterface[] $fields
-     * @param array<string,mixed> $variables
      */
     public function prepareDirective(
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $fields,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
         parent::prepareDirective(
             $relationalTypeResolver,
             $fields,
-            $variables,
             $engineIterationFeedbackStore,
         );
         if ($this->hasValidationErrors) {
@@ -60,7 +57,6 @@ abstract class AbstractMetaDirectiveResolver extends AbstractDirectiveResolver i
         $nestedDirectivePipelineData = $this->getNestedDirectivePipelineData(
             $relationalTypeResolver,
             $fields,
-            $variables,
             $engineIterationFeedbackStore,
         );
         if ($nestedDirectivePipelineData === null) {
@@ -77,7 +73,6 @@ abstract class AbstractMetaDirectiveResolver extends AbstractDirectiveResolver i
     protected function getNestedDirectivePipelineData(
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $fields,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): ?SplObjectStorage {
         /** @var MetaDirective */
@@ -119,7 +114,6 @@ abstract class AbstractMetaDirectiveResolver extends AbstractDirectiveResolver i
         $nestedDirectivePipelineData = $relationalTypeResolver->resolveDirectivesIntoPipelineData(
             $nestedDirectives,
             $nestedDirectiveFields,
-            $variables,
             $separateEngineIterationFeedbackStore,
         );
         $engineIterationFeedbackStore->incorporate($separateEngineIterationFeedbackStore);

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
@@ -40,7 +40,6 @@ abstract class AbstractValidateConditionDirectiveResolver extends AbstractValida
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $idFieldSet,
         FieldDataAccessProviderInterface $fieldDataAccessProvider,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array {
         if ($this->isValidationSuccessful($relationalTypeResolver)) {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
@@ -60,7 +60,6 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
             $succeedingPipelineIDFieldSet,
             $idObjects,
             $resolvedIDFieldValues,
-            $variables,
             $engineIterationFeedbackStore,
         );
     }
@@ -76,14 +75,12 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
         array &$succeedingPipelineIDFieldSet,
         array $idObjects,
         array &$resolvedIDFieldValues,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
         $failedIDFieldSet = $this->validateIDFieldSet(
             $relationalTypeResolver,
             $idFieldSet,
             $fieldDataAccessProvider,
-            $variables,
             $engineIterationFeedbackStore,
         );
 
@@ -108,7 +105,6 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $idFieldSet,
         FieldDataAccessProviderInterface $fieldDataAccessProvider,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array;
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
@@ -58,7 +58,6 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
             $idFieldSet,
             $fieldDataAccessProvider,
             $succeedingPipelineIDFieldSet,
-            $idObjects,
             $resolvedIDFieldValues,
             $engineIterationFeedbackStore,
         );
@@ -73,7 +72,6 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
         array $idFieldSet,
         FieldDataAccessProviderInterface $fieldDataAccessProvider,
         array &$succeedingPipelineIDFieldSet,
-        array $idObjects,
         array &$resolvedIDFieldValues,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateDirectiveResolver.php
@@ -50,7 +50,6 @@ abstract class AbstractValidateDirectiveResolver extends AbstractGlobalDirective
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
@@ -284,7 +284,6 @@ trait AliasSchemaDirectiveResolverTrait
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
@@ -300,7 +299,6 @@ trait AliasSchemaDirectiveResolverTrait
             $succeedingPipelineIDFieldSet,
             $succeedingPipelineFieldDataAccessProviders,
             $resolvedIDFieldValues,
-            $variables,
             $messages,
             $engineIterationFeedbackStore,
         );

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -40,12 +40,10 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface, Schem
      * in the query.
      *
      * @param FieldInterface[] $fields
-     * @param array<string,mixed> $variables
      */
     public function prepareDirective(
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $fields,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void;
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -146,7 +146,6 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface, Schem
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -75,7 +75,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
             $fieldDataAccessProvider,
             $resolvedIDFieldValues,
             $previouslyResolvedIDFieldValues,
-            $variables,
             $messages,
             $engineIterationFeedbackStore,
         );
@@ -93,7 +92,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
         FieldDataAccessProviderInterface $fieldDataAccessProvider,
         array &$resolvedIDFieldValues,
         array $previouslyResolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
@@ -135,7 +133,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
                 $fieldDataAccessProvider,
                 $resolvedIDFieldValues,
                 $previouslyResolvedIDFieldValues,
-                $variables,
                 $expressions,
                 $engineIterationFeedbackStore,
             );
@@ -183,7 +180,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
         FieldDataAccessProviderInterface $fieldDataAccessProvider,
         array &$resolvedIDFieldValues,
         array $previouslyResolvedIDFieldValues,
-        array &$variables,
         array &$expressions,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
@@ -196,7 +192,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
                 $fieldDataAccessProvider,
                 $resolvedIDFieldValues,
                 $previouslyResolvedIDFieldValues,
-                $variables,
                 $expressions,
                 $engineIterationFeedbackStore,
             );
@@ -215,7 +210,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
         FieldDataAccessProviderInterface $fieldDataAccessProvider,
         array &$resolvedIDFieldValues,
         array $previouslyResolvedIDFieldValues,
-        array &$variables,
         array &$expressions,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -126,7 +126,7 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
                 continue;
             }
 
-            $expressions = $this->getExpressionsForObject($id, $variables, $messages);
+            $expressions = $this->getExpressionsForObject($id, $messages);
             $this->resolveValuesForObject(
                 $relationalTypeResolver,
                 $id,

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -61,7 +61,6 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
@@ -61,7 +61,6 @@ final class SerializeLeafOutputTypeValuesDirectiveResolver extends AbstractGloba
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
@@ -97,7 +97,7 @@ final class SerializeLeafOutputTypeValuesDirectiveResolver extends AbstractGloba
             }
             foreach ($fieldSet->fields as $field) {
                 $separateObjectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
-                $fieldTypeResolver = $targetObjectTypeResolver->getFieldTypeResolver($field, $variables, $separateObjectTypeFieldResolutionFeedbackStore);
+                $fieldTypeResolver = $targetObjectTypeResolver->getFieldTypeResolver($field, $separateObjectTypeFieldResolutionFeedbackStore);
                 $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
                     $separateObjectTypeFieldResolutionFeedbackStore,
                     $targetObjectTypeResolver,
@@ -119,7 +119,7 @@ final class SerializeLeafOutputTypeValuesDirectiveResolver extends AbstractGloba
                 }
 
                 /** @var int */
-                $fieldTypeModifiers = $targetObjectTypeResolver->getFieldTypeModifiers($field, $variables, $separateObjectTypeFieldResolutionFeedbackStore);
+                $fieldTypeModifiers = $targetObjectTypeResolver->getFieldTypeModifiers($field, $separateObjectTypeFieldResolutionFeedbackStore);
                 $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
                     $separateObjectTypeFieldResolutionFeedbackStore,
                     $targetObjectTypeResolver,

--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -1680,12 +1680,6 @@ class Engine implements EngineInterface
         // but we need to avoid fetching those DB objects that were already fetched in a previous iteration
         $already_loaded_id_fields = [];
 
-        /**
-         * The variables initially come from the AppState, but then they
-         * can be modified by directiveResolvers (eg: for @export)
-         */
-        $variables = App::getState('variables');
-
         // Initiate a new $messages interchange across directives
         $messages = [];
 
@@ -1731,7 +1725,6 @@ class Engine implements EngineInterface
                 $combinedUnionTypeOutputKeyIDs,
                 $previouslyResolvedIDFieldValues,
                 $iterationResolvedIDFieldValues,
-                $variables,
                 $messages,
                 $engineIterationFeedbackStore,
             );

--- a/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php
@@ -71,9 +71,8 @@ class DataloadHelperService implements DataloadHelperServiceInterface
         $objectTypeResolver = $relationalTypeResolver;
 
         // If this field doesn't have a typeResolver, show a schema error
-        $variables = [];
         $objectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
-        $subcomponentFieldNodeTypeResolver = $objectTypeResolver->getFieldTypeResolver($field, $variables, $objectTypeFieldResolutionFeedbackStore);
+        $subcomponentFieldNodeTypeResolver = $objectTypeResolver->getFieldTypeResolver($field, $objectTypeFieldResolutionFeedbackStore);
         if ($schemaFeedbackStore !== null) {
             $schemaFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore($objectTypeFieldResolutionFeedbackStore, $objectTypeResolver, [$field]);
         }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1189,7 +1189,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
                 $unionTypeOutputKeyIDs,
                 $previouslyResolvedIDFieldValues,
                 $resolvedIDFieldValues,
-                $variables,
                 $messages,
                 $engineIterationFeedbackStore,
             );

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -185,13 +185,11 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
      *
      * @param Directive[] $directives
      * @param SplObjectStorage<Directive,FieldInterface[]> $directiveFields
-     * @param array<string,mixed> $variables
      * @return SplObjectStorage<DirectiveResolverInterface,FieldInterface[]>
      */
     public function resolveDirectivesIntoPipelineData(
         array $directives,
         SplObjectStorage $directiveFields,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): SplObjectStorage {
         /**
@@ -216,7 +214,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         $directiveResolverFields = $this->validateAndResolveDirectiveResolverToFields(
             $directives,
             $directiveFields,
-            $variables,
             $engineIterationFeedbackStore,
         );
 
@@ -248,13 +245,11 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
     /**
      * @param Directive[] $directives
      * @param SplObjectStorage<Directive,FieldInterface[]> $directiveFields
-     * @param array<string,mixed> $variables
      * @return SplObjectStorage<DirectiveResolverInterface,FieldInterface[]>
      */
     protected function validateAndResolveDirectiveResolverToFields(
         array $directives,
         SplObjectStorage $directiveFields,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): SplObjectStorage {
         /** @var SplObjectStorage<DirectiveResolverInterface,FieldInterface[]> */
@@ -361,7 +356,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             $directiveResolver->prepareDirective(
                 $this,
                 $directiveResolverFields,
-                $variables,
                 $engineIterationFeedbackStore,
             );
 
@@ -569,7 +563,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         array $unionTypeOutputKeyIDs,
         array $previouslyResolvedIDFieldValues,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array {
@@ -643,7 +636,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             $idObjects,
             $previouslyResolvedIDFieldValues,
             $resolvedIDFieldValues,
-            $variables,
             $messages,
             $engineIterationFeedbackStore,
         );
@@ -1000,7 +992,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         array $idObjects,
         array $previouslyResolvedIDFieldValues,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
@@ -1065,7 +1056,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             $directivePipelineData = $this->resolveDirectivesIntoPipelineData(
                 $directives,
                 $directiveFields,
-                $variables,
                 $separateEngineIterationFeedbackStore,
             );
             $engineIterationFeedbackStore->incorporate($separateEngineIterationFeedbackStore);

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -265,7 +265,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
 
     final public function getFieldTypeResolver(
         FieldInterface $field,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): ?ConcreteTypeResolverInterface {
         $executableObjectTypeFieldResolver = $this->getExecutableObjectTypeFieldResolverForField($field);

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -232,7 +232,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
 
     final public function collectFieldValidationWarnings(
         FieldDataAccessorInterface $fieldDataAccessor,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void {
         $executableObjectTypeFieldResolver = $this->getExecutableObjectTypeFieldResolverForField($fieldDataAccessor->getField());
@@ -254,7 +253,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
 
     final public function collectFieldDeprecations(
         FieldDataAccessorInterface $fieldDataAccessor,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void {
         $executableObjectTypeFieldResolver = $this->getExecutableObjectTypeFieldResolverForField($fieldDataAccessor->getField());
@@ -277,7 +275,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
 
     final public function getFieldTypeModifiers(
         FieldInterface $field,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): ?int {
         $executableObjectTypeFieldResolver = $this->getExecutableObjectTypeFieldResolverForField($field);
@@ -290,7 +287,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
 
     final public function getFieldMutationResolver(
         FieldInterface $field,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): ?MutationResolverInterface {
         $executableObjectTypeFieldResolver = $this->getExecutableObjectTypeFieldResolverForField($field);

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
@@ -22,12 +22,10 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface, O
     public function hasObjectTypeFieldResolversForField(FieldInterface $field): bool;
     public function collectFieldValidationWarnings(
         FieldDataAccessorInterface $fieldDataAccessor,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void;
     public function collectFieldDeprecations(
         FieldDataAccessorInterface $fieldDataAccessor,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void;
     public function getFieldTypeResolver(
@@ -36,12 +34,10 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface, O
     ): ?ConcreteTypeResolverInterface;
     public function getFieldTypeModifiers(
         FieldInterface $field,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): ?int;
     public function getFieldMutationResolver(
         FieldInterface $field,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): ?MutationResolverInterface;
     public function isFieldAMutation(FieldInterface|string $fieldOrFieldName): ?bool;

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
@@ -32,7 +32,6 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface, O
     ): void;
     public function getFieldTypeResolver(
         FieldInterface $field,
-        array $variables,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): ?ConcreteTypeResolverInterface;
     public function getFieldTypeModifiers(

--- a/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/RelationalTypeResolverInterface.php
@@ -48,7 +48,6 @@ interface RelationalTypeResolverInterface extends ConcreteTypeResolverInterface
         array $unionTypeOutputKeyIDs,
         array $previouslyResolvedIDFieldValues,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array;
@@ -71,13 +70,11 @@ interface RelationalTypeResolverInterface extends ConcreteTypeResolverInterface
      *
      * @param Directive[] $directives
      * @param SplObjectStorage<Directive,FieldInterface[]> $directiveFields
-     * @param array<string,mixed> $variables
      * @return SplObjectStorage<DirectiveResolverInterface,FieldInterface[]>
      */
     public function resolveDirectivesIntoPipelineData(
         array $directives,
         SplObjectStorage $directiveFields,
-        array &$variables,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): SplObjectStorage;
 

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
@@ -21,7 +21,6 @@ trait FilterIDsSatisfyingConditionDirectiveResolverTrait
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $idObjects,
         array $idFieldSet,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/FilterIDsSatisfyingConditionDirectiveResolverTrait.php
@@ -29,7 +29,7 @@ trait FilterIDsSatisfyingConditionDirectiveResolverTrait
         $idsSatisfyingCondition = [];
         foreach (array_keys($idFieldSet) as $id) {
             // Validate directive args for the object
-            $expressions = $this->getExpressionsForObject($id, $variables, $messages);
+            $expressions = $this->getExpressionsForObject($id, $messages);
             $objectDirectiveArgs = $this->getObjectDirectiveArgs($expressions);
             if ($objectDirectiveArgs['if'] ?? null) {
                 $idsSatisfyingCondition[] = $id;

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
@@ -65,7 +65,7 @@ class IncludeDirectiveResolver extends AbstractGlobalDirectiveResolver
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
         // Check the condition field. If it is satisfied, then keep those fields, otherwise remove them from the $idFieldSet in the upcoming stages of the pipeline
-        $includeFieldSetForIDs = $this->getIDsSatisfyingCondition($relationalTypeResolver, $idObjects, $idFieldSet, $variables, $messages, $engineIterationFeedbackStore);
+        $includeFieldSetForIDs = $this->getIDsSatisfyingCondition($relationalTypeResolver, $idObjects, $idFieldSet, $messages, $engineIterationFeedbackStore);
         $idsToRemove = array_diff(array_keys($idFieldSet), $includeFieldSetForIDs);
         $this->removeFieldSetForIDs($idFieldSet, $idsToRemove, $succeedingPipelineIDFieldSet);
     }

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/IncludeDirectiveResolver.php
@@ -61,7 +61,6 @@ class IncludeDirectiveResolver extends AbstractGlobalDirectiveResolver
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
@@ -65,7 +65,7 @@ class SkipDirectiveResolver extends AbstractGlobalDirectiveResolver
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
         // Check the condition field. If it is satisfied, then skip those fields
-        $idsToRemove = $this->getIDsSatisfyingCondition($relationalTypeResolver, $idObjects, $idFieldSet, $variables, $messages, $engineIterationFeedbackStore);
+        $idsToRemove = $this->getIDsSatisfyingCondition($relationalTypeResolver, $idObjects, $idFieldSet, $messages, $engineIterationFeedbackStore);
         $this->removeFieldSetForIDs($idFieldSet, $idsToRemove, $succeedingPipelineIDFieldSet);
     }
     public function getDirectiveDescription(RelationalTypeResolverInterface $relationalTypeResolver): ?string

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/SkipDirectiveResolver.php
@@ -61,7 +61,6 @@ class SkipDirectiveResolver extends AbstractGlobalDirectiveResolver
         array &$succeedingPipelineIDFieldSet,
         array &$succeedingPipelineFieldDataAccessProviders,
         array &$resolvedIDFieldValues,
-        array &$variables,
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -101,7 +101,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends A
                 $value = array();
                 $type = strtolower($objectTypeResolver->getTypeName());
                 // If it has categories, use it. Otherwise, only use the post type
-                if ($cats = $objectTypeResolver->resolveValue($post, 'categories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($cats = $objectTypeResolver->resolveValue($post, 'categories', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     foreach ($cats as $cat) {
                         $value[] = $type.'-'.$cat;
                     }

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-application/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -68,7 +68,7 @@ class PoP_Application_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends A
         switch ($field->getName()) {
             case 'multilayoutKeys':
                 return array(
-                    $objectTypeResolver->resolveValue($user, 'role', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
+                    $objectTypeResolver->resolveValue($user, 'role', $expressions, $objectTypeFieldResolutionFeedbackStore, $options),
                 );
 
              // Needed for tinyMCE-mention plug-in

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-individualusers-hook.php
@@ -64,7 +64,7 @@ class ObjectTypeFieldResolver_IndividualUsers extends AbstractObjectTypeFieldRes
                 return \PoPCMSSchema\UserMeta\Utils::getUserMeta($objectTypeResolver->getID($user), GD_URE_METAKEY_PROFILE_INDIVIDUALINTERESTS);
 
             case 'hasIndividualDetails':
-                return !empty($objectTypeResolver->resolveValue($user, 'individualinterests', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
+                return !empty($objectTypeResolver->resolveValue($user, 'individualinterests', $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-commonuserroles/library/dataload/fieldprocessors/fieldprocessor-organizationusers-hook.php
@@ -87,9 +87,9 @@ class ObjectTypeFieldResolver_OrganizationUsers extends AbstractObjectTypeFieldR
 
             case 'hasOrganizationDetails':
                 return
-                    $objectTypeResolver->resolveValue($user, 'organizationtypes', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
-                    $objectTypeResolver->resolveValue($user, 'organizationcategories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
-                    $objectTypeResolver->resolveValue($user, 'contactPerson', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
+                    $objectTypeResolver->resolveValue($user, 'organizationtypes', $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
+                    $objectTypeResolver->resolveValue($user, 'organizationcategories', $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
+                    $objectTypeResolver->resolveValue($user, 'contactPerson', $expressions, $objectTypeFieldResolutionFeedbackStore, $options) ||
                     $objectTypeResolver->resolveValue($user, 'contactNumber', $objectTypeFieldResolutionFeedbackStore);
         }
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-contentpostlinks/library/dataload/fieldprocessors/fieldprocessor-posts-hook.php
@@ -164,7 +164,7 @@ class PoP_ContentPostLinks_DataLoad_ObjectTypeFieldResolver_Posts extends Abstra
                 return $linkcategories->getSelectedValue();
 
             case 'hasLinkCategories':
-                if ($objectTypeResolver->resolveValue($post, 'linkcategories', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($objectTypeResolver->resolveValue($post, 'linkcategories', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return true;
                 }
                 return false;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-socialnetwork/pop-library/dataload/fieldprocessors/fieldprocessor-posts-functionalhook.php
@@ -82,7 +82,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNRECOMMENDPOST));
 
             case 'recommendPostCountPlus1':
-                if ($count = $objectTypeResolver->resolveValue($object, 'recommendPostCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($count = $objectTypeResolver->resolveValue($object, 'recommendPostCount', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return $count+1;
                 }
                 return 1;
@@ -98,7 +98,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNDOUPVOTEPOST));
 
             case 'upvotePostCountPlus1':
-                if ($count = $objectTypeResolver->resolveValue($object, 'upvotePostCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($count = $objectTypeResolver->resolveValue($object, 'upvotePostCount', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return $count+1;
                 }
                 return 1;
@@ -114,7 +114,7 @@ class GD_SocialNetwork_DataLoad_ObjectTypeFieldResolver_FunctionalPosts extends 
                 ], RouteUtils::getRouteURL(POP_SOCIALNETWORK_ROUTE_UNDODOWNVOTEPOST));
 
             case 'downvotePostCountPlus1':
-                if ($count = $objectTypeResolver->resolveValue($object, 'downvotePostCount', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($count = $objectTypeResolver->resolveValue($object, 'downvotePostCount', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     return $count+1;
                 }
                 return 1;

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-useravatar/library/dataload/fieldprocessors/fieldprocessor-users-functionalhook.php
@@ -44,10 +44,10 @@ class PoP_UserAvatar_DataLoad_ObjectTypeFieldResolver_FunctionalUsers extends Ab
         \PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
         $user = $object;
-        switch ($field->getName()) {
+        switch ($fieldDataAccessor->getFieldName()) {
             case 'fileUploadPictureURL':
                 // URL which will upload the images for the user
-                return GD_FileUpload_Picture_Utils::getFileuploadUrl($objectTypeResolver->resolveValue($object, 'id', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
+                return GD_FileUpload_Picture_Utils::getFileuploadUrl($objectTypeResolver->resolveValue($object, 'id', $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-usercommunities/library/dataload/fieldprocessors/fieldprocessor-communityusers-hook.php
@@ -67,7 +67,7 @@ class ObjectTypeFieldResolver_CommunityUsers extends AbstractObjectTypeFieldReso
                 return URE_CommunityUtils::getCommunityMembers($objectTypeResolver->getID($user));
 
             case 'hasMembers':
-                return !empty($objectTypeResolver->resolveValue($user, 'members', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
+                return !empty($objectTypeResolver->resolveValue($user, 'members', $expressions, $objectTypeFieldResolutionFeedbackStore, $options));
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -84,7 +84,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
     ): mixed {
         $user = $object;
 
-        switch ($field->getName()) {
+        switch ($fieldDataAccessor->getFieldName()) {
             case 'shortDescription':
                 return gdGetUserShortdescription($objectTypeResolver->getID($user));
 

--- a/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
+++ b/layers/Legacy/Schema/packages/migrate-everythingelse/migrate/plugins/pop-userplatform/library/dataload/fieldprocessors/fieldprocessor-users-hook.php
@@ -98,7 +98,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
             case 'contact':
                 $value = array();
                 // This one is a quasi copy/paste from the typeResolver
-                if ($user_url = $objectTypeResolver->resolveValue($user, 'websiteURL', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($user_url = $objectTypeResolver->resolveValue($user, 'websiteURL', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Website', 'pop-coreprocessors'),
                         'url' => maybeAddHttp($user_url),
@@ -107,8 +107,8 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'fontawesome' => 'fa-home',
                     );
                 }
-                if ($objectTypeResolver->resolveValue($user, 'displayEmail', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
-                    if ($email = $objectTypeResolver->resolveValue($user, 'email', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($objectTypeResolver->resolveValue($user, 'displayEmail', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                    if ($email = $objectTypeResolver->resolveValue($user, 'email', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                         $value[] = array(
                             'fontawesome' => 'fa-envelope',
                             'tooltip' => TranslationAPIFacade::getInstance()->__('Email', 'pop-coreprocessors'),
@@ -117,7 +117,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         );
                     }
                 }
-                // if ($blog = $objectTypeResolver->resolveValue($user, 'blog', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                // if ($blog = $objectTypeResolver->resolveValue($user, 'blog', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
 
                 //     $value[] = array(
                 //         'tooltip' => TranslationAPIFacade::getInstance()->__('Blog', 'poptheme-wassup'),
@@ -127,7 +127,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                 //         'fontawesome' => 'fa-pencil',
                 //     );
                 // }
-                if ($facebook = $objectTypeResolver->resolveValue($user, 'facebook', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($facebook = $objectTypeResolver->resolveValue($user, 'facebook', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Facebook', 'poptheme-wassup'),
                         'fontawesome' => 'fa-facebook',
@@ -136,7 +136,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'target' => '_blank'
                     );
                 }
-                if ($twitter = $objectTypeResolver->resolveValue($user, 'twitter', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($twitter = $objectTypeResolver->resolveValue($user, 'twitter', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Twitter', 'poptheme-wassup'),
                         'fontawesome' => 'fa-twitter',
@@ -145,7 +145,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'target' => '_blank'
                     );
                 }
-                if ($linkedin = $objectTypeResolver->resolveValue($user, 'linkedin', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($linkedin = $objectTypeResolver->resolveValue($user, 'linkedin', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('LinkedIn', 'poptheme-wassup'),
                         'url' => maybeAddHttp($linkedin),
@@ -154,7 +154,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'fontawesome' => 'fa-linkedin'
                     );
                 }
-                if ($youtube = $objectTypeResolver->resolveValue($user, 'youtube', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($youtube = $objectTypeResolver->resolveValue($user, 'youtube', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Youtube', 'poptheme-wassup'),
                         'url' => maybeAddHttp($youtube),
@@ -163,7 +163,7 @@ class GD_UserPlatform_DataLoad_ObjectTypeFieldResolver_Users extends AbstractObj
                         'fontawesome' => 'fa-youtube',
                     );
                 }
-                if ($instagram = $objectTypeResolver->resolveValue($user, 'instagram', $variables, $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
+                if ($instagram = $objectTypeResolver->resolveValue($user, 'instagram', $expressions, $objectTypeFieldResolutionFeedbackStore, $options)) {
                     $value[] = array(
                         'tooltip' => TranslationAPIFacade::getInstance()->__('Instagram', 'poptheme-wassup'),
                         'url' => maybeAddHttp($instagram),


### PR DESCRIPTION
It's not needed anymore in `->resolveDirective`, since they are now accessed via `App::getState('document-dynamic-variables');`