### PR TITLE
Pass `ObjectTypeFieldResolutionFeedbackStore` to `executeMutation` and others

### DIFF
--- a/layers/CMSSchema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
+++ b/layers/CMSSchema/packages/comment-mutations/src/MutationResolvers/AddCommentToCustomPostMutationResolver.php
@@ -190,8 +190,10 @@ class AddCommentToCustomPostMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $comment_data = $this->getCommentData($fieldDataAccessor);
         $comment_id = $this->insertComment($comment_data);
 

--- a/layers/CMSSchema/packages/custompost-category-mutations/src/MutationResolvers/AbstractSetCategoriesOnCustomPostMutationResolver.php
+++ b/layers/CMSSchema/packages/custompost-category-mutations/src/MutationResolvers/AbstractSetCategoriesOnCustomPostMutationResolver.php
@@ -21,8 +21,10 @@ abstract class AbstractSetCategoriesOnCustomPostMutationResolver extends Abstrac
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $customPostID = $fieldDataAccessor->getValue(MutationInputProperties::CUSTOMPOST_ID);
         $postCategoryIDs = $fieldDataAccessor->getValue(MutationInputProperties::CATEGORY_IDS);
         $append = $fieldDataAccessor->getValue(MutationInputProperties::APPEND);

--- a/layers/CMSSchema/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
+++ b/layers/CMSSchema/packages/custompost-mutations/src/MutationResolvers/AbstractCreateUpdateCustomPostMutationResolver.php
@@ -376,8 +376,10 @@ abstract class AbstractCreateUpdateCustomPostMutationResolver extends AbstractMu
      * @return string|int The ID of the updated entity
      * @throws CustomPostCRUDMutationException If there was an error (eg: Custom Post does not exists)
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $post_data = $this->getUpdateCustomPostData($fieldDataAccessor);
         $customPostID = $post_data['id'];
 

--- a/layers/CMSSchema/packages/custompost-mutations/src/MutationResolvers/CreateCustomPostMutationResolverTrait.php
+++ b/layers/CMSSchema/packages/custompost-mutations/src/MutationResolvers/CreateCustomPostMutationResolverTrait.php
@@ -16,6 +16,7 @@ trait CreateCustomPostMutationResolverTrait
      */
     public function executeMutation(
         FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
         return $this->create($fieldDataAccessor);
     }

