### PR TITLE
Support block strings in parser

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -667,6 +667,7 @@ class Parser extends Tokenizer implements ParserInterface
                 return $this->parseVariableReference();
 
             case Token::TYPE_NUMBER:
+            case Token::TYPE_BLOCK_STRING:
             case Token::TYPE_STRING:
             case Token::TYPE_NULL:
             case Token::TYPE_TRUE:

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Token.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Token.php
@@ -6,11 +6,12 @@ namespace PoP\GraphQLParser\Spec\Parser;
 
 class Token
 {
-    public final const TYPE_END        = 'end';
-    public final const TYPE_IDENTIFIER = 'identifier';
-    public final const TYPE_NUMBER     = 'number';
-    public final const TYPE_STRING     = 'string';
-    public final const TYPE_ON         = 'on';
+    public final const TYPE_END          = 'end';
+    public final const TYPE_IDENTIFIER   = 'identifier';
+    public final const TYPE_NUMBER       = 'number';
+    public final const TYPE_BLOCK_STRING = 'block string';
+    public final const TYPE_STRING       = 'string';
+    public final const TYPE_ON           = 'on';
 
     public final const TYPE_QUERY              = 'query';
     public final const TYPE_MUTATION           = 'mutation';
@@ -65,6 +66,7 @@ class Token
             self::TYPE_END                => 'END',
             self::TYPE_IDENTIFIER         => 'IDENTIFIER',
             self::TYPE_NUMBER             => 'NUMBER',
+            self::TYPE_BLOCK_STRING       => 'BLOCK_STRING',
             self::TYPE_STRING             => 'STRING',
             self::TYPE_ON                 => 'ON',
             self::TYPE_QUERY              => 'QUERY',

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Tokenizer.php
@@ -151,6 +151,15 @@ class Tokenizer
             return $this->scanNumber();
         }
 
+
+        if ($this->pos + 2 < strlen($this->source)) {
+            $chars = substr($this->source, $this->pos, 3);
+            if ($chars === '"""') {
+                $this->pos += 2;
+                return $this->scanString();
+            }
+        }
+
         if ($ch === '"') {
             return $this->scanString();
         }
@@ -298,6 +307,16 @@ class Tokenizer
 
         $value = '';
         while ($this->pos < $len) {
+            if ($this->pos + 2 < $len) {
+                $chars = substr($this->source, $this->pos, 3);
+                if ($chars === '"""') {
+                    $token = new Token(Token::TYPE_BLOCK_STRING, $this->getLine(), $this->getColumn(), $value);
+                    $this->pos += 3;
+
+                    return $token;
+                }
+            }
+
             $ch = $this->source[$this->pos];
             if ($ch === '"') {
                 $token = new Token(Token::TYPE_STRING, $this->getLine(), $this->getColumn(), $value);

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -875,6 +875,38 @@ GRAPHQL;
                 ),
                 'query { user(id: 10, name: "max", float: 123.123) { id name } }',
             ],
+            // Block Strings with newlines
+            [
+                '{ user (id: 10, name: """
+                    max
+                """, float: 123.123 ) { id, name } }',
+                new Document(
+                    [
+                        new QueryOperation('', [], [], [
+                            new RelationalField(
+                                'user',
+                                null,
+                                [
+                                    new Argument('id', new Literal(10, new Location(1, 13)), new Location(1, 9)),
+                                    new Argument('name', new Literal('
+                    max
+                ', new Location(1, 26)), new Location(1, 17)),
+                                    new Argument('float', new Literal(123.123, new Location(1, 79)), new Location(1, 72)),
+                                ],
+                                [
+                                    new LeafField('id', null, [], [], new Location(1, 91)),
+                                    new LeafField('name', null, [], [], new Location(1, 95)),
+                                ],
+                                [],
+                                new Location(1, 3)
+                            ),
+                        ], new Location(1, 1))
+                    ]
+                ),
+                'query { user(id: 10, name: "
+                    max
+                ", float: 123.123) { id name } }',
+            ],
             [
                 '{ allUsers : users ( id: [ 1, 2, 3] ) { id } }',
                 new Document(

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -172,6 +172,7 @@ GRAPHQL;
             ['{ test (a: "asd", b: <basd>) { id }'],
             ['{ test (asd: [..., asd]) { id } }'],
             ['{ test (asd: { "a": 4, "m": null, "asd": false  "b": 5, "c" : { a }}) { id } }'],
+            ['{ test (a: """asd") { id }'],
             ['asdasd'],
             ['mutation { test(asd: ... ){ ...,asd, asd } }'],
             ['mutation { test{ . test on Test { id } } }'],

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -849,6 +849,32 @@ GRAPHQL;
                 ),
                 'query { user(id: 10, name: "max", float: 123.123) { id name } }',
             ],
