### PR TITLE
Hide the GraphiQL Explorer module

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/ModuleListTable.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Admin/Tables/ModuleListTable.php
@@ -65,6 +65,7 @@ class ModuleListTable extends AbstractItemListTable
                     'can-be-disabled' => $moduleResolver->canBeDisabled($module),
                     'can-be-enabled' => !$isEnabled && $moduleRegistry->canModuleBeEnabled($module),
                     'has-settings' => $moduleResolver->hasSettings($module),
+                    'are-settings-hidden' => $moduleResolver->areSettingsHidden($module),
                     'name' => $moduleResolver->getName($module),
                     'description' => $moduleResolver->getDescription($module),
                     'depends-on' => $moduleResolver->getDependedModuleLists($module),
@@ -325,7 +326,7 @@ class ModuleListTable extends AbstractItemListTable
             }
 
             // Maybe add settings links
-            if ($item['has-settings']) {
+            if ($item['has-settings'] && !$item['are-settings-hidden']) {
                 $instanceManager = InstanceManagerFacade::getInstance();
                 /**
                  * @var SettingsMenuPage

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/AbstractModuleResolver.php
@@ -55,6 +55,11 @@ abstract class AbstractModuleResolver implements ModuleResolverInterface
         return false;
     }
 
+    public function areSettingsHidden(string $module): bool
+    {
+        return false;
+    }
+
     public function getID(string $module): string
     {
         $moduleID = strtolower($module);

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ClientFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ClientFunctionalityModuleResolver.php
@@ -265,4 +265,22 @@ class ClientFunctionalityModuleResolver extends AbstractFunctionalityModuleResol
             default => parent::isHidden($module),
         };
     }
+
+    /**
+     * Because GraphiQL v2.0 (yet to be integrated) has the
+     * Explorer already built-in, there's no need to have a
+     * separate module for it.
+     *
+     * Since this functionality is already built and working,
+     * simply hide it.
+     *
+     * @see https://github.com/leoloso/PoP/issues/1902
+     */
+    public function areSettingsHidden(string $module): bool
+    {
+        return match ($module) {
+            self::GRAPHIQL_EXPLORER => true,
+            default => parent::areSettingsHidden($module),
+        };
+    }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ClientFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ClientFunctionalityModuleResolver.php
@@ -247,4 +247,22 @@ class ClientFunctionalityModuleResolver extends AbstractFunctionalityModuleResol
         }
         return $moduleSettings;
     }
+
+    /**
+     * Because GraphiQL v2.0 (yet to be integrated) has the
+     * Explorer already built-in, there's no need to have a
+     * separate module for it.
+     *
+     * Since this functionality is already built and working,
+     * simply hide it.
+     *
+     * @see https://github.com/leoloso/PoP/issues/1902
+     */
+    public function isHidden(string $module): bool
+    {
+        return match ($module) {
+            self::GRAPHIQL_EXPLORER => true,
+            default => parent::isHidden($module),
+        };
+    }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/ModuleResolverInterface.php
@@ -38,6 +38,7 @@ interface ModuleResolverInterface
      */
     public function canBeDisabled(string $module): bool;
     public function isHidden(string $module): bool;
+    public function areSettingsHidden(string $module): bool;
     public function getID(string $module): string;
     public function getName(string $module): string;
     public function getDescription(string $module): string;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistry.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistry.php