--- a/layers/CMSSchema/packages/custompost-mutations/src/MutationResolvers/UpdateCustomPostMutationResolverTrait.php
+++ b/layers/CMSSchema/packages/custompost-mutations/src/MutationResolvers/UpdateCustomPostMutationResolverTrait.php
@@ -16,8 +16,12 @@ trait UpdateCustomPostMutationResolverTrait
      */
     public function executeMutation(
         FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
-        return $this->update($fieldDataAccessor);
+        return $this->update(
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
     }
 
     /**
@@ -26,6 +30,7 @@ trait UpdateCustomPostMutationResolverTrait
      */
     abstract protected function update(
         FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): string|int;
 
     public function validateErrors(

--- a/layers/CMSSchema/packages/custompost-tag-mutations/src/MutationResolvers/AbstractSetTagsOnCustomPostMutationResolver.php
+++ b/layers/CMSSchema/packages/custompost-tag-mutations/src/MutationResolvers/AbstractSetTagsOnCustomPostMutationResolver.php
@@ -21,8 +21,10 @@ abstract class AbstractSetTagsOnCustomPostMutationResolver extends AbstractMutat
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $customPostID = $fieldDataAccessor->getValue(MutationInputProperties::CUSTOMPOST_ID);
         $postTags = $fieldDataAccessor->getValue(MutationInputProperties::TAGS);
         $append = $fieldDataAccessor->getValue(MutationInputProperties::APPEND);

--- a/layers/CMSSchema/packages/custompostmedia-mutations/src/MutationResolvers/RemoveFeaturedImageOnCustomPostMutationResolver.php
+++ b/layers/CMSSchema/packages/custompostmedia-mutations/src/MutationResolvers/RemoveFeaturedImageOnCustomPostMutationResolver.php
@@ -32,8 +32,10 @@ class RemoveFeaturedImageOnCustomPostMutationResolver extends AbstractMutationRe
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $customPostID = $fieldDataAccessor->getValue(MutationInputProperties::CUSTOMPOST_ID);
         $this->getCustomPostMediaTypeMutationAPI()->removeFeaturedImage($customPostID);
         return $customPostID;

--- a/layers/CMSSchema/packages/custompostmedia-mutations/src/MutationResolvers/SetFeaturedImageOnCustomPostMutationResolver.php
+++ b/layers/CMSSchema/packages/custompostmedia-mutations/src/MutationResolvers/SetFeaturedImageOnCustomPostMutationResolver.php
@@ -32,8 +32,10 @@ class SetFeaturedImageOnCustomPostMutationResolver extends AbstractMutationResol
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $customPostID = $fieldDataAccessor->getValue(MutationInputProperties::CUSTOMPOST_ID);
         $mediaItemID = $fieldDataAccessor->getValue(MutationInputProperties::MEDIA_ITEM_ID);
         $this->getCustomPostMediaTypeMutationAPI()->setFeaturedImage($customPostID, $mediaItemID);

--- a/layers/CMSSchema/packages/user-state-mutations/src/MutationResolvers/LoginUserByCredentialsMutationResolver.php
+++ b/layers/CMSSchema/packages/user-state-mutations/src/MutationResolvers/LoginUserByCredentialsMutationResolver.php
@@ -91,8 +91,10 @@ class LoginUserByCredentialsMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         // If the user is already logged in, then return the error
         $username_or_email = $fieldDataAccessor->getValue(MutationInputProperties::USERNAME_OR_EMAIL);
         $pwd = $fieldDataAccessor->getValue(MutationInputProperties::PASSWORD);

--- a/layers/CMSSchema/packages/user-state-mutations/src/MutationResolvers/LogoutUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-state-mutations/src/MutationResolvers/LogoutUserMutationResolver.php
@@ -45,8 +45,10 @@ class LogoutUserMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $user_id = App::getState('current-user-id');
 
         $this->getUserStateTypeMutationAPI()->logout();

--- a/layers/Engine/packages/component-model/phpstan.neon.dist
+++ b/layers/Engine/packages/component-model/phpstan.neon.dist
@@ -13,3 +13,7 @@ parameters:
 		- 
 			message: '#Default value of the parameter \#2 \$conditionalFields \(SplObjectStorage\<object, mixed\>\) of method PoP\\ComponentModel\\Engine\\EngineIterationFieldSet::__construct\(\) is incompatible with type SplObjectStorage\<PoP\\GraphQLParser\\Spec\\Parser\\Ast\\FieldInterface, array\<PoP\\GraphQLParser\\Spec\\Parser\\Ast\\FieldInterface\>\>\.#'
 			path: src/Engine/EngineIterationFieldSet.php
+		# Some bug in PHPStan
+		- 
+			message: '#Strict comparison using !== between array{} and array{} will always evaluate to false\.#'
+			path: src/MutationResolverBridges/AbstractComponentMutationResolverBridge.php                                                               

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1034,27 +1034,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         return null;
     }
 
-    /**
-     * Add warnings, logs, suggestions, etc
-     *
-     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
-     * @param array<string|int,object> $idObjects
-     * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
-     */
-    protected function addDirectiveResolutionFeedback(
-        RelationalTypeResolverInterface $relationalTypeResolver,
-        array $idFieldSet,
-        array $idObjects,
-        array $resolvedIDFieldValues,
-        EngineIterationFeedbackStore $engineIterationFeedbackStore,
-    ): void {
-        $this->maybeAddSemanticVersionConstraintsWarningFeedback(
-            $relationalTypeResolver,
-            $idFieldSet,
-            $engineIterationFeedbackStore,
-        );
-    }
-
     protected function maybeAddSemanticVersionConstraintsWarningFeedback(
         RelationalTypeResolverInterface $relationalTypeResolver,
         array $idFieldSet,
@@ -1184,14 +1163,9 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         // For instance, executing ?query=posts.id|title<default,translate(from:en,to:es)> will fail
         // after directive "default", so directive "translate" must not even execute
         if (!$this->needsSomeIDFieldToExecute() || $this->hasSomeIDField($idFieldSet)) {
-            /**
-             * Add warnings, logs, suggestions, etc
-             */
-            $this->addDirectiveResolutionFeedback(
+            $this->maybeAddSemanticVersionConstraintsWarningFeedback(
                 $relationalTypeResolver,
                 $idFieldSet,
-                $idObjects,
-                $resolvedIDFieldValues,
                 $engineIterationFeedbackStore,
             );
 

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -29,6 +29,7 @@ use PoP\ComponentModel\Schema\FieldQueryInterpreterInterface;
 use PoP\ComponentModel\Schema\SchemaCastingServiceInterface;
 use PoP\ComponentModel\Schema\SchemaDefinition;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\StaticHelpers\MethodHelpers;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\PipelinePositions;
@@ -1024,15 +1025,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         return [];
     }
 
-    public function getDirectiveWarning(RelationalTypeResolverInterface $relationalTypeResolver): ?FeedbackItemResolution
-    {
-        $schemaDefinitionResolver = $this->getSchemaDefinitionResolver($relationalTypeResolver);
-        if ($schemaDefinitionResolver !== $this) {
-            return $schemaDefinitionResolver->getDirectiveWarning($relationalTypeResolver);
-        }
-        return null;
-    }
-
     public function getDirectiveDeprecationMessage(RelationalTypeResolverInterface $relationalTypeResolver): ?string
     {
         $schemaDefinitionResolver = $this->getSchemaDefinitionResolver($relationalTypeResolver);
@@ -1042,30 +1034,68 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         return null;
     }
 
-    public function resolveDirectiveWarning(RelationalTypeResolverInterface $relationalTypeResolver): ?FeedbackItemResolution
-    {
-        if (Environment::enableSemanticVersionConstraints()) {
-            /**
-             * If restricting the version, and this fieldResolver doesn't have any version, then show a warning
-             */
-            if ($versionConstraint = $this->directiveArgs[SchemaDefinition::VERSION_CONSTRAINT] ?? null) {
-                /**
-                 * If this fieldResolver doesn't have versioning, then it accepts everything
-                 */
-                if (!$this->decideCanProcessBasedOnVersionConstraint($relationalTypeResolver)) {
-                    return new FeedbackItemResolution(
-                        WarningFeedbackItemProvider::class,
-                        WarningFeedbackItemProvider::W3,
-                        [
-                            $this->getDirectiveName(),
-                            $this->getDirectiveVersion($relationalTypeResolver) ?? '',
-                            $versionConstraint,
-                        ]
-                    );
-                }
-            }
+    /**
+     * Add warnings, logs, suggestions, etc
+     *
+     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
+     * @param array<string|int,object> $idObjects
+     * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
+     */
+    protected function addDirectiveResolutionFeedback(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        array $idFieldSet,
+        array $idObjects,
+        array $resolvedIDFieldValues,
+        EngineIterationFeedbackStore $engineIterationFeedbackStore,
+    ): void {
+        $this->maybeAddSemanticVersionConstraintsWarningFeedback(
+            $relationalTypeResolver,
+            $idFieldSet,
+            $engineIterationFeedbackStore,
+        );
+    }
+
+    protected function maybeAddSemanticVersionConstraintsWarningFeedback(
+        RelationalTypeResolverInterface $relationalTypeResolver,
+        array $idFieldSet,
+        EngineIterationFeedbackStore $engineIterationFeedbackStore,
+    ): void {
+        if (!Environment::enableSemanticVersionConstraints()) {
+            return;
         }
-        return $this->getDirectiveWarning($relationalTypeResolver);
+
+        /**
+         * If restricting the version, and this fieldResolver doesn't have any version, then show a warning
+         */
+        $versionConstraint = $this->directiveArgs[SchemaDefinition::VERSION_CONSTRAINT] ?? null;
+        if (!$versionConstraint) {
+            return;
+        }
+
+        /**
+         * If this fieldResolver doesn't have versioning, then it accepts everything
+         */
+        if ($this->decideCanProcessBasedOnVersionConstraint($relationalTypeResolver)) {
+            return;
+        }
+
+        $fields = MethodHelpers::getFieldsFromIDFieldSet($idFieldSet);
+        $engineIterationFeedbackStore->schemaFeedbackStore->addWarning(
+            new SchemaFeedback(
+                new FeedbackItemResolution(
+                    WarningFeedbackItemProvider::class,
+                    WarningFeedbackItemProvider::W3,
+                    [
+                        $this->getDirectiveName(),
+                        $this->getDirectiveVersion($relationalTypeResolver) ?? '',
+                        $versionConstraint,
+                    ]
+                ),
+                $this->directive,
+                $relationalTypeResolver,
+                $fields
+            )
+        );
     }
 
     public function getDirectiveExpressions(RelationalTypeResolverInterface $relationalTypeResolver): array
@@ -1154,6 +1184,17 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         // For instance, executing ?query=posts.id|title<default,translate(from:en,to:es)> will fail
         // after directive "default", so directive "translate" must not even execute
         if (!$this->needsSomeIDFieldToExecute() || $this->hasSomeIDField($idFieldSet)) {
+            /**
+             * Add warnings, logs, suggestions, etc
+             */
+            $this->addDirectiveResolutionFeedback(
+                $relationalTypeResolver,
+                $idFieldSet,
+                $idObjects,
+                $resolvedIDFieldValues,
+                $engineIterationFeedbackStore,
+            );
+
             // If the directive resolver throws an Exception,
             // catch it and add objectErrors
             $feedbackItemResolution = null;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
@@ -166,17 +166,6 @@ trait AliasSchemaDirectiveResolverTrait
     /**
      * Proxy pattern: execute same function on the aliased DirectiveResolver
      */
-    public function getDirectiveWarning(RelationalTypeResolverInterface $relationalTypeResolver): ?FeedbackItemResolution
-    {
-        $aliasedDirectiveResolver = $this->getAliasedDirectiveResolver();
-        return $aliasedDirectiveResolver->getDirectiveWarning(
-            $relationalTypeResolver
-        );
-    }
-
-    /**
-     * Proxy pattern: execute same function on the aliased DirectiveResolver
-     */
     public function getDirectiveDeprecationMessage(RelationalTypeResolverInterface $relationalTypeResolver): ?string
     {
         $aliasedDirectiveResolver = $this->getAliasedDirectiveResolver();

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AliasSchemaDirectiveResolverTrait.php
@@ -11,7 +11,6 @@ use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
-use PoP\Root\Feedback\FeedbackItemResolution;
 use SplObjectStorage;
 
 /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -12,7 +12,6 @@ use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
-use PoP\Root\Feedback\FeedbackItemResolution;
 use SplObjectStorage;
 
 interface DirectiveResolverInterface extends AttachableExtensionInterface, SchemaDirectiveResolverInterface

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -164,7 +164,6 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface, Schem
     public function hasDirectiveVersion(RelationalTypeResolverInterface $relationalTypeResolver): bool;
     public function getDirectiveVersionInputTypeResolver(RelationalTypeResolverInterface $relationalTypeResolver): ?InputTypeResolverInterface;
 
-    public function resolveDirectiveWarning(RelationalTypeResolverInterface $relationalTypeResolver): ?FeedbackItemResolution;
     public function getDirectiveDeprecationMessage(RelationalTypeResolverInterface $relationalTypeResolver): ?string;
     /**
      * Name for the directive arg to indicate which additional fields

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -129,6 +129,7 @@ interface DirectiveResolverInterface extends AttachableExtensionInterface, Schem
      *
      * @param array<string|int,EngineIterationFieldSet> $idFieldSet
      * @param array<array<string|int,EngineIterationFieldSet>> $succeedingPipelineIDFieldSet
+     * @param array<string|int,object> $idObjects
      * @param array<FieldDataAccessProviderInterface> $succeedingPipelineFieldDataAccessProviders
      * @param array<string,array<string|int,SplObjectStorage<FieldInterface,mixed>>> $previouslyResolvedIDFieldValues
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
@@ -41,10 +41,6 @@ interface SchemaDirectiveResolverInterface
      */
     public function getDirectiveExpressions(RelationalTypeResolverInterface $relationalTypeResolver): array;
     /**
-     * Raise warnings concerning the directive
-     */
-    public function getDirectiveWarning(RelationalTypeResolverInterface $relationalTypeResolver): ?FeedbackItemResolution;
-    /**
      * Indicate if the directive has been deprecated, why, when, and/or how it must be replaced
      */
     public function getDirectiveDeprecationMessage(RelationalTypeResolverInterface $relationalTypeResolver): ?string;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/SchemaDirectiveResolverInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\ComponentModel\DirectiveResolvers;
 
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\RelationalTypeResolverInterface;
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -883,6 +883,18 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         return null;
     }
 
+    protected function addValueResolutionFeedback(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        $this->maybeAddSemanticVersionConstraintsWarning(
+            $objectTypeResolver,
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
+    }
+    
     protected function maybeAddSemanticVersionConstraintsWarning(
         ObjectTypeResolverInterface $objectTypeResolver,
         FieldDataAccessorInterface $fieldDataAccessor,
@@ -1001,7 +1013,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
-        $this->maybeAddSemanticVersionConstraintsWarning(
+        $this->addValueResolutionFeedback(
             $objectTypeResolver,
             $fieldDataAccessor,
             $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -912,15 +912,6 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
                 }
             }
         }
-        // If a MutationResolver is declared, let it resolve the value
-        $mutationResolver = $this->getFieldMutationResolver($objectTypeResolver, $fieldDataAccessor->getFieldName());
-        if ($mutationResolver !== null) {
-            $fieldDataAccessorForMutation = $objectTypeResolver->getFieldDataAccessorForMutation($fieldDataAccessor);
-            $warningFeedbackItemResolutions = array_merge(
-                $warningFeedbackItemResolutions,
-                $mutationResolver->validateWarnings($fieldDataAccessorForMutation)
-            );
-        }
         return $warningFeedbackItemResolutions;
     }
 

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -894,7 +894,7 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
             $objectTypeFieldResolutionFeedbackStore,
         );
     }
-    
+
     protected function maybeAddSemanticVersionConstraintsWarningFeedback(
         ObjectTypeResolverInterface $objectTypeResolver,
         FieldDataAccessorInterface $fieldDataAccessor,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -888,14 +888,14 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void {
-        $this->maybeAddSemanticVersionConstraintsWarning(
+        $this->maybeAddSemanticVersionConstraintsWarningFeedback(
             $objectTypeResolver,
             $fieldDataAccessor,
             $objectTypeFieldResolutionFeedbackStore,
         );
     }
     
-    protected function maybeAddSemanticVersionConstraintsWarning(
+    protected function maybeAddSemanticVersionConstraintsWarningFeedback(
         ObjectTypeResolverInterface $objectTypeResolver,
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AbstractObjectTypeFieldResolver.php
@@ -1041,7 +1041,10 @@ abstract class AbstractObjectTypeFieldResolver extends AbstractFieldResolver imp
                 );
             }
             $fieldDataAccessorForMutation = $objectTypeResolver->getFieldDataAccessorForMutation($fieldDataAccessor);
-            return $mutationResolver->executeMutation($fieldDataAccessorForMutation);
+            return $mutationResolver->executeMutation(
+                $fieldDataAccessorForMutation,
+                $objectTypeFieldResolutionFeedbackStore,
+            );
         } catch (Exception $e) {
             /** @var ModuleConfiguration */
             $moduleConfiguration = App::getModule(Module::class)->getConfiguration();

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/AliasSchemaObjectTypeFieldResolverTrait.php
@@ -150,21 +150,6 @@ trait AliasSchemaObjectTypeFieldResolverTrait
      * Proxy pattern: execute same function on the aliased ObjectTypeFieldResolver,
      * for the aliased $fieldName
      */
-    public function resolveFieldValidationWarnings(
-        ObjectTypeResolverInterface $objectTypeResolver,
-        FieldDataAccessorInterface $fieldDataAccessor
-    ): array {
-        $aliasedObjectTypeFieldResolver = $this->getAliasedObjectTypeFieldResolver();
-        return $aliasedObjectTypeFieldResolver->resolveFieldValidationWarnings(
-            $objectTypeResolver,
-            $this->getAliasedFieldDataAccessor($objectTypeResolver, $fieldDataAccessor),
-        );
-    }
-
-    /**
-     * Proxy pattern: execute same function on the aliased ObjectTypeFieldResolver,
-     * for the aliased $fieldName
-     */
     public function validateFieldDataForObject(
         ObjectTypeResolverInterface $objectTypeResolver,
         object $object,

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
@@ -13,7 +13,6 @@ use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
-use PoP\Root\Feedback\FeedbackItemResolution;
 
 interface ObjectTypeFieldResolverInterface extends FieldResolverInterface, ObjectTypeFieldSchemaDefinitionResolverInterface
 {

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/ObjectTypeFieldResolverInterface.php
@@ -87,13 +87,6 @@ interface ObjectTypeFieldResolverInterface extends FieldResolverInterface, Objec
         ObjectTypeResolverInterface $objectTypeResolver,
         string $fieldName
     ): ?MutationResolverInterface;
-    /**
-     * @return FeedbackItemResolution[]
-     */
-    public function resolveFieldValidationWarnings(
-        ObjectTypeResolverInterface $objectTypeResolver,
-        FieldDataAccessorInterface $fieldDataAccessor
-    ): array;
     public function enableOrderedSchemaFieldArgs(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): bool;
     public function validateFieldDataForObject(
         ObjectTypeResolverInterface $objectTypeResolver,

--- a/layers/Engine/packages/component-model/src/MutationResolverBridges/AbstractComponentMutationResolverBridge.php
+++ b/layers/Engine/packages/component-model/src/MutationResolverBridges/AbstractComponentMutationResolverBridge.php
@@ -19,7 +19,6 @@ use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\StaticHelpers\LocationHelper;
 use PoP\Root\Exception\AbstractClientException;
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\Root\Services\BasicServiceTrait;
 
 abstract class AbstractComponentMutationResolverBridge implements ComponentMutationResolverBridgeInterface

--- a/layers/Engine/packages/component-model/src/MutationResolverBridges/AbstractComponentMutationResolverBridge.php
+++ b/layers/Engine/packages/component-model/src/MutationResolverBridges/AbstractComponentMutationResolverBridge.php
@@ -93,18 +93,6 @@ abstract class AbstractComponentMutationResolverBridge implements ComponentMutat
             }
             return $mutationResponse;
         }
-        if ($warnings = $mutationResolver->validateWarnings($fieldDataAccessorForMutation)) {
-            $warningTypeKeys = [
-                ErrorTypes::DESCRIPTIONS => ResponseConstants::WARNINGSTRINGS,
-                ErrorTypes::CODES => ResponseConstants::WARNINGCODES,
-            ];
-            $warningTypeKey = $warningTypeKeys[$errorType];
-            // @todo Migrate from string to FeedbackItemProvider
-            $mutationResponse[$warningTypeKey] = array_map(
-                fn (FeedbackItemResolution $feedbackItemResolution) => $feedbackItemResolution->getMessage(),
-                $warnings
-            );
-        }
 
         $errorMessage = null;
         $resultID = null;

--- a/layers/Engine/packages/component-model/src/MutationResolvers/AbstractMutationResolver.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/AbstractMutationResolver.php
@@ -6,7 +6,6 @@ namespace PoP\ComponentModel\MutationResolvers;
 
 use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
-use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\Root\Services\BasicServiceTrait;
 
 abstract class AbstractMutationResolver implements MutationResolverInterface
@@ -17,14 +16,6 @@ abstract class AbstractMutationResolver implements MutationResolverInterface
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void {
-    }
-
-    /**
-     * @return FeedbackItemResolution[]
-     */
-    public function validateWarnings(FieldDataAccessorInterface $fieldDataAccessor): array
-    {
-        return [];
     }
 
     public function getErrorType(): int

--- a/layers/Engine/packages/component-model/src/MutationResolvers/AbstractOneofMutationResolver.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/AbstractOneofMutationResolver.php
@@ -178,23 +178,6 @@ abstract class AbstractOneofMutationResolver extends AbstractMutationResolver
     }
 
     /**
-     * @param InputObjectSubpropertyFieldDataAccessorInterface $fieldDataAccessor
-     * @return FeedbackItemResolution[]
-     * @throws AbstractValueResolutionPromiseException
-     */
-    final public function validateWarnings(FieldDataAccessorInterface $fieldDataAccessor): array
-    {
-        try {
-            [$inputFieldMutationResolver, $fieldDataAccessor] = $this->getInputFieldMutationResolverAndOneOfFieldDataAccessor($fieldDataAccessor);
-            /** @var MutationResolverInterface $inputFieldMutationResolver */
-            return $inputFieldMutationResolver->validateWarnings($fieldDataAccessor);
-        } catch (QueryResolutionException $e) {
-            // Do nothing since the Error will already return the problem
-            return [];
-        }
-    }
-
-    /**
      * @return mixed[] An array of 2 items: the current input field's mutation resolver, and the AST with the current input field's form data
      * @throws QueryResolutionException If there is not MutationResolver for the input field
      * @throws AbstractValueResolutionPromiseException

--- a/layers/Engine/packages/component-model/src/MutationResolvers/AbstractOneofMutationResolver.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/AbstractOneofMutationResolver.php
@@ -145,7 +145,10 @@ abstract class AbstractOneofMutationResolver extends AbstractMutationResolver
     ): mixed {
         [$inputFieldMutationResolver, $fieldDataAccessor] = $this->getInputFieldMutationResolverAndOneOfFieldDataAccessor($fieldDataAccessor);
         /** @var MutationResolverInterface $inputFieldMutationResolver */
-        return $inputFieldMutationResolver->executeMutation($fieldDataAccessor);
+        return $inputFieldMutationResolver->executeMutation(
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/MutationResolvers/AbstractOneofMutationResolver.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/AbstractOneofMutationResolver.php
@@ -139,8 +139,10 @@ abstract class AbstractOneofMutationResolver extends AbstractMutationResolver
      * @param InputObjectSubpropertyFieldDataAccessorInterface $fieldDataAccessor
      * @throws AbstractException In case of error
      */
-    final public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    final public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         [$inputFieldMutationResolver, $fieldDataAccessor] = $this->getInputFieldMutationResolverAndOneOfFieldDataAccessor($fieldDataAccessor);
         /** @var MutationResolverInterface $inputFieldMutationResolver */
         return $inputFieldMutationResolver->executeMutation($fieldDataAccessor);

--- a/layers/Engine/packages/component-model/src/MutationResolvers/MutationResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/MutationResolverInterface.php
@@ -7,7 +7,6 @@ namespace PoP\ComponentModel\MutationResolvers;
 use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
 use PoP\Root\Exception\AbstractException;
-use PoP\Root\Feedback\FeedbackItemResolution;
 
 interface MutationResolverInterface
 {
@@ -22,9 +21,5 @@ interface MutationResolverInterface
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void;
-    /**
-     * @return FeedbackItemResolution[]
-     */
-    public function validateWarnings(FieldDataAccessorInterface $fieldDataAccessor): array;
     public function getErrorType(): int;
 }

--- a/layers/Engine/packages/component-model/src/MutationResolvers/MutationResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/MutationResolvers/MutationResolverInterface.php
@@ -12,12 +12,12 @@ use PoP\Root\Feedback\FeedbackItemResolution;
 interface MutationResolverInterface
 {
     /**
-     * Please notice: the return type `mixed` includes `Error`
-     */
-    /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed;
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed;
     public function validateErrors(
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -371,19 +371,6 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             $directive = $directiveResolver->getDirective();
             $directiveName = $directive->getName();
 
-            // Check for warnings
-            if ($warningFeedbackItemResolution = $directiveResolver->resolveDirectiveWarning($this)) {
-                $fields = $directiveFields[$directive];
-                $engineIterationFeedbackStore->schemaFeedbackStore->addWarning(
-                    new SchemaFeedback(
-                        $warningFeedbackItemResolution,
-                        $directive,
-                        $this,
-                        $fields,
-                    )
-                );
-            }
-
             // Check for deprecations
             if ($deprecationMessage = $directiveResolver->getDirectiveDeprecationMessage($this)) {
                 $fields = $directiveFields[$directive];

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -235,27 +235,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
         return $executableObjectTypeFieldResolver->getFieldSchemaDefinition($this, $field->getName());
     }
 
-    final public function collectFieldValidationWarnings(
-        FieldDataAccessorInterface $fieldDataAccessor,
-        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
-    ): void {
-        $executableObjectTypeFieldResolver = $this->getExecutableObjectTypeFieldResolverForField($fieldDataAccessor->getField());
-        if ($executableObjectTypeFieldResolver === null) {
-            return;
-        }
-
-        if ($maybeWarningFeedbackItemResolutions = $executableObjectTypeFieldResolver->resolveFieldValidationWarnings($this, $fieldDataAccessor)) {
-            foreach ($maybeWarningFeedbackItemResolutions as $warningFeedbackItemResolution) {
-                $objectTypeFieldResolutionFeedbackStore->addWarning(
-                    new ObjectTypeFieldResolutionFeedback(
-                        $warningFeedbackItemResolution,
-                        $fieldDataAccessor->getField(),
-                    )
-                );
-            }
-        }
-    }
-
     final public function collectFieldDeprecations(
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -235,16 +235,6 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
         return $executableObjectTypeFieldResolver->getFieldSchemaDefinition($this, $field->getName());
     }
 
-    final public function collectFieldDeprecations(
-        FieldDataAccessorInterface $fieldDataAccessor,
-        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
-    ): void {
-        $executableObjectTypeFieldResolver = $this->getExecutableObjectTypeFieldResolverForField($fieldDataAccessor->getField());
-        if ($executableObjectTypeFieldResolver === null) {
-            return;
-        }
-    }
-
     final public function getFieldTypeResolver(
         FieldInterface $field,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
@@ -20,10 +20,6 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface, O
 {
     public function getFieldSchemaDefinition(FieldInterface $field): ?array;
     public function hasObjectTypeFieldResolversForField(FieldInterface $field): bool;
-    public function collectFieldValidationWarnings(
-        FieldDataAccessorInterface $fieldDataAccessor,
-        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
-    ): void;
     public function collectFieldDeprecations(
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/ObjectTypeResolverInterface.php
@@ -20,10 +20,6 @@ interface ObjectTypeResolverInterface extends RelationalTypeResolverInterface, O
 {
     public function getFieldSchemaDefinition(FieldInterface $field): ?array;
     public function hasObjectTypeFieldResolversForField(FieldInterface $field): bool;
-    public function collectFieldDeprecations(
-        FieldDataAccessorInterface $fieldDataAccessor,
-        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
-    ): void;
     public function getFieldTypeResolver(
         FieldInterface $field,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/AbstractEmailInviteMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/AbstractEmailInviteMutationResolver.php
@@ -23,8 +23,10 @@ abstract class AbstractEmailInviteMutationResolver extends AbstractMutationResol
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $emails = $fieldDataAccessor->getValue('emails');
         // Remove the invalid emails
         $emails = array_diff($emails, $this->getInvalidEmails($emails));

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/AbstractEmailInviteMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/AbstractEmailInviteMutationResolver.php
@@ -10,7 +10,6 @@ use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
 use PoP\ComponentModel\FeedbackItemProviders\GenericFeedbackItemProvider;
 use PoP\ComponentModel\MutationResolvers\AbstractMutationResolver;
 use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
-use PoP\GraphQLParser\Spec\Parser\Ast\WithArgumentsInterface;
 use PoP\Root\App;
 use PoP\Root\Exception\AbstractException;
 use PoP\Root\Exception\GenericClientException;
@@ -27,6 +26,11 @@ abstract class AbstractEmailInviteMutationResolver extends AbstractMutationResol
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
+        $this->maybeAddWarnings(
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
+
         $emails = $fieldDataAccessor->getValue('emails');
         // Remove the invalid emails
         $emails = array_diff($emails, $this->getInvalidEmails($emails));
@@ -103,11 +107,10 @@ abstract class AbstractEmailInviteMutationResolver extends AbstractMutationResol
         );
     }
 
-    /**
-     * @return FeedbackItemResolution[]
-     */
-    public function validateWarnings(FieldDataAccessorInterface $fieldDataAccessor): array
-    {
+    protected function maybeAddWarnings(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
         $warnings = [];
 
         $emails = $fieldDataAccessor->getValue('emails');
@@ -123,7 +126,20 @@ abstract class AbstractEmailInviteMutationResolver extends AbstractMutationResol
             );
         }
 
-        return $warnings;
+        foreach ($warnings as $warning) {
+            $objectTypeFieldResolutionFeedbackStore->addWarning(
+                new ObjectTypeFieldResolutionFeedback(
+                    new FeedbackItemResolution(
+                        GenericFeedbackItemProvider::class,
+                        GenericFeedbackItemProvider::W1,
+                        [
+                            $warning
+                        ]
+                    ),
+                    $fieldDataAccessor->getField()
+                )
+            );
+        }
     }
 
     abstract protected function getEmailContent(FieldDataAccessorInterface $fieldDataAccessor);

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/ChangeUserPasswordMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/ChangeUserPasswordMutationResolver.php
@@ -127,8 +127,10 @@ class ChangeUserPasswordMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $user_data = $this->getChangepasswordData($fieldDataAccessor);
         $result = $this->executeChangepassword($user_data);
 

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
@@ -336,8 +336,10 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         // If user is logged in => It's Update
         // Otherwise => It's Create
         if (App::getState('is-user-logged-in')) {

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/CreateUpdateUserMutationResolver.php
@@ -343,7 +343,10 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
         // If user is logged in => It's Update
         // Otherwise => It's Create
         if (App::getState('is-user-logged-in')) {
-            return $this->update($fieldDataAccessor);
+            return $this->update(
+                $fieldDataAccessor,
+                $objectTypeFieldResolutionFeedbackStore
+            );
         }
 
         return $this->create($fieldDataAccessor);
@@ -378,8 +381,10 @@ class CreateUpdateUserMutationResolver extends AbstractMutationResolver
      * @return mixed The ID of the updated entity, or an Error
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         // Do the Post update
         $user_id = $this->updateuser($fieldDataAccessor);
 

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/EditMembershipMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/EditMembershipMutationResolver.php
@@ -23,8 +23,10 @@ class EditMembershipMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $user_id = $fieldDataAccessor->getValue('user_id');
         $community = $fieldDataAccessor->getValue('community');
         $new_community_status = $fieldDataAccessor->getValue('status');

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/FileUploadPictureMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/FileUploadPictureMutationResolver.php
@@ -15,8 +15,10 @@ class FileUploadPictureMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         // Copy the images to the fileupload-userphoto upload folder
         $user_id = $fieldDataAccessor->getValue('user_id');
         $gd_fileupload_userphoto = GD_FileUpload_UserPhotoFactory::getInstance();

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/SettingsMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/SettingsMutationResolver.php
@@ -31,8 +31,10 @@ class SettingsMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $componentprocessor_manager = ComponentProcessorManagerFacade::getInstance();
         $cmsService = CMSServiceFacade::getInstance();
 

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyCommunitiesMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyCommunitiesMutationResolver.php
@@ -30,8 +30,10 @@ class UpdateMyCommunitiesMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $user_id = $fieldDataAccessor->getValue('user_id');
 
         $previous_communities = gdUreGetCommunities($user_id);

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyPreferencesMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateMyPreferencesMutationResolver.php
@@ -15,8 +15,10 @@ class UpdateMyPreferencesMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $user_id = $fieldDataAccessor->getValue('user_id');
         Utils::updateUserMeta($user_id, GD_METAKEY_PROFILE_USERPREFERENCES, $fieldDataAccessor->getValue('userPreferences'));
         return $user_id;

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateUserAvatarMutationResolver.php
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/src/SchemaServices/MutationResolvers/UpdateUserAvatarMutationResolver.php
@@ -23,8 +23,10 @@ class UpdateUserAvatarMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $user_id = $fieldDataAccessor->getValue('user_id');
         $this->savePicture($user_id);
         $this->additionals($user_id, $fieldDataAccessor);

--- a/layers/Wassup/packages/contactus-mutations/src/MutationResolvers/ContactUsMutationResolver.php
+++ b/layers/Wassup/packages/contactus-mutations/src/MutationResolvers/ContactUsMutationResolver.php
@@ -123,8 +123,10 @@ class ContactUsMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $result = $this->doExecute($fieldDataAccessor);
 
         // Allow for additional operations

--- a/layers/Wassup/packages/contactuser-mutations/src/MutationResolvers/ContactUserMutationResolver.php
+++ b/layers/Wassup/packages/contactuser-mutations/src/MutationResolvers/ContactUserMutationResolver.php
@@ -173,8 +173,10 @@ class ContactUserMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $result = $this->doExecute($fieldDataAccessor);
 
         // Allow for additional operations

--- a/layers/Wassup/packages/flag-mutations/src/MutationResolvers/FlagCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/flag-mutations/src/MutationResolvers/FlagCustomPostMutationResolver.php
@@ -172,8 +172,10 @@ class FlagCustomPostMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $result = $this->doExecute($fieldDataAccessor);
 
         // Allow for additional operations

--- a/layers/Wassup/packages/gravityforms-mutations/src/MutationResolvers/GravityFormsAddEntryToFormMutationResolver.php
+++ b/layers/Wassup/packages/gravityforms-mutations/src/MutationResolvers/GravityFormsAddEntryToFormMutationResolver.php
@@ -14,8 +14,10 @@ class GravityFormsAddEntryToFormMutationResolver extends AbstractMutationResolve
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         // $execution_response = do_shortcode('[gravityform id="'.$form_id.'" title="false" description="false" ajax="false"]');
         return RGForms::get_form($fieldDataAccessor->getValue('form_id'), false, false);
     }

--- a/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterSubscriptionMutationResolver.php
+++ b/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterSubscriptionMutationResolver.php
@@ -87,8 +87,10 @@ class NewsletterSubscriptionMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $result = $this->doExecute($fieldDataAccessor);
 
         // Allow for additional operations

--- a/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterUnsubscriptionMutationResolver.php
+++ b/layers/Wassup/packages/newsletter-mutations/src/MutationResolvers/NewsletterUnsubscriptionMutationResolver.php
@@ -147,8 +147,10 @@ class NewsletterUnsubscriptionMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $newsletter_data = $this->getNewsletterData($fieldDataAccessor);
         $result = $this->doExecute($newsletter_data);
 

--- a/layers/Wassup/packages/notification-mutations/src/MutationResolvers/AbstractMarkAsReadOrUnreadNotificationMutationResolver.php
+++ b/layers/Wassup/packages/notification-mutations/src/MutationResolvers/AbstractMarkAsReadOrUnreadNotificationMutationResolver.php
@@ -66,8 +66,10 @@ abstract class AbstractMarkAsReadOrUnreadNotificationMutationResolver extends Ab
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $hist_ids = $this->setStatus($fieldDataAccessor);
         $this->additionals($fieldDataAccessor->getValue('histid'), $fieldDataAccessor);
 

--- a/layers/Wassup/packages/notification-mutations/src/MutationResolvers/MarkAllAsReadNotificationMutationResolver.php
+++ b/layers/Wassup/packages/notification-mutations/src/MutationResolvers/MarkAllAsReadNotificationMutationResolver.php
@@ -26,8 +26,10 @@ class MarkAllAsReadNotificationMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $hist_ids = $this->markAllAsRead($fieldDataAccessor);
         $this->additionals($fieldDataAccessor);
 

--- a/layers/Wassup/packages/share-mutations/src/MutationResolvers/ShareByEmailMutationResolver.php
+++ b/layers/Wassup/packages/share-mutations/src/MutationResolvers/ShareByEmailMutationResolver.php
@@ -133,8 +133,10 @@ class ShareByEmailMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $result = $this->doExecute($fieldDataAccessor);
 
         // Allow for additional operations

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
@@ -50,8 +50,10 @@ abstract class AbstractUpdateUserMetaValueMutationResolver extends AbstractMutat
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $target_id = $this->update($fieldDataAccessor);
         $this->additionals($target_id, $fieldDataAccessor);
 

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/AbstractUpdateUserMetaValueMutationResolver.php
@@ -41,8 +41,10 @@ abstract class AbstractUpdateUserMetaValueMutationResolver extends AbstractMutat
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $target_id = $fieldDataAccessor->getValue('target_id');
         return $target_id;
     }
@@ -54,7 +56,10 @@ abstract class AbstractUpdateUserMetaValueMutationResolver extends AbstractMutat
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
-        $target_id = $this->update($fieldDataAccessor);
+        $target_id = $this->update(
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore
+        );
         $this->additionals($target_id, $fieldDataAccessor);
 
         return $target_id;

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/DownvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/DownvoteCustomPostMutationResolver.php
@@ -68,8 +68,10 @@ class DownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownvoteC
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -85,9 +87,12 @@ class DownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownvoteC
         // Had the user already executed the opposite (Up-vote => Down-vote, etc), then undo it
         $opposite = Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_UPVOTESPOSTS);
         if (in_array($target_id, $opposite)) {
-            $this->getUpvoteCustomPostMutationResolver()->executeMutation($fieldDataAccessor);
+            $this->getUpvoteCustomPostMutationResolver()->executeMutation(
+                $fieldDataAccessor,
+                $objectTypeFieldResolutionFeedbackStore,
+            );
         }
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/FollowUserMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/FollowUserMutationResolver.php
@@ -76,8 +76,10 @@ class FollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationRes
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -92,6 +94,6 @@ class FollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationRes
         $count = $count ? $count : 0;
         Utils::updateUserMeta($target_id, \GD_METAKEY_PROFILE_FOLLOWERSCOUNT, ($count + 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/RecommendCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/RecommendCustomPostMutationResolver.php
@@ -62,8 +62,10 @@ class RecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecommend
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -76,6 +78,6 @@ class RecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecommend
         $count = $count ? $count : 0;
         \PoPCMSSchema\CustomPostMeta\Utils::updateCustomPostMeta($target_id, \GD_METAKEY_POST_RECOMMENDCOUNT, ($count + 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/SubscribeToTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/SubscribeToTagMutationResolver.php
@@ -60,8 +60,10 @@ class SubscribeToTagMutationResolver extends AbstractSubscribeToOrUnsubscribeFro
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -74,6 +76,6 @@ class SubscribeToTagMutationResolver extends AbstractSubscribeToOrUnsubscribeFro
         $count = $count ? $count : 0;
         \PoPCMSSchema\TaxonomyMeta\Utils::updateTermMeta($target_id, \GD_METAKEY_TERM_SUBSCRIBERSCOUNT, ($count + 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoDownvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoDownvoteCustomPostMutationResolver.php
@@ -57,8 +57,10 @@ class UndoDownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownv
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -71,14 +73,19 @@ class UndoDownvoteCustomPostMutationResolver extends AbstractDownvoteOrUndoDownv
         $count = $count ? $count : 0;
         \PoPCMSSchema\CustomPostMeta\Utils::updateCustomPostMeta($target_id, \GD_METAKEY_POST_DOWNVOTECOUNT, ($count - 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 
     /**
      * Function to be called by the opposite function (Up-vote/Down-vote)
      */
-    public function undo(FieldDataAccessorInterface $fieldDataAccessor)
-    {
-        return $this->update($fieldDataAccessor);
+    public function undo(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
+        return $this->update(
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore
+        );
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoUpvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UndoUpvoteCustomPostMutationResolver.php
@@ -57,8 +57,10 @@ class UndoUpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCus
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -71,14 +73,19 @@ class UndoUpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCus
         $count = $count ? $count : 0;
         \PoPCMSSchema\CustomPostMeta\Utils::updateCustomPostMeta($target_id, \GD_METAKEY_POST_UPVOTECOUNT, ($count - 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 
     /**
      * Function to be called by the opposite function (Up-vote/Down-vote)
      */
-    public function undo(FieldDataAccessorInterface $fieldDataAccessor)
-    {
-        return $this->update($fieldDataAccessor);
+    public function undo(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
+        return $this->update(
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore
+        );
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnfollowUserMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnfollowUserMutationResolver.php
@@ -62,8 +62,10 @@ class UnfollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationR
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -76,6 +78,6 @@ class UnfollowUserMutationResolver extends AbstractFollowOrUnfollowUserMutationR
         $count = $count ? $count : 0;
         Utils::updateUserMeta($target_id, \GD_METAKEY_PROFILE_FOLLOWERSCOUNT, ($count - 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnrecommendCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnrecommendCustomPostMutationResolver.php
@@ -62,8 +62,10 @@ class UnrecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecomme
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -76,6 +78,6 @@ class UnrecommendCustomPostMutationResolver extends AbstractRecommendOrUnrecomme
         $count = $count ? $count : 0;
         \PoPCMSSchema\CustomPostMeta\Utils::updateCustomPostMeta($target_id, \GD_METAKEY_POST_RECOMMENDCOUNT, ($count - 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnsubscribeFromTagMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UnsubscribeFromTagMutationResolver.php
@@ -60,8 +60,10 @@ class UnsubscribeFromTagMutationResolver extends AbstractSubscribeToOrUnsubscrib
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -74,6 +76,6 @@ class UnsubscribeFromTagMutationResolver extends AbstractSubscribeToOrUnsubscrib
         $count = $count ? $count : 0;
         \PoPCMSSchema\TaxonomyMeta\Utils::updateTermMeta($target_id, \GD_METAKEY_TERM_SUBSCRIBERSCOUNT, ($count - 1), true);
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UpvoteCustomPostMutationResolver.php
+++ b/layers/Wassup/packages/socialnetwork-mutations/src/MutationResolvers/UpvoteCustomPostMutationResolver.php
@@ -68,8 +68,10 @@ class UpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCustomP
     /**
      * @throws AbstractException In case of error
      */
-    protected function update(FieldDataAccessorInterface $fieldDataAccessor): string|int
-    {
+    protected function update(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int {
         $user_id = App::getState('current-user-id');
         $target_id = $fieldDataAccessor->getValue('target_id');
 
@@ -85,9 +87,12 @@ class UpvoteCustomPostMutationResolver extends AbstractUpvoteOrUndoUpvoteCustomP
         // Had the user already executed the opposite (Up-vote => Down-vote, etc), then undo it
         $opposite = Utils::getUserMeta($user_id, \GD_METAKEY_PROFILE_DOWNVOTESPOSTS);
         if (in_array($target_id, $opposite)) {
-            $this->getDownvoteCustomPostMutationResolver()->executeMutation($fieldDataAccessor);
+            $this->getDownvoteCustomPostMutationResolver()->executeMutation(
+                $fieldDataAccessor,
+                $objectTypeFieldResolutionFeedbackStore,
+            );
         }
 
-        return parent::update($fieldDataAccessor);
+        return parent::update($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Wassup/packages/stance-mutations/src/MutationResolvers/CreateOrUpdateStanceMutationResolver.php
+++ b/layers/Wassup/packages/stance-mutations/src/MutationResolvers/CreateOrUpdateStanceMutationResolver.php
@@ -14,8 +14,10 @@ class CreateOrUpdateStanceMutationResolver extends AbstractCreateUpdateStanceMut
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         if ($this->isUpdate($fieldDataAccessor)) {
             return $this->update($fieldDataAccessor);
         }

--- a/layers/Wassup/packages/stance-mutations/src/MutationResolvers/CreateOrUpdateStanceMutationResolver.php
+++ b/layers/Wassup/packages/stance-mutations/src/MutationResolvers/CreateOrUpdateStanceMutationResolver.php
@@ -19,7 +19,10 @@ class CreateOrUpdateStanceMutationResolver extends AbstractCreateUpdateStanceMut
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
         if ($this->isUpdate($fieldDataAccessor)) {
-            return $this->update($fieldDataAccessor);
+            return $this->update(
+                $fieldDataAccessor,
+                $objectTypeFieldResolutionFeedbackStore
+            );
         }
         return $this->create($fieldDataAccessor);
     }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/ActivatePluginsMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/ActivatePluginsMutationResolver.php
@@ -59,8 +59,10 @@ class ActivatePluginsMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         // Plugins needed by the website. Check the website version, if it's the one indicated,
         // then proceed to install the required plugin
         $plugin_version = App::applyFilters(

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/BuildSystemMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/BuildSystemMutationResolver.php
@@ -14,8 +14,10 @@ class BuildSystemMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         App::doAction('PoP:system-build');
         return true;
     }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateSystemMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateSystemMutationResolver.php
@@ -14,8 +14,10 @@ class GenerateSystemMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         App::doAction('PoP:system-generate');
         return true;
     }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateThemeMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/GenerateThemeMutationResolver.php
@@ -14,8 +14,10 @@ class GenerateThemeMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         App::doAction('PoP:system-generate:theme');
         return true;
     }

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/InstallSystemMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/InstallSystemMutationResolver.php
@@ -26,8 +26,10 @@ class InstallSystemMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         // Save the new version on the DB
         update_option('PoP:version', $this->getApplicationInfo()->getVersion());
 

--- a/layers/Wassup/packages/system-mutations/src/MutationResolvers/SaveDefinitionFileMutationResolver.php
+++ b/layers/Wassup/packages/system-mutations/src/MutationResolvers/SaveDefinitionFileMutationResolver.php
@@ -14,8 +14,10 @@ class SaveDefinitionFileMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         App::doAction('PoP:system:save-definition-file');
         return true;
     }

--- a/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LostPasswordMutationResolver.php
+++ b/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/LostPasswordMutationResolver.php
@@ -143,8 +143,10 @@ class LostPasswordMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $cmsuseraccountapi = \PoP\UserAccount\FunctionAPIFactory::getInstance();
         $user_login = $fieldDataAccessor->getValue(MutationInputProperties::USER_LOGIN);
 

--- a/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/ResetLostPasswordMutationResolver.php
+++ b/layers/Wassup/packages/user-state-mutations/src/MutationResolvers/ResetLostPasswordMutationResolver.php
@@ -110,8 +110,10 @@ class ResetLostPasswordMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $code = $fieldDataAccessor->getValue(MutationInputProperties::CODE);
         $pwd = $fieldDataAccessor->getValue(MutationInputProperties::PASSWORD);
 

--- a/layers/Wassup/packages/volunteer-mutations/src/MutationResolvers/VolunteerMutationResolver.php
+++ b/layers/Wassup/packages/volunteer-mutations/src/MutationResolvers/VolunteerMutationResolver.php
@@ -176,8 +176,10 @@ class VolunteerMutationResolver extends AbstractMutationResolver
     /**
      * @throws AbstractException In case of error
      */
-    public function executeMutation(FieldDataAccessorInterface $fieldDataAccessor): mixed
-    {
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
         $result = $this->doExecute($fieldDataAccessor);
 
         // Allow for additional operations


### PR DESCRIPTION
- Removed "warning" methods
- Instead it is added as feedback directly into the FeedbackStore in `->resolveValue` or `->resolveDirective`