### PR TITLE
Pass `$idFieldSetToRemove` to `processFailure`

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1183,7 +1183,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     }
 
     /**
-     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
+     * @param array<string|int,EngineIterationFieldSet> $idFieldSetToRemove
      * @param array<array<string|int,EngineIterationFieldSet>> $succeedingPipelineIDFieldSet
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
      * @param array<FieldInterface>|null $failedFields Either which fields failed, or `null` to signify _all_ of them
@@ -1191,8 +1191,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     protected function processObjectFailure(
         RelationalTypeResolverInterface $relationalTypeResolver,
         FeedbackItemResolution $feedbackItemResolution,
-        ?array $failedFields,
-        array $idFieldSet,
+        array $idFieldSetToRemove,
         array &$succeedingPipelineIDFieldSet,
         AstInterface $astNode,
         array &$resolvedIDFieldValues,
@@ -1201,8 +1200,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         $this->processFailure(
             $relationalTypeResolver,
             $feedbackItemResolution,
-            $failedFields,
-            $idFieldSet,
+            $idFieldSetToRemove,
             $succeedingPipelineIDFieldSet,
             $astNode,
             $resolvedIDFieldValues,
@@ -1214,7 +1212,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      * Depending on environment configuration, either show a warning,
      * or show an error and remove the fields from the directive pipeline for further execution
      *
-     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
+     * @param array<string|int,EngineIterationFieldSet> $idFieldSetToRemove
      * @param array<array<string|int,EngineIterationFieldSet>> $succeedingPipelineIDFieldSet
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
      * @param array<FieldInterface>|null $failedFields Either which fields failed, or `null` to signify _all_ of them
@@ -1222,30 +1220,12 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     private function processFailure(
         RelationalTypeResolverInterface $relationalTypeResolver,
         FeedbackItemResolution $feedbackItemResolution,
-        ?array $failedFields,
-        array $idFieldSet,
+        array $idFieldSetToRemove,
         array &$succeedingPipelineIDFieldSet,
         AstInterface $astNode,
         array &$resolvedIDFieldValues,
         ObjectResolutionFeedbackStore|SchemaFeedbackStore $schemaOrObjectResolutionFeedbackStore,
     ): void {
-        if ($failedFields === null) {
-            // Remove all fields
-            $idFieldSetToRemove = $idFieldSet;
-            $failedFields = MethodHelpers::getFieldsFromIDFieldSet($idFieldSet);
-        } else {
-            $idFieldSetToRemove = [];
-            // Calculate which fields to remove
-            foreach ($idFieldSet as $id => $fieldSet) {
-                $idFieldSetToRemove[$id] = new EngineIterationFieldSet(
-                    array_intersect(
-                        $fieldSet->fields,
-                        $failedFields
-                    )
-                );
-            }
-        }
-
         /**
          * Remove the fields from the directive pipeline
          */
@@ -1270,7 +1250,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
                     $feedbackItemResolution,
                     $astNode,
                     $relationalTypeResolver,
-                    $failedFields
+                    MethodHelpers::getFieldsFromIDFieldSet($idFieldSetToRemove)
                 )
             );
             return;
