### PR TITLE
Allow to validate cardinality for DangerouslyNonSpecificScalar

### DIFF
--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -79,7 +79,7 @@ class InputCoercingService implements InputCoercingServiceInterface
      * Nullable booleans can be `null` for the DangerouslyNonSpecificScalar,
      * so they can also validate their cardinality:
      *
-     *   - DangerouslyNonSpecificScalar does not need to validate anything => all null 
+     *   - DangerouslyNonSpecificScalar does not need to validate anything => all null
      *   - [DangerouslyNonSpecificScalar] must certainly be an array, but it doesn't care
      *     inside if it's an array or not => $inputIsArrayType => true, $inputIsArrayOfArraysType => null
      *   - [[DangerouslyNonSpecificScalar]] must be array of arrays => $inputIsArrayType => true, $inputIsArrayOfArraysType => true

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingServiceInterface.php
@@ -32,7 +32,7 @@ interface InputCoercingServiceInterface
      * Nullable booleans can be `null` for the DangerouslyNonSpecificScalar,
      * so they can also validate their cardinality:
      *
-     *   - DangerouslyNonSpecificScalar does not need to validate anything => all null 
+     *   - DangerouslyNonSpecificScalar does not need to validate anything => all null
      *   - [DangerouslyNonSpecificScalar] must certainly be an array, but it doesn't care
      *     inside if it's an array or not => $inputIsArrayType => true, $inputIsArrayOfArraysType => null
      *   - [[DangerouslyNonSpecificScalar]] must be array of arrays => $inputIsArrayType => true, $inputIsArrayOfArraysType => true

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingServiceInterface.php
@@ -29,16 +29,24 @@ interface InputCoercingServiceInterface
      * Validate that the expected array/non-array input is provided,
      * checking that the WrappingType is respected.
      *
+     * Nullable booleans can be `null` for the DangerouslyNonSpecificScalar,
+     * so they can also validate their cardinality:
+     *
+     *   - DangerouslyNonSpecificScalar does not need to validate anything => all null 
+     *   - [DangerouslyNonSpecificScalar] must certainly be an array, but it doesn't care
+     *     inside if it's an array or not => $inputIsArrayType => true, $inputIsArrayOfArraysType => null
+     *   - [[DangerouslyNonSpecificScalar]] must be array of arrays => $inputIsArrayType => true, $inputIsArrayOfArraysType => true
+     *
      * Eg: `["hello"]` must be `[String]`, can't be `[[String]]` or `String`.
      */
     public function validateInputArrayModifiers(
         InputTypeResolverInterface $inputTypeResolver,
         mixed $inputValue,
         string $inputName,
-        bool $inputIsArrayType,
-        bool $inputIsNonNullArrayItemsType,
-        bool $inputIsArrayOfArraysType,
-        bool $inputIsNonNullArrayOfArraysItemsType,
+        ?bool $inputIsArrayType,
+        ?bool $inputIsNonNullArrayItemsType,
+        ?bool $inputIsArrayOfArraysType,
+        ?bool $inputIsNonNullArrayOfArraysItemsType,
         AstInterface $astNode,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): void;

--- a/layers/Engine/packages/component-model/src/Schema/SchemaCastingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaCastingService.php
@@ -96,7 +96,7 @@ class SchemaCastingService implements SchemaCastingServiceInterface
              * if explicitly set to `true`. Otherwise change from `false`
              * to `null`, to indicate "do not validate".
              *
-             *   - DangerouslyNonSpecificScalar does not need to validate anything => all null 
+             *   - DangerouslyNonSpecificScalar does not need to validate anything => all null
              *   - [DangerouslyNonSpecificScalar] must certainly be an array, but it doesn't care
              *     inside if it's an array or not => $inputIsArrayType => true, $inputIsArrayOfArraysType => null
              *   - [[DangerouslyNonSpecificScalar]] must be array of arrays => $inputIsArrayType => true, $inputIsArrayOfArraysType => true

--- a/layers/Engine/packages/component-model/src/Schema/SchemaCastingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaCastingService.php
@@ -108,21 +108,19 @@ class SchemaCastingService implements SchemaCastingServiceInterface
                 if (!$fieldOrDirectiveArgIsArrayOfArraysType) {
                     $fieldOrDirectiveArgIsArrayOfArraysType = null;
                 }
