### PR TITLE
Start Object Resolved Field Value Reference with  `__` instead of `_`

### DIFF
--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationServiceInterface.php
@@ -22,20 +22,20 @@ interface QueryASTTransformationServiceInterface
      *
      *     query One {
      *       user(by: {id: 1}) {
-     *         name @export(as: "_name")
+     *         name @export(as: "name")
      *       }
      *     }
      *
      *     query Two {
-     *       firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
+     *       firstEcho: echo(value: $name) @upperCase @export(as: "ucName")
      *     }
      *
      *     query Three {
-     *       secondEcho: echo(value: $_ucName)
+     *       secondEcho: echo(value: $ucName)
      *     }
      *
      * `firstEcho` is normally resolved on the first iteration for `Root`,
-     * that is before `name @export(as: "_name")` is resolved on the
+     * that is before `name @export(as: "name")` is resolved on the
      * second iteration on `User`.
      *
      * For that reason, the fields are wrapped in `self`, and the query
@@ -43,14 +43,14 @@ interface QueryASTTransformationServiceInterface
      *
      *     query One {
      *       user(by: {id: 1}) {
-     *         name @export(as: "_name")
+     *         name @export(as: "name")
      *       }
      *     }
      *
      *     query Two {
      *       self {
      *         self {
-     *           firstEcho: echo(value: $_name) @upperCase @export(as: "_ucName")
+     *           firstEcho: echo(value: $name) @upperCase @export(as: "ucName")
      *         }
      *       }
      *     }
@@ -59,14 +59,14 @@ interface QueryASTTransformationServiceInterface
      *       self {
      *         self {
      *           self {
-     *             secondEcho: echo(value: $_ucName)
+     *             secondEcho: echo(value: $ucName)
      *           }
      *         }
      *       }
      *     }
      *
      * Now, `firstEcho` is resolved on the third iteration (second on `Root`),
-     * which is after `name @export(as: "_name")`.
+     * which is after `name @export(as: "name")`.
      *
      * --------------------------------------------------------------------
      *

--- a/layers/Engine/packages/component-model/src/QueryResolution/FieldDataAccessor.php
+++ b/layers/Engine/packages/component-model/src/QueryResolution/FieldDataAccessor.php
@@ -94,7 +94,7 @@ class FieldDataAccessor implements FieldDataAccessorInterface
              *   ```
              *   {
              *     id
-             *     echo(value: [$_id])
+             *     echo(value: [$__id])
              *   }
              *   ```
              */
@@ -109,7 +109,7 @@ class FieldDataAccessor implements FieldDataAccessorInterface
              *   ```
              *   {
              *     id
-             *     echo(value: {id: $_id})
+             *     echo(value: {id: $__id})
              *   }
              *   ```
              */

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
@@ -70,7 +70,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                 )
             
                 userListLang: extract(
-                    object: $_userList,
+                    object: $__userList,
                     path: "lang"
                 )
             }
@@ -144,7 +144,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
         $query = '
             {
                 userListLang: extract(
-                    object: $_userList,
+                    object: $__userList,
                     path: "lang"
                 )
 
@@ -213,13 +213,13 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
         $query = '
             {
                 userListLang: extract(
-                    object: $_userList,
+                    object: $__userList,
                     path: "lang"
                 )
 
                 userList: getJSON(
                     url: "https://someurl.com/rest/users",
-                    source: $_userListLang
+                    source: $__userListLang
                 )
             }
         ';
@@ -289,7 +289,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                 )
             
                 userListLang: extract(
-                    object: $_getJSON,
+                    object: $__getJSON,
                     path: "lang"
                 )
             }
@@ -349,7 +349,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                 )
             
                 userListLang: extract @default(
-                    value: $_userList,
+                    value: $__userList,
                 )
             }
         ';
@@ -411,7 +411,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                 )
             
                 userListLang: extract(
-                    object: $_nonExistingField,
+                    object: $__nonExistingField,
                     path: "lang"
                 )
             }
@@ -470,7 +470,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                 )
             
                 userListLang: extract @default(
-                    value: $_nonExistingField,
+                    value: $__nonExistingField,
                 )
             }
         ';
@@ -532,7 +532,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                 )
             
                 userListLang: extract(
-                    object: $_getJSON,
+                    object: $__getJSON,
                     path: "lang"
                 )
             }
@@ -589,7 +589,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                     ...RootData
 
                     userListLang: extract(
-                        object: $_userList,
+                        object: $__userList,
                         path: "lang"
                     )
                 }
@@ -666,7 +666,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                     }
 
                     userListLang: extract(
-                        object: $_userList,
+                        object: $__userList,
                         path: "lang"
                     )
                 }
@@ -743,7 +743,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             
                 self {
                     userListLang: extract(
-                        object: $_userList,
+                        object: $__userList,
                         path: "lang"
                     )
                 }

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
@@ -93,8 +93,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(3, 27)
         );
         $variableReference = static::enabled()
