### PR TITLE
Serialize resolved field value references

### DIFF
--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -29,6 +29,9 @@ services:
     PoP\ComponentModel\ObjectSerialization\ObjectSerializationManagerInterface:
         class: \PoP\ComponentModel\ObjectSerialization\ObjectSerializationManager
 
+    PoP\ComponentModel\TypeSerialization\LeafOutputTypeSerializationServiceInterface:
+        class: \PoP\ComponentModel\TypeSerialization\LeafOutputTypeSerializationService
+
     PoP\ComponentModel\DirectivePipeline\DirectivePipelineServiceInterface:
         class: \PoP\ComponentModel\DirectivePipeline\DirectivePipelineService
 

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -36,7 +36,7 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
     {
         return $this->leafOutputTypeSerializationService ??= $this->instanceManager->getInstance(LeafOutputTypeSerializationServiceInterface::class);
     }
-    
+
     public function getDirectiveName(): string
     {
         return 'resolveValueAndMerge';

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -17,6 +17,8 @@ use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\PipelinePositions;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+use PoP\GraphQLParser\Module as GraphQLParserModule;
+use PoP\GraphQLParser\ModuleConfiguration as GraphQLParserModuleConfiguration;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\Root\Feedback\FeedbackItemResolution;
 use SplObjectStorage;
@@ -210,6 +212,12 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
      */
     protected function resetAppStateForFieldValuePromises(): void
     {
+        /** @var GraphQLParserModuleConfiguration */
+        $moduleConfiguration = App::getModule(GraphQLParserModule::class)->getConfiguration();
+        if (!$moduleConfiguration->enableObjectResolvedFieldValueReferences()) {
+            return;
+        }
+        
         /**
          * @var SplObjectStorage<FieldInterface,mixed>
          */
@@ -226,6 +234,12 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
         FieldInterface $field,
         mixed $value,
     ): void {
+        /** @var GraphQLParserModuleConfiguration */
+        $moduleConfiguration = App::getModule(GraphQLParserModule::class)->getConfiguration();
+        if (!$moduleConfiguration->enableObjectResolvedFieldValueReferences()) {
+            return;
+        }
+
         /**
          * @var SplObjectStorage<FieldInterface,mixed>
          */

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
@@ -9,18 +9,25 @@ use PoP\ComponentModel\Container\ServiceTags\MandatoryDirectiveServiceTagInterfa
 use PoP\ComponentModel\Directives\DirectiveKinds;
 use PoP\ComponentModel\Engine\EngineIterationFieldSet;
 use PoP\ComponentModel\Feedback\EngineIterationFeedbackStore;
-use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
-use PoP\ComponentModel\Schema\SchemaTypeModifiers;
-use PoP\ComponentModel\TypeResolvers\LeafOutputTypeResolverInterface;
-use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\PipelinePositions;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
-use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+use PoP\ComponentModel\TypeSerialization\LeafOutputTypeSerializationServiceInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use SplObjectStorage;
 
 final class SerializeLeafOutputTypeValuesDirectiveResolver extends AbstractGlobalDirectiveResolver implements MandatoryDirectiveServiceTagInterface
 {
+    private ?LeafOutputTypeSerializationServiceInterface $leafOutputTypeSerializationService = null;
+
+    final public function setLeafOutputTypeSerializationService(LeafOutputTypeSerializationServiceInterface $leafOutputTypeSerializationService): void
+    {
+        $this->leafOutputTypeSerializationService = $leafOutputTypeSerializationService;
+    }
+    final protected function getLeafOutputTypeSerializationService(): LeafOutputTypeSerializationServiceInterface
+    {
+        return $this->leafOutputTypeSerializationService ??= $this->instanceManager->getInstance(LeafOutputTypeSerializationServiceInterface::class);
+    }
+
     public function getDirectiveName(): string
     {
         return 'serializeLeafOutputTypeValues';
@@ -64,134 +71,20 @@ final class SerializeLeafOutputTypeValuesDirectiveResolver extends AbstractGloba
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void {
-        if (!$idObjects) {
-            return;
-        }
-        $unionTypeResolver = null;
-        $targetObjectTypeResolver = null;
-        $isUnionTypeResolver = $relationalTypeResolver instanceof UnionTypeResolverInterface;
-        if ($isUnionTypeResolver) {
-            /** @var UnionTypeResolverInterface */
-            $unionTypeResolver = $relationalTypeResolver;
-        } else {
-            /** @var ObjectTypeResolverInterface */
-            $targetObjectTypeResolver = $relationalTypeResolver;
-        }
-
-        foreach ($idFieldSet as $id => $fieldSet) {
-            // Obtain its ID and the required data-fields for that ID
-            $object = $idObjects[$id];
-            /**
-             * It could be that the object is NULL. In that case,
-             * simply return a dbError, and set the result as an empty array.
-             *
-             * For instance: a post has a location stored a meta value,
-             * and the corresponding location object was deleted,
-             * so the ID is pointing to a non-existing object.
-             */
-            if ($object === null) {
-                continue;
-            }
-            if ($isUnionTypeResolver) {
-                $targetObjectTypeResolver = $unionTypeResolver->getTargetObjectTypeResolver($object);
-            }
-            foreach ($fieldSet->fields as $field) {
-                $separateObjectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
-                $fieldTypeResolver = $targetObjectTypeResolver->getFieldTypeResolver($field, $separateObjectTypeFieldResolutionFeedbackStore);
-                $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
-                    $separateObjectTypeFieldResolutionFeedbackStore,
-                    $targetObjectTypeResolver,
-                    $this->directive,
-                    [$id => new EngineIterationFieldSet([$field])]
-                );
-                if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
-                    continue;
-                }
-                if (!($fieldTypeResolver instanceof LeafOutputTypeResolverInterface)) {
-                    continue;
-                }
-
-                /** @var LeafOutputTypeResolverInterface */
-                $fieldLeafOutputTypeResolver = $fieldTypeResolver;
-                $value = $resolvedIDFieldValues[$id][$field] ?? null;
-                if ($value === null) {
-                    continue;
-                }
-
-                /** @var int */
-                $fieldTypeModifiers = $targetObjectTypeResolver->getFieldTypeModifiers($field, $separateObjectTypeFieldResolutionFeedbackStore);
-                $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
-                    $separateObjectTypeFieldResolutionFeedbackStore,
-                    $targetObjectTypeResolver,
-                    $this->directive,
-                    [$id => new EngineIterationFieldSet([$field])]
-                );
-                if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
-                    continue;
-                }
-                $fieldLeafOutputTypeIsArrayOfArrays = ($fieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
-                $fieldLeafOutputTypeIsArray = ($fieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
-                // Serialize the scalar/enum value stored in $resolvedIDFieldValues
-                $resolvedIDFieldValues[$id][$field] = $this->serializeLeafOutputTypeValue(
-                    $value,
-                    $fieldLeafOutputTypeResolver,
-                    $fieldLeafOutputTypeIsArrayOfArrays,
-                    $fieldLeafOutputTypeIsArray,
-                );
+        $serializedIDFieldValues = $this->getLeafOutputTypeSerializationService()->serializeLeafOutputTypeIDFieldValues(
+            $relationalTypeResolver,
+            $resolvedIDFieldValues,
+            $idFieldSet,
+            $idObjects,
+            $engineIterationFeedbackStore,
+        );
+        foreach ($serializedIDFieldValues as $id => $serializedFieldValues) {
+            /** @var FieldInterface $field */
+            foreach ($serializedFieldValues as $field) {
+                $serializedValue = $serializedFieldValues[$field];
+                $resolvedIDFieldValues[$id][$field] = $serializedValue;
             }
         }
-    }
-
-    /**
-     * The response for Scalar Types and Enum types must be serialized.
-     * The response type is the same as in the type's `serialize` method.
-     */
-    private function serializeLeafOutputTypeValue(
-        mixed $value,
-        LeafOutputTypeResolverInterface $fieldLeafOutputTypeResolver,
-        bool $fieldLeafOutputTypeIsArrayOfArrays,
-        bool $fieldLeafOutputTypeIsArray,
-    ): string|int|float|bool|array {
-        /**
-         * `DangerouslyNonSpecificScalar` is a special scalar type which is not coerced or validated.
-         * In particular, it does not need to validate if it is an array or not,
-         * as according to the applied WrappingType.
-         */
-        if ($fieldLeafOutputTypeResolver === $this->getDangerouslyNonSpecificScalarTypeScalarTypeResolver()) {
-            /**
-             * Array is not supported by `serialize`, but can still be handled
-             * by DangerouslyNonSpecificScalar. So convert it into stdClass
-             */
-            if (is_array($value)) {
-                $value = (object) $value;
-            }
-            return $fieldLeafOutputTypeResolver->serialize($value);
-        }
-
-        // If the value is an array of arrays, then serialize each subelement to the item type
-        // To make sure the array is not associative (on which case it should be treated
-        // as a JSONObject instead of an array), also apply `array_values`
-        if ($fieldLeafOutputTypeIsArrayOfArrays) {
-            return array_values(array_map(
-                // If it contains a null value, return it as is
-                fn (?array $arrayValueElem) => $arrayValueElem === null ? null : array_values(array_map(
-                    fn (mixed $arrayOfArraysValueElem) => $arrayOfArraysValueElem === null ? null : $fieldLeafOutputTypeResolver->serialize($arrayOfArraysValueElem),
-                    $arrayValueElem
-                )),
-                $value
-            ));
-        }
-
-        // If the value is an array, then serialize each element to the item type
-        if ($fieldLeafOutputTypeIsArray) {
-            return array_values(array_map(
-                fn (mixed $arrayValueElem) => $arrayValueElem === null ? null : $fieldLeafOutputTypeResolver->serialize($arrayValueElem),
-                $value
-            ));
-        }
-
-        // Otherwise, simply serialize the given value directly
-        return $fieldLeafOutputTypeResolver->serialize($value);
     }
 
     public function getDirectiveDescription(RelationalTypeResolverInterface $relationalTypeResolver): ?string

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SerializeLeafOutputTypeValuesDirectiveResolver.php
@@ -76,6 +76,7 @@ final class SerializeLeafOutputTypeValuesDirectiveResolver extends AbstractGloba
             $resolvedIDFieldValues,
             $idFieldSet,
             $idObjects,
+            $this->directive,
             $engineIterationFeedbackStore,
         );
         foreach ($serializedIDFieldValues as $id => $serializedFieldValues) {

--- a/layers/Engine/packages/component-model/src/Facades/TypeSerialization/LeafOutputTypeSerializationServiceFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/TypeSerialization/LeafOutputTypeSerializationServiceFacade.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\Facades\ObjectSerialization;
+
+use PoP\Root\App;
+use PoP\ComponentModel\TypeSerialization\LeafOutputTypeSerializationServiceInterface;
+
+class LeafOutputTypeSerializationServiceFacade
+{
+    public static function getInstance(): LeafOutputTypeSerializationServiceInterface
+    {
+        /**
+         * @var LeafOutputTypeSerializationServiceInterface
+         */
+        $service = App::getContainer()->get(LeafOutputTypeSerializationServiceInterface::class);
+        return $service;
+    }
+}

--- a/layers/Engine/packages/component-model/src/Facades/TypeSerialization/LeafOutputTypeSerializationServiceFacade.php
+++ b/layers/Engine/packages/component-model/src/Facades/TypeSerialization/LeafOutputTypeSerializationServiceFacade.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoP\ComponentModel\Facades\ObjectSerialization;
+namespace PoP\ComponentModel\Facades\TypeSerialization;
 
 use PoP\Root\App;
 use PoP\ComponentModel\TypeSerialization\LeafOutputTypeSerializationServiceInterface;

--- a/layers/Engine/packages/component-model/src/QueryResolution/FieldDataAccessor.php
+++ b/layers/Engine/packages/component-model/src/QueryResolution/FieldDataAccessor.php
@@ -71,9 +71,11 @@ class FieldDataAccessor implements FieldDataAccessorInterface
     {
         /** @var ModuleConfiguration */
         $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
-        if (!($moduleConfiguration->enableDynamicVariables()
+        if (
+            !($moduleConfiguration->enableDynamicVariables()
             || $moduleConfiguration->enableObjectResolvedFieldValueReferences()
-        )) {
+            )
+        ) {
             return $fieldArgs;
         }
 

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
@@ -4,6 +4,178 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeSerialization;
 
+use PoP\ComponentModel\Engine\EngineIterationFieldSet;
+use PoP\ComponentModel\Feedback\EngineIterationFeedbackStore;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\LeafOutputTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyNonSpecificScalarTypeScalarTypeResolver;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
+use PoP\Root\Services\BasicServiceTrait;
+use SplObjectStorage;
+
 class LeafOutputTypeSerializationService implements LeafOutputTypeSerializationServiceInterface
 {
+    use BasicServiceTrait;
+
+    private ?DangerouslyNonSpecificScalarTypeScalarTypeResolver $dangerouslyNonSpecificScalarTypeScalarTypeResolver = null;
+
+    final public function setDangerouslyNonSpecificScalarTypeScalarTypeResolver(DangerouslyNonSpecificScalarTypeScalarTypeResolver $dangerouslyNonSpecificScalarTypeScalarTypeResolver): void
+    {
+        $this->dangerouslyNonSpecificScalarTypeScalarTypeResolver = $dangerouslyNonSpecificScalarTypeScalarTypeResolver;
+    }
+    final protected function getDangerouslyNonSpecificScalarTypeScalarTypeResolver(): DangerouslyNonSpecificScalarTypeScalarTypeResolver
+    {
+        return $this->dangerouslyNonSpecificScalarTypeScalarTypeResolver ??= $this->instanceManager->getInstance(DangerouslyNonSpecificScalarTypeScalarTypeResolver::class);
+    }
+    
+    /**
+     * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $idFieldValues
+     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
+     * @return array<string|int,SplObjectStorage<FieldInterface,mixed>>
+     */
+    public function serializeLeafOutputTypeIDFieldValues(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        array $idFieldValues,
+        array $idFieldSet,
+        array $idObjects,
+        EngineIterationFeedbackStore $engineIterationFeedbackStore,
+    ): array {
+        if (!$idObjects) {
+            return [];
+        }
+        /** @var array<string|int,SplObjectStorage<FieldInterface,mixed>> */
+        $serializedIDFieldValues = [];
+        $unionTypeResolver = null;
+        $targetObjectTypeResolver = null;
+        $isUnionTypeResolver = $relationalTypeResolver instanceof UnionTypeResolverInterface;
+        if ($isUnionTypeResolver) {
+            /** @var UnionTypeResolverInterface */
+            $unionTypeResolver = $relationalTypeResolver;
+        } else {
+            /** @var ObjectTypeResolverInterface */
+            $targetObjectTypeResolver = $relationalTypeResolver;
+        }
+
+        foreach ($idFieldSet as $id => $fieldSet) {
+            // Obtain its ID and the required data-fields for that ID
+            $object = $idObjects[$id];
+            /**
+             * It could be that the object is NULL. In that case,
+             * simply return a dbError, and set the result as an empty array.
+             *
+             * For instance: a post has a location stored a meta value,
+             * and the corresponding location object was deleted,
+             * so the ID is pointing to a non-existing object.
+             */
+            if ($object === null) {
+                continue;
+            }
+            if ($isUnionTypeResolver) {
+                $targetObjectTypeResolver = $unionTypeResolver->getTargetObjectTypeResolver($object);
+            }
+            /** @var SplObjectStorage<FieldInterface,mixed> */
+            $fieldValues = $serializedIDFieldValues[$id] ?? new SplObjectStorage();
+            foreach ($fieldSet->fields as $field) {
+                $separateObjectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
+                $fieldTypeResolver = $targetObjectTypeResolver->getFieldTypeResolver($field, $separateObjectTypeFieldResolutionFeedbackStore);
+                $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
+                    $separateObjectTypeFieldResolutionFeedbackStore,
+                    $targetObjectTypeResolver,
+                    $this->directive,
+                    [$id => new EngineIterationFieldSet([$field])]
+                );
+                if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+                    continue;
+                }
+                if (!($fieldTypeResolver instanceof LeafOutputTypeResolverInterface)) {
+                    continue;
+                }
+
+                /** @var LeafOutputTypeResolverInterface */
+                $fieldLeafOutputTypeResolver = $fieldTypeResolver;
+                $value = $idFieldValues[$id][$field] ?? null;
+                if ($value === null) {
+                    continue;
+                }
+
+                /** @var int */
+                $fieldTypeModifiers = $targetObjectTypeResolver->getFieldTypeModifiers($field, $separateObjectTypeFieldResolutionFeedbackStore);
+                $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
+                    $separateObjectTypeFieldResolutionFeedbackStore,
+                    $targetObjectTypeResolver,
+                    $this->directive,
+                    [$id => new EngineIterationFieldSet([$field])]
+                );
+                if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+                    continue;
+                }
+                $fieldLeafOutputTypeIsArrayOfArrays = ($fieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS) === SchemaTypeModifiers::IS_ARRAY_OF_ARRAYS;
+                $fieldLeafOutputTypeIsArray = ($fieldTypeModifiers & SchemaTypeModifiers::IS_ARRAY) === SchemaTypeModifiers::IS_ARRAY;
+                // Serialize the scalar/enum value stored in $idFieldValues
+                $fieldValues[$field] = $this->serializeLeafOutputTypeValue(
+                    $value,
+                    $fieldLeafOutputTypeResolver,
+                    $fieldLeafOutputTypeIsArrayOfArrays,
+                    $fieldLeafOutputTypeIsArray,
+                );
+            }
+            $serializedIDFieldValues[$id] = $fieldValues;
+        }
+        return $serializedIDFieldValues;
+    }
+
+    /**
+     * The response for Scalar Types and Enum types must be serialized.
+     * The response type is the same as in the type's `serialize` method.
+     */
+    private function serializeLeafOutputTypeValue(
+        mixed $value,
+        LeafOutputTypeResolverInterface $fieldLeafOutputTypeResolver,
+        bool $fieldLeafOutputTypeIsArrayOfArrays,
+        bool $fieldLeafOutputTypeIsArray,
+    ): string|int|float|bool|array {
+        /**
+         * `DangerouslyNonSpecificScalar` is a special scalar type which is not coerced or validated.
+         * In particular, it does not need to validate if it is an array or not,
+         * as according to the applied WrappingType.
+         */
+        if ($fieldLeafOutputTypeResolver === $this->getDangerouslyNonSpecificScalarTypeScalarTypeResolver()) {
+            /**
+             * Array is not supported by `serialize`, but can still be handled
+             * by DangerouslyNonSpecificScalar. So convert it into stdClass
+             */
+            if (is_array($value)) {
+                $value = (object) $value;
+            }
+            return $fieldLeafOutputTypeResolver->serialize($value);
+        }
+
+        // If the value is an array of arrays, then serialize each subelement to the item type
+        // To make sure the array is not associative (on which case it should be treated
+        // as a JSONObject instead of an array), also apply `array_values`
+        if ($fieldLeafOutputTypeIsArrayOfArrays) {
+            return array_values(array_map(
+                // If it contains a null value, return it as is
+                fn (?array $arrayValueElem) => $arrayValueElem === null ? null : array_values(array_map(
+                    fn (mixed $arrayOfArraysValueElem) => $arrayOfArraysValueElem === null ? null : $fieldLeafOutputTypeResolver->serialize($arrayOfArraysValueElem),
+                    $arrayValueElem
+                )),
+                $value
+            ));
+        }
+
+        // If the value is an array, then serialize each element to the item type
+        if ($fieldLeafOutputTypeIsArray) {
+            return array_values(array_map(
+                fn (mixed $arrayValueElem) => $arrayValueElem === null ? null : $fieldLeafOutputTypeResolver->serialize($arrayValueElem),
+                $value
+            ));
+        }
+
+        // Otherwise, simply serialize the given value directly
+        return $fieldLeafOutputTypeResolver->serialize($value);
+    }
 }

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
@@ -12,6 +12,7 @@ use PoP\ComponentModel\TypeResolvers\LeafOutputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyNonSpecificScalarTypeScalarTypeResolver;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\Root\Services\BasicServiceTrait;
 use SplObjectStorage;
@@ -41,6 +42,7 @@ class LeafOutputTypeSerializationService implements LeafOutputTypeSerializationS
         array $idFieldValues,
         array $idFieldSet,
         array $idObjects,
+        Directive $directive,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array {
         if (!$idObjects) {
@@ -84,7 +86,7 @@ class LeafOutputTypeSerializationService implements LeafOutputTypeSerializationS
                 $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
                     $separateObjectTypeFieldResolutionFeedbackStore,
                     $targetObjectTypeResolver,
-                    $this->directive,
+                    $directive,
                     [$id => new EngineIterationFieldSet([$field])]
                 );
                 if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
@@ -106,7 +108,7 @@ class LeafOutputTypeSerializationService implements LeafOutputTypeSerializationS
                 $engineIterationFeedbackStore->objectFeedbackStore->incorporateFromObjectTypeFieldResolutionFeedbackStore(
                     $separateObjectTypeFieldResolutionFeedbackStore,
                     $targetObjectTypeResolver,
-                    $this->directive,
+                    $directive,
                     [$id => new EngineIterationFieldSet([$field])]
                 );
                 if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
@@ -9,6 +9,7 @@ use PoP\ComponentModel\Feedback\EngineIterationFeedbackStore;
 use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\LeafOutputTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyNonSpecificScalarTypeScalarTypeResolver;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\TypeSerialization;
+
+class LeafOutputTypeSerializationService implements LeafOutputTypeSerializationServiceInterface
+{
+}

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationService.php
@@ -31,7 +31,7 @@ class LeafOutputTypeSerializationService implements LeafOutputTypeSerializationS
     {
         return $this->dangerouslyNonSpecificScalarTypeScalarTypeResolver ??= $this->instanceManager->getInstance(DangerouslyNonSpecificScalarTypeScalarTypeResolver::class);
     }
-    
+
     /**
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $idFieldValues
      * @param array<string|int,EngineIterationFieldSet> $idFieldSet

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
@@ -25,5 +25,5 @@ interface LeafOutputTypeSerializationServiceInterface
         array $idObjects,
         Directive $directive,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
-    ): array;    
+    ): array;
 }

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\TypeSerialization;
+
+interface LeafOutputTypeSerializationServiceInterface
+{
+    
+}

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
@@ -7,6 +7,7 @@ namespace PoP\ComponentModel\TypeSerialization;
 use PoP\ComponentModel\Engine\EngineIterationFieldSet;
 use PoP\ComponentModel\Feedback\EngineIterationFeedbackStore;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
+use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use SplObjectStorage;
 
@@ -22,6 +23,7 @@ interface LeafOutputTypeSerializationServiceInterface
         array $idFieldValues,
         array $idFieldSet,
         array $idObjects,
+        Directive $directive,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): array;    
 }

--- a/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeSerialization/LeafOutputTypeSerializationServiceInterface.php
@@ -4,7 +4,24 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\TypeSerialization;
 
+use PoP\ComponentModel\Engine\EngineIterationFieldSet;
+use PoP\ComponentModel\Feedback\EngineIterationFeedbackStore;
+use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
+use SplObjectStorage;
+
 interface LeafOutputTypeSerializationServiceInterface
 {
-    
+    /**
+     * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $idFieldValues
+     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
+     * @return array<string|int,SplObjectStorage<FieldInterface,mixed>>
+     */
+    public function serializeLeafOutputTypeIDFieldValues(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        array $idFieldValues,
+        array $idFieldSet,
+        array $idObjects,
+        EngineIterationFeedbackStore $engineIterationFeedbackStore,
+    ): array;    
 }


### PR DESCRIPTION
So that this query works:

```graphql
{
    post(by: {id: 1724}) {
        # Date is a DateTime Object
        date
        comments(
            filter: {
                dateQuery: {
                    # The value of the reference must be the
                    # serialization of the DateTime object
                    after: $_date
                }
            }
        ) {
            id
        }
    }
}
```