-            }
-
-            /**
-             * Modifying the AST and not directly its value, because
-             * a VariableReference may be converted to InputList([VariableReference]),
-             * so the underlying AST holding the value must also change.
-             *
-             * Support passing a single value where a list is expected:
-             * `{ posts(ids: 1) }` means `{ posts(ids: [1]) }`
-             *
-             * Defined in the GraphQL spec.
-             *
-             * @see https://spec.graphql.org/draft/#sec-List.Input-Coercion
-             */
-            if (!$isDangerouslyNonSpecificScalar) {
+            } else {
+                /**
+                 * Modifying the AST and not directly its value, because
+                 * a VariableReference may be converted to InputList([VariableReference]),
+                 * so the underlying AST holding the value must also change.
+                 *
+                 * Support passing a single value where a list is expected:
+                 * `{ posts(ids: 1) }` means `{ posts(ids: [1]) }`
+                 *
+                 * Defined in the GraphQL spec.
+                 *
+                 * @see https://spec.graphql.org/draft/#sec-List.Input-Coercion
+                 */
                 $argValue = $this->getInputCoercingService()->maybeConvertInputValueFromSingleToList(
                     $argValue,
                     $fieldOrDirectiveArgIsArrayType,

--- a/layers/Engine/packages/component-model/src/Schema/SchemaCastingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaCastingService.php
@@ -162,6 +162,12 @@ class SchemaCastingService implements SchemaCastingServiceInterface
                 continue;
             }
 
+            /**
+             * Cast (or "coerce" in GraphQL terms) the value
+             *
+             * @var bool $fieldOrDirectiveArgIsArrayType
+             * @var bool $fieldOrDirectiveArgIsArrayOfArraysType
+             */
             $coercedArgValue = $this->getInputCoercingService()->coerceInputValue(
                 $fieldOrDirectiveArgTypeResolver,
                 $argValue,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -363,7 +363,12 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                 continue;
             }
 
-            // Cast (or "coerce" in GraphQL terms) the value
+            /**
+             * Cast (or "coerce" in GraphQL terms) the value
+             *
+             * @var bool $inputFieldIsArrayType
+             * @var bool $inputFieldIsArrayOfArraysType
+             */
             $coercedInputFieldValue = $this->getInputCoercingService()->coerceInputValue(
                 $inputFieldTypeResolver,
                 $inputFieldValue,

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -309,7 +309,7 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
              * if explicitly set to `true`. Otherwise change from `false`
              * to `null`, to indicate "do not validate".
              *
-             *   - DangerouslyNonSpecificScalar does not need to validate anything => all null 
+             *   - DangerouslyNonSpecificScalar does not need to validate anything => all null
              *   - [DangerouslyNonSpecificScalar] must certainly be an array, but it doesn't care
              *     inside if it's an array or not => $inputIsArrayType => true, $inputIsArrayOfArraysType => null
              *   - [[DangerouslyNonSpecificScalar]] must be array of arrays => $inputIsArrayType => true, $inputIsArrayOfArraysType => true

--- a/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php
@@ -321,17 +321,15 @@ abstract class AbstractInputObjectTypeResolver extends AbstractTypeResolver impl
                 if (!$inputFieldIsArrayType) {
                     $inputFieldIsArrayType = null;
                 }
-            }
-
-            /**
-             * Support passing a single value where a list is expected:
-             * `{ posts(ids: 1) }` means `{ posts(ids: [1]) }`
-             *
-             * Defined in the GraphQL spec.
-             *
-             * @see https://spec.graphql.org/draft/#sec-List.Input-Coercion
-             */
-            if (!$isDangerouslyNonSpecificScalar) {
+            } else {
+                /**
+                 * Support passing a single value where a list is expected:
+                 * `{ posts(ids: 1) }` means `{ posts(ids: [1]) }`
+                 *
+                 * Defined in the GraphQL spec.
+                 *
+                 * @see https://spec.graphql.org/draft/#sec-List.Input-Coercion
+                 */
                 $inputFieldValue = $this->getInputCoercingService()->maybeConvertInputValueFromSingleToList(
                     $inputFieldValue,
                     $inputFieldIsArrayType,


### PR DESCRIPTION
In function `validateInputArrayModifiers`, boolean params `$inputIsArrayType` and `$inputIsArrayOfArraysType` were made nullable.

This is to allow type `DangerouslyNonSpecificScalar` to also validate its cardinality:

- `DangerouslyNonSpecificScalar` does not need to validate anything => both are `null`
- `[DangerouslyNonSpecificScalar]` must certainly be an array, but it doesn't care inside if it's an array or not => `$inputIsArrayType` => `true`, `$inputIsArrayOfArraysType` => `null`
- `[[DangerouslyNonSpecificScalar]]` must be array of arrays => `$inputIsArrayType` => `true`, `$inputIsArrayOfArraysType` => `true`