+            // Block Strings
+            [
+                '{ user (id: 10, name: """max""", float: 123.123 ) { id, name } }',
+                new Document(
+                    [
+                        new QueryOperation('', [], [], [
+                            new RelationalField(
+                                'user',
+                                null,
+                                [
+                                    new Argument('id', new Literal(10, new Location(1, 13)), new Location(1, 9)),
+                                    new Argument('name', new Literal('max', new Location(1, 26)), new Location(1, 17)),
+                                    new Argument('float', new Literal(123.123, new Location(1, 41)), new Location(1, 34)),
+                                ],
+                                [
+                                    new LeafField('id', null, [], [], new Location(1, 53)),
+                                    new LeafField('name', null, [], [], new Location(1, 57)),
+                                ],
+                                [],
+                                new Location(1, 3)
+                            ),
+                        ], new Location(1, 1))
+                    ]
+                ),
+                'query { user(id: 10, name: "max", float: 123.123) { id name } }',
+            ],
             [
                 '{ allUsers : users ( id: [ 1, 2, 3] ) { id } }',
                 new Document(

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -173,6 +173,7 @@ GRAPHQL;
             ['{ test (asd: [..., asd]) { id } }'],
             ['{ test (asd: { "a": 4, "m": null, "asd": false  "b": 5, "c" : { a }}) { id } }'],
             ['{ test (a: """asd") { id }'],
+            ['{ test (a: "asd""") { id }'],
             ['asdasd'],
             ['mutation { test(asd: ... ){ ...,asd, asd } }'],
             ['mutation { test{ . test on Test { id } } }'],

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -180,6 +180,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - Support fragment spread on unions
   - Variables are input types
   - Queried fields are unambiguous
+- Support block string characters
 - Query schema extensions via introspection
   - Implemented extension `isSensitiveDataElement`
 - Performance improvement: Avoid regenerating the container when the schema is modified

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
@@ -1220,18 +1220,25 @@ The following ones where added:
 
 Added support for the GraphQL spec-defined [block strings](https://spec.graphql.org/draft/#BlockStringCharacter), which are are strings that use `"""` as delimiter instead of `"`, allowing us to input multi-line strings.
 
-Now we can execute this query:
+This query:
 
 ```graphql
 {
-  posts(
-    filter:{
-      search: """
-        hello world
-      """
-    }
-  ) {
-    id
+  _echo(
+    value: """
+        hello
+        world
+    """
+  ) 
+}
+```
+
+...would produce:
+
+```json
+{
+  "data": {
+    "_echo": "\n        hello\n        world\n    "
   }
 }
 ```

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
@@ -1216,6 +1216,26 @@ The following ones where added:
 - Variables are input types ([spec](https://spec.graphql.org/draft/#sec-Variables-Are-Input-Types))
 - Queried fields are unambiguous ([spec](https://spec.graphql.org/draft/#sec-Field-Selection-Merging))
 
+## Support block string characthers
+
+Added support for the GraphQL spec-defined [block strings](https://spec.graphql.org/draft/#BlockStringCharacter), which are are strings that use `"""` as delimiter instead of `"`, allowing us to input multi-line strings.
+
+Now we can execute this query:
+
+```graphql
+{
+  posts(
+    filter:{
+      search: """
+        hello world
+      """
+    }
+  ) {
+    id
+  }
+}
+```
+
 ## Query schema extensions via introspection
 
 Custom metadata attached to schema elements can now be queried via field `extensions`. This is a feature [requested for the GraphQL spec](https://github.com/graphql/graphql-spec/issues/300#issuecomment-504734306), but not yet approved. This GraphQL server already implements it, though, since it is very useful.


### PR DESCRIPTION
Added support for the GraphQL spec-defined [block strings](https://spec.graphql.org/draft/#BlockStringCharacter), which are are strings that use `"""` as delimiter instead of `"`, allowing us to input multi-line strings.

This query:

```graphql
{
  _echo(
    value: """
        hello
        world
    """
  ) 
}
```

...would produce:

```json
{
  "data": {
    "_echo": "\n        hello\n        world\n    "
  }
}
```