### PR TITLE
Multiple Query Execution: Add multiple `self` fields based on maximum depth of all previous operations

### DIFF
--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -151,7 +151,10 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
          * order as the operations (which is necessary for `@export`
          * to work), then wrap them on a "self" field.
          */
-        $operationFieldOrFragmentBonds = $this->getQueryASTTransformationService()->prepareOperationFieldAndFragmentBondsForMultipleQueryExecution($requestedOperations);
+        $operationFieldOrFragmentBonds = $this->getQueryASTTransformationService()->prepareOperationFieldAndFragmentBondsForMultipleQueryExecution(
+            $requestedOperations,
+            $fragments,
+        );
         /** @var OperationInterface $operation */
         foreach ($operationFieldOrFragmentBonds as $operation) {
             $fieldOrFragmentBonds = $operationFieldOrFragmentBonds[$operation];

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -61,6 +61,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
          * Wrap subsequent queries "field and fragment bonds" under
          * the required multiple levels of `self`
          */
+        $accumulatedMaximumFieldDepth = 0;
         for ($operationOrder = 0; $operationOrder < $operationsCount; $operationOrder++) {
             $operation = $operations[$operationOrder];
             $fieldOrFragmentBonds = $operation->getFieldsOrFragmentBonds();
@@ -139,7 +140,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
              *   }
              *   ```
              */
-            for ($i = 0; $i < $operationOrder; $i++) {
+            for ($level = 0; $level < $accumulatedMaximumFieldDepth; $level++) {
                 /**
                  * Use an alias to both help visualize which is the field (optional),
                  * and get its cached instance (mandatory!)
@@ -148,7 +149,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
                     '_%s_op%s_level%s_',
                     'dynamicSelf',
                     $operationOrder,
-                    $i
+                    $level
                 );
                 if (!isset($this->fieldInstanceContainer[$alias])) {
                     $this->fieldInstanceContainer[$alias] = new RelationalField(

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -152,7 +152,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
                     '_%s_op%s_level%s_',
                     'dynamicSelf',
                     $operationOrder,
-                    $level
+                    $accumulatedMaximumFieldDepth - $level
                 );
                 if (!isset($this->fieldInstanceContainer[$alias])) {
                     $this->fieldInstanceContainer[$alias] = new RelationalField(

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -59,7 +59,10 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
 
         /**
          * Wrap subsequent queries "field and fragment bonds" under
-         * the required multiple levels of `self`
+         * the required multiple levels of `self`.
+         *
+         * Because it starts in `0`, the first operation will not
+         * receive any `self`
          */
         $accumulatedMaximumFieldDepth = 0;
         for ($operationOrder = 0; $operationOrder < $operationsCount; $operationOrder++) {

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -166,7 +166,17 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
                 ];
             }
             $operationFieldOrFragmentBonds[$operation] = $fieldOrFragmentBonds;
+
+            /**
+             * Add the maximum depth of this operation to the counter
+             */
+            $accumulatedMaximumFieldDepth += $this->getOperationMaximumFieldDepth($operation);
         }
         return $operationFieldOrFragmentBonds;
+    }
+
+    public function getOperationMaximumFieldDepth(OperationInterface $operation): int
+    {
+        return 0;
     }
 }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoPAPI\API\QueryResolution;
 
 use function max;
+
 use PoP\ComponentModel\App;
 use PoP\GraphQLParser\Module as GraphQLParserModule;
 use PoP\GraphQLParser\ModuleConfiguration as GraphQLParserModuleConfiguration;
@@ -14,7 +15,6 @@ use PoP\GraphQLParser\Spec\Parser\Ast\FragmentBondInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
 use PoP\GraphQLParser\Spec\Parser\Ast\InlineFragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
-
 use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\StaticHelpers\LocationHelper;
@@ -43,7 +43,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         /** @var SplObjectStorage<OperationInterface,array<FieldInterface|FragmentBondInterface>> */
         $operationFieldOrFragmentBonds = new SplObjectStorage();
         $operationsCount = count($operations);
-        
+
         /**
          * If there's only 1 operation, then return its contents directly
          * (no need to calculate anything!).
@@ -220,7 +220,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         if ($fieldOrFragmentBond instanceof RelationalField) {
             /** @var RelationalField */
             $relationalField = $fieldOrFragmentBond;
-            
+
             /**
              * Also handle the boundaries: an empty relational field
              */
@@ -235,7 +235,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
             );
             return max($depths);
         }
-        
+
         /**
          * Both Fragment References and Inline Fragments also do +1
          * because the engine will add an extra conditional module
@@ -246,7 +246,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         if ($fieldOrFragmentBond instanceof InlineFragment) {
             /** @var InlineFragment */
             $inlineFragment = $fieldOrFragmentBond;
-            
+
             /**
              * Also handle the boundaries: an empty inline fragment
              */
@@ -268,7 +268,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         if ($fragment === null) {
             return $accumulator;
         }
-            
+
         /**
          * Also handle the boundaries: an empty fragment
          */

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -254,7 +254,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
      */
     protected function getFragment(string $name, array $fragments): ?Fragment
     {
-        foreach ($this->fragments as $fragment) {
+        foreach ($fragments as $fragment) {
             if ($fragment->getName() === $name) {
                 return $fragment;
             }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -219,11 +219,18 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
             return max($depths);
         }
         
+        /**
+         * Both Fragment References and Inline Fragments also do +1
+         * because the engine will add an extra conditional module
+         * to calculate these (with alias "_..._isTypeOrImplementsAll_..._").
+         *
+         * @see layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+         */
         if ($fieldOrFragmentBond instanceof InlineFragment) {
             /** @var InlineFragment */
             $inlineFragment = $fieldOrFragmentBond;
             $depths = array_map(
-                fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth($accumulator, $fieldOrFragmentBond, $fragments),
+                fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth(1 + $accumulator, $fieldOrFragmentBond, $fragments),
                 $inlineFragment->getFieldsOrFragmentBonds()
             );
             return max($depths);
@@ -236,7 +243,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
             return $accumulator;
         }
         $depths = array_map(
-            fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth($accumulator, $fieldOrFragmentBond, $fragments),
+            fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth(1 + $accumulator, $fieldOrFragmentBond, $fragments),
             $fragment->getFieldsOrFragmentBonds()
         );
         return max($depths);

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -192,9 +192,17 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
      */
     public function getOperationMaximumFieldDepth(OperationInterface $operation, array $fragments): int
     {
+        /**
+         * Also handle the boundaries: an empty operation
+         */
+        $fieldsOrFragmentBonds = $operation->getFieldsOrFragmentBonds();
+        if ($fieldsOrFragmentBonds === []) {
+            return 0;
+        }
+
         $depths = array_map(
             fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth(1, $fieldOrFragmentBond, $fragments),
-            $operation->getFieldsOrFragmentBonds()
+            $fieldsOrFragmentBonds
         );
         return max($depths);
     }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -14,6 +14,8 @@ use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\StaticHelpers\LocationHelper;
 use SplObjectStorage;
 
+use function max;
+
 class QueryASTTransformationService implements QueryASTTransformationServiceInterface
 {
     /**
@@ -179,6 +181,15 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
     }
 
     public function getOperationMaximumFieldDepth(OperationInterface $operation): int
+    {
+        $depths = array_map(
+            $this->getFieldOrFragmentBondDepth(...),
+            $operation->getFieldsOrFragmentBonds()
+        );
+        return max($depths);
+    }
+
+    protected function getFieldOrFragmentBondDepth(FieldInterface|FragmentBondInterface $fieldOrFragmentBond): int
     {
         return 0;
     }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -220,9 +220,18 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         if ($fieldOrFragmentBond instanceof RelationalField) {
             /** @var RelationalField */
             $relationalField = $fieldOrFragmentBond;
+            
+            /**
+             * Also handle the boundaries: an empty relational field
+             */
+            $fieldsOrFragmentBonds = $relationalField->getFieldsOrFragmentBonds();
+            if ($fieldsOrFragmentBonds === []) {
+                return $accumulator;
+            }
+
             $depths = array_map(
                 fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth(1 + $accumulator, $fieldOrFragmentBond, $fragments),
-                $relationalField->getFieldsOrFragmentBonds()
+                $fieldsOrFragmentBonds
             );
             return max($depths);
         }
@@ -237,9 +246,18 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         if ($fieldOrFragmentBond instanceof InlineFragment) {
             /** @var InlineFragment */
             $inlineFragment = $fieldOrFragmentBond;
+            
+            /**
+             * Also handle the boundaries: an empty inline fragment
+             */
+            $fieldsOrFragmentBonds = $inlineFragment->getFieldsOrFragmentBonds();
+            if ($fieldsOrFragmentBonds === []) {
+                return $accumulator;
+            }
+
             $depths = array_map(
                 fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth(1 + $accumulator, $fieldOrFragmentBond, $fragments),
-                $inlineFragment->getFieldsOrFragmentBonds()
+                $fieldsOrFragmentBonds
             );
             return max($depths);
         }
@@ -250,9 +268,18 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         if ($fragment === null) {
             return $accumulator;
         }
+            
+        /**
+         * Also handle the boundaries: an empty fragment
+         */
+        $fieldsOrFragmentBonds = $fragment->getFieldsOrFragmentBonds();
+        if ($fieldsOrFragmentBonds === []) {
+            return $accumulator;
+        }
+
         $depths = array_map(
             fn (FieldInterface|FragmentBondInterface $fieldOrFragmentBond) => $this->getFieldOrFragmentBondDepth(1 + $accumulator, $fieldOrFragmentBond, $fragments),
-            $fragment->getFieldsOrFragmentBonds()
+            $fieldsOrFragmentBonds
         );
         return max($depths);
     }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -66,7 +66,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
              *       field {
              *         field {
              *           field {
-             *             maximumDepthField: field
+             *             firstQueryMaximumDepthField: field
              *           }
              *         }
              *       }
@@ -74,7 +74,11 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
              *   }
              *
              *   query Two {
-             *     field # <= Must be resolved after "maximumDepthField"
+             *     secondQueryField: field # <= Must be resolved after "firstQueryMaximumDepthField"
+             *   }
+             *
+             *   query Three {
+             *     field # <= Must be resolved after "secondQueryField"
              *   }
              *   ```
              *
@@ -86,7 +90,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
              *       field {
              *         field {
              *           field {
-             *             maximumDepthField: field
+             *             firstQueryMaximumDepthField: field
              *           }
              *         }
              *       }
@@ -99,7 +103,23 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
              *         self {
              *           self {
              *             self {
-             *               field # <= Must be resolved after "maximumDepthField"
+             *               secondQueryField: field # <= Must be resolved after "firstQueryMaximumDepthField"
+             *             }
+             *           }
+             *         }
+             *       }
+             *     }
+             *   }
+             *
+             *   query Three {
+             *     self {
+             *       self {
+             *         self {
+             *           self {
+             *             self {
+             *               self {
+             *                 field # <= Must be resolved after "secondQueryField"
+             *               }
              *             }
              *           }
              *         }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoPAPI\API\QueryResolution;
 
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
+use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentBondInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use SplObjectStorage;
@@ -72,9 +73,13 @@ interface QueryASTTransformationServiceInterface
      * all together.
      *
      * @param OperationInterface[] $operations
+     * @param Fragment[] $fragments
      * @return SplObjectStorage<OperationInterface,array<FieldInterface|FragmentBondInterface>>
      */
-    public function prepareOperationFieldAndFragmentBondsForMultipleQueryExecution(array $operations): SplObjectStorage;
+    public function prepareOperationFieldAndFragmentBondsForMultipleQueryExecution(
+        array $operations,
+        array $fragments,
+    ): SplObjectStorage;
     /**
      * Calculate the maximum field depth in an operation.
      *
@@ -91,6 +96,8 @@ interface QueryASTTransformationServiceInterface
      *   }
      * }
      * ```
+     *
+     * @param Fragment[] $fragments
      */
-    public function getOperationMaximumFieldDepth(OperationInterface $operation): int;
+    public function getOperationMaximumFieldDepth(OperationInterface $operation, array $fragments): int;
 }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
@@ -49,14 +49,18 @@ interface QueryASTTransformationServiceInterface
      *
      *     query Two {
      *       self {
-     *         firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
+     *         self {
+     *           firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
+     *         }
      *       }
      *     }
      *
      *     query Three {
      *       self {
      *         self {
-     *           secondEcho: echo(value: $_ucName)
+     *           self {
+     *             secondEcho: echo(value: $_ucName)
+     *           }
      *         }
      *       }
      *     }
@@ -80,6 +84,7 @@ interface QueryASTTransformationServiceInterface
         array $operations,
         array $fragments,
     ): SplObjectStorage;
+
     /**
      * Calculate the maximum field depth in an operation.
      *

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
@@ -70,6 +70,81 @@ interface QueryASTTransformationServiceInterface
      *
      * --------------------------------------------------------------------
      *
+     * Each level needs to add as many "self" as the sum of the
+     * maximum field depth in all previous queries, so that
+     * the 1st field in the subsequent operation is executed
+     * after the deepest field in the previous query:
+     *
+     *   ```
+     *   query One {
+     *     field {
+     *       field {
+     *         field {
+     *           field {
+     *             firstQueryMaximumDepthField: field
+     *           }
+     *         }
+     *       }
+     *     }
+     *   }
+     *
+     *   query Two {
+     *     secondQueryField: field # <= Must be resolved after "firstQueryMaximumDepthField"
+     *   }
+     *
+     *   query Three {
+     *     field # <= Must be resolved after "secondQueryField"
+     *   }
+     *   ```
+     *
+     * This will then become:
+     *
+     *   ```
+     *   query One {
+     *     field {
+     *       field {
+     *         field {
+     *           field {
+     *             firstQueryMaximumDepthField: field
+     *           }
+     *         }
+     *       }
+     *     }
+     *   }
+     *
+     *   query Two {
+     *     self {
+     *       self {
+     *         self {
+     *           self {
+     *             self {
+     *               secondQueryField: field # <= Must be resolved after "firstQueryMaximumDepthField"
+     *             }
+     *           }
+     *         }
+     *       }
+     *     }
+     *   }
+     *
+     *   query Three {
+     *     self {
+     *       self {
+     *         self {
+     *           self {
+     *             self {
+     *               self {
+     *                 field # <= Must be resolved after "secondQueryField"
+     *               }
+     *             }
+     *           }
+     *         }
+     *       }
+     *     }
+     *   }
+     *   ```
+     *
+     * --------------------------------------------------------------------
+     *
      * If Multiple Query Execution is disabled, then there's no need
      * to wrap the fields under "self".
      *

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
@@ -75,4 +75,22 @@ interface QueryASTTransformationServiceInterface
      * @return SplObjectStorage<OperationInterface,array<FieldInterface|FragmentBondInterface>>
      */
     public function prepareOperationFieldAndFragmentBondsForMultipleQueryExecution(array $operations): SplObjectStorage;
+    /**
+     * Calculate the maximum field depth in an operation.
+     *
+     * Eg: this query has maximum field depth 4:
+     *
+     * ```
+     * {
+     *   level1 {
+     *     level2 {
+     *       level3 {
+     *         level4 # <= maximum depth field
+     *       }
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    public function getOperationMaximumFieldDepth(OperationInterface $operation): int;
 }

--- a/layers/API/packages/api/tests/QueryResolution/AbstractMultipleQueryExecutionDisabledQueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/AbstractMultipleQueryExecutionDisabledQueryASTTransformationServiceTest.php
@@ -19,7 +19,7 @@ use PoP\GraphQLParser\StaticHelpers\LocationHelper;
 use PoP\Root\AbstractTestCase;
 use SplObjectStorage;
 
-abstract class AbstractQueryASTTransformationServiceTest extends AbstractTestCase
+abstract class AbstractMultipleQueryExecutionDisabledQueryASTTransformationServiceTest extends AbstractTestCase
 {
     /**
      * @return array<string, mixed> [key]: Module class, [value]: Configuration
@@ -38,7 +38,7 @@ abstract class AbstractQueryASTTransformationServiceTest extends AbstractTestCas
         return $this->getService(QueryASTTransformationServiceInterface::class);
     }
 
-    public function testQueryASTTransformationService()
+    public function testPrepareOperationFieldAndFragmentBondsForMultipleQueryExecution()
     {
         /**
          * This is the AST for this GraphQL query:
@@ -47,6 +47,7 @@ abstract class AbstractQueryASTTransformationServiceTest extends AbstractTestCas
          *   query One {
          *     film(id: 1) {
          *       title
+         *     }
          *   }
          *
          *   query Two {

--- a/layers/API/packages/api/tests/QueryResolution/AbstractMultipleQueryExecutionDisabledQueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/AbstractMultipleQueryExecutionDisabledQueryASTTransformationServiceTest.php
@@ -241,7 +241,7 @@ abstract class AbstractMultipleQueryExecutionDisabledQueryASTTransformationServi
             ];
         }
 
-        $operationFieldAndFragmentBonds = $this->getQueryASTTransformationService()->prepareOperationFieldAndFragmentBondsForMultipleQueryExecution($operations);
+        $operationFieldAndFragmentBonds = $this->getQueryASTTransformationService()->prepareOperationFieldAndFragmentBondsForMultipleQueryExecution($operations, []);
 
         /**
          * Doing `assertEquals` on SplObjectStorage doesn't work!

--- a/layers/API/packages/api/tests/QueryResolution/AbstractQueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/AbstractQueryASTTransformationServiceTest.php
@@ -196,7 +196,7 @@ abstract class AbstractQueryASTTransformationServiceTest extends AbstractTestCas
                     [
                         new RelationalField(
                             'self',
-                            '_dynamicSelf_op2_level0_',
+                            '_dynamicSelf_op2_level2_',
                             [],
                             [
                                 $leafField31,

--- a/layers/API/packages/api/tests/QueryResolution/AbstractQueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/AbstractQueryASTTransformationServiceTest.php
@@ -179,10 +179,19 @@ abstract class AbstractQueryASTTransformationServiceTest extends AbstractTestCas
             $expectedOperationFieldAndFragmentBonds[$queryTwoOperation] = [
                 new RelationalField(
                     'self',
-                    '_dynamicSelf_op1_level0_',
+                    '_dynamicSelf_op1_level1_',
                     [],
                     [
-                        $relationalField2,
+                        new RelationalField(
+                            'self',
+                            '_dynamicSelf_op1_level2_',
+                            [],
+                            [
+                                $relationalField2,
+                            ],
+                            [],
+                            LocationHelper::getNonSpecificLocation()
+                        ),
                     ],
                     [],
                     LocationHelper::getNonSpecificLocation()
@@ -199,9 +208,27 @@ abstract class AbstractQueryASTTransformationServiceTest extends AbstractTestCas
                             '_dynamicSelf_op2_level2_',
                             [],
                             [
-                                $leafField31,
-                                $inlineFragment3,
-                                $relationalField3,
+                                new RelationalField(
+                                    'self',
+                                    '_dynamicSelf_op2_level3_',
+                                    [],
+                                    [
+                                        new RelationalField(
+                                            'self',
+                                            '_dynamicSelf_op2_level4_',
+                                            [],
+                                            [
+                                                $leafField31,
+                                                $inlineFragment3,
+                                                $relationalField3,
+                                            ],
+                                            [],
+                                            LocationHelper::getNonSpecificLocation()
+                                        ),
+                                    ],
+                                    [],
+                                    LocationHelper::getNonSpecificLocation()
+                                ),
                             ],
                             [],
                             LocationHelper::getNonSpecificLocation()

--- a/layers/API/packages/api/tests/QueryResolution/MultipleQueryExecutionDisabledQueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/MultipleQueryExecutionDisabledQueryASTTransformationServiceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoPAPI\API\QueryResolution;
 
-class MultipleQueryExecutionDisabledQueryASTTransformationServiceTest extends AbstractQueryASTTransformationServiceTest
+class MultipleQueryExecutionDisabledQueryASTTransformationServiceTest extends AbstractMultipleQueryExecutionDisabledQueryASTTransformationServiceTest
 {
     protected static function enabled(): bool
     {

--- a/layers/API/packages/api/tests/QueryResolution/MultipleQueryExecutionEnabledQueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/MultipleQueryExecutionEnabledQueryASTTransformationServiceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PoPAPI\API\QueryResolution;
 
-class MultipleQueryExecutionEnabledQueryASTTransformationServiceTest extends AbstractQueryASTTransformationServiceTest
+class MultipleQueryExecutionEnabledQueryASTTransformationServiceTest extends AbstractMultipleQueryExecutionDisabledQueryASTTransformationServiceTest
 {
     protected static function enabled(): bool
     {

--- a/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
@@ -23,6 +23,30 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
     }
 
     /**
+     * This is the AST for this GraphQL query (it's a not valid one!):
+     *
+     *   ```
+     *   {}
+     *   ```
+     */
+    public function testEmptyOperationMaximumFieldDepth()
+    {
+        $operation = new QueryOperation(
+            '',
+            [],
+            [],
+            [
+            ],
+            new Location(2, 15)
+        );
+        $operationMaximumFieldDepth = $this->getQueryASTTransformationService()->getOperationMaximumFieldDepth($operation, []);
+        $this->assertEquals(
+            0,
+            $operationMaximumFieldDepth
+        );
+    }
+
+    /**
      * This is the AST for this GraphQL query:
      *
      *   ```

--- a/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
@@ -27,6 +27,34 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
      *
      *   ```
      *   query {
+     *     id # level 1
+     *   }
+     *   ```
+     */
+    public function testOperationWithLeafFieldMaximumFieldDepth()
+    {
+        $leafField = new LeafField('id', null, [], [], new Location(3, 17));
+        $operation = new QueryOperation(
+            '',
+            [],
+            [],
+            [
+                $leafField,
+            ],
+            new Location(2, 15)
+        );
+        $operationMaximumFieldDepth = $this->getQueryASTTransformationService()->getOperationMaximumFieldDepth($operation, []);
+        $this->assertEquals(
+            1,
+            $operationMaximumFieldDepth
+        );
+    }
+
+    /**
+     * This is the AST for this GraphQL query:
+     *
+     *   ```
+     *   query {
      *     film(id: 1) { # level 1
      *       title # level 2
      *       director { # level 2
@@ -39,7 +67,7 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
      *   }
      *   ```
      */
-    public function testOperationMaximumFieldDepth()
+    public function testOperationWithRelationalFieldMaximumFieldDepth()
     {
         $leafField2 = new LeafField('name', null, [], [], new Location(6, 23));
         $relationalField2 = new RelationalField(

--- a/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
@@ -122,7 +122,7 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
      *   }
      *   ```
      */
-    public function testOperationMaximumFieldDepthWithFragment()
+    public function testOperationWithFragmentMaximumFieldDepth()
     {
         $leafField2 = new LeafField('name', null, [], [], new Location(6, 23));
         $relationalField2 = new RelationalField(

--- a/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
@@ -89,7 +89,7 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
             new Location(8, 19)
         );
 
-        $operationMaximumFieldDepth = $this->getQueryASTTransformationService()->getOperationMaximumFieldDepth($operation);
+        $operationMaximumFieldDepth = $this->getQueryASTTransformationService()->getOperationMaximumFieldDepth($operation, []);
         $this->assertEquals(
             3,
             $operationMaximumFieldDepth

--- a/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPAPI\API\QueryResolution;
+
+use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
+use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
+use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
+use PoP\GraphQLParser\Spec\Parser\Ast\QueryOperation;
+use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
+use PoP\GraphQLParser\Spec\Parser\Location;
+use PoP\Root\AbstractTestCase;
+
+class QueryASTTransformationServiceTest extends AbstractTestCase
+{
+    protected function getQueryASTTransformationService(): QueryASTTransformationServiceInterface
+    {
+        return $this->getService(QueryASTTransformationServiceInterface::class);
+    }
+
+    public function testOperationMaximumFieldDepth()
+    {
+        /**
+         * This is the AST for this GraphQL query:
+         *
+         *   ```
+         *   query {
+         *     film(id: 1) { # level 1
+         *       title # level 2
+         *       director { # level 2
+         *         name # level 3 # <= maximum depth!
+         *       }
+         *     }
+         *     post(id: 2) { # level 1
+         *       title # level 2
+         *     }
+         *   }
+         *   ```
+         */
+        $leafField2 = new LeafField('name', null, [], [], new Location(6, 23));
+        $relationalField2 = new RelationalField(
+            'director',
+            null,
+            [],
+            [
+                $leafField2,
+            ],
+            [],
+            new Location(5, 21)
+        );
+        $leafField1 = new LeafField('title', null, [], [], new Location(4, 21));
+        $argument1 = new Argument('id', new Literal(1, new Location(3, 26)), new Location(3, 22));
+        $relationalField1 = new RelationalField(
+            'film',
+            null,
+            [
+                $argument1,
+            ],
+            [
+                $leafField1,
+                $relationalField2,
+            ],
+            [],
+            new Location(3, 17)
+        );
+        $argument2 = new Argument('id', new Literal(2, new Location(9, 26)), new Location(9, 22));
+        $leafField3 = new LeafField('title', null, [], [], new Location(10, 21));
+        $relationalField3 = new RelationalField(
+            'post',
+            null,
+            [
+                $argument2,
+            ],
+            [
+                $leafField3,
+            ],
+            [],
+            new Location(9, 17)
+        );
+        $operation = new QueryOperation(
+            '',
+            [],
+            [],
+            [
+                $relationalField1,
+                $relationalField3,
+            ],
+            new Location(8, 19)
+        );
+
+        $operationMaximumFieldDepth = $this->getQueryASTTransformationService()->getOperationMaximumFieldDepth($operation);
+        $this->assertEquals(
+            3,
+            $operationMaximumFieldDepth
+        );
+    }
+}

--- a/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
+++ b/layers/API/packages/api/tests/QueryResolution/QueryASTTransformationServiceTest.php
@@ -117,7 +117,7 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
                 $relationalField1,
                 $relationalField3,
             ],
-            new Location(8, 19)
+            new Location(2, 15)
         );
         $operationMaximumFieldDepth = $this->getQueryASTTransformationService()->getOperationMaximumFieldDepth($operation, []);
         $this->assertEquals(
@@ -155,7 +155,7 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
                 $leafField,
                 $fragmentReference,
             ],
-            new Location(8, 19)
+            new Location(2, 15)
         );
 
         $fragmentFields = [
@@ -220,7 +220,7 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
                 $fragmentReference1,
                 $relationalField,
             ],
-            new Location(8, 19)
+            new Location(2, 15)
         );
 
         $fragmentFields = [
@@ -285,7 +285,7 @@ class QueryASTTransformationServiceTest extends AbstractTestCase
                 $leafField1,
                 $relationalField,
             ],
-            new Location(8, 19)
+            new Location(2, 15)
         );
 
         $operationMaximumFieldDepth = $this->getQueryASTTransformationService()->getOperationMaximumFieldDepth($operation, []);


### PR DESCRIPTION
Each level needs to add as many `self` as the sum of the maximum field depth in all previous operations, so that the 1st field in the subsequent operation is executed after the deepest field in the previous one:

```graphql
query One {
  field {
    field {
      field {
        field {
          firstQueryMaximumDepthField: field
        }
      }
    }
  }
}

query Two {
  secondQueryField: field # <= Must be resolved after "firstQueryMaximumDepthField"
}

query Three {
  field # <= Must be resolved after "secondQueryField"
}
```

On resolution time, the engine will then resolve the AST for the transformed query:

```graphql
query One {
  field {
    field {
      field {
        field {
          firstQueryMaximumDepthField: field
        }
      }
    }
  }
}

query Two {
  self {
    self {
      self {
        self {
          self {
            secondQueryField: field # <= Must be resolved after "firstQueryMaximumDepthField"
          }
        }
      }
    }
  }
}

query Three {
  self {
    self {
      self {
        self {
          self {
            self {
              field # <= Must be resolved after "secondQueryField"
            }
          }
        }
      }
    }
  }
}
```
