### PR TITLE
Add field `CustomPost.contentSource`

### DIFF
--- a/layers/WPSchema/packages/customposts/config/schema-services.yaml
+++ b/layers/WPSchema/packages/customposts/config/schema-services.yaml
@@ -3,5 +3,8 @@ services:
         public: true
         autowire: true
 
+    PoPWPSchema\CustomPosts\FieldResolvers\:
+        resource: '../src/FieldResolvers/*'
+
     PoPWPSchema\CustomPosts\SchemaHooks\:
         resource: '../src/SchemaHooks/*'

--- a/layers/WPSchema/packages/customposts/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/customposts/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -51,7 +51,7 @@ class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeField
     public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
     {
         return match ($fieldName) {
-            'contentSource' => $this->__('Retrieve the format slug for a post', 'posts'),
+            'contentSource' => $this->__('Retrieve the content in its \'source\' format, including the (Gutenberg) block delimiter HTML comments', 'customposts'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }

--- a/layers/WPSchema/packages/customposts/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
+++ b/layers/WPSchema/packages/customposts/src/FieldResolvers/ObjectType/CustomPostObjectTypeFieldResolver.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPWPSchema\CustomPosts\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\CustomPosts\TypeResolvers\ObjectType\AbstractCustomPostObjectTypeResolver;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractQueryableObjectTypeFieldResolver;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\StringScalarTypeResolver;
+use WP_Post;
+
+class CustomPostObjectTypeFieldResolver extends AbstractQueryableObjectTypeFieldResolver
+{
+    private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+
+    final public function setStringScalarTypeResolver(StringScalarTypeResolver $stringScalarTypeResolver): void
+    {
+        $this->stringScalarTypeResolver = $stringScalarTypeResolver;
+    }
+    final protected function getStringScalarTypeResolver(): StringScalarTypeResolver
+    {
+        /** @var StringScalarTypeResolver */
+        return $this->stringScalarTypeResolver ??= $this->instanceManager->getInstance(StringScalarTypeResolver::class);
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCustomPostObjectTypeResolver::class,
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'contentSource',
+        ];
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'contentSource' => $this->__('Retrieve the format slug for a post', 'posts'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            'contentSource' => $this->getStringScalarTypeResolver(),
+            default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        return match ($fieldName) {
+            'contentSource' => SchemaTypeModifiers::NON_NULLABLE,
+            default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        /** @var WP_Post */
+        $customPost = $object;
+        switch ($fieldDataAccessor->getFieldName()) {
+            case 'contentSource':
+                return $customPost->post_content;
+        }
+
+        return parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+    }
+}


### PR DESCRIPTION
New field for any CPT to retrieve the content in its "source" format, including the (Gutenberg) block delimiter HTML comments