### PR TITLE
Remove `objectTypeResolvedValuesCache` in EngineState

### DIFF
--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoP\ComponentModel\Engine;
 
 use PoP\ComponentModel\Component\Component;
+use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 
 class EngineState
 {
@@ -57,11 +58,5 @@ class EngineState
          */
         public array $relationalTypeOutputKeyIDFieldSets = [],
     ) {
-    }
-
-    protected function getDataHash(array $data): string
-    {
-        return json_encode($data);
-        // return (string)hash('crc32', json_encode($data));
     }
 }

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -336,36 +336,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
         array $options = [],
     ): mixed {
-        $engineState = App::getEngineState();
-        if ($fieldOrFieldDataAccessor instanceof FieldDataAccessorInterface) {
-            /** @var FieldDataAccessorInterface */
-            $fieldDataAccessor = $fieldOrFieldDataAccessor;
-            $field = $fieldDataAccessor->getField();
-        } else {
-            /** @var FieldInterface */
-            $field = $fieldOrFieldDataAccessor;
-        }
-        if (!$engineState->hasObjectTypeResolvedValue($this, $object, $field)) {
-            $value = $this->doResolveValue(
-                $object,
-                $fieldOrFieldDataAccessor,
-                $objectTypeFieldResolutionFeedbackStore,
-                $options,
-            );
-            $engineState->setObjectTypeResolvedValue($this, $object, $field, $value);
-        }
-        return $engineState->getObjectTypeResolvedValue($this, $object, $field);
-    }
-
-    /**
-     * @param array<string,mixed> $options
-     */
-    final protected function doResolveValue(
-        object $object,
-        FieldInterface|FieldDataAccessorInterface $fieldOrFieldDataAccessor,
-        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
-        array $options = [],
-    ): mixed {
         $fieldDataAccessor = null;
         $isFieldDataAccessor = $fieldOrFieldDataAccessor instanceof FieldDataAccessorInterface;
         if ($isFieldDataAccessor) {


### PR DESCRIPTION
Removed because it doesn't apply anymore: "Object Resolved Field Value References" now creates a DynamicVariableReference instead of duplicating the AST node.

**Old description for why this development was needed (which doesn't apply anymore):**

After executing `resolveValue` on the Object/UnionTypeResolver, store the results to re-use for subsequent calls for same object/field. 

This is mandatory due to the "Object Resolved Field Value References", which re-create the same field in the AST. 

For instance, in this query, the `id` field is created twice in the AST: 

```graphql 
{ 
  id 
  echo(value: $_id) 
} 
``` 

But the 2nd AST must not be recalculated. 