### PR TITLE
Create a hierarchy of classes for DirectiveResolvers

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -33,7 +33,7 @@ use PoP\Root\Services\BasicServiceTrait;
 abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
 {
     use BasicServiceTrait;
-    
+
     protected Directive $directive;
 
     /**
@@ -102,5 +102,5 @@ abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
     public function isRepeatable(): bool
     {
         return !($this->getDirectiveKind() == DirectiveKinds::SYSTEM || $this->getDirectiveKind() == DirectiveKinds::SCHEMA);
-    }    
+    }
 }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -9,6 +9,27 @@ use PoP\GraphQLParser\ASTNodes\ASTNodesFactory;
 use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
 use PoP\Root\Services\BasicServiceTrait;
 
+/**
+ * Top most ancestor class on the hierarchy of the
+ * Directive Resolver classes.
+ *
+ * This hierarchy, in theory, allows the creation of
+ * resolvers for all types of directives defined by the
+ * GraphQL spec:
+ *
+ * - OperationDirectiveResolver
+ * - FragmentDirectiveResolver
+ * - ArgumentDirectiveResolver
+ *
+ * However, in practice, only FieldDirectives are supported
+ * by the GraphQL server, via the directive pipeline.
+ *
+ * It is through FieldDirectives that functionality for
+ * Operation Directives and Fragment Directives is also
+ * supported.
+ *
+ * @see AbstractFieldDirectiveResolver
+ */
 abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
 {
     use BasicServiceTrait;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractDirectiveResolver.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\DirectiveResolvers;
+
+use PoP\ComponentModel\Directives\DirectiveKinds;
+use PoP\GraphQLParser\ASTNodes\ASTNodesFactory;
+use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
+use PoP\Root\Services\BasicServiceTrait;
+
+abstract class AbstractDirectiveResolver implements DirectiveResolverInterface
+{
+    use BasicServiceTrait;
+    
+    protected Directive $directive;
+
+    /**
+     * The directiveResolvers are instantiated through the service container,
+     * but NOT for the directivePipeline, since there each directiveResolver
+     * will require the actual $directive to process.
+     *
+     * By default, the directive is directly the directive name.
+     * This is what is used when instantiating the directive through the container.
+     */
+    public function __construct()
+    {
+        $this->directive = new Directive(
+            $this->getDirectiveName(),
+            [],
+            ASTNodesFactory::getNonSpecificLocation()
+        );
+    }
+
+    /**
+     * Invoked when creating the non-shared directive instance
+     * to resolve a directive in the pipeline
+     */
+    final public function setDirective(Directive $directive): void
+    {
+        $this->directive = $directive;
+    }
+
+    public function getDirective(): Directive
+    {
+        return $this->directive;
+    }
+
+    /**
+     * Directives can be either of type "Schema" or "Query" and,
+     * depending on one case or the other, might be exposed to the user.
+     * By default, use the Query type
+     */
+    public function getDirectiveKind(): string
+    {
+        return DirectiveKinds::QUERY;
+    }
+
+    /**
+     * ModuleConfiguration values cannot be accessed in `isServiceEnabled`,
+     * because the DirectiveResolver services are initialized on
+     * the "boot" event, and by then the `SchemaConfigurationExecuter`
+     * services, to set-up configuration hooks, have not been initialized yet.
+     * Then, the GraphQL custom endpoint will not have its Schema Configuration
+     * applied.
+     *
+     * That's why it is done in this method instead.
+     *
+     * @see BootAttachExtensionCompilerPass.php
+     */
+    public function isDirectiveEnabled(): bool
+    {
+        return true;
+    }
+
+    /**
+     * By default, a directive can be executed only one time for "Schema" and "System"
+     * type directives (eg: <translate(en,es),translate(es,en)>),
+     * and many times for the other types, "Query", "Scripting" and "Indexing"
+     */
+    public function isRepeatable(): bool
+    {
+        return !($this->getDirectiveKind() == DirectiveKinds::SYSTEM || $this->getDirectiveKind() == DirectiveKinds::SCHEMA);
+    }    
+}

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractFieldDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractFieldDirectiveResolver.php
@@ -8,7 +8,6 @@ use Exception;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionManagerInterface;
 use PoP\ComponentModel\AttachableExtensions\AttachableExtensionTrait;
 use PoP\ComponentModel\DirectivePipeline\DirectivePipelineUtils;
-use PoP\ComponentModel\Directives\DirectiveKinds;
 use PoP\ComponentModel\Engine\EngineIterationFieldSet;
 use PoP\ComponentModel\Environment;
 use PoP\ComponentModel\FeedbackItemProviders\ErrorFeedbackItemProvider;
@@ -43,7 +42,6 @@ use PoP\ComponentModel\TypeResolvers\ScalarType\DangerouslyNonSpecificScalarType
 use PoP\ComponentModel\TypeResolvers\ScalarType\IntScalarTypeResolver;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
 use PoP\ComponentModel\Versioning\VersioningServiceInterface;
-use PoP\GraphQLParser\ASTNodes\ASTNodesFactory;
 use PoP\GraphQLParser\Exception\AbstractQueryException;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Module as GraphQLParserModule;
@@ -55,20 +53,17 @@ use PoP\Root\App;
 use PoP\Root\Exception\AbstractClientException;
 use PoP\Root\FeedbackItemProviders\GenericFeedbackItemProvider;
 use PoP\Root\Feedback\FeedbackItemResolution;
-use PoP\Root\Services\BasicServiceTrait;
 use SplObjectStorage;
 
-abstract class AbstractFieldDirectiveResolver implements FieldDirectiveResolverInterface
+abstract class AbstractFieldDirectiveResolver extends AbstractDirectiveResolver implements FieldDirectiveResolverInterface
 {
     use AttachableExtensionTrait;
     use RemoveIDFieldSetFieldDirectiveResolverTrait;
     use FieldOrDirectiveSchemaDefinitionResolverTrait;
     use WithVersionConstraintFieldOrFieldDirectiveResolverTrait;
-    use BasicServiceTrait;
     use CheckDangerouslyNonSpecificScalarTypeFieldOrFieldDirectiveResolverTrait;
     use ObjectTypeOrFieldDirectiveResolverTrait;
 
-    protected Directive $directive;
     /** @var array<string,array<string,InputTypeResolverInterface>> */
     protected array $consolidatedDirectiveArgNameTypeResolversCache = [];
     /** @var array<string,string|null> */
@@ -156,52 +151,11 @@ abstract class AbstractFieldDirectiveResolver implements FieldDirectiveResolverI
     }
 
     /**
-     * The directiveResolvers are instantiated through the service container,
-     * but NOT for the directivePipeline, since there each directiveResolver
-     * will require the actual $directive to process.
-     *
-     * By default, the directive is directly the directive name.
-     * This is what is used when instantiating the directive through the container.
-     */
-    public function __construct()
-    {
-        $this->directive = new Directive(
-            $this->getDirectiveName(),
-            [],
-            ASTNodesFactory::getNonSpecificLocation()
-        );
-    }
-
-    /**
-     * Invoked when creating the non-shared directive instance
-     * to resolve a directive in the pipeline
-     */
-    final public function setDirective(Directive $directive): void
-    {
-        $this->directive = $directive;
-    }
-
-    public function getDirective(): Directive
-    {
-        return $this->directive;
-    }
-
-    /**
      * @return string[]
      */
     final public function getClassesToAttachTo(): array
     {
         return $this->getRelationalTypeOrInterfaceTypeResolverClassesToAttachTo();
-    }
-
-    /**
-     * Directives can be either of type "Schema" or "Query" and,
-     * depending on one case or the other, might be exposed to the user.
-     * By default, use the Query type
-     */
-    public function getDirectiveKind(): string
-    {
-        return DirectiveKinds::QUERY;
     }
 
     /**
@@ -550,23 +504,6 @@ abstract class AbstractFieldDirectiveResolver implements FieldDirectiveResolverI
     }
 
     /**
-     * ModuleConfiguration values cannot be accessed in `isServiceEnabled`,
-     * because the DirectiveResolver services are initialized on
-     * the "boot" event, and by then the `SchemaConfigurationExecuter`
-     * services, to set-up configuration hooks, have not been initialized yet.
-     * Then, the GraphQL custom endpoint will not have its Schema Configuration
-     * applied.
-     *
-     * That's why it is done in this method instead.
-     *
-     * @see BootAttachExtensionCompilerPass.php
-     */
-    public function isDirectiveEnabled(): bool
-    {
-        return true;
-    }
-
-    /**
      * Define if to use the version to decide if to process the directive or not
      */
     public function decideCanProcessBasedOnVersionConstraint(RelationalTypeResolverInterface $relationalTypeResolver): bool
@@ -757,16 +694,6 @@ abstract class AbstractFieldDirectiveResolver implements FieldDirectiveResolverI
     public function getPipelinePosition(): string
     {
         return PipelinePositions::AFTER_RESOLVE;
-    }
-
-    /**
-     * By default, a directive can be executed only one time for "Schema" and "System"
-     * type directives (eg: <translate(en,es),translate(es,en)>),
-     * and many times for the other types, "Query", "Scripting" and "Indexing"
-     */
-    public function isRepeatable(): bool
-    {
-        return !($this->getDirectiveKind() == DirectiveKinds::SYSTEM || $this->getDirectiveKind() == DirectiveKinds::SCHEMA);
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractFieldDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractFieldDirectiveResolver.php
@@ -55,6 +55,17 @@ use PoP\Root\FeedbackItemProviders\GenericFeedbackItemProvider;
 use PoP\Root\Feedback\FeedbackItemResolution;
 use SplObjectStorage;
 
+/**
+ * The GraphQL server resolves only FieldDirectiveResolvers
+ * via the directive pipeline.
+ *
+ * FieldDirectiveResolvers can also handle Operation Directives,
+ * by having these be duplicated into the SuperRoot type fields.
+ *
+ * In addition, FieldDirectiveResolvers can also handle
+ * Fragment Reference Directives, by spreading these to the
+ * conditional fields that resolve the fragment.
+ */
 abstract class AbstractFieldDirectiveResolver extends AbstractDirectiveResolver implements FieldDirectiveResolverInterface
 {
     use AttachableExtensionTrait;

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DirectiveResolverInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\DirectiveResolvers;
+
+use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
+
+interface DirectiveResolverInterface
+{
+    public function getDirectiveName(): string;
+
+    public function getDirective(): Directive;
+
+    /**
+     * Set the Directive to be resolved by the DirectiveResolver.
+     */
+    public function setDirective(
+        Directive $directive,
+    ): void;
+
+    /**
+     * ModuleConfiguration values cannot be accessed in `isServiceEnabled`,
+     * because the DirectiveResolver services are initialized on
+     * the "boot" event, and by then the `SchemaConfigurationExecuter`
+     * services, to set-up configuration hooks, have not been initialized yet.
+     * Then, the GraphQL custom endpoint will not have its Schema Configuration
+     * applied.
+     *
+     * That's why it is done in this method instead.
+     *
+     * @see BootAttachExtensionCompilerPass.php
+     */
+    public function isDirectiveEnabled(): bool;
+
+    /**
+     * Directives can be either of type "Schema" or "Query" and,
+     * depending on one case or the other, might be exposed to the user.
+     * By default, use the Query type
+     */
+    public function getDirectiveKind(): string;
+
+    /**
+     * Indicates if the directive can be added several times to the pipeline, or only once
+     */
+    public function isRepeatable(): bool;
+}

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/FieldDirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/FieldDirectiveResolverInterface.php
@@ -15,7 +15,7 @@ use PoP\GraphQLParser\Spec\Parser\Ast\Directive;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use SplObjectStorage;
 
-interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, SchemaFieldDirectiveResolverInterface
+interface FieldDirectiveResolverInterface extends DirectiveResolverInterface, AttachableExtensionInterface, SchemaFieldDirectiveResolverInterface
 {
     /**
      * The classes of the ObjectTypeResolvers and/or InterfaceTypeResolvers
@@ -26,14 +26,7 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
      * @return array<class-string<InterfaceTypeResolverInterface|RelationalTypeResolverInterface>>
      */
     public function getRelationalTypeOrInterfaceTypeResolverClassesToAttachTo(): array;
-    public function getDirectiveName(): string;
-    public function getDirective(): Directive;
-    /**
-     * Set the Directive to be resolved by the DirectiveResolver.
-     */
-    public function setDirective(
-        Directive $directive,
-    ): void;
+
     /**
      * Validate and initialize the Directive, such as adding
      * the default values for Arguments which were not provided
@@ -46,11 +39,13 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
         array $fields,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void;
+
     /**
      * After calling `prepareDirective`, indicate if casting
      * the Directive Arguments produced any error.
      */
     public function hasValidationErrors(): bool;
+
     /**
      * Indicate to what fieldNames this directive can be applied.
      * Returning an empty array means all of them
@@ -58,25 +53,6 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
      * @return string[]
      */
     public function getFieldNamesToApplyTo(): array;
-    /**
-     * ModuleConfiguration values cannot be accessed in `isServiceEnabled`,
-     * because the DirectiveResolver services are initialized on
-     * the "boot" event, and by then the `SchemaConfigurationExecuter`
-     * services, to set-up configuration hooks, have not been initialized yet.
-     * Then, the GraphQL custom endpoint will not have its Schema Configuration
-     * applied.
-     *
-     * That's why it is done in this method instead.
-     *
-     * @see BootAttachExtensionCompilerPass.php
-     */
-    public function isDirectiveEnabled(): bool;
-    /**
-     * Directives can be either of type "Schema" or "Query" and,
-     * depending on one case or the other, might be exposed to the user.
-     * By default, use the Query type
-     */
-    public function getDirectiveKind(): string;
 
     /**
      * Define where to place the directive in the directive execution pipeline
@@ -111,6 +87,7 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
      * @return mixed[]
      */
     public function resolveDirectivePipelinePayload(array $payload): array;
+
     /**
      * Indicate if the directiveResolver can process the directive with the given name and args
      */
@@ -118,6 +95,7 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
         RelationalTypeResolverInterface $relationalTypeResolver,
         Directive $directive,
     ): bool;
+
     /**
      * Indicate if the directiveResolver can process the directive with the given name and args
      */
@@ -125,14 +103,12 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
         RelationalTypeResolverInterface $relationalTypeResolver,
         FieldInterface $field,
     ): bool;
-    /**
-     * Indicates if the directive can be added several times to the pipeline, or only once
-     */
-    public function isRepeatable(): bool;
+
     /**
      * Indicate if the directive needs to be passed $idFieldSet filled with data to be able to execute
      */
     public function needsSomeIDFieldToExecute(): bool;
+
     /**
      * Execute the directive
      *
@@ -160,6 +136,7 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
         array &$messages,
         EngineIterationFeedbackStore $engineIterationFeedbackStore,
     ): void;
+
     /**
      * A directive can decide to not be added to the schema, eg: when it is repeated/implemented several times
      */
@@ -181,6 +158,7 @@ interface FieldDirectiveResolverInterface extends AttachableExtensionInterface, 
     public function getDirectiveVersionInputTypeResolver(RelationalTypeResolverInterface $relationalTypeResolver): ?InputTypeResolverInterface;
 
     public function getDirectiveDeprecationMessage(RelationalTypeResolverInterface $relationalTypeResolver): ?string;
+
     /**
      * Name for the directive arg to indicate which additional fields
      * must be affected by the directive, by indicating their relative position.


### PR DESCRIPTION
Split `AbstractFieldDirectiveResolver` into `AbstractFieldDirectiveResolver` and `AbstractDirectiveResolver` (and the same with its interface `FieldDirectiveResolverInterface`, creating `DirectiveResolverInterface`)

`AbstractDirectiveResolver` is not the top most ancestor class on the hierarchy of the Directive Resolver classes.

This hierarchy, in theory, allows the creation of resolvers for all types of directives defined by the GraphQL spec:
    
- `OperationDirectiveResolver`
- `FragmentDirectiveResolver`
- `ArgumentDirectiveResolver`

However, in practice, only FieldDirectives are supported by the GraphQL server, via the directive pipeline.

It is through FieldDirectives that functionality for Operation Directives and Fragment Directives is also supported. 