@@ -70,7 +70,8 @@ class ModuleRegistry implements ModuleRegistryInterface
     public function getAllModules(
         bool $onlyEnabled = false,
         bool $onlyHasSettings = false,
-        bool $onlyVisible = true
+        bool $onlyVisible = true,
+        bool $onlyWithVisibleSettings = false,
     ): array {
         $modules = array_keys($this->getModuleResolversByModuleAndPriority());
         if ($onlyEnabled) {
@@ -89,6 +90,12 @@ class ModuleRegistry implements ModuleRegistryInterface
             $modules = array_filter(
                 $modules,
                 fn (string $module) => !$this->getModuleResolver($module)->isHidden($module)
+            );
+        }
+        if ($onlyWithVisibleSettings) {
+            $modules = array_filter(
+                $modules,
+                fn (string $module) => !$this->getModuleResolver($module)->areSettingsHidden($module)
             );
         }
         return array_values($modules);

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistryInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistryInterface.php
@@ -16,7 +16,8 @@ interface ModuleRegistryInterface
     public function getAllModules(
         bool $onlyEnabled = false,
         bool $onlyHasSettings = false,
-        bool $onlyVisible = true
+        bool $onlyVisible = true,
+        bool $onlyWithVisibleSettings = false,
     ): array;
     /**
      * @throws ModuleNotExistsException If module does not exist

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
@@ -133,7 +133,7 @@ class SettingsNormalizer implements SettingsNormalizerInterface
     public function getAllSettingsItems(): array
     {
         $items = [];
-        $modules = $this->getModuleRegistry()->getAllModules(true, true, false);
+        $modules = $this->getModuleRegistry()->getAllModules(true, true, false, true);
         foreach ($modules as $module) {
             $moduleResolver = $this->getModuleRegistry()->getModuleResolver($module);
             $items[] = [

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -28,6 +28,18 @@ class PluginDataSource
                     sprintf($excludeJSBlockFilesPlaceholder, 'blocks'),
                     sprintf($excludeJSBlockFilesPlaceholder, 'editor-scripts'),
                     sprintf($excludeJSBlockFilesPlaceholder, 'packages'),
+                    /**
+                     * Because GraphiQL v2.0 (yet to be integrated) has the
+                     * Explorer already built-in, there's no need to have a
+                     * separate module for it.
+                     *
+                     * As a performance improvement, we can then exclude the
+                     * "graphiql" block from the plugin, since it won't ever
+                     * be used, and it's a good 700kb in size.
+                     *
+                     * @see https://github.com/leoloso/PoP/issues/1902
+                     */
+                    'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/graphiql/\*',
                 ]),
                 'dist_repo_organization' => 'GraphQLAPI',
                 'dist_repo_name' => 'graphql-api-for-wp-dist',

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -39,7 +39,7 @@ class PluginDataSource
                      *
                      * @see https://github.com/leoloso/PoP/issues/1902
                      */
-                    'layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/blocks/graphiql/\*',
+                    'blocks/graphiql/\*',
                 ]),
                 'dist_repo_organization' => 'GraphQLAPI',
                 'dist_repo_name' => 'graphql-api-for-wp-dist',

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -28,18 +28,6 @@ class PluginDataSource
                     sprintf($excludeJSBlockFilesPlaceholder, 'blocks'),
                     sprintf($excludeJSBlockFilesPlaceholder, 'editor-scripts'),
                     sprintf($excludeJSBlockFilesPlaceholder, 'packages'),
-                    /**
-                     * Because GraphiQL v2.0 (yet to be integrated) has the
-                     * Explorer already built-in, there's no need to have a
-                     * separate module for it.
-                     *
-                     * As a performance improvement, we can then exclude the
-                     * "graphiql" block from the plugin, since it won't ever
-                     * be used, and it's a good 700kb in size.
-                     *
-                     * @see https://github.com/leoloso/PoP/issues/1902
-                     */
-                    'blocks/graphiql/\*',
                 ]),
                 'dist_repo_organization' => 'GraphQLAPI',
                 'dist_repo_name' => 'graphql-api-for-wp-dist',


### PR DESCRIPTION
In preparation to upgrading to GraphiQL v2.0, the "GraphiQL Explorer" module doesn't make any sense:

- https://github.com/leoloso/PoP/issues/1902

Instead of removing it altogether, this PR merely hides it, so there's no functional difference, and no breaking change will happen after the upgrade takes place.

In addition, `blocks/graphiql` is excluded from the plugin, making it leaner in some 700 kb.
