### PR TITLE
Commented status "auto-draft"

### DIFF
--- a/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -147,14 +147,18 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
             $status = $query['status'];
             unset($query['status']);
             /**
+             * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+             *       Until then, this code is commented
+             *
              * The status may need to be converted to some underlying value
              */
-            $query['post_status'] = is_array($status)
-                ? array_map(
-                    $this->getStatusQueryArgValue(...),
-                    $status
-                )
-                : $this->getStatusQueryArgValue($status);
+            // $query['post_status'] = is_array($status)
+            //     ? array_map(
+            //         $this->getStatusQueryArgValue(...),
+            //         $status
+            //     )
+            //     : $this->getStatusQueryArgValue($status);
+            $query['post_status'] = $status;
         }
         if (isset($query['include']) && is_array($query['include'])) {
             // It can be an array or a string
@@ -232,15 +236,18 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
     }
 
     /**
+     * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+     *       Until then, this code is commented
+     *
      * Allow "auto_draft" to be converted to "auto-draft"
      */
-    protected function getStatusQueryArgValue(string $status): string
-    {
-        return App::applyFilters(
-            self::HOOK_STATUS_QUERY_ARG_VALUE,
-            $status
-        );
-    }
+    // protected function getStatusQueryArgValue(string $status): string
+    // {
+    //     return App::applyFilters(
+    //         self::HOOK_STATUS_QUERY_ARG_VALUE,
+    //         $status
+    //     );
+    // }
     protected function getOrderByQueryArgValue(string $orderBy): string
     {
         $orderBy = match ($orderBy) {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-client/introspection-query.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-client/introspection-query.json
@@ -16813,12 +16813,6 @@
           "interfaces": null,
           "enumValues": [
             {
-              "name": "auto_draft",
-              "description": "Revisions that WordPress saves automatically while you are editing",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "draft",
               "description": "Draft content",
               "isDeprecated": false,

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query.json
@@ -16813,12 +16813,6 @@
           "interfaces": null,
           "enumValues": [
             {
-              "name": "auto_draft",
-              "description": "Revisions that WordPress saves automatically while you are editing",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "draft",
               "description": "Draft content",
               "isDeprecated": false,

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query:0.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query:0.json
@@ -16813,12 +16813,6 @@
           "interfaces": null,
           "enumValues": [
             {
-              "name": "auto_draft",
-              "description": "Revisions that WordPress saves automatically while you are editing",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "draft",
               "description": "Draft content",
               "isDeprecated": false,

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-generic-customposts-enable-disable-modules/graphqlapi_graphqlapi/schema-pages:disabled.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-generic-customposts-enable-disable-modules/graphqlapi_graphqlapi/schema-pages:disabled.json
@@ -935,9 +935,6 @@
                     "name": "FilterCustomPostStatusEnum",
                     "enumValues": [
                         {
-                            "name": "auto_draft"
-                        },
-                        {
                             "name": "draft"
                         },
                         {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-generic-customposts-enable-disable-modules/graphqlapi_graphqlapi/schema-pages:enabled.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-generic-customposts-enable-disable-modules/graphqlapi_graphqlapi/schema-pages:enabled.json
@@ -955,9 +955,6 @@
                     "name": "FilterCustomPostStatusEnum",
                     "enumValues": [
                         {
-                            "name": "auto_draft"
-                        },
-                        {
                             "name": "draft"
                         },
                         {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts.gql
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts.gql
@@ -11,8 +11,7 @@
       ],
       status:[
         publish,
-        inherit,
-        auto_draft
+        inherit
       ]
     },
     pagination: {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts.json
@@ -10,13 +10,13 @@
       ],
       "extensions": {
         "path": [
-          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}",
-          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]})",
-          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}",
+          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]})",
+          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
           "query { ... }"
         ],
         "type": "QueryRoot",
-        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
         "code": "gql@5.6.1[14]",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Values-of-Correct-Type"
       }

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts:0.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts:0.json
@@ -10,13 +10,13 @@
       ],
       "extensions": {
         "path": [
-          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}",
-          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]})",
-          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}",
+          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]})",
+          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
           "query { ... }"
         ],
         "type": "QueryRoot",
-        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
         "code": "gql@5.6.1[14]",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Values-of-Correct-Type"
       }
