### PR TITLE
Do not cache fragment field values

### DIFF
--- a/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
+++ b/layers/API/packages/api/src/ComponentProcessors/AbstractRelationalFieldQueryDataComponentProcessor.php
@@ -573,7 +573,7 @@ abstract class AbstractRelationalFieldQueryDataComponentProcessor extends Abstra
             if ($fieldOrFragmentBond instanceof FragmentReference) {
                 /** @var FragmentReference */
                 $fragmentReference = $fieldOrFragmentBond;
-                $fragment = $this->getASTNodeDuplicatorService()->getFragment($fragmentReference, $fragments);
+                $fragment = $this->getASTNodeDuplicatorService()->getExclusiveFragment($fragmentReference, $fragments);
                 if ($fragment === null) {
                     continue;
                 }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PoPAPI\API\QueryResolution;
 
 use PoP\ComponentModel\App;
+use PoP\GraphQLParser\ASTNodes\ASTNodesFactory;
+use PoP\GraphQLParser\AST\ASTNodeDuplicatorServiceInterface;
 use PoP\GraphQLParser\Module as GraphQLParserModule;
 use PoP\GraphQLParser\ModuleConfiguration as GraphQLParserModuleConfiguration;
 use PoP\GraphQLParser\Spec\Parser\Ast\Document;
@@ -16,10 +18,9 @@ use PoP\GraphQLParser\Spec\Parser\Ast\InlineFragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
-use PoP\GraphQLParser\ASTNodes\ASTNodesFactory;
 use PoP\Root\Services\BasicServiceTrait;
-use SplObjectStorage;
 
+use SplObjectStorage;
 use function max;
 
 class QueryASTTransformationService implements QueryASTTransformationServiceInterface
@@ -35,6 +36,18 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
      */
     private SplObjectStorage $fieldInstanceContainer;
 
+    private ?ASTNodeDuplicatorServiceInterface $astNodeDuplicatorService = null;
+
+    final public function setASTNodeDuplicatorService(ASTNodeDuplicatorServiceInterface $astNodeDuplicatorService): void
+    {
+        $this->astNodeDuplicatorService = $astNodeDuplicatorService;
+    }
+    final protected function getASTNodeDuplicatorService(): ASTNodeDuplicatorServiceInterface
+    {
+        /** @var ASTNodeDuplicatorServiceInterface */
+        return $this->astNodeDuplicatorService ??= $this->instanceManager->getInstance(ASTNodeDuplicatorServiceInterface::class);
+    }
+    
     public function __construct()
     {
         /**
@@ -336,7 +349,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
 
         /** @var FragmentReference */
         $fragmentReference = $fieldOrFragmentBond;
-        $fragment = $this->getFragment($fragmentReference->getName(), $fragments);
+        $fragment = $this->getASTNodeDuplicatorService()->getFragment($fragmentReference, $fragments);
         if ($fragment === null) {
             return $accumulator;
         }
@@ -367,19 +380,5 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
     protected function getOperationInitialDepth(): int
     {
         return 0;
-    }
-
-    /**
-     * @param Fragment[] $fragments
-     */
-    protected function getFragment(string $name, array $fragments): ?Fragment
-    {
-        foreach ($fragments as $fragment) {
-            if ($fragment->getName() === $name) {
-                return $fragment;
-            }
-        }
-
-        return null;
     }
 }

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -19,8 +19,8 @@ use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\Spec\Parser\Ast\OperationInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
 use PoP\Root\Services\BasicServiceTrait;
-
 use SplObjectStorage;
+
 use function max;
 
 class QueryASTTransformationService implements QueryASTTransformationServiceInterface

--- a/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
+++ b/layers/API/packages/api/src/QueryResolution/QueryASTTransformationService.php
@@ -47,7 +47,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
         /** @var ASTNodeDuplicatorServiceInterface */
         return $this->astNodeDuplicatorService ??= $this->instanceManager->getInstance(ASTNodeDuplicatorServiceInterface::class);
     }
