### PR TITLE
Split `AFTER_RESOLVE_BEFORE_SERIALIZE`

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -731,7 +731,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      */
     public function getPipelinePosition(): string
     {
-        return PipelinePositions::AFTER_RESOLVE_BEFORE_SERIALIZE;
+        return PipelinePositions::AFTER_RESOLVE;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractValidateConditionDirectiveResolver.php
@@ -27,7 +27,7 @@ abstract class AbstractValidateConditionDirectiveResolver extends AbstractValida
     public function getPipelinePosition(): string
     {
         if ($this->isValidatingDirective()) {
-            return PipelinePositions::AFTER_RESOLVE_BEFORE_SERIALIZE;
+            return PipelinePositions::AFTER_RESOLVE;
         }
         return PipelinePositions::BEFORE_RESOLVE;
     }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -40,7 +40,7 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
      */
     public function getPipelinePosition(): string
     {
-        return PipelinePositions::AFTER_RESOLVE_BEFORE_SERIALIZE;
+        return PipelinePositions::AFTER_RESOLVE;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -205,7 +205,8 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
         $directiveResolversByPosition = $fieldDirectivesByPosition = $directiveFieldsByPosition = [
             PipelinePositions::BEGINNING => [],
             PipelinePositions::BEFORE_RESOLVE => [],
-            PipelinePositions::AFTER_RESOLVE_BEFORE_SERIALIZE => [],
+            PipelinePositions::AFTER_RESOLVE => [],
+            PipelinePositions::BEFORE_RESOLVE => [],
             PipelinePositions::AFTER_SERIALIZE => [],
             PipelinePositions::END => [],
         ];

--- a/layers/Engine/packages/component-model/src/TypeResolvers/PipelinePositions.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/PipelinePositions.php
@@ -32,7 +32,8 @@ class PipelinePositions
 {
     public final const BEGINNING = 'beginning';
     public final const BEFORE_RESOLVE = 'before-resolve';
-    public final const AFTER_RESOLVE_BEFORE_SERIALIZE = 'after-resolve-before-serialize';
+    public final const AFTER_RESOLVE = 'after-resolve';
+    public final const BEFORE_SERIALIZE = 'before-serialize';
     public final const AFTER_SERIALIZE = 'after-serialize';
     public final const END = 'end';
 }


### PR DESCRIPTION
So that we can always specify `@export` to be applied after all other directives, such as `@titleCase`:

```graphql
query One {
    id @upperCase
    again: id @titleCase
        @export(as: "_props", affectAdditionalFieldsUnderPos: [1])
}

query Two {
    mirror: echo(value: $_props)
}

query __ALL { id }
```

Producing:

```json
{
    "data": {
        "id": "ROOT",
        "again": "Root",
        "mirror": {
            "id": "ROOT",
            "again": "Root"
        }
    }
}
```

Otherwise, `again` in `mirror` would have value `root`, not `Root`, i.e. without `@titleCase` applied