### PR TITLE
Create a dictionary of all the fields that have been referenced for Object Resolved Field Value References

### DIFF
--- a/layers/API/packages/api-rest/src/DataStructureFormatters/RESTDataStructureFormatter.php
+++ b/layers/API/packages/api-rest/src/DataStructureFormatters/RESTDataStructureFormatter.php
@@ -44,12 +44,12 @@ class RESTDataStructureFormatter extends MirrorQueryDataStructureFormatter
         }
 
         // Parse the GraphQL query
-        $variableValues = App::getState('variables');
+        $variables = App::getState('variables');
 
         try {
             $executableDocument = GraphQLParserHelpers::parseGraphQLQuery(
                 $query,
-                $variableValues,
+                $variables,
                 null,
             );
             $executableDocument->validateAndInitialize();

--- a/layers/API/packages/api-rest/src/DataStructureFormatters/RESTDataStructureFormatter.php
+++ b/layers/API/packages/api-rest/src/DataStructureFormatters/RESTDataStructureFormatter.php
@@ -47,11 +47,12 @@ class RESTDataStructureFormatter extends MirrorQueryDataStructureFormatter
         $variables = App::getState('variables');
 
         try {
-            $executableDocument = GraphQLParserHelpers::parseGraphQLQuery(
+            $graphQLQueryParsingPayload = GraphQLParserHelpers::parseGraphQLQuery(
                 $query,
                 $variables,
                 null,
             );
+            $executableDocument = $graphQLQueryParsingPayload->executableDocument;
             $executableDocument->validateAndInitialize();
         } catch (SyntaxErrorException | AbstractQueryException $e) {
             return [];

--- a/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
+++ b/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace PoPAPI\ObjectModels\GraphQLQueryParsingPayload;
 
 use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 
 class GraphQLQueryParsingPayload
 {
     public function __construct(
         public readonly ExecutableDocument $executableDocument,
+        /**
+         * List of all the Fields in the query which are
+         * referenced via an ObjectResolvedFieldValueReference.
+         *
+         * @var FieldInterface[]
+         * */
+        public readonly array $objectResolvedFieldValueReferencedFields,
     ) {
     }
 }

--- a/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
+++ b/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PoPAPI\ObjectModels\GraphQLQueryParsingPayload;
+namespace PoPAPI\API\ObjectModels;
 
 use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;

--- a/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
+++ b/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
@@ -9,7 +9,7 @@ use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
 class GraphQLQueryParsingPayload
 {
     public function __construct(
-        public ExecutableDocument $executableDocument,
+        public readonly ExecutableDocument $executableDocument,
     ) {
     }
 }

--- a/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
+++ b/layers/API/packages/api/src/ObjectModels/GraphQLQueryParsingPayload.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPAPI\ObjectModels\GraphQLQueryParsingPayload;
+
+use PoP\ComponentModel\ExtendedSpec\Execution\ExecutableDocument;
+
+class GraphQLQueryParsingPayload
+{
+    public function __construct(
+        public ExecutableDocument $executableDocument,
+    ) {
+    }
+}

--- a/layers/API/packages/api/src/State/AppStateProvider.php
+++ b/layers/API/packages/api/src/State/AppStateProvider.php
@@ -84,11 +84,12 @@ class AppStateProvider extends AbstractAppStateProvider
 
         $executableDocument = null;
         try {
-            $executableDocument = GraphQLParserHelpers::parseGraphQLQuery(
+            $graphQLQueryParsingPayload = GraphQLParserHelpers::parseGraphQLQuery(
                 $query,
                 $variableValues,
                 $operationName
             );
+            $executableDocument = $graphQLQueryParsingPayload->executableDocument;
         } catch (SyntaxErrorException $syntaxErrorException) {
             App::getFeedbackStore()->documentFeedbackStore->addError(
                 new DocumentFeedback(

--- a/layers/API/packages/api/src/State/AppStateProvider.php
+++ b/layers/API/packages/api/src/State/AppStateProvider.php
@@ -28,6 +28,7 @@ class AppStateProvider extends AbstractAppStateProvider
     {
         $state['executable-document-ast'] = null;
         $state['document-ast-node-ancestors'] = null;
+        $state['document-object-resolved-field-value-referenced-fields'] = [];
         $state['does-api-query-have-errors'] = null;
 
         // Passing the query via URL param?
@@ -90,6 +91,7 @@ class AppStateProvider extends AbstractAppStateProvider
                 $operationName
             );
             $executableDocument = $graphQLQueryParsingPayload->executableDocument;
+            $state['document-object-resolved-field-value-referenced-fields'] = $graphQLQueryParsingPayload->objectResolvedFieldValueReferencedFields;
         } catch (SyntaxErrorException $syntaxErrorException) {
             App::getFeedbackStore()->documentFeedbackStore->addError(
                 new DocumentFeedback(

--- a/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
+++ b/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
@@ -10,7 +10,7 @@ use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface;
 use PoP\GraphQLParser\Spec\Execution\Context;
-use PoPAPI\ObjectModels\GraphQLQueryParsingPayload\GraphQLQueryParsingPayload;
+use PoPAPI\API\ObjectModels\GraphQLQueryParsingPayload;
 
 class GraphQLParserHelpers
 {

--- a/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
+++ b/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
@@ -35,7 +35,8 @@ class GraphQLParserHelpers
             new Context($operationName, $variableValues)
         );
         return new GraphQLQueryParsingPayload(
-            $executableDocument
+            $executableDocument,
+            $parser->getObjectResolvedFieldValueReferencedFields(),
         );
     }
 }

--- a/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
+++ b/layers/API/packages/api/src/StaticHelpers/GraphQLParserHelpers.php
@@ -10,6 +10,7 @@ use PoP\GraphQLParser\Exception\Parser\InvalidRequestException;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorException;
 use PoP\GraphQLParser\ExtendedSpec\Parser\ParserInterface;
 use PoP\GraphQLParser\Spec\Execution\Context;
+use PoPAPI\ObjectModels\GraphQLQueryParsingPayload\GraphQLQueryParsingPayload;
 
 class GraphQLParserHelpers
 {
@@ -26,12 +27,15 @@ class GraphQLParserHelpers
         string $query,
         array $variableValues,
         ?string $operationName,
-    ): ExecutableDocument {
+    ): GraphQLQueryParsingPayload {
         $parser = static::createParser();
         $document = $parser->parse($query);
-        return new ExecutableDocument(
+        $executableDocument = new ExecutableDocument(
             $document,
             new Context($operationName, $variableValues)
+        );
+        return new GraphQLQueryParsingPayload(
+            $executableDocument
         );
     }
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeDirectiveResolver.php
@@ -259,6 +259,16 @@ final class ResolveValueAndMergeDirectiveResolver extends AbstractGlobalDirectiv
             return;
         }
 
+        /**
+         * Optimization: Check if the field was referenced in the query,
+         * otherwise can skip
+         */
+        /** @var FieldInterface[] */
+        $documentObjectResolvedFieldValueReferencedFields = App::getState('document-object-resolved-field-value-referenced-fields');
+        if (!in_array($field, $documentObjectResolvedFieldValueReferencedFields)) {
+            return;
+        }
+
         if ($value === null) {
             return;
         }

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ObjectResolvedFieldValueReferences/AbstractObjectResolvedFieldValueReferencesTest.php
@@ -13,6 +13,7 @@ use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Literal;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\VariableReference;
 use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
 use PoP\GraphQLParser\Spec\Parser\Ast\InlineFragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
@@ -115,16 +116,22 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = static::enabled() ? [
+            $field,
+        ] : [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     protected function executeAssertion(
         string $query,
         Context $context,
-        QueryOperation $queryOperation
+        QueryOperation $queryOperation,
+        /** @var FieldInterface[] */
+        array $expectedObjectResolvedFieldValueReferencedFields,
     ): void {
+        $parser = $this->getParser();
         $executableDocument = new ExecutableDocument(
-            $this->getParser()->parse($query),
+            $parser->parse($query),
             $context,
         );
         $this->assertEquals(
@@ -132,6 +139,10 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
                 $queryOperation,
             ],
             $executableDocument->getDocument()->getOperations()
+        );
+        $this->assertEquals(
+            $expectedObjectResolvedFieldValueReferencedFields,
+            $parser->getObjectResolvedFieldValueReferencedFields()
         );
     }
 
@@ -191,7 +202,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -273,7 +285,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
     */
 
@@ -334,7 +347,10 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = static::enabled() ? [
+            $field,
+        ] : [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -396,7 +412,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -454,7 +471,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -517,7 +535,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -575,7 +594,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -648,7 +668,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 19)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -726,7 +747,8 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 19)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 
     /**
@@ -796,6 +818,7 @@ abstract class AbstractObjectResolvedFieldValueReferencesTest extends AbstractTe
             new Location(2, 13)
         );
 
-        $this->executeAssertion($query, $context, $queryOperation);
+        $expectedObjectResolvedFieldValueReferencedFields = [];
+        $this->executeAssertion($query, $context, $queryOperation, $expectedObjectResolvedFieldValueReferencedFields);
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -486,7 +486,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
         ?Variable $variable,
         Location $location,
     ): VariableReference {
-        $resolvedFieldValueReferenceField = $this->findResolvedFieldValueReferenceField($name);
+        $resolvedFieldValueReferenceField = $this->findObjectResolvedFieldValueReferenceField($name);
         if ($resolvedFieldValueReferenceField !== null) {
             $this->objectResolvedFieldValueReferencedFields[] = $resolvedFieldValueReferenceField;
             return $this->createObjectResolvedFieldValueReference($name, $resolvedFieldValueReferenceField, $location);
@@ -509,7 +509,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
      * in the same query block, then it's a reference to the value
      * of the resolved field on the same object
      */
-    protected function findResolvedFieldValueReferenceField(
+    protected function findObjectResolvedFieldValueReferenceField(
         string $name,
     ): ?FieldInterface {
         /** @var ModuleConfiguration */

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -655,7 +655,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
      */
     public function getObjectResolvedFieldValueReferencedFields(): array
     {
-        return $this->objectResolvedFieldValueReferencedFields;
+        return array_values(array_unique($this->objectResolvedFieldValueReferencedFields));
     }
 
     public function createDocument(

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/ParserInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/ParserInterface.php
@@ -4,8 +4,27 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\ExtendedSpec\Parser;
 
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\GraphQLParser\Spec\Parser\ParserInterface as UpstreamParserInterface;
 
 interface ParserInterface extends UpstreamParserInterface
 {
+    /**
+     * This function must be invoked after running `->parse()`.
+     *
+     * It produces the list of all the Fields in the query
+     * which are referenced via an ObjectResolvedFieldValueReference.
+     *
+     * Eg: field `id` in:
+     *
+     *   ```
+     *   {
+     *     id
+     *     echo(value: $__id)
+     *   }
+     *   ```
+     *
+     * @return FieldInterface[]
+     */
+    public function getObjectResolvedFieldValueReferencedFields(): array;
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Standalone/GraphQLServer.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Standalone/GraphQLServer.php
@@ -141,11 +141,12 @@ class GraphQLServer implements GraphQLServerInterface
         $executableDocument = null;
         $documentASTNodeAncestors = null;
         try {
-            $executableDocument = GraphQLParserHelpers::parseGraphQLQuery(
+            $graphQLQueryParsingPayload = GraphQLParserHelpers::parseGraphQLQuery(
                 $query,
                 $variables,
                 $operationName
             );
+            $executableDocument = $graphQLQueryParsingPayload->executableDocument;
         } catch (SyntaxErrorException $syntaxErrorException) {
             App::getFeedbackStore()->documentFeedbackStore->addError(
                 new DocumentFeedback(

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Standalone/GraphQLServer.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Standalone/GraphQLServer.php
@@ -140,6 +140,7 @@ class GraphQLServer implements GraphQLServerInterface
         // Convert the GraphQL query to AST
         $executableDocument = null;
         $documentASTNodeAncestors = null;
+        $documentObjectResolvedFieldValueReferencedFields = [];
         try {
             $graphQLQueryParsingPayload = GraphQLParserHelpers::parseGraphQLQuery(
                 $query,
@@ -147,6 +148,7 @@ class GraphQLServer implements GraphQLServerInterface
                 $operationName
             );
             $executableDocument = $graphQLQueryParsingPayload->executableDocument;
+            $documentObjectResolvedFieldValueReferencedFields = $graphQLQueryParsingPayload->objectResolvedFieldValueReferencedFields;
         } catch (SyntaxErrorException $syntaxErrorException) {
             App::getFeedbackStore()->documentFeedbackStore->addError(
                 new DocumentFeedback(
@@ -162,6 +164,8 @@ class GraphQLServer implements GraphQLServerInterface
                 )
             );
         }
+
+        $appStateManager->override('document-object-resolved-field-value-referenced-fields', $documentObjectResolvedFieldValueReferencedFields);
 
         if ($executableDocument !== null) {
             /**


### PR DESCRIPTION
Optimization for serializing fields in `@resolveValueAndMerge`: Check if the field was referenced in the query, otherwise can skip