### PR TITLE
Show error when Variable is defined with 3 levels of List modifiers

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Exception/Parser/UnsupportedSyntaxErrorParserException.php
+++ b/layers/Engine/packages/graphql-parser/src/Exception/Parser/UnsupportedSyntaxErrorParserException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\Exception\Parser;
+
+final class UnsupportedSyntaxErrorParserException extends AbstractParserException
+{
+}

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\ExtendedSpec\Parser;
 
-use PoP\GraphQLParser\Exception\Parser\LogicErrorParserException;
 use PoP\GraphQLParser\Exception\FeatureNotSupportedException;
+use PoP\GraphQLParser\Exception\Parser\LogicErrorParserException;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorParserException;
+use PoP\GraphQLParser\Exception\Parser\UnsupportedSyntaxErrorParserException;
 use PoP\GraphQLParser\ExtendedSpec\Constants\QuerySyntax;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\AbstractDocument;
 use PoP\GraphQLParser\ExtendedSpec\Parser\Ast\ArgumentValue\DocumentDynamicVariableReference;
@@ -109,12 +110,16 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
      * @throws LogicErrorParserException
      * @throws SyntaxErrorParserException
      * @throws FeatureNotSupportedException
+     * @throws UnsupportedSyntaxErrorParserException
      */
     public function parse(string $source): Document
     {
         return parent::parse($source);
     }
 
+    /**
+     * @throws UnsupportedSyntaxErrorParserException
+     */
     protected function parseOperation(string $type): OperationInterface
     {
         $this->parsedFieldBlockStack = [];

--- a/layers/Engine/packages/graphql-parser/src/FeedbackItemProviders/GraphQLUnsupportedFeatureErrorFeedbackItemProvider.php
+++ b/layers/Engine/packages/graphql-parser/src/FeedbackItemProviders/GraphQLUnsupportedFeatureErrorFeedbackItemProvider.php
@@ -12,6 +12,7 @@ class GraphQLUnsupportedFeatureErrorFeedbackItemProvider extends AbstractFeedbac
     public final const E_1 = '1';
     public final const E_2 = '2';
     public final const E_3 = '3';
+    public final const E_4 = '4';
 
     protected function getNamespace(): string
     {
@@ -27,6 +28,7 @@ class GraphQLUnsupportedFeatureErrorFeedbackItemProvider extends AbstractFeedbac
             self::E_1,
             self::E_2,
             self::E_3,
+            self::E_4,
         ];
     }
 
@@ -36,6 +38,7 @@ class GraphQLUnsupportedFeatureErrorFeedbackItemProvider extends AbstractFeedbac
             self::E_1 => $this->__('Subscriptions are currently not supported', 'graphql-server'),
             self::E_2 => $this->__('Fragment Definition Directives are currently not supported', 'graphql-server'),
             self::E_3 => $this->__('Variable Definition Directives are currently not supported', 'graphql-server'),
+            self::E_4 => $this->__('Only up to 2 levels of List modifiers are supported (eg: `[[String]]`)', 'graphql-server'),
             default => parent::getMessagePlaceholder($code),
         };
     }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/ParserInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/ParserInterface.php
@@ -6,6 +6,7 @@ namespace PoP\GraphQLParser\Spec\Parser;
 
 use PoP\GraphQLParser\Exception\FeatureNotSupportedException;
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorParserException;
+use PoP\GraphQLParser\Exception\Parser\UnsupportedSyntaxErrorParserException;
 use PoP\GraphQLParser\Spec\Parser\Ast\Document;
 
 interface ParserInterface
@@ -13,6 +14,7 @@ interface ParserInterface
     /**
      * @throws SyntaxErrorParserException
      * @throws FeatureNotSupportedException
+     * @throws UnsupportedSyntaxErrorParserException
      */
     public function parse(string $source): Document;
 }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace PoP\GraphQLParser\Spec\Parser;
 
 use PoP\GraphQLParser\Exception\Parser\SyntaxErrorParserException;
+use PoP\GraphQLParser\Exception\Parser\UnsupportedSyntaxErrorParserException;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLParserErrorFeedbackItemProvider;
 use PoP\GraphQLParser\FeedbackItemProviders\GraphQLSpecErrorFeedbackItemProvider;
+use PoP\GraphQLParser\FeedbackItemProviders\GraphQLUnsupportedFeatureErrorFeedbackItemProvider;
 use PoP\GraphQLParser\Spec\Execution\Context;
 use PoP\GraphQLParser\Spec\Parser\Ast\Argument;
 use PoP\GraphQLParser\Spec\Parser\Ast\ArgumentValue\Enum;
@@ -2173,5 +2175,13 @@ GRAPHQL;
             }
           }
         ');
+    }
+
+    public function testNoSurpassingListModifiersCardinalityInVariables(): void
+    {
+        $this->expectException(UnsupportedSyntaxErrorParserException::class);
+        $this->expectExceptionMessage((new FeedbackItemResolution(GraphQLUnsupportedFeatureErrorFeedbackItemProvider::class, GraphQLUnsupportedFeatureErrorFeedbackItemProvider::E_4))->getMessage());
+        $parser = $this->getParser();
+        $parser->parse('query ($variable: [[[String]]]){ query ( teas: $variable ) { alias: name } }');
     }
 }


### PR DESCRIPTION
Only up to 2 levels of List modifiers are supported (eg: `[[String]]`), hence show an error with this query:

```graphql
query SomeQuery($variable: [[[String]]]) {
  query (teas: $variable) {
    name
  }
}
```