### PR TITLE
Upgraded deprecated `set-output` in GitHub Actions

### DIFF
--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -28,7 +28,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=package_code_paths::$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests)"
+                    echo "package_code_paths=$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests)" >> $GITHUB_OUTPUT
 
         outputs:
             package_code_paths: ${{ steps.output_data.outputs.package_code_paths }}

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -27,12 +27,12 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=package_srcs::$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src)"
-                    echo "::set-output name=exclude_package_tests::$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=tests | sed -e 's/ / --exclude /g')"
-                    echo "::set-output name=skip_downgrade_test_paths::$(vendor/bin/monorepo-builder skip-downgrade-test-paths --config=config/monorepo-builder/skip-downgrade-test-paths.php | sed -e 's/ / --exclude /g')"
-                    echo "::set-output name=generate_artifact_with_downgraded_code::$(vendor/bin/monorepo-builder env-var GENERATE_ARTIFACT_WITH_DOWNGRADED_CODE --config=config/monorepo-builder/env-var.php)"
-                    echo "::set-output name=additional_downgrade_rector_configs::$(vendor/bin/monorepo-builder additional-downgrade-rector-configs --config=config/monorepo-builder/additional-downgrade-rector-configs.php)"
-                    echo "::set-output name=local_package_owners::$(vendor/bin/monorepo-builder local-package-owners --config=config/monorepo-builder/local-package-owners.php)"
+                    echo "package_srcs=$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src)" >> $GITHUB_OUTPUT
+                    echo "exclude_package_tests=$(vendor/bin/monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=tests | sed -e 's/ / --exclude /g')" >> $GITHUB_OUTPUT
+                    echo "skip_downgrade_test_paths=$(vendor/bin/monorepo-builder skip-downgrade-test-paths --config=config/monorepo-builder/skip-downgrade-test-paths.php | sed -e 's/ / --exclude /g')" >> $GITHUB_OUTPUT
+                    echo "generate_artifact_with_downgraded_code=$(vendor/bin/monorepo-builder env-var GENERATE_ARTIFACT_WITH_DOWNGRADED_CODE --config=config/monorepo-builder/env-var.php)" >> $GITHUB_OUTPUT
+                    echo "additional_downgrade_rector_configs=$(vendor/bin/monorepo-builder additional-downgrade-rector-configs --config=config/monorepo-builder/additional-downgrade-rector-configs.php)" >> $GITHUB_OUTPUT
+                    echo "local_package_owners=$(vendor/bin/monorepo-builder local-package-owners --config=config/monorepo-builder/local-package-owners.php)" >> $GITHUB_OUTPUT
 
         outputs:
             package_srcs: ${{ steps.output_data.outputs.package_srcs }}

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -54,9 +54,9 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json --config=config/monorepo-builder/plugin-config-entries-json.php)"
-                    echo "::set-output name=retention_days_for_generated_plugins::$(vendor/bin/monorepo-builder env-var RETENTION_DAYS_FOR_GENERATED_PLUGINS --config=config/monorepo-builder/env-var.php)"
-                    echo "::set-output name=local_package_owners::$(vendor/bin/monorepo-builder local-package-owners --config=config/monorepo-builder/local-package-owners.php)"
+                    echo "plugin_config_entries=$(vendor/bin/monorepo-builder plugin-config-entries-json --config=config/monorepo-builder/plugin-config-entries-json.php)" >> $GITHUB_OUTPUT
+                    echo "retention_days_for_generated_plugins=$(vendor/bin/monorepo-builder env-var RETENTION_DAYS_FOR_GENERATED_PLUGINS --config=config/monorepo-builder/env-var.php)" >> $GITHUB_OUTPUT
+                    echo "local_package_owners=$(vendor/bin/monorepo-builder local-package-owners --config=config/monorepo-builder/local-package-owners.php)" >> $GITHUB_OUTPUT
         outputs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
             retention_days: ${{ steps.output_data.outputs.retention_days_for_generated_plugins }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=additional_integration_test_plugins::$(vendor/bin/monorepo-builder additional-integration-test-plugins --config=config/monorepo-builder/additional-integration-test-plugins.php)"
+                    echo "additional_integration_test_plugins=$(vendor/bin/monorepo-builder additional-integration-test-plugins --config=config/monorepo-builder/additional-integration-test-plugins.php)" >> $GITHUB_OUTPUT
     
             -   name: Retrieve artifact URLs from GitHub workflow
                 uses: actions/github-script@v6

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -34,7 +34,7 @@ jobs:
 
             -   id: output_data
                 run: |
-                    echo "::set-output name=plugin_config_entries::$(vendor/bin/monorepo-builder plugin-config-entries-json --config=config/monorepo-builder/plugin-config-entries-json.php --scoped-only)"
+                    echo "plugin_config_entries=$(vendor/bin/monorepo-builder plugin-config-entries-json --config=config/monorepo-builder/plugin-config-entries-json.php --scoped-only)" >> $GITHUB_OUTPUT
         outputs:
             plugin_config_entries: ${{ steps.output_data.outputs.plugin_config_entries }}
 

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -48,7 +48,7 @@ jobs:
                     packages_in_diff="$(echo $clean_diff | grep -E -o 'layers/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/[A-Za-z0-9_\-]*/' | sort -u)"
                     echo "[Packages in diff] $(echo $packages_in_diff | tr '\n' ' ')"
                     filter_arg="--filter=$(echo $packages_in_diff | sed -e 's/ / --filter=/g')"
-                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json --config=config/monorepo-builder/package-entries-json.php $(echo $filter_arg))"
+                    echo "matrix=$(vendor/bin/monorepo-builder package-entries-json --config=config/monorepo-builder/package-entries-json.php $(echo $filter_arg))" >> $GITHUB_OUTPUT
 
         # this step is needed, so the output gets to the next defined job
         outputs:

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -34,7 +34,7 @@ jobs:
             -   id: output_data
                 name: Calculate matrix for packages
                 run: |
-                    echo "::set-output name=matrix::$(vendor/bin/monorepo-builder package-entries-json --config=config/monorepo-builder/package-entries-json.php)"
+                    echo "matrix=$(vendor/bin/monorepo-builder package-entries-json --config=config/monorepo-builder/package-entries-json.php)" >> $GITHUB_OUTPUT
 
         # this step is needed, so the output gets to the next defined job
         outputs:


### PR DESCRIPTION
As explained in their blog: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/