### PR TITLE
Add introspection extension for "possibleValues"

### DIFF
--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
@@ -30,7 +30,7 @@ abstract class AbstractNamedTypeSchemaDefinitionProvider extends AbstractTypeSch
         ];
 
         /**
-         * Enum-like "possible values": only for EnumString type resolvers
+         * Enum-like "possible values" for EnumString type resolvers, `null` otherwise
          */
         if ($this->typeResolver instanceof EnumStringScalarTypeResolverInterface) {
             /** @var EnumStringScalarTypeResolverInterface */

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PoPAPI\API\ObjectModels\SchemaDefinition;
 
 use PoPAPI\API\Schema\SchemaDefinition;
-use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\AbstractEnumStringScalarTypeResolver;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\EnumStringScalarTypeResolverInterface;
 
 abstract class AbstractNamedTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
 {
@@ -32,8 +32,8 @@ abstract class AbstractNamedTypeSchemaDefinitionProvider extends AbstractTypeSch
         /**
          * Enum-like "possible values": only for EnumString type resolvers
          */
-        if ($this->typeResolver instanceof AbstractEnumStringScalarTypeResolver) {
-            /** @var AbstractEnumStringScalarTypeResolver */
+        if ($this->typeResolver instanceof EnumStringScalarTypeResolverInterface) {
+            /** @var EnumStringScalarTypeResolverInterface */
             $enumStringScalarTypeResolver = $this->typeResolver;
             $namedTypeExtensions[SchemaDefinition::POSSIBLE_VALUES] = $enumStringScalarTypeResolver->getConsolidatedPossibleValues();
         }

--- a/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
+++ b/layers/API/packages/api/src/ObjectModels/SchemaDefinition/AbstractNamedTypeSchemaDefinitionProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoPAPI\API\ObjectModels\SchemaDefinition;
 
 use PoPAPI\API\Schema\SchemaDefinition;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\AbstractEnumStringScalarTypeResolver;
 
 abstract class AbstractNamedTypeSchemaDefinitionProvider extends AbstractTypeSchemaDefinitionProvider
 {
@@ -23,9 +24,20 @@ abstract class AbstractNamedTypeSchemaDefinitionProvider extends AbstractTypeSch
      */
     protected function getNamedTypeExtensions(): array
     {
-        return [
+        $namedTypeExtensions = [
             SchemaDefinition::NAMESPACED_NAME => $this->typeResolver->getNamespacedTypeName(),
             SchemaDefinition::ELEMENT_NAME => $this->typeResolver->getTypeName(),
         ];
+
+        /**
+         * Enum-like "possible values": only for EnumString type resolvers
+         */
+        if ($this->typeResolver instanceof AbstractEnumStringScalarTypeResolver) {
+            /** @var AbstractEnumStringScalarTypeResolver */
+            $enumStringScalarTypeResolver = $this->typeResolver;
+            $namedTypeExtensions[SchemaDefinition::POSSIBLE_VALUES] = $enumStringScalarTypeResolver->getConsolidatedPossibleValues();
+        }
+
+        return $namedTypeExtensions;
     }
 }

--- a/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
+++ b/layers/Engine/packages/component-model/src/Schema/SchemaDefinition.php
@@ -50,4 +50,5 @@ class SchemaDefinition
     public final const DIRECTIVE_NEEDS_DATA_TO_EXECUTE = 'needsDataToExecute';
     public final const DIRECTIVE_LIMITED_TO_FIELDS = 'limitedToFields';
     public final const SCHEMA_IS_NAMESPACED = 'isSchemaNamespaced';
+    public final const POSSIBLE_VALUES = 'possibleValues';
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/implicit-features/query-schema-extensions-via-introspection/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/implicit-features/query-schema-extensions-via-introspection/en.md
@@ -29,6 +29,9 @@ type _NamedTypeExtensions {
 
   # The "namespaced" type name
   namespacedName: String!
+
+  # Enum-like "possible values" for EnumString type resolvers, `null` otherwise
+  possibleValues: [String!]
 }
 
 extend type __Type {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
@@ -1628,6 +1628,9 @@ type _NamedTypeExtensions {
 
   # The "namespaced" type name
   namespacedName: String!
+
+  # Enum-like "possible values" for EnumString type resolvers, `null` otherwise
+  possibleValues: [String!]
 }
 
 extend type __Type {

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/NamedTypeExtensionsObjectTypeFieldResolver.php
@@ -46,6 +46,7 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         return [
             'elementName',
             'namespacedName',
+            'possibleValues',
         ];
     }
 
@@ -55,6 +56,8 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
             'elementName',
             'namespacedName'
                 => SchemaTypeModifiers::NON_NULLABLE,
+            'possibleValues',
+                => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
             default
                 => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
         };
@@ -65,6 +68,7 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         return match ($fieldName) {
             'elementName' => $this->__('The type\'s non-namespaced name', 'graphql-server'),
             'namespacedName' => $this->__('The type\'s namespaced name', 'graphql-server'),
+            'possibleValues' => $this->__('Enum-like "possible values" for EnumString type resolvers, `null` otherwise', 'graphql-server'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -80,6 +84,7 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
         return match ($fieldDataAccessor->getFieldName()) {
             'elementName' => $namedTypeExtensions->getTypeElementName(),
             'namespacedName' => $namedTypeExtensions->getTypeNamespacedName(),
+            'possibleValues' => $namedTypeExtensions->getTypePossibleValues(),
             default => parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore),
         };
     }
@@ -88,7 +93,8 @@ class NamedTypeExtensionsObjectTypeFieldResolver extends AbstractObjectTypeField
     {
         return match ($fieldName) {
             'elementName',
-            'namespacedName'
+            'namespacedName',
+            'possibleValues'
                 => $this->getStringScalarTypeResolver(),
             default
                 => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeExtensions.php
@@ -17,4 +17,12 @@ class NamedTypeExtensions extends AbstractSchemaDefinitionReferenceObject
     {
         return $this->schemaDefinition[SchemaDefinition::NAMESPACED_NAME];
     }
+
+    /**
+     * @return string[]|null
+     */
+    public function getTypePossibleValues(): ?array
+    {
+        return $this->schemaDefinition[SchemaDefinition::POSSIBLE_VALUES] ?? null;
+    }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeExtensions.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/ObjectModels/NamedTypeExtensions.php
@@ -19,6 +19,8 @@ class NamedTypeExtensions extends AbstractSchemaDefinitionReferenceObject
     }
 
     /**
+     * Enum-like "possible values" for EnumString type resolvers, `null` otherwise
+     *
      * @return string[]|null
      */
     public function getTypePossibleValues(): ?array

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractEnumStringScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractEnumStringScalarTypeResolver.php
@@ -25,7 +25,7 @@ use stdClass;
  * For whenever the option values may not satisfy these constraints,
  * this type can be used instead
  */
-abstract class AbstractEnumStringScalarTypeResolver extends AbstractScalarTypeResolver
+abstract class AbstractEnumStringScalarTypeResolver extends AbstractScalarTypeResolver implements EnumStringScalarTypeResolverInterface
 {
     /** @var string[]|null */
     protected ?array $consolidatedPossibleValuesCache = null;
@@ -88,11 +88,6 @@ abstract class AbstractEnumStringScalarTypeResolver extends AbstractScalarTypeRe
         );
         return $this->consolidatedPossibleValuesCache;
     }
-
-    /**
-     * @return string[]
-     */
-    abstract public function getPossibleValues(): array;
 
     public function getTypeDescription(): string
     {

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractEnumStringScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractEnumStringScalarTypeResolver.php
@@ -67,7 +67,7 @@ abstract class AbstractEnumStringScalarTypeResolver extends AbstractScalarTypeRe
     }
 
     /**
-     * Consolidation of the schema directive arguments. Call this function to read the data
+     * Consolidation of the possible values. Call this function to read the data
      * instead of the individual functions, since it applies hooks to override/extend.
      *
      * @return string[]

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/EnumStringScalarTypeResolverInterface.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/EnumStringScalarTypeResolverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
+
+/**
+ * This type is similar to Enum in that only values from a fixed-set
+ * can be provided, but it is validated as a String.
+ *
+ * This is because Enum values have several constraints:
+ *
+ * - Can't have spaces
+ * - Can't have special chars, such as `-`
+ *
+ * For whenever the option values may not satisfy these constraints,
+ * this type can be used instead
+ */
+interface EnumStringScalarTypeResolverInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getPossibleValues(): array;
+}

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/EnumStringScalarTypeResolverInterface.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/EnumStringScalarTypeResolverInterface.php
@@ -22,4 +22,12 @@ interface EnumStringScalarTypeResolverInterface
      * @return string[]
      */
     public function getPossibleValues(): array;
+
+    /**
+     * Consolidation of the possible values. Call this function to read the data
+     * instead of the individual functions, since it applies hooks to override/extend.
+     *
+     * @return string[]
+     */
+    public function getConsolidatedPossibleValues(): array;
 }


### PR DESCRIPTION
Added extension `possibleValues` to the type, which returns the enum-like "possible values" for `EnumString` type resolvers, or `null` otherwise.

```graphql
query ViewEnumStringTypePossibleValues {
  __schema {
    types {
      name
      extensions {
        possibleValues
      }
    }
  }
}
```