@@ -31,13 +31,13 @@
       ],
       "extensions": {
         "path": [
-          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}",
-          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]})",
-          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}",
+          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]})",
+          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
           "query { ... }"
         ],
         "type": "QueryRoot",
-        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
         "code": "gql@5.6.1[14]",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Values-of-Correct-Type"
       }
@@ -52,13 +52,13 @@
       ],
       "extensions": {
         "path": [
-          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}",
-          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]})",
-          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}",
+          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]})",
+          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
           "query { ... }"
         ],
         "type": "QueryRoot",
-        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
         "code": "gql@5.6.1[14]",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Values-of-Correct-Type"
       }
@@ -73,13 +73,13 @@
       ],
       "extensions": {
         "path": [
-          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}",
-          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]})",
-          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+          "{customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}",
+          "(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]})",
+          "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
           "query { ... }"
         ],
         "type": "QueryRoot",
-        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit, auto_draft]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
+        "field": "customPosts(filter: {customPostTypes: [\"post\", \"page\", \"attachment\", \"nav_menu_item\", \"custom_css\", \"revision\"], status: [publish, inherit]}, pagination: {limit: 15}, sort: {order: ASC}) { ... }",
         "code": "gql@5.6.1[14]",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Values-of-Correct-Type"
       }

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts:1.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/queryable-customposts:1.json
@@ -86,13 +86,6 @@
         "__typename": "GenericCustomPost"
       },
       {
-        "id": 591,
-        "title": "Auto Draft",
-        "customPostType": "post",
-        "status": "auto-draft",
-        "__typename": "Post"
-      },
-      {
         "id": 592,
         "title": "Website",
         "customPostType": "revision",
@@ -102,6 +95,13 @@
       {
         "id": 593,
         "title": "Website",
+        "customPostType": "revision",
+        "status": "inherit",
+        "__typename": "GenericCustomPost"
+      },
+      {
+        "id": 594,
+        "title": "New title",
         "customPostType": "revision",
         "status": "inherit",
         "__typename": "GenericCustomPost"

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/type-introspection.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/type-introspection.json
@@ -982,9 +982,6 @@
                     "name": "FilterCustomPostStatusEnum",
                     "enumValues": [
                         {
-                            "name": "auto_draft"
-                        },
-                        {
                             "name": "draft"
                         },
                         {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/type-introspection:0.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/type-introspection:0.json
@@ -947,9 +947,6 @@
                     "name": "FilterCustomPostStatusEnum",
                     "enumValues": [
                         {
-                            "name": "auto_draft"
-                        },
-                        {
                             "name": "draft"
                         },
                         {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/type-introspection:1.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-queryable-customposts/type-introspection:1.json
@@ -985,9 +985,6 @@
                     "name": "FilterCustomPostStatusEnum",
                     "enumValues": [
                         {
-                            "name": "auto_draft"
-                        },
-                        {
                             "name": "draft"
                         },
                         {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/modules/schema-customposts/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/modules/schema-customposts/en.md
@@ -79,8 +79,7 @@ For instance, this query retrieves entries from multiple CPTS:
       ],
       status: [
         publish,
-        inherit,
-        auto_draft
+        inherit
       ]
     }
   ) {

--- a/layers/WPSchema/packages/customposts/src/Enums/CustomPostStatus.php
+++ b/layers/WPSchema/packages/customposts/src/Enums/CustomPostStatus.php
@@ -9,6 +9,9 @@ class CustomPostStatus
     public final const FUTURE = 'future';
     public final const PRIVATE = 'private';
     public final const INHERIT = 'inherit';
-    public final const AUTO_DRAFT = 'auto_draft';
-    // public final const ANY = 'any';
+    /**
+     * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+     *       Until then, this code is commented
+     */
+    //public final const AUTO_DRAFT = 'auto_draft';
 }

--- a/layers/WPSchema/packages/customposts/src/SchemaHooks/CustomPostQueryHookSet.php
+++ b/layers/WPSchema/packages/customposts/src/SchemaHooks/CustomPostQueryHookSet.php
@@ -13,17 +13,25 @@ class CustomPostQueryHookSet extends AbstractHookSet
 {
     protected function init(): void
     {
-        App::addFilter(
-            CustomPostTypeAPI::HOOK_STATUS_QUERY_ARG_VALUE,
-            $this->getStatusQueryArgValue(...)
-        );
+        /**
+         * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+         *       Until then, this code is commented
+         */
+        // App::addFilter(
+        //     CustomPostTypeAPI::HOOK_STATUS_QUERY_ARG_VALUE,
+        //     $this->getStatusQueryArgValue(...)
+        // );
     }
 
-    public function getStatusQueryArgValue(string $status): string
-    {
-        return match ($status) {
-            CustomPostStatus::AUTO_DRAFT => 'auto-draft',
-            default => $status,
-        };
-    }
+    /**
+     * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+     *       Until then, this code is commented
+     */
+    // public function getStatusQueryArgValue(string $status): string
+    // {
+    //     return match ($status) {
+    //         CustomPostStatus::AUTO_DRAFT => 'auto-draft',
+    //         default => $status,
+    //     };
+    // }
 }

--- a/layers/WPSchema/packages/customposts/src/SchemaHooks/CustomPostQueryHookSet.php
+++ b/layers/WPSchema/packages/customposts/src/SchemaHooks/CustomPostQueryHookSet.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace PoPWPSchema\CustomPosts\SchemaHooks;
 
-use PoPCMSSchema\CustomPostsWP\TypeAPIs\CustomPostTypeAPI;
-use PoPWPSchema\CustomPosts\Enums\CustomPostStatus;
-use PoP\Root\App;
 use PoP\Root\Hooks\AbstractHookSet;
 
 class CustomPostQueryHookSet extends AbstractHookSet

--- a/layers/WPSchema/packages/customposts/src/SchemaHooks/FilterCustomPostStatusEnumTypeHookSet.php
+++ b/layers/WPSchema/packages/customposts/src/SchemaHooks/FilterCustomPostStatusEnumTypeHookSet.php
@@ -57,8 +57,11 @@ class FilterCustomPostStatusEnumTypeHookSet extends AbstractHookSet
                 CustomPostStatus::FUTURE,
                 CustomPostStatus::PRIVATE,
                 CustomPostStatus::INHERIT,
-                CustomPostStatus::AUTO_DRAFT,
-                // CustomPostStatus::ANY,
+                /**
+                 * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+                 *       Until then, this code is commented
+                 */
+                // CustomPostStatus::AUTO_DRAFT,
             ]
         );
     }
@@ -80,8 +83,11 @@ class FilterCustomPostStatusEnumTypeHookSet extends AbstractHookSet
                 CustomPostStatus::FUTURE,
                 CustomPostStatus::PRIVATE,
                 CustomPostStatus::INHERIT,
-                CustomPostStatus::AUTO_DRAFT,
-                // CustomPostStatus::ANY,
+                /**
+                 * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+                 *       Until then, this code is commented
+                 */
+                //CustomPostStatus::AUTO_DRAFT,
             ]
         );
     }