-            ? new ObjectResolvedFieldValueReference('_userList', $field, new Location(8, 29))
-            : new VariableReference('_userList', null, new Location(8, 29));
+            ? new ObjectResolvedFieldValueReference('__userList', $field, new Location(8, 29))
+            : new VariableReference('__userList', null, new Location(8, 29));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -170,7 +170,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(8, 27)
         );
-        $variableReference = new VariableReference('_userList', null, new Location(4, 29));
+        $variableReference = new VariableReference('__userList', null, new Location(4, 29));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -245,11 +245,11 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(8, 27)
         );
-        $variableReference = new VariableReference('_userList', null, new Location(4, 29));
+        $variableReference = new VariableReference('__userList', null, new Location(4, 29));
         $variableReference->setContext($context);
         $dynamicVariableReference2 = static::enabled()
-            ? new ObjectResolvedFieldValueReference('_userListLang', $field, new Location(10, 29))
-            : new VariableReference('_userListLang', null, new Location(10, 29));
+            ? new ObjectResolvedFieldValueReference('__userListLang', $field, new Location(10, 29))
+            : new VariableReference('__userListLang', null, new Location(10, 29));
         if (!static::enabled()) {
             $dynamicVariableReference2->setContext($context);
         }
@@ -312,8 +312,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(3, 17)
         );
         $variableReference = static::enabled()
-            ? new ObjectResolvedFieldValueReference('_getJSON', $field, new Location(8, 29))
-            : new VariableReference('_getJSON', null, new Location(8, 29));
+            ? new ObjectResolvedFieldValueReference('__getJSON', $field, new Location(8, 29))
+            : new VariableReference('__getJSON', null, new Location(8, 29));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -370,7 +370,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(3, 27)
         );
-        $variableReference = new VariableReference('_userList', null, new Location(8, 28));
+        $variableReference = new VariableReference('__userList', null, new Location(8, 28));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -433,7 +433,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(3, 27)
         );
-        $variableReference = new VariableReference('_nonExistingField', null, new Location(8, 29));
+        $variableReference = new VariableReference('__nonExistingField', null, new Location(8, 29));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -491,7 +491,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(3, 27)
         );
-        $variableReference = new VariableReference('_nonExistingField', null, new Location(8, 28));
+        $variableReference = new VariableReference('__nonExistingField', null, new Location(8, 28));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -554,7 +554,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(3, 27)
         );
-        $variableReference = new VariableReference('_getJSON', null, new Location(8, 29));
+        $variableReference = new VariableReference('__getJSON', null, new Location(8, 29));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -618,7 +618,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(14, 27)
         );
-        $variableReference = new VariableReference('_userList', null, new Location(7, 33));
+        $variableReference = new VariableReference('__userList', null, new Location(7, 33));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -689,7 +689,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(5, 35)
         );
-        $variableReference = new VariableReference('_userList', null, new Location(11, 33));
+        $variableReference = new VariableReference('__userList', null, new Location(11, 33));
         $queryOperation = new QueryOperation(
             '',
             [],
@@ -766,7 +766,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             [],
             new Location(3, 27)
         );
-        $variableReference = new VariableReference('_userList', null, new Location(9, 33));
+        $variableReference = new VariableReference('__userList', null, new Location(9, 33));
         $queryOperation = new QueryOperation(
             '',
             [],

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Constants/QuerySyntax.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Constants/QuerySyntax.php
@@ -6,5 +6,5 @@ namespace PoP\GraphQLParser\ExtendedSpec\Constants;
 
 class QuerySyntax
 {
-    const OBJECT_RESOLVED_FIELD_VALUE_REFERENCE_PREFIX = '_';
+    const OBJECT_RESOLVED_FIELD_VALUE_REFERENCE_PREFIX = '__';
 }

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -512,12 +512,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
             return null;
         }
 
-        if (
-            !str_starts_with(
-                $name,
-                QuerySyntax::OBJECT_RESOLVED_FIELD_VALUE_REFERENCE_PREFIX
-            )
-        ) {
+        if (!$this->isObjectResolvedFieldValueReferenceName($name)) {
             return null;
         }
 
@@ -527,6 +522,17 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
          */
         $fieldNameOrAlias = $this->extractObjectResolvedFieldName($name);
         return $this->findFieldWithNameWithinCurrentSiblingFields($fieldNameOrAlias);
+    }
+
+    /**
+     * Actual name of the field (without the leading "__")
+     */
+    protected function isObjectResolvedFieldValueReferenceName(string $name): bool
+    {
+        return \str_starts_with(
+            $name,
+            QuerySyntax::OBJECT_RESOLVED_FIELD_VALUE_REFERENCE_PREFIX
+        );
     }
 
     /**


### PR DESCRIPTION
Eg:

```graphql
{
    names: echo(value: ["James", "John"])
    referenced: echo(value: $__names)
}
```