### PR TITLE
Don't use the Service Container for `Parser`

### DIFF
--- a/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
+++ b/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PoPAPI\API\StaticHelpers;
 
-use PoP\ComponentModel\App;
 use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
+use PoP\ComponentModel\GraphQLParser\ExtendedSpec\Parser\Parser;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface;
@@ -13,9 +13,9 @@ use PoP\GraphQLParser\Spec\Execution\Context;
 
 class GraphQLParserHelpers
 {
-    protected static function getParser(): ParserInterface
+    protected static function createParser(): ParserInterface
     {
-        return App::getContainer()->get(ParserInterface::class);
+        return new Parser();
     }
 
     /**
@@ -27,7 +27,8 @@ class GraphQLParserHelpers
         array $variableValues,
         ?string $operationName,
     ): ExecutableDocument {
-        $document = static::getParser()->parse($query);
+        $parser = static::createParser();
+        $document = $parser->parse($query);
         return new ExecutableDocument(
             $document,
             new Context($operationName, $variableValues)

--- a/layers/Engine/packages/component-model/config/services.yaml
+++ b/layers/Engine/packages/component-model/config/services.yaml
@@ -150,9 +150,6 @@ services:
     PoP\ComponentRouting\ComponentRoutingProcessorManagerInterface:
         class: \PoP\ComponentModel\ComponentRouting\ComponentRoutingProcessorManager
 
-    PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface:
-        class: \PoP\ComponentModel\GraphQLParser\ExtendedSpec\Parser\Parser
-
     PoP\ComponentModel\Versioning\VersioningServiceInterface:
         class: \PoP\ComponentModel\Versioning\VersioningService
 

--- a/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
+++ b/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
@@ -15,6 +15,7 @@ use PoP\GraphQLParser\ExtendedSpec\Parser\AbstractParser;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\AbstractDocument;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
+use PoP\Root\Facades\Instances\InstanceManagerFacade;
 
 class Parser extends AbstractParser
 {
@@ -28,7 +29,7 @@ class Parser extends AbstractParser
     }
     final protected function getMetaDirectiveRegistry(): MetaDirectiveRegistryInterface
     {
-        return $this->metaDirectiveRegistry ??= $this->instanceManager->getInstance(MetaDirectiveRegistryInterface::class);
+        return $this->metaDirectiveRegistry ??= InstanceManagerFacade::getInstance()->getInstance(MetaDirectiveRegistryInterface::class);
     }
     final public function setDynamicVariableDefinerDirectiveRegistry(DynamicVariableDefinerDirectiveRegistryInterface $dynamicVariableDefinerDirectiveRegistry): void
     {
@@ -36,7 +37,7 @@ class Parser extends AbstractParser
     }
     final protected function getDynamicVariableDefinerDirectiveRegistry(): DynamicVariableDefinerDirectiveRegistryInterface
     {
-        return $this->dynamicVariableDefinerDirectiveRegistry ??= $this->instanceManager->getInstance(DynamicVariableDefinerDirectiveRegistryInterface::class);
+        return $this->dynamicVariableDefinerDirectiveRegistry ??= InstanceManagerFacade::getInstance()->getInstance(DynamicVariableDefinerDirectiveRegistryInterface::class);
     }
     final public function setDirectiveRegistry(DirectiveRegistryInterface $directiveRegistry): void
     {
@@ -44,7 +45,7 @@ class Parser extends AbstractParser
     }
     final protected function getDirectiveRegistry(): DirectiveRegistryInterface
     {
-        return $this->directiveRegistry ??= $this->instanceManager->getInstance(DirectiveRegistryInterface::class);
+        return $this->directiveRegistry ??= InstanceManagerFacade::getInstance()->getInstance(DirectiveRegistryInterface::class);
     }
 
     protected function isMetaDirective(string $directiveName): bool

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ExecutableDocumentTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ExecutableDocumentTest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Upstream\GraphQLParser\ExtendedSpec\Execution;
 
+use PoP\ComponentModel\GraphQLParser\ExtendedSpec\Parser\Parser;
 use PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface;
 use PoP\GraphQLParser\Spec\Execution\ExecutableDocumentTest as UpstreamExecutableDocumentTest;
 
 class ExecutableDocumentTest extends UpstreamExecutableDocumentTest
 {
+    private ?ParserInterface $parser = null;
+
     protected function getParser(): ParserInterface
     {
-        return $this->getService(ParserInterface::class);
+        return $this->parser ??= new Parser();
     }
 }

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\Upstream\GraphQLParser\ExtendedSpec\Execution\ObjectResolvedFieldValueReferences;
 
+use PoP\ComponentModel\GraphQLParser\ExtendedSpec\Parser\Parser;
 use PoP\GraphQLParser\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\ArgumentValue\ObjectResolvedFieldValueReference;
 use PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface;
@@ -38,6 +39,8 @@ use PoP\Root\AbstractTestCase;
  */
 abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTestCase
 {
+    private ?ParserInterface $parser = null;
+
     /**
      * @return array<string, mixed> [key]: Module class, [value]: Configuration
      */
@@ -52,7 +55,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
 
     protected function getParser(): ParserInterface
     {
-        return $this->getService(ParserInterface::class);
+        return $this->parser ??= new Parser();
     }
 
     /**

--- a/layers/Engine/packages/graphql-parser/config/services.yaml
+++ b/layers/Engine/packages/graphql-parser/config/services.yaml
@@ -7,9 +7,6 @@ services:
     PoP\GraphQLParser\Spec\Parser\ParserInterface:
         class: \PoP\GraphQLParser\Spec\Parser\Parser
 
-    PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface:
-        class: \PoP\GraphQLParser\ExtendedSpec\Parser\Parser
-
     PoP\GraphQLParser\Query\QueryAugmenterServiceInterface:
         class: \PoP\GraphQLParser\Query\QueryAugmenterService
 

--- a/layers/Engine/packages/graphql-parser/config/services.yaml
+++ b/layers/Engine/packages/graphql-parser/config/services.yaml
@@ -4,9 +4,6 @@ services:
         autowire: true
         autoconfigure: true
 
-    PoP\GraphQLParser\Spec\Parser\ParserInterface:
-        class: \PoP\GraphQLParser\Spec\Parser\Parser
-
     PoP\GraphQLParser\Query\QueryAugmenterServiceInterface:
         class: \PoP\GraphQLParser\Query\QueryAugmenterService
 

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -53,13 +53,13 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
      *
      * @var array<FieldInterface[]>
      */
-    protected array $parsedFieldBlockStack = [];
+    protected array $parsedFieldBlockStack;
 
     /**
      * ObjectResolvedFieldValueReferences are not supported
      * within Directive Arguments.
      */
-    protected bool $parsingDirectiveArgumentList = false;
+    protected bool $parsingDirectiveArgumentList;
 
     /**
      * Use this variable to keep track of which
@@ -68,7 +68,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
      *
      * @var string[]
      */
-    protected array $parsedDefinedDynamicVariableNames = [];
+    protected array $parsedDefinedDynamicVariableNames;
 
     protected function resetState(): void
     {

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -70,9 +70,9 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
      */
     protected array $parsedDefinedDynamicVariableNames = [];
 
-    protected function init(string $source): void
+    protected function resetState(): void
     {
-        parent::init($source);
+        parent::resetState();
 
         $this->parsedFieldBlockStack = [];
         $this->parsingDirectiveArgumentList = false;

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -33,11 +33,11 @@ use stdClass;
 class Parser extends Tokenizer implements ParserInterface
 {
     /** @var OperationInterface[] */
-    protected array $operations = [];
+    protected array $operations;
     /** @var Fragment[] */
-    protected array $fragments = [];
+    protected array $fragments;
     /** @var Variable[] */
-    protected array $variables = [];
+    protected array $variables;
 
     /**
      * @throws SyntaxErrorException

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -95,7 +95,11 @@ class Parser extends Tokenizer implements ParserInterface
     protected function init(string $source): void
     {
         $this->initTokenizer($source);
+        $this->resetState();
+    }
 
+    protected function resetState(): void
+    {
         $this->operations = [];
         $this->fragments = [];
         $this->variables = [];

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
@@ -7,11 +7,11 @@ namespace PoP\GraphQLParser\Spec\Parser;
 use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLParserErrorFeedbackItemProvider;
-use PoP\Root\Services\BasicServiceTrait;
+use PoP\Root\Services\StandaloneServiceTrait;
 
 class Tokenizer
 {
-    use BasicServiceTrait;
+    use StandaloneServiceTrait;
 
     protected string $source;
     protected int $pos = 0;

--- a/layers/Engine/packages/graphql-parser/tests/ExtendedSpec/Execution/MultipleQueryExecution/AbstractMultipleQueryExecutionTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/ExtendedSpec/Execution/MultipleQueryExecution/AbstractMultipleQueryExecutionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\ExtendedSpec\Execution\MultipleQueryExecution;
 
+use PoP\ComponentModel\GraphQLParser\ExtendedSpec\Parser\Parser;
 use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
@@ -20,6 +21,8 @@ use PoP\Root\Feedback\FeedbackItemResolution;
 
 abstract class AbstractMultipleQueryExecutionTest extends AbstractTestCase
 {
+    private ?ParserInterface $parser = null;
+
     /**
      * @return array<string, mixed> [key]: Module class, [value]: Configuration
      */
@@ -34,7 +37,7 @@ abstract class AbstractMultipleQueryExecutionTest extends AbstractTestCase
 
     protected function getParser(): ParserInterface
     {
-        return $this->getService(ParserInterface::class);
+        return $this->parser ??= new Parser();
     }
 
     public function testMultipleQueryExecution(): void

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Execution/ExecutableDocumentTest.php
@@ -13,6 +13,7 @@ use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\Spec\Parser\Ast\QueryOperation;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\GraphQLParser\Spec\Parser\Location;
+use PoP\GraphQLParser\Spec\Parser\Parser;
 use PoP\GraphQLParser\Spec\Parser\ParserInterface;
 use PoP\Root\AbstractTestCase;
 use PoP\Root\Exception\ShouldNotHappenException;
@@ -20,9 +21,11 @@ use PoP\Root\Feedback\FeedbackItemResolution;
 
 class ExecutableDocumentTest extends AbstractTestCase
 {
+    private ?ParserInterface $parser = null;
+
     protected function getParser(): ParserInterface
     {
-        return $this->getService(ParserInterface::class);
+        return $this->parser ??= new Parser();
     }
 
     protected function createExecutableDocument(

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/DocumentTest.php
@@ -11,9 +11,11 @@ use PoP\Root\AbstractTestCase;
 
 class DocumentTest extends AbstractTestCase
 {
+    private ?ParserInterface $parser = null;
+
     protected function getParser(): ParserInterface
     {
-        return $this->getService(ParserInterface::class);
+        return $this->parser ??= new Parser();
     }
 
     public function testValidationWorks()

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -33,9 +33,11 @@ use stdClass;
 
 class ParserTest extends AbstractTestCase
 {
+    private ?ParserInterface $parser = null;
+
     protected function getParser(): ParserInterface
     {
-        return $this->getService(ParserInterface::class);
+        return $this->parser ??= new Parser();
     }
 
     public function testEmptyParser()


### PR DESCRIPTION
Because it contains state, so 2 processes accessing the same instance and executing `->parse()` at the same time can mess up with each other.