### PR TITLE
Add `hasValue` for Variable

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/AbstractRuntimeVariableReference.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/AbstractRuntimeVariableReference.php
@@ -20,4 +20,13 @@ abstract class AbstractRuntimeVariableReference extends VariableReference implem
     ) {
         parent::__construct($name, null, $location);
     }
+
+    /**
+     * Do not constrain the dynamic variables to statically check
+     * if they have value, as it will be satisfied on runtime
+     */
+    public function hasValue(): bool
+    {
+        return true;
+    }
 }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Argument.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Argument.php
@@ -50,6 +50,11 @@ class Argument extends AbstractAst
         return $this->value;
     }
 
+    final public function hasValue(): bool
+    {
+        return true;
+    }
+
     final public function getValue(): mixed
     {
         return $this->value->getValue();

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Enum.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Enum.php
@@ -26,6 +26,11 @@ class Enum extends AbstractAst implements ArgumentValueAstInterface
         return $this->enumValue;
     }
 
+    final public function hasValue(): bool
+    {
+        return true;
+    }
+
     /**
      * @return string
      */

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputList.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputList.php
@@ -33,6 +33,11 @@ class InputList extends AbstractAst implements ArgumentValueAstInterface, WithAs
         return $this->getGraphQLQueryStringFormatter()->getListAsQueryString($this->list);
     }
 
+    final public function hasValue(): bool
+    {
+        return true;
+    }
+
     /**
      * Transform from Ast to actual value.
      * Eg: replace VariableReferences with their value,
@@ -45,6 +50,16 @@ class InputList extends AbstractAst implements ArgumentValueAstInterface, WithAs
         $list = [];
         foreach ($this->list as $key => $value) {
             if ($value instanceof WithValueInterface) {
+                /**
+                 * If a Variable is non mandatory, and it is not
+                 * provided a value, then do NOT inject it.
+                 *
+                 * Otherwise, the `null` value would make a non-nullable
+                 * type fail.
+                 */
+                if (!$value->hasValue()) {
+                    continue;
+                }
                 $list[$key] = $value->getValue();
                 continue;
             }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputObject.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/InputObject.php
@@ -33,6 +33,11 @@ class InputObject extends AbstractAst implements ArgumentValueAstInterface, With
         return $this->getGraphQLQueryStringFormatter()->getObjectAsQueryString($this->object);
     }
 
+    final public function hasValue(): bool
+    {
+        return true;
+    }
+
     /**
      * Transform from Ast to actual value.
      * Eg: replace VariableReferences with their value,
@@ -45,6 +50,16 @@ class InputObject extends AbstractAst implements ArgumentValueAstInterface, With
         $object = new stdClass();
         foreach ((array) $this->object as $key => $value) {
             if ($value instanceof WithValueInterface) {
+                /**
+                 * If a Variable is non mandatory, and it is not
+                 * provided a value, then do NOT inject it.
+                 *
+                 * Otherwise, the `null` value would make a non-nullable
+                 * type fail.
+                 */
+                if (!$value->hasValue()) {
+                    continue;
+                }
                 $object->$key = $value->getValue();
                 continue;
             }

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Literal.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/Literal.php
@@ -26,6 +26,11 @@ class Literal extends AbstractAst implements ArgumentValueAstInterface
         return $this->getGraphQLQueryStringFormatter()->getLiteralAsQueryString($this->value);
     }
 
+    final public function hasValue(): bool
+    {
+        return true;
+    }
+
     /**
      * @return string|int|float|bool|null
      */

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/ArgumentValue/VariableReference.php
@@ -50,6 +50,11 @@ class VariableReference extends AbstractAst implements VariableReferenceInterfac
         return $this->name;
     }
 