@@ -1290,7 +1270,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     }
 
     /**
-     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
+     * @param array<string|int,EngineIterationFieldSet> $idFieldSetToRemove
      * @param array<array<string|int,EngineIterationFieldSet>> $succeedingPipelineIDFieldSet
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
      * @param array<FieldInterface>|null $failedFields Either which fields failed, or `null` to signify _all_ of them
@@ -1298,8 +1278,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     protected function processSchemaFailure(
         RelationalTypeResolverInterface $relationalTypeResolver,
         FeedbackItemResolution $feedbackItemResolution,
-        ?array $failedFields,
-        array $idFieldSet,
+        array $idFieldSetToRemove,
         array &$succeedingPipelineIDFieldSet,
         AstInterface $astNode,
         array &$resolvedIDFieldValues,
@@ -1308,8 +1287,7 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
         $this->processFailure(
             $relationalTypeResolver,
             $feedbackItemResolution,
-            $failedFields,
-            $idFieldSet,
+            $idFieldSetToRemove,
             $succeedingPipelineIDFieldSet,
             $astNode,
             $resolvedIDFieldValues,

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1185,7 +1185,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      * @param array<string|int,EngineIterationFieldSet> $idFieldSetToRemove
      * @param array<array<string|int,EngineIterationFieldSet>> $succeedingPipelineIDFieldSet
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
-     * @param array<FieldInterface>|null $failedFields Either which fields failed, or `null` to signify _all_ of them
      */
     protected function processObjectFailure(
         RelationalTypeResolverInterface $relationalTypeResolver,
@@ -1214,7 +1213,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      * @param array<string|int,EngineIterationFieldSet> $idFieldSetToRemove
      * @param array<array<string|int,EngineIterationFieldSet>> $succeedingPipelineIDFieldSet
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
-     * @param array<FieldInterface>|null $failedFields Either which fields failed, or `null` to signify _all_ of them
      */
     private function processFailure(
         RelationalTypeResolverInterface $relationalTypeResolver,
@@ -1272,7 +1270,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
      * @param array<string|int,EngineIterationFieldSet> $idFieldSetToRemove
      * @param array<array<string|int,EngineIterationFieldSet>> $succeedingPipelineIDFieldSet
      * @param array<string|int,SplObjectStorage<FieldInterface,mixed>> $resolvedIDFieldValues
-     * @param array<FieldInterface>|null $failedFields Either which fields failed, or `null` to signify _all_ of them
      */
     protected function processSchemaFailure(
         RelationalTypeResolverInterface $relationalTypeResolver,

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1157,7 +1157,6 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
                 $this->processObjectFailure(
                     $relationalTypeResolver,
                     $feedbackItemResolution,
-                    null,
                     $idFieldSet,
                     $pipelineIDFieldSet,
                     $astNode ?? $this->directive,

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ValidateDirectiveResolver.php
@@ -182,8 +182,7 @@ final class ValidateDirectiveResolver extends AbstractGlobalDirectiveResolver im
                         $objectTypeResolver->getMaybeNamespacedTypeName(),
                     ]
                 ),
-                [$field],
-                $idFieldSet,
+                MethodHelpers::filterFieldsInIDFieldSet($idFieldSet, [$field]),
                 $succeedingPipelineIDFieldSet,
                 $field,
                 $resolvedIDFieldValues,

--- a/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
+++ b/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
@@ -48,7 +48,7 @@ class MethodHelpers
     /**
      * @param array<string|int,EngineIterationFieldSet> $idFieldSet
      * @param FieldInterface[] $fields
-     * @return FieldInterface[]
+     * @return array<string|int,EngineIterationFieldSet>
      */
     public static function filterFieldsInIDFieldSet(
         array $idFieldSet,

--- a/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
+++ b/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
@@ -63,7 +63,10 @@ class MethodHelpers
             if ($matchingFields === []) {
                 continue;
             }
-            $restrictedIDFieldSet[$id] = new EngineIterationFieldSet($matchingFields);
+            $restrictedIDFieldSet[$id] = new EngineIterationFieldSet(
+                $matchingFields,
+                $fieldSet->conditionalFields
+            );
         }
         return $restrictedIDFieldSet;
     }

--- a/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
+++ b/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
@@ -44,4 +44,27 @@ class MethodHelpers
         }
         return array_values(array_unique($fields));
     }
+
+    /**
+     * @param array<string|int,EngineIterationFieldSet> $idFieldSet
+     * @param FieldInterface[] $fields
+     * @return FieldInterface[]
+     */
+    public static function filterFieldsInIDFieldSet(
+        array $idFieldSet,
+        array $fields
+    ): array {
+        $restrictedIDFieldSet = [];
+        foreach ($idFieldSet as $id => $fieldSet) {
+            $matchingFields = array_intersect(
+                $fields,
+                $fieldSet->fields
+            );
+            if ($matchingFields === []) {
+                continue;
+            }
+            $restrictedIDFieldSet[$id] = $matchingFields;
+        }
+        return $restrictedIDFieldSet;
+    }
 }

--- a/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
+++ b/layers/Engine/packages/component-model/src/StaticHelpers/MethodHelpers.php
@@ -63,7 +63,7 @@ class MethodHelpers
             if ($matchingFields === []) {
                 continue;
             }
-            $restrictedIDFieldSet[$id] = $matchingFields;
+            $restrictedIDFieldSet[$id] = new EngineIterationFieldSet($matchingFields);
         }
         return $restrictedIDFieldSet;
     }


### PR DESCRIPTION
Because it's not only `failedFields` that can be restricted to, but also what IDs are affected, as when validating a schema on a union type resolver, and it fails only for one type (eg: `Post`) but not for another (eg: `Page`) so only a subset of IDs needs to be removed.

To simplify, just pass `$idFieldSetToRemove` always.