@@ -98,8 +104,11 @@ class FilterCustomPostStatusEnumTypeHookSet extends AbstractHookSet
             CustomPostStatus::FUTURE => $this->__('Future content - custom posts to publish in the future', 'customposts'),
             CustomPostStatus::PRIVATE => $this->__('Private content - not visible to users who are not logged in', 'customposts'),
             CustomPostStatus::INHERIT => $this->__('Used with a child custom post (such as Attachments and Revisions) to determine the actual status from the parent custom post', 'customposts'),
-            CustomPostStatus::AUTO_DRAFT => $this->__('Revisions that WordPress saves automatically while you are editing', 'customposts'),
-            // CustomPostStatus::ANY => $this->__('Custom posts with any status', 'customposts'),
+            /**
+             * @todo "auto-draft" must be converted to enum value "auto_draft" on `Post.status`.
+             *       Until then, this code is commented
+             */
+            //CustomPostStatus::AUTO_DRAFT => $this->__('Revisions that WordPress saves automatically while you are editing', 'customposts'),
             default => $enumValueDescription,
         };
     }


### PR DESCRIPTION
As it should also be converted in `Post.status`: 

- from: WordPress status value `"auto-draft"`
- to: enum value `auto_draft`
 
As this has not been done, to keep consistency, using "auto-draft" has been commented out.

(It can be added again, once it's proven that it's needed.)