+    public function hasValue(): bool
+    {
+        return $this->variable?->hasValue() ?? false;
+    }
+
     /**
      * Get the value from the context or from the variable
      *

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Variable.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Variable.php
@@ -185,6 +185,32 @@ class Variable extends AbstractAst implements WithValueInterface
     }
 
     /**
+     * If a Variable is non mandatory, and it is not
+     * provided a value, then do NOT inject it.
+     *
+     * Otherwise, the `null` value would make a non-nullable
+     * type fail.
+     */
+    final public function hasValue(): bool
+    {
+        if ($this->context === null) {
+            throw new ShouldNotHappenException(
+                sprintf(
+                    $this->__('Context has not been set for Variable object (with name \'%s\')', 'graphql-server'),
+                    $this->name,
+                )
+            );
+        }
+        if ($this->context->hasVariableValue($this->name)) {
+            return true;
+        }
+        if ($this->hasDefaultValue()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Get the value from the context or from the variable
      *
      * @return InputList|InputObject|Literal|Enum|null

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/WithValueInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/WithValueInterface.php
@@ -6,5 +6,11 @@ namespace PoP\GraphQLParser\Spec\Parser\Ast;
 
 interface WithValueInterface extends AstInterface
 {
+    /**
+     * Allow the Variable to indicate it has not been provided
+     * a value, as to not inject `null` in the argument in that case,
+     * which would break a non-nullable type.
+     */
+    public function hasValue(): bool;
     public function getValue(): mixed;
 }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/AstTest.php
@@ -95,12 +95,15 @@ class AstTest extends AbstractTestCase
     {
         $list = new InputList(['a', 'b'], new Location(1, 1));
         $this->assertEquals(['a', 'b'], $list->getValue());
+        $this->assertEquals(true, $list->hasValue());
 
         $inputObject = new InputObject((object) ['a', 'b'], new Location(1, 1));
         $this->assertEquals((object) ['a', 'b'], $inputObject->getValue());
+        $this->assertEquals(true, $inputObject->hasValue());
 
         $literal = new Literal('text', new Location(1, 1));
         $this->assertEquals('text', $literal->getValue());
+        $this->assertEquals(true, $literal->hasValue());
     }
 
     public function testVariable(): void

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -2130,7 +2130,7 @@ GRAPHQL;
         /** @var Variable $var */
         $var = $document->getOperations()[0]->getVariables()[0];
         $var->setContext(new Context());
-        $this->assertTrue($var->hasDefaultValue());
+        $this->assertFalse($var->hasDefaultValue());
         $this->assertEquals(false, $var->hasValue());
     }
 

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -2117,6 +2117,23 @@ GRAPHQL;
         );
     }
 
+    public function testVariableWithoutValue(): void
+    {
+        $parser          = $this->getParser();
+        $document = $parser->parse('
+            query ($format: String){
+              user {
+                avatar(format: $format)
+              }
+            }
+        ');
+        /** @var Variable $var */
+        $var = $document->getOperations()[0]->getVariables()[0];
+        $var->setContext(new Context());
+        $this->assertTrue($var->hasDefaultValue());
+        $this->assertEquals(false, $var->hasValue());
+    }
+
     public function testNoDuplicateKeysInInputObjectInVariable(): void
     {
         $this->expectException(SyntaxErrorParserException::class);

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/VariableTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/VariableTest.php
@@ -45,6 +45,21 @@ class VariableTest extends AbstractTestCase
             'default-value',
             $var->getValue()
         );
+        $this->assertEquals(
+            true,
+            $var->hasValue()
+        );
+    }
+
+    public function testHasValue(): void
+    {
+        $var = new Variable('foo', 'bar', false, false, true, false, false, [], new Location(1, 1));
+        $var->setContext(new Context());
+
+        $this->assertEquals(
+            false,
+            $var->hasValue()
+        );
     }
 
     public function testGetValueReturnsSetValueEvenWithDefaultValue(): void


### PR DESCRIPTION
If a variable is not provided, then it must not be injected into the corresponding argument, as otherwise its value would be `null` and this would break non-nullable types.

For instance, in this query, `$append` is not mandatory:

```graphql
mutation ($append: Boolean) {
  setTagsOnPost(input:{
    id: 1,
    tags: ["tag"],
    append: $append
  }) {
    # ...
  }
}
```

And, let's say, it is not provided via the variables dictionary when executing the query:

```json
{}
```

Before this PR the `null` value would be provided, braking field arg `append` which does not expect a `null` value.

As solution, with this PR, the `append` arg is not provided to the field.