-    
+
     public function __construct()
     {
         /**
@@ -349,7 +349,7 @@ class QueryASTTransformationService implements QueryASTTransformationServiceInte
 
         /** @var FragmentReference */
         $fragmentReference = $fieldOrFragmentBond;
-        $fragment = $this->getASTNodeDuplicatorService()->getFragment($fragmentReference, $fragments);
+        $fragment = $this->getASTNodeDuplicatorService()->getExclusiveFragment($fragmentReference, $fragments);
         if ($fragment === null) {
             return $accumulator;
         }

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
@@ -320,13 +320,42 @@ final class ResolveValueAndMergeFieldDirectiveResolver extends AbstractGlobalFie
          *   
          *   fragment RootFragment on QueryRoot {
          *     id
-         *     direct: _echo(value: $__id)
+         *     _echo(value: $__id)
          *   }
          *   ```
          *
          * Please notice: the upstream node will only contain 1 value.
          * So it doesn't support having two references to the fragment,
-         * with these values being different (eg: before/after a mutation)
+         * with these values being different (eg: before/after a mutation):
+         *
+         *   ```
+         *   mutation {
+         *     post(by: { id: 1 }) {
+         *       # This will print title "Hello world!"
+         *       ...PostData
+         *
+         *       # This will update the title
+         *       update(input: {
+         *         title: "Updated title"
+         *       }) {
+         *         post {
+         *           # This must print title "Updated title"
+         *           ...PostData
+         *         }
+         *       }
+         *     }
+         *   }
+         *
+         *   fragment PostData on Post {
+         *     title
+         *
+         *     # Watch out! Field `title` will have 2 different values
+         *     # coming from the 2 referencing fields, but here the
+         *     # value stored under $__title is always the same, so this
+         *     # use case is not supported!
+         *     _echo(value: $__title)
+         *   }
+         *   ```
          *
          * @see ASTNodeDuplicatorService.php
          */

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
@@ -260,7 +260,8 @@ final class ResolveValueAndMergeFieldDirectiveResolver extends AbstractGlobalFie
          */
         /** @var FieldInterface[] */
         $documentObjectResolvedFieldValueReferencedFields = App::getState('document-object-resolved-field-value-referenced-fields');
-        if (!in_array($field, $documentObjectResolvedFieldValueReferencedFields)
+        if (
+            !in_array($field, $documentObjectResolvedFieldValueReferencedFields)
             && (
                 $staticField === null
                 || ($staticField !== null && !in_array($staticField, $documentObjectResolvedFieldValueReferencedFields))
@@ -310,14 +311,14 @@ final class ResolveValueAndMergeFieldDirectiveResolver extends AbstractGlobalFie
          * Eg: Field Value References in Fragments still point to the static node
          * (they have not been replaced with a clone of the AST), but the Field
          * in the Fragment is a clone:
-         * 
+         *
          *   ```
          *   query {
          *     self {
          *       ...RootFragment
          *     }
          *   }
-         *   
+         *
          *   fragment RootFragment on QueryRoot {
          *     id
          *     _echo(value: $__id)

--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
@@ -324,8 +324,7 @@ final class ResolveValueAndMergeFieldDirectiveResolver extends AbstractGlobalFie
          *   }
          *   ```
          *
-         * Please notice: the upstream node will only contain 1 value.
-         * So it doesn't support having two references to the fragment,
+         * This also works when having two references to the fragment,
          * with these values being different (eg: before/after a mutation):
          *
          *   ```
@@ -350,12 +349,14 @@ final class ResolveValueAndMergeFieldDirectiveResolver extends AbstractGlobalFie
          *     title
          *
          *     # Watch out! Field `title` will have 2 different values
-         *     # coming from the 2 referencing fields, but here the
-         *     # value stored under $__title is always the same, so this
-         *     # use case is not supported!
+         *     # coming from the 2 referencing fields!
          *     _echo(value: $__title)
          *   }
          *   ```
+         *
+         * It still works because the storing of the value happens right
+         * before reading it, then the new value overrides the 1st one
+         * and then it's read again.
          *
          * @see ASTNodeDuplicatorService.php
          */

--- a/layers/Engine/packages/component-model/src/Feedback/FeedbackEntryManager.php
+++ b/layers/Engine/packages/component-model/src/Feedback/FeedbackEntryManager.php
@@ -545,15 +545,15 @@ class FeedbackEntryManager implements FeedbackEntryManagerInterface
          */
         if ($location === null) {
             $location = $astNode->getLocation();
-            /**
-             * If it is a RuntimeLocation and it has a static AST node,
-             * then use that Location
-             */
-            if ($location instanceof RuntimeLocation) {
-                /** @var RuntimeLocation $location */
-                $location = $location->getStaticASTNode()?->getLocation();
-                /** @var Location|null $location */
-            }
+        }
+        /**
+         * If it is a RuntimeLocation and it has a static AST node,
+         * then use that Location
+         */
+        if ($location instanceof RuntimeLocation) {
+            /** @var RuntimeLocation $location */
+            $location = $location->getStaticASTNode()?->getLocation();
+            /** @var Location|null $location */
         }
         $locations = [];
         if ($location !== null && !($location instanceof RuntimeLocation)) {

--- a/layers/Engine/packages/graphql-parser/config/services.yaml
+++ b/layers/Engine/packages/graphql-parser/config/services.yaml
@@ -10,6 +10,9 @@ services:
     PoP\GraphQLParser\AST\ASTHelperServiceInterface:
         class: \PoP\GraphQLParser\AST\ASTHelperService
 
+    PoP\GraphQLParser\AST\ASTNodeDuplicatorServiceInterface:
+        class: \PoP\GraphQLParser\AST\ASTNodeDuplicatorService
+
     PoP\GraphQLParser\FeedbackItemProviders\:
         resource: '../src/FeedbackItemProviders/*'
 

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTHelperService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTHelperService.php
@@ -44,7 +44,7 @@ class ASTHelperService implements ASTHelperServiceInterface
             if ($fieldOrFragmentBond instanceof FragmentReference) {
                 /** @var FragmentReference */
                 $fragmentReference = $fieldOrFragmentBond;
-                $fragment = $this->getASTNodeDuplicatorService()->getFragment($fragmentReference, $fragments);
+                $fragment = $this->getASTNodeDuplicatorService()->getExclusiveFragment($fragmentReference, $fragments);
                 if ($fragment === null) {
                     continue;
                 }

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTHelperService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTHelperService.php
@@ -16,7 +16,7 @@ use PoP\Root\Services\BasicServiceTrait;
 class ASTHelperService implements ASTHelperServiceInterface
 {
     use BasicServiceTrait;
-    
+
     private ?ASTNodeDuplicatorServiceInterface $astNodeDuplicatorService = null;
 
     final public function setASTNodeDuplicatorService(ASTNodeDuplicatorServiceInterface $astNodeDuplicatorService): void
@@ -28,7 +28,7 @@ class ASTHelperService implements ASTHelperServiceInterface
         /** @var ASTNodeDuplicatorServiceInterface */
         return $this->astNodeDuplicatorService ??= $this->instanceManager->getInstance(ASTNodeDuplicatorServiceInterface::class);
     }
-    
+
     /**
      * @param array<FieldInterface|FragmentBondInterface> $fieldsOrFragmentBonds
      * @param Fragment[] $fragments

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTHelperServiceInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTHelperServiceInterface.php
@@ -23,14 +23,6 @@ interface ASTHelperServiceInterface
     /**
      * @param Fragment[] $fragments
      */
-    public function getFragment(
-        string $fragmentName,
-        array $fragments,
-    ): ?Fragment;
-
-    /**
-     * @param Fragment[] $fragments
-     */
     public function isFieldEquivalentToField(
         FieldInterface $thisField,
         FieldInterface $oppositeField,

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -6,18 +6,30 @@ namespace PoP\GraphQLParser\AST;
 
 use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
+use SplObjectStorage;
 
 class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
 {
     /**
+     * @var SplObjectStorage<FragmentReference,Fragment>
+     */
+    protected SplObjectStorage $fragmentReferenceFragments;
+
+    /**
+     * Retrieve a specific and dynamic Fragment for that FragmentReference
+     *
      * @param Fragment[] $fragments
      */
     public function getFragment(
         FragmentReference $fragmentReference,
         array $fragments,
     ): ?Fragment {
+        if ($this->fragmentReferenceFragments->contains($fragmentReference)) {
+            return $this->fragmentReferenceFragments[$fragmentReference];
+        }
         foreach ($fragments as $fragment) {
             if ($fragment->getName() === $fragmentReference->getName()) {
+                $this->fragmentReferenceFragments[$fragmentReference] = $fragment;
                 return $fragment;
             }
         }

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -4,16 +4,33 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\AST;
 
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
+use PoP\GraphQLParser\Spec\Parser\Ast\FragmentBondInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
+use PoP\GraphQLParser\Spec\Parser\Ast\InlineFragment;
+use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
+use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
+use PoP\Root\Services\BasicServiceTrait;
 use SplObjectStorage;
 
 class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
 {
+    use BasicServiceTrait;
+
     /**
      * @var SplObjectStorage<FragmentReference,Fragment>
      */
     protected SplObjectStorage $fragmentReferenceFragments;
+    
+    public function __construct()
+    {
+        /**
+         * @var SplObjectStorage<FragmentReference,Fragment>
+         */
+        $fragmentReferenceFragments = new SplObjectStorage();
+        $this->fragmentReferenceFragments = $fragmentReferenceFragments;
+    }
 
     /**
      * Retrieve a specific and dynamic Fragment for that FragmentReference
@@ -28,11 +45,111 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             return $this->fragmentReferenceFragments[$fragmentReference];
         }
         foreach ($fragments as $fragment) {
-            if ($fragment->getName() === $fragmentReference->getName()) {
-                $this->fragmentReferenceFragments[$fragmentReference] = $fragment;
-                return $fragment;
+            if ($fragment->getName() !== $fragmentReference->getName()) {
+                continue;
             }
+            $this->fragmentReferenceFragments[$fragmentReference] = $this->recursivelyCloneFragment(
+                $fragment,
+                $fragments
+            );
+            return $this->fragmentReferenceFragments[$fragmentReference];
         }
         return null;
+    }
+
+    /**
+     * @param Fragment[] $fragments
+     */
+    protected function recursivelyCloneFragment(
+        Fragment $fragment,
+        array $fragments,
+    ): Fragment {
+        return new Fragment(
+            $fragment->getName(),
+            $fragment->getModel(),
+            $fragment->getDirectives(),
+            $this->recursivelyCloneFieldOrFragmentBonds(
+                $fragment->getFieldsOrFragmentBonds($fragments),
+            ),
+            $fragment->getLocation(),
+        );
+    }
+    
+    /**
+     * @param array<FieldInterface|FragmentBondInterface> $fieldsOrFragmentBonds
+     * @return array<FieldInterface|FragmentBondInterface>
+     */
+    protected function recursivelyCloneFieldOrFragmentBonds(
+        array $fieldsOrFragmentBonds,
+    ): array {
+        $clonedFieldsOrFragmentBonds = [];
+        foreach ($fieldsOrFragmentBonds as $fieldOrFragmentBond) {
+            if ($fieldOrFragmentBond instanceof FragmentReference) {
+                /** @var FragmentReference */
+                $fragmentReference = $fieldOrFragmentBond;
+                $clonedFragmentReference = $this->cloneFragmentReference($fragmentReference);
+                $clonedFieldsOrFragmentBonds[] = $clonedFragmentReference;
+                continue;
+            }
+            if ($fieldOrFragmentBond instanceof InlineFragment) {
+                /** @var InlineFragment */
+                $inlineFragment = $fieldOrFragmentBond;
+                $clonedFieldsOrFragmentBonds = array_merge(
+                    $clonedFieldsOrFragmentBonds,
+                    $this->recursivelyCloneFieldOrFragmentBonds(
+                        $inlineFragment->getFieldsOrFragmentBonds(),
+                    )
+                );
+                continue;
+            }
+            if ($fieldOrFragmentBond instanceof RelationalField) {
+                /** @var RelationalField */
+                $relationalField = $fieldOrFragmentBond;
+                $clonedRelationalField = $this->cloneRelationalField($relationalField);
+                $clonedFieldsOrFragmentBonds[] = $clonedRelationalField;
+                continue;
+            }
+            /** @var LeafField */
+            $leafField = $fieldOrFragmentBond;
+            $clonedLeafField = $this->cloneLeafField($leafField);
+            $clonedFieldsOrFragmentBonds[] = $clonedLeafField;
+        }
+        return $clonedFieldsOrFragmentBonds;
+    }
+
+    protected function cloneFragmentReference(
+        FragmentReference $fragmentReference,
+    ): FragmentReference {
+        return new FragmentReference(
+            $fragmentReference->getName(),
+            $fragmentReference->getLocation(),
+        );
+    }
+
+    protected function cloneRelationalField(
+        RelationalField $relationalField,
+    ): RelationalField {
+        return new RelationalField(
+            $relationalField->getName(),
+            $relationalField->getAlias(),
+            $relationalField->getArguments(),
+            $this->recursivelyCloneFieldOrFragmentBonds(
+                $relationalField->getFieldsOrFragmentBonds(),
+            ),
+            $relationalField->getDirectives(),
+            $relationalField->getLocation(),
+        );
+    }
+
+    protected function cloneLeafField(
+        LeafField $field,
+    ): LeafField {
+        return new LeafField(
+            $field->getName(),
+            $field->getAlias(),
+            $field->getArguments(),
+            $field->getDirectives(),
+            $field->getLocation(),
+        );
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -88,23 +88,15 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             if ($fragment->getName() !== $fragmentReference->getName()) {
                 continue;
             }
-            $clonedFragment = $this->recursivelyCloneFragment(
-                $fragment,
-                $fragments
-            );
+            $clonedFragment = $this->recursivelyCloneFragment($fragment);
             $this->fragmentReferenceFragments[$fragmentReference] = $clonedFragment;
             return $clonedFragment;
         }
         return null;
     }
 
-    /**
-     * @param Fragment[] $fragments
-     */
-    protected function recursivelyCloneFragment(
-        Fragment $fragment,
-        array $fragments,
-    ): Fragment {
+    protected function recursivelyCloneFragment(Fragment $fragment): Fragment
+    {
         return new Fragment(
             $fragment->getName(),
             $fragment->getModel(),

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\AST;
 
+use PoP\GraphQLParser\ASTNodes\ASTNodesFactory;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentBondInterface;
@@ -65,6 +66,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
         Fragment $fragment,
         array $fragments,
     ): Fragment {
+        // return $fragment;
         return new Fragment(
             $fragment->getName(),
             $fragment->getModel(),
@@ -72,7 +74,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             $this->recursivelyCloneFieldOrFragmentBonds(
                 $fragment->getFieldsOrFragmentBonds($fragments),
             ),
-            $fragment->getLocation(),
+            ASTNodesFactory::getNonSpecificLocation(),
         );
     }
     
@@ -123,7 +125,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
     ): FragmentReference {
         return new FragmentReference(
             $fragmentReference->getName(),
-            $fragmentReference->getLocation(),
+            ASTNodesFactory::getNonSpecificLocation(),
         );
     }
 
@@ -138,7 +140,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
                 $relationalField->getFieldsOrFragmentBonds(),
             ),
             $relationalField->getDirectives(),
-            $relationalField->getLocation(),
+            ASTNodesFactory::getNonSpecificLocation(),
         );
     }
 
@@ -150,7 +152,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             $field->getAlias(),
             $field->getArguments(),
             $field->getDirectives(),
-            $field->getLocation(),
+            ASTNodesFactory::getNonSpecificLocation(),
         );
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PoP\GraphQLParser\AST;
 
-use PoP\GraphQLParser\ASTNodes\ASTNodesFactory;
 use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
 use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\FragmentBondInterface;
@@ -25,13 +24,13 @@ use SplObjectStorage;
  * For instance, in the following query (with nested mutations),
  * `PostData` is referenced twice, once before and after mutating
  * the post's title:
- * 
+ *
  *   ```
  *   mutation {
  *     post(by: { id: 1 }) {
  *       # This will print title "Hello world!"
  *       ...PostData
- *   
+ *
  *       # This will update the title
  *       update(input: {
  *         title: "Updated title"
@@ -43,12 +42,12 @@ use SplObjectStorage;
  *       }
  *     }
  *   }
- *   
+ *
  *   fragment PostData on Post {
  *     title
  *   }
  *   ```
- * 
+ *
  * If the same Fragment AST node is used, both `title` Fields would
  * produce value "Hello world!", as that's the first value that then
  * gets cached at the AST node level. By duplicating the node, both
@@ -63,7 +62,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
      * @var SplObjectStorage<FragmentReference,Fragment>
      */
     protected SplObjectStorage $fragmentReferenceFragments;
-    
+
     public function __construct()
     {
         /**
@@ -111,12 +110,12 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             $fragment->getModel(),
             $fragment->getDirectives(),
             $this->recursivelyCloneFieldOrFragmentBonds(
-                $fragment->getFieldsOrFragmentBonds($fragments),
+                $fragment->getFieldsOrFragmentBonds(),
             ),
             new RuntimeLocation($fragment),
         );
     }
-    
+
     /**
      * @param array<FieldInterface|FragmentBondInterface> $fieldsOrFragmentBonds
      * @return array<FieldInterface|FragmentBondInterface>

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -77,7 +77,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
      *
      * @param Fragment[] $fragments
      */
-    public function getFragment(
+    public function getExclusiveFragment(
         FragmentReference $fragmentReference,
         array $fragments,
     ): ?Fragment {

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -12,6 +12,7 @@ use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
 use PoP\GraphQLParser\Spec\Parser\Ast\InlineFragment;
 use PoP\GraphQLParser\Spec\Parser\Ast\LeafField;
 use PoP\GraphQLParser\Spec\Parser\Ast\RelationalField;
+use PoP\GraphQLParser\Spec\Parser\RuntimeLocation;
 use PoP\Root\Services\BasicServiceTrait;
 use SplObjectStorage;
 
@@ -112,7 +113,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             $this->recursivelyCloneFieldOrFragmentBonds(
                 $fragment->getFieldsOrFragmentBonds($fragments),
             ),
-            ASTNodesFactory::getNonSpecificLocation(),
+            new RuntimeLocation($fragment),
         );
     }
     
@@ -168,19 +169,19 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
                 $relationalField->getFieldsOrFragmentBonds(),
             ),
             $relationalField->getDirectives(),
-            ASTNodesFactory::getNonSpecificLocation(),
+            new RuntimeLocation($relationalField),
         );
     }
 
     protected function cloneLeafField(
-        LeafField $field,
+        LeafField $leafField,
     ): LeafField {
         return new LeafField(
-            $field->getName(),
-            $field->getAlias(),
-            $field->getArguments(),
-            $field->getDirectives(),
-            ASTNodesFactory::getNonSpecificLocation(),
+            $leafField->getName(),
+            $leafField->getAlias(),
+            $leafField->getArguments(),
+            $leafField->getDirectives(),
+            new RuntimeLocation($leafField),
         );
     }
 }

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -48,11 +48,12 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             if ($fragment->getName() !== $fragmentReference->getName()) {
                 continue;
             }
-            $this->fragmentReferenceFragments[$fragmentReference] = $this->recursivelyCloneFragment(
+            $clonedFragment = $this->recursivelyCloneFragment(
                 $fragment,
                 $fragments
             );
-            return $this->fragmentReferenceFragments[$fragmentReference];
+            $this->fragmentReferenceFragments[$fragmentReference] = $clonedFragment;
+            return $clonedFragment;
         }
         return null;
     }

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -105,7 +105,6 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
         Fragment $fragment,
         array $fragments,
     ): Fragment {
-        // return $fragment;
         return new Fragment(
             $fragment->getName(),
             $fragment->getModel(),

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\AST;
+
+use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
+use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
+
+class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
+{
+    /**
+     * @param Fragment[] $fragments
+     */
+    public function getFragment(
+        FragmentReference $fragmentReference,
+        array $fragments,
+    ): ?Fragment {
+        foreach ($fragments as $fragment) {
+            if ($fragment->getName() === $fragmentReference->getName()) {
+                return $fragment;
+            }
+        }
+        return null;
+    }
+}

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorService.php
@@ -129,8 +129,7 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             if ($fieldOrFragmentBond instanceof FragmentReference) {
                 /** @var FragmentReference */
                 $fragmentReference = $fieldOrFragmentBond;
-                $clonedFragmentReference = $this->cloneFragmentReference($fragmentReference);
-                $clonedFieldsOrFragmentBonds[] = $clonedFragmentReference;
+                $clonedFieldsOrFragmentBonds[] = $fragmentReference;
                 continue;
             }
             if ($fieldOrFragmentBond instanceof InlineFragment) {
@@ -157,15 +156,6 @@ class ASTNodeDuplicatorService implements ASTNodeDuplicatorServiceInterface
             $clonedFieldsOrFragmentBonds[] = $clonedLeafField;
         }
         return $clonedFieldsOrFragmentBonds;
-    }
-
-    protected function cloneFragmentReference(
-        FragmentReference $fragmentReference,
-    ): FragmentReference {
-        return new FragmentReference(
-            $fragmentReference->getName(),
-            ASTNodesFactory::getNonSpecificLocation(),
-        );
     }
 
     protected function cloneRelationalField(

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorServiceInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorServiceInterface.php
@@ -12,7 +12,7 @@ interface ASTNodeDuplicatorServiceInterface
     /**
      * @param Fragment[] $fragments
      */
-    public function getFragment(
+    public function getExclusiveFragment(
         FragmentReference $fragmentReference,
         array $fragments,
     ): ?Fragment;

--- a/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorServiceInterface.php
+++ b/layers/Engine/packages/graphql-parser/src/AST/ASTNodeDuplicatorServiceInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\GraphQLParser\AST;
+
+use PoP\GraphQLParser\Spec\Parser\Ast\Fragment;
+use PoP\GraphQLParser\Spec\Parser\Ast\FragmentReference;
+
+interface ASTNodeDuplicatorServiceInterface
+{
+    /**
+     * @param Fragment[] $fragments
+     */
+    public function getFragment(
+        FragmentReference $fragmentReference,
+        array $fragments,
+    ): ?Fragment;
+}

--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/AbstractOperation.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/AbstractOperation.php
@@ -137,18 +137,4 @@ abstract class AbstractOperation extends AbstractAst implements OperationInterfa
     {
         return $this->variables;
     }
-
-    /**
-     * @param Fragment[] $fragments
-     */
-    protected function getFragment(array $fragments, string $fragmentName): ?Fragment
-    {
-        foreach ($fragments as $fragment) {
-            if ($fragment->getName() === $fragmentName) {
-                return $fragment;
-            }
-        }
-
-        return null;
-    }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/fixture/error/non-existing-directive-arg-provided.json
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/fixture/error/non-existing-directive-arg-provided.json
@@ -64,6 +64,27 @@
       }
     },
     {
+      "message": "On directive 'skip', there is no argument with name 'inFragment'",
+      "locations": [
+        {
+          "line": 17,
+          "column": 27
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(inFragment: false)",
+          "@skip(if: false, inFragment: false)",
+          "self @skip(if: false, inFragment: false) { ... }",
+          "fragment SelfData on QueryRoot { ... }"
+        ],
+        "type": "QueryRoot",
+        "field": "self @skip(if: false, inFragment: false) { ... }",
+        "code": "gql@5.4.1[b]",
+        "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Argument-Names"
+      }
+    },
+    {
       "message": "On directive 'skip', there is no argument with name 'inInlineFragment'",
       "locations": [
         {
@@ -82,27 +103,6 @@
         ],
         "type": "QueryRoot",
         "field": "againSelf: self @skip(if: false, inInlineFragment: false) { ... }",
-        "code": "gql@5.4.1[b]",
-        "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Argument-Names"
-      }
-    },
-    {
-      "message": "On directive 'skip', there is no argument with name 'inFragment'",
-      "locations": [
-        {
-          "line": 17,
-          "column": 27
-        }
-      ],
-      "extensions": {
-        "path": [
-          "(inFragment: false)",
-          "@skip(if: false, inFragment: false)",
-          "self @skip(if: false, inFragment: false) { ... }",
-          "fragment SelfData on QueryRoot { ... }"
-        ],
-        "type": "QueryRoot",
-        "field": "self @skip(if: false, inFragment: false) { ... }",
         "code": "gql@5.4.1[b]",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Argument-Names"
       }

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/fixture/error/non-existing-directive.json
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/fixture/error/non-existing-directive.json
@@ -21,6 +21,26 @@
       }
     },
     {
+      "message": "There is no directive with name 'nonExistingInFragment'",
+      "locations": [
+        {
+          "line": 16,
+          "column": 11
+        }
+      ],
+      "extensions": {
+        "path": [
+          "@nonExistingInFragment",
+          "self @nonExistingInFragment { ... }",
+          "fragment SelfData on QueryRoot { ... }"
+        ],
+        "type": "QueryRoot",
+        "field": "self @nonExistingInFragment { ... }",
+        "code": "gql@5.7.1",
+        "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Directives-Are-Defined"
+      }
+    },
+    {
       "message": "There is no directive with name 'nonExistingInInlineFragment'",
       "locations": [
         {
@@ -38,26 +58,6 @@
         ],
         "type": "QueryRoot",
         "field": "againSelf: self @nonExistingInInlineFragment { ... }",
-        "code": "gql@5.7.1",
-        "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Directives-Are-Defined"
-      }
-    },
-    {
-      "message": "There is no directive with name 'nonExistingInFragment'",
-      "locations": [
-        {
-          "line": 16,
-          "column": 11
-        }
-      ],
-      "extensions": {
-        "path": [
-          "@nonExistingInFragment",
-          "self @nonExistingInFragment { ... }",
-          "fragment SelfData on QueryRoot { ... }"
-        ],
-        "type": "QueryRoot",
-        "field": "self @nonExistingInFragment { ... }",
         "code": "gql@5.7.1",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Directives-Are-Defined"
       }

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/fixture/error/non-existing-field.json
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/fixture/error/non-existing-field.json
@@ -20,6 +20,25 @@
       }
     },
     {
+      "message": "There is no field 'nonExistingInFragment' on type 'QueryRoot'",
+      "locations": [
+        {
+          "line": 12,
+          "column": 5
+        }
+      ],
+      "extensions": {
+        "path": [
+          "nonExistingInFragment",
+          "fragment SelfData on QueryRoot { ... }"
+        ],
+        "type": "QueryRoot",
+        "field": "nonExistingInFragment",
+        "code": "gql@5.3.1",
+        "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Field-Selections"
+      }
+    },
+    {
       "message": "There is no field 'nonExistingInInlineFragment' on type 'QueryRoot'",
       "locations": [
         {
@@ -36,25 +55,6 @@
         ],
         "type": "QueryRoot",
         "field": "nonExistingInInlineFragment",
-        "code": "gql@5.3.1",
-        "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Field-Selections"
-      }
-    },
-    {
-      "message": "There is no field 'nonExistingInFragment' on type 'QueryRoot'",
-      "locations": [
-        {
-          "line": 12,
-          "column": 5
-        }
-      ],
-      "extensions": {
-        "path": [
-          "nonExistingInFragment",
-          "fragment SelfData on QueryRoot { ... }"
-        ],
-        "type": "QueryRoot",
-        "field": "nonExistingInFragment",
         "code": "gql@5.3.1",
         "specifiedBy": "https:\/\/spec.graphql.org\/draft\/#sec-Field-Selections"
       }


### PR DESCRIPTION
When executing this query:

```graphql
query ExportOriginalPostData(
  $postId: ID!
) {
  post(by: {id: $postId}) {
    id
    title @export(as: "postTitle")
    contentSource @export(as: "postContent")
    status @export(as: "postStatus")
  }
}

mutation UpdatePost(
  $postId: ID!
) {
  updatePost(input: {
    id: $postId
    title: "Updated title"
    content: "Updated content",
    status: pending
  }) {
    status
    errors {
      __typename
      ...on IsErrorPayload {
        message
      }
    }
    post {
      ...PostData
    }
  }
}

mutation RevertPost(
  $postId: ID!
) {
  revertPost: updatePost(input: {
    id: $postId
    title: $postTitle
    content: $postContent
    status: $postStatus
  }) {
    status
    errors {
      __typename
      ...on IsErrorPayload {
        message
      }
    }
    post {
      ...PostData
    }
  }
}

query ExecuteAll @depends(on: [
  "ExportOriginalPostData",
  "UpdatePost",
  "RevertPost"
]) {
}

fragment PostData on Post {
  id
  title
  contentSource
  status
}
```

Two fields reference fragment `PostData`, with them before/after a mutation. Before this PR, the 2 values would be the same, since the Field is the same for both of them, and the field value is resolved only once.

This PR fixes the issue, by cloning all Fields inside the Fragment, and assigning en "exclusive" Field to be resolved to each of the FragmentReferences. This way, the 2nd reference to fragment `PostData` will print the updated (mutated) value.