### PR TITLE
When Field Value Reference fails: throw `ObjectFieldValuePromiseException`

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Exception/ObjectFieldValuePromiseException.php
+++ b/layers/Engine/packages/graphql-parser/src/Exception/ObjectFieldValuePromiseException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\Exception;
+
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
+use PoP\Root\Feedback\FeedbackItemResolution;
+
+final class ObjectFieldValuePromiseException extends AbstractValueResolutionPromiseException
+{
+    public function __construct(
+        FeedbackItemResolution $feedbackItemResolution,
+        private readonly FieldInterface $field,
+    ) {
+        parent::__construct(
+            $feedbackItemResolution,
+            $field,
+        );
+    }
+
+    public function getField(): FieldInterface
+    {
+        return $this->field;
+    }
+}

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Execution/ObjectFieldValuePromise.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Execution/ObjectFieldValuePromise.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\ExtendedSpec\Execution;
 
+use PoP\GraphQLParser\Exception\ObjectFieldValuePromiseException;
+use PoP\GraphQLParser\FeedbackItemProviders\GraphQLExtendedSpecErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\Root\App;
-use PoP\Root\Exception\ShouldNotHappenException;
+use PoP\Root\Feedback\FeedbackItemResolution;
 use PoP\Root\Services\StandaloneServiceTrait;
 use SplObjectStorage;
 
@@ -24,11 +26,15 @@ class ObjectFieldValuePromise implements ValueResolutionPromiseInterface
         /** @var SplObjectStorage<FieldInterface,mixed> */
         $objectResolvedFieldValues = App::getState('engine-iteration-object-resolved-field-values');
         if (!$objectResolvedFieldValues->contains($this->field)) {
-            throw new ShouldNotHappenException(
-                sprintf(
-                    $this->__('The ObjectFieldValuePromise cannot resolve field \'%s\'', 'graphql-parser'),
-                    $this->field->asFieldOutputQueryString()
-                )
+            throw new ObjectFieldValuePromiseException(
+                new FeedbackItemResolution(
+                    GraphQLExtendedSpecErrorFeedbackItemProvider::class,
+                    GraphQLExtendedSpecErrorFeedbackItemProvider::E11,
+                    [
+                        $this->field->asFieldOutputQueryString(),
+                    ]
+                ),
+                $this->field
             );
         }
 

--- a/layers/Engine/packages/graphql-parser/src/FeedbackItemProviders/GraphQLExtendedSpecErrorFeedbackItemProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/FeedbackItemProviders/GraphQLExtendedSpecErrorFeedbackItemProvider.php
@@ -19,6 +19,7 @@ class GraphQLExtendedSpecErrorFeedbackItemProvider extends AbstractFeedbackItemP
     public final const E8 = '8';
     public final const E9 = '9';
     public final const E10 = '10';
+    public final const E11 = '11';
     public final const E_5_8_3 = '5.8.3';
 
     protected function getNamespace(): string
@@ -42,6 +43,7 @@ class GraphQLExtendedSpecErrorFeedbackItemProvider extends AbstractFeedbackItemP
             self::E8,
             self::E9,
             self::E10,
+            self::E11,
             self::E_5_8_3,
         ];
     }
@@ -59,6 +61,7 @@ class GraphQLExtendedSpecErrorFeedbackItemProvider extends AbstractFeedbackItemP
             self::E8 => $this->__('The reference to the Resolved Field Value \'%1$s\' cannot share the same name with the variable \'%1$s\'', 'graphql-parser'),
             self::E9 => $this->__('Dynamic variable \'%1$s\' cannot share the same name with the reference to the Resolved Field Value \'%2$s\'', 'graphql-parser'),
             self::E10 => $this->__('No value has been exported for dynamic variable \'%s\' for object with ID \'%s\'', 'graphql-server'),
+            self::E11 => $this->__('The reference to field \'%s\' cannot be resolved', 'graphql-server'),
             self::E_5_8_3 => $this->__('No value has been exported for dynamic variable \'%s\'', 'graphql-server'),
             default => parent::getMessagePlaceholder($code),
         };


### PR DESCRIPTION
In replacement of `ShouldNotHappenException`, because it can also happen due to issues in the GraphQL query, i.e. not only from an error from the developer.

Eg: if there's an ACL on `authorURL` so that the field is disabled, the reference to that field will fail, and the error message must be pleasant for the PROD user (instead of the exception message only intended for DEV):

```graphql
{
  comments {
    authorURL
    _empty(value: $__authorURL)
  }
}
```

