### PR TITLE
Added field `globalID` to all types in the schema

### DIFF
--- a/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/IdentifiableObjectInterfaceTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/InterfaceType/IdentifiableObjectInterfaceTypeFieldResolver.php
@@ -41,30 +41,33 @@ class IdentifiableObjectInterfaceTypeFieldResolver extends AbstractInterfaceType
     {
         return [
             'id',
+            'globalID',
         ];
     }
 
     public function getFieldTypeResolver(string $fieldName): ConcreteTypeResolverInterface
     {
         return match ($fieldName) {
-            'id' => $this->getIDScalarTypeResolver(),
+            'id',
+            'globalID' => $this->getIDScalarTypeResolver(),
             default => parent::getFieldTypeResolver($fieldName),
         };
     }
 
     public function getFieldTypeModifiers(string $fieldName): int
     {
-        switch ($fieldName) {
-            case 'id':
-                return SchemaTypeModifiers::NON_NULLABLE;
-        }
-        return parent::getFieldTypeModifiers($fieldName);
+        return match ($fieldName) {
+            'id',
+            'globalID' => SchemaTypeModifiers::NON_NULLABLE,
+            default => parent::getFieldTypeModifiers($fieldName),
+        };
     }
 
     public function getFieldDescription(string $fieldName): ?string
     {
         return match ($fieldName) {
             'id' => $this->__('The object\'s unique identifier for its type', 'component-model'),
+            'globalID' => $this->__('The object\'s globally unique identifier', 'component-model'),
             default => parent::getFieldDescription($fieldName),
         };
     }

--- a/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/IdentifiableObjectObjectTypeFieldResolver.php
+++ b/layers/Engine/packages/component-model/src/FieldResolvers/ObjectType/IdentifiableObjectObjectTypeFieldResolver.php
@@ -52,6 +52,7 @@ class IdentifiableObjectObjectTypeFieldResolver extends AbstractObjectTypeFieldR
     {
         return [
             'id',
+            'globalID',
         ];
     }
 
@@ -61,9 +62,16 @@ class IdentifiableObjectObjectTypeFieldResolver extends AbstractObjectTypeFieldR
         FieldDataAccessorInterface $fieldDataAccessor,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): mixed {
-        return match ($fieldDataAccessor->getFieldName()) {
-            'id' => $objectTypeResolver->getID($object),
-            default => parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore),
-        };
+        switch ($fieldDataAccessor->getFieldName()) {
+            case 'id':
+                return $objectTypeResolver->getID($object);
+            case 'globalID':
+                return sprintf(
+                    '%s:%s',
+                    $objectTypeResolver->getNamespacedTypeName(),
+                    $objectTypeResolver->getID($object)
+                );
+        }
+        return parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
     }
 }

--- a/layers/Engine/packages/component-model/src/Hooks/AbstractRemoveIDAndSelfFieldsFromObjectTypeHookSet.php
+++ b/layers/Engine/packages/component-model/src/Hooks/AbstractRemoveIDAndSelfFieldsFromObjectTypeHookSet.php
@@ -22,7 +22,9 @@ abstract class AbstractRemoveIDAndSelfFieldsFromObjectTypeHookSet extends Abstra
         ObjectTypeFieldResolverInterface | InterfaceTypeFieldResolverInterface $objectTypeOrInterfaceTypeFieldResolver,
         string $fieldName
     ): bool {
-        return $fieldName === 'id' || ($fieldName === 'self' && $this->removeSelfField());
+        return $fieldName === 'id'
+            || $fieldName === 'globalID'
+            || ($fieldName === 'self' && $this->removeSelfField());
     }
 
     protected function removeSelfField(): bool

--- a/layers/Engine/packages/engine/src/DirectiveResolvers/OneYearCacheControlFieldDirectiveResolver.php
+++ b/layers/Engine/packages/engine/src/DirectiveResolvers/OneYearCacheControlFieldDirectiveResolver.php
@@ -15,6 +15,7 @@ class OneYearCacheControlFieldDirectiveResolver extends AbstractCacheControlFiel
     {
         return [
             'id',
+            'globalID',
         ];
     }
 

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-client/introspection-extensions.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-client/introspection-extensions.json
@@ -144,6 +144,14 @@
                             ]
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -490,6 +498,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -803,6 +819,14 @@
                         },
                         {
                             "name": "excerpt",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "globalID",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -1158,6 +1182,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -1430,6 +1462,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "height",
                             "extensions": {
                                 "isMutation": false,
@@ -1654,6 +1694,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -1747,6 +1795,14 @@
                         },
                         {
                             "name": "description",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "globalID",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -2195,6 +2251,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "hasComments",
                             "extensions": {
                                 "isMutation": false,
@@ -2609,6 +2673,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "hasComments",
                             "extensions": {
                                 "isMutation": false,
@@ -2953,6 +3025,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -3103,6 +3183,14 @@
                         },
                         {
                             "name": "description",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "globalID",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -3489,6 +3577,14 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
                         },
                         {
                             "name": "id",
@@ -4657,6 +4753,14 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
                         },
                         {
                             "name": "id",
@@ -6209,6 +6313,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "hasAnyCapability",
                             "extensions": {
                                 "isMutation": false,
@@ -6489,6 +6601,14 @@
                     },
                     "fields": [
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -6584,6 +6704,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -6629,6 +6757,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -6658,6 +6794,14 @@
                     },
                     "fields": [
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -6686,6 +6830,14 @@
                         "isOneOf": false
                     },
                     "fields": [
+                        {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
                         {
                             "name": "id",
                             "extensions": {
@@ -6732,6 +6884,14 @@
                     },
                     "fields": [
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -6762,6 +6922,14 @@
                     "fields": [
                         {
                             "name": "elementName",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "globalID",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -6814,6 +6982,14 @@
                     },
                     "fields": [
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -6860,6 +7036,14 @@
                         },
                         {
                             "name": "extensions",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "globalID",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -6936,6 +7120,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -7005,6 +7197,14 @@
                             "args": []
                         },
                         {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
                             "name": "id",
                             "extensions": {
                                 "isMutation": false,
@@ -7067,6 +7267,14 @@
                         },
                         {
                             "name": "extensions",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "globalID",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -7147,6 +7355,14 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
                         },
                         {
                             "name": "id",
@@ -7261,6 +7477,14 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
                         },
                         {
                             "name": "id",
@@ -7627,6 +7851,14 @@
                         "isOneOf": false
                     },
                     "fields": [
+                        {
+                            "name": "globalID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
                         {
                             "name": "id",
                             "extensions": {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-client/introspection-query.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-client/introspection-query.json
@@ -248,6 +248,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -854,6 +870,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1493,6 +1525,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2191,6 +2239,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -2678,6 +2742,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "height",
               "description": "Media item's height",
               "args": [
@@ -3075,6 +3155,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -3282,6 +3378,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4120,6 +4232,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasComments",
               "description": "Does the custom post have comments?",
               "args": [],
@@ -4948,6 +5076,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasComments",
               "description": "Does the custom post have comments?",
               "args": [],
@@ -5650,6 +5794,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -5953,6 +6113,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6748,6 +6924,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -9136,6 +9328,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -12064,6 +12272,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasAnyCapability",
               "description": "Does the user have any capability from a provided list?",
               "args": [
@@ -12650,6 +12874,22 @@
           "description": "User avatar",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12821,6 +13061,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12906,6 +13162,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12955,6 +13227,22 @@
           "description": "Extensions (custom metadata) added to the enum value",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13003,6 +13291,22 @@
           "name": "_FieldExtensions",
           "description": "Extensions (custom metadata) added to the field",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",
@@ -13085,6 +13389,22 @@
           "description": "Extensions (custom metadata) added to the input value",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13143,6 +13463,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13234,6 +13570,22 @@
           "name": "_SchemaExtensions",
           "description": "Extensions (custom metadata) added to the GraphQL schema",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",
@@ -13329,6 +13681,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "_DirectiveExtensions",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13465,6 +13833,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13594,6 +13978,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13708,6 +14108,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "_InputValueExtensions",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13868,6 +14284,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -14078,6 +14510,22 @@
                     "name": "__Field",
                     "ofType": null
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -14539,6 +14987,22 @@
           "name": "IdentifiableObject",
           "description": "An object that can be uniquely identifiable within its type via an 'ID', and within the whole schema via a 'global ID'",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-editor-block-queries/get-type-fields.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-admin-editor-block-queries/get-type-fields.json
@@ -51,6 +51,9 @@
               "name": "dateStr"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -181,6 +184,9 @@
               "name": "description"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -256,6 +262,9 @@
             },
             {
               "name": "excerpt"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "hasComments"
@@ -344,6 +353,9 @@
             },
             {
               "name": "description"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -454,6 +466,9 @@
               "name": "description"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "height"
             },
             {
@@ -521,6 +536,9 @@
               "name": "count"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -557,6 +575,9 @@
             },
             {
               "name": "description"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -680,6 +701,9 @@
               "name": "featuredImage"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "hasComments"
             },
             {
@@ -792,6 +816,9 @@
               "name": "featuredImage"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "hasComments"
             },
             {
@@ -875,6 +902,9 @@
               "name": "description"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -920,6 +950,9 @@
             },
             {
               "name": "description"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -991,6 +1024,9 @@
             },
             {
               "name": "customPosts"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -1179,6 +1215,9 @@
             },
             {
               "name": "customPosts"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -1578,6 +1617,9 @@
               "name": "firstName"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "hasAnyCapability"
             },
             {
@@ -1658,6 +1700,9 @@
           "namespacedName": "UserAvatar",
           "fields": [
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1703,6 +1748,9 @@
               "name": "capabilities"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1723,6 +1771,9 @@
               "name": "fieldDirectiveSupportedTypeNamesOrDescriptions"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1737,6 +1788,9 @@
           "namespacedName": "_EnumValueExtensions",
           "fields": [
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1750,6 +1804,9 @@
           "name": "_FieldExtensions",
           "namespacedName": "_FieldExtensions",
           "fields": [
+            {
+              "name": "globalID"
+            },
             {
               "name": "id"
             },
@@ -1771,6 +1828,9 @@
           "namespacedName": "_InputValueExtensions",
           "fields": [
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1786,6 +1846,9 @@
           "fields": [
             {
               "name": "elementName"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -1808,6 +1871,9 @@
           "namespacedName": "_SchemaExtensions",
           "fields": [
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1829,6 +1895,9 @@
             },
             {
               "name": "extensions"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -1860,6 +1929,9 @@
               "name": "extensions"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1887,6 +1959,9 @@
             },
             {
               "name": "extensions"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -1918,6 +1993,9 @@
               "name": "extensions"
             },
             {
+              "name": "globalID"
+            },
+            {
               "name": "id"
             },
             {
@@ -1942,6 +2020,9 @@
             },
             {
               "name": "globalFields"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -1980,6 +2061,9 @@
             },
             {
               "name": "fields"
+            },
+            {
+              "name": "globalID"
             },
             {
               "name": "id"
@@ -2152,6 +2236,9 @@
           "name": "IdentifiableObject",
           "namespacedName": "IdentifiableObject",
           "fields": [
+            {
+              "name": "globalID"
+            },
             {
               "name": "id"
             }

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query.json
@@ -248,6 +248,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -854,6 +870,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1493,6 +1525,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2191,6 +2239,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -2678,6 +2742,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "height",
               "description": "Media item's height",
               "args": [
@@ -3075,6 +3155,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -3282,6 +3378,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4120,6 +4232,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasComments",
               "description": "Does the custom post have comments?",
               "args": [],
@@ -4948,6 +5076,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasComments",
               "description": "Does the custom post have comments?",
               "args": [],
@@ -5650,6 +5794,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -5953,6 +6113,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6748,6 +6924,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -9136,6 +9328,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -12064,6 +12272,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasAnyCapability",
               "description": "Does the user have any capability from a provided list?",
               "args": [
@@ -12650,6 +12874,22 @@
           "description": "User avatar",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12821,6 +13061,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12906,6 +13162,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12955,6 +13227,22 @@
           "description": "Extensions (custom metadata) added to the enum value",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13003,6 +13291,22 @@
           "name": "_FieldExtensions",
           "description": "Extensions (custom metadata) added to the field",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",
@@ -13085,6 +13389,22 @@
           "description": "Extensions (custom metadata) added to the input value",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13143,6 +13463,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13234,6 +13570,22 @@
           "name": "_SchemaExtensions",
           "description": "Extensions (custom metadata) added to the GraphQL schema",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",
@@ -13329,6 +13681,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "_DirectiveExtensions",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13465,6 +13833,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13594,6 +13978,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13708,6 +14108,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "_InputValueExtensions",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13868,6 +14284,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -14078,6 +14510,22 @@
                     "name": "__Field",
                     "ofType": null
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -14539,6 +14987,22 @@
           "name": "IdentifiableObject",
           "description": "An object that can be uniquely identifiable within its type via an 'ID', and within the whole schema via a 'global ID'",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query:0.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-canonical-namespacing/introspection-query:0.json
@@ -248,6 +248,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -854,6 +870,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1493,6 +1525,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2191,6 +2239,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -2678,6 +2742,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "height",
               "description": "Media item's height",
               "args": [
@@ -3075,6 +3155,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -3282,6 +3378,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4120,6 +4232,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasComments",
               "description": "Does the custom post have comments?",
               "args": [],
@@ -4948,6 +5076,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasComments",
               "description": "Does the custom post have comments?",
               "args": [],
@@ -5650,6 +5794,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -5953,6 +6113,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6748,6 +6924,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -9136,6 +9328,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -12064,6 +12272,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hasAnyCapability",
               "description": "Does the user have any capability from a provided list?",
               "args": [
@@ -12650,6 +12874,22 @@
           "description": "User avatar",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12821,6 +13061,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12906,6 +13162,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -12955,6 +13227,22 @@
           "description": "Extensions (custom metadata) added to the enum value",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13003,6 +13291,22 @@
           "name": "_FieldExtensions",
           "description": "Extensions (custom metadata) added to the field",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",
@@ -13085,6 +13389,22 @@
           "description": "Extensions (custom metadata) added to the input value",
           "fields": [
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13143,6 +13463,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13234,6 +13570,22 @@
           "name": "_SchemaExtensions",
           "description": "Extensions (custom metadata) added to the GraphQL schema",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",
@@ -13329,6 +13681,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "_DirectiveExtensions",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13465,6 +13833,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13594,6 +13978,22 @@
               "deprecationReason": null
             },
             {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": "The object's unique identifier for its type",
               "args": [],
@@ -13708,6 +14108,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "_InputValueExtensions",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -13868,6 +14284,22 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -14078,6 +14510,22 @@
                     "name": "__Field",
                     "ofType": null
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
@@ -14539,6 +14987,22 @@
           "name": "IdentifiableObject",
           "description": "An object that can be uniquely identifiable within its type via an 'ID', and within the whole schema via a 'global ID'",
           "fields": [
+            {
+              "name": "globalID",
+              "description": "The object's globally unique identifier",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "ID!",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": "The object's unique identifier for its type",

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-schema-self-fields/self-fields.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-schema-self-fields/self-fields.json
@@ -37,6 +37,9 @@
                         "name": "customPosts"
                     },
                     {
+                        "name": "globalID"
+                    },
+                    {
                         "name": "id"
                     },
                     {

--- a/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-schema-self-fields/self-fields:0.json
+++ b/layers/GraphQLAPIForWP/phpunit-packages/graphql-api-for-wp/tests/Integration/fixture-schema-self-fields/self-fields:0.json
@@ -37,6 +37,9 @@
                         "name": "customPosts"
                     },
                     {
+                        "name": "globalID"
+                    },
+                    {
                         "name": "id"
                     },
                     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### GraphQL schema upgrade
 
+- Added field `globalID` to all types in the schema
 - In addition to `id`, fetch single entities by `slug`, `path` and other properties, on fields:
   - `Root.customPost`
   - `Root.genericCustomPost`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/modules/global-id-field/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/modules/global-id-field/en.md
@@ -1,0 +1,99 @@
+# Global ID Field
+
+Addition of a `globalID` field to all types in the GraphQL schema, which provides a unique ID for every entity across all types.
+
+The value returned by this field is the composition of:
+
+- the entity's namespaced type name
+- the separator `:`
+- the entity's ID
+
+## Description
+
+All types in the GraphQL schema corresponding to the WordPress data model, such as `Post` and `User`, offer the `id` field, which returns the ID for the entity in WordPress.
+
+For instance, in this query:
+
+```graphql
+{
+    posts {
+        id
+    }
+
+    users {
+        id
+    }
+}
+```
+
+...we may obtain this response:
+
+```json
+{
+    "data": {
+        "posts": [
+            {
+                "id": 1
+            },
+            {
+                "id": 2
+            },
+            {
+                "id": 3
+            }
+        ],
+        "users": [
+            {
+                "id": 1
+            }
+        ]
+    }
+}
+```
+
+While posts will always have a different ID from each other, they may share the same ID a user (or another entity type), as can be seen in the example above where both a post and a user have ID `1`.
+
+If a unique ID is required for all entities across all types in the GraphQL schema (for instance, when using a GraphQL client that caches the response), then we can use the `globalID` field instead:
+
+```graphql
+{
+    posts {
+        id
+        globalID
+    }
+
+    users {
+        id
+        globalID
+    }
+}
+```
+
+...which will produce a unique ID for all posts and users:
+
+```json
+{
+    "data": {
+        "posts": [
+            {
+                "id": 1,
+                "globalID": "Post:1"
+            },
+            {
+                "id": 2,
+                "globalID": "Post:2"
+            },
+            {
+                "id": 3,
+                "globalID": "Post:3"
+            }
+        ],
+        "users": [
+            {
+                "id": 1,
+                "globalID": "User:1"
+            }
+        ]
+    }
+}
+```

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/0.9/en.md
@@ -12,6 +12,55 @@ The GraphQL schema mapping the WordPress data model has been significantly compl
 
 Let's see what new elements have been added.
 
+### Added field `globalID` to all types in the schema
+
+All types in the GraphQL schema offer the `id` field, which returns the ID for the entity in WordPress. This ID makes the object unique only within their types, so that both a user and a post (from types `User` and `Post` respectively) can have ID `1`.
+
+If a unique ID is required for all entities across all types in the GraphQL schema, for instance when using a GraphQL client that caches the response, then we can use the newly-added `globalID` field instead:
+
+```graphql
+{
+  posts {
+    id
+    globalID
+  }
+
+  users {
+    id
+    globalID
+  }
+}
+```
+
+...producing
+
+```json
+{
+  "data": {
+    "posts": [
+      {
+        "id": 1,
+        "globalID": "Post:1"
+      },
+      {
+        "id": 2,
+        "globalID": "Post:2"
+      },
+      {
+        "id": 3,
+        "globalID": "Post:3"
+      }
+    ],
+    "users": [
+      {
+        "id": 1,
+        "globalID": "User:1"
+      }
+    ]
+  }
+}
+```
+
 ### In addition to `id`, fetch single entities by `slug`, `path` and other properties
 
 Fields to fetch a single entity, such as `Root.post` or `Root.user`, used to receive argument `id` to select the entity. Now they have been expanded: `id` has been replaced with argument `by`, which is a oneof input object (explained later on) to query the entity by different properties.

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/PluginManagementFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/PluginManagementFunctionalityModuleResolver.php
@@ -45,20 +45,18 @@ class PluginManagementFunctionalityModuleResolver extends AbstractFunctionalityM
 
     public function canBeDisabled(string $module): bool
     {
-        switch ($module) {
-            case self::GENERAL:
-                return false;
-        }
-        return parent::canBeDisabled($module);
+        return match ($module) {
+            self::GENERAL => false,
+            default => parent::canBeDisabled($module),
+        };
     }
 
     public function isHidden(string $module): bool
     {
-        switch ($module) {
-            case self::GENERAL:
-                return true;
-        }
-        return parent::isHidden($module);
+        return match ($module) {
+            self::GENERAL => true,
+            default => parent::isHidden($module),
+        };
     }
 
     public function getName(string $module): string
@@ -71,11 +69,10 @@ class PluginManagementFunctionalityModuleResolver extends AbstractFunctionalityM
 
     public function getDescription(string $module): string
     {
-        switch ($module) {
-            case self::GENERAL:
-                return \__('General options for the plugin', 'graphql-api');
-        }
-        return parent::getDescription($module);
+        return match ($module) {
+            self::GENERAL => \__('General options for the plugin', 'graphql-api'),
+            default => parent::getDescription($module),
+        };
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
@@ -116,6 +116,14 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
         };
     }
 
+    public function isHidden(string $module): bool
+    {
+        return match ($module) {
+            self::GLOBAL_ID_FIELD => true,
+            default => parent::isHidden($module),
+        };
+    }
+
     /**
      * Default value for an option set by the module
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
@@ -24,6 +24,7 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
     public final const NESTED_MUTATIONS = Plugin::NAMESPACE . '\nested-mutations';
     public final const SCHEMA_EXPOSE_SENSITIVE_DATA = Plugin::NAMESPACE . '\schema-expose-sensitive-data';
     public final const SCHEMA_SELF_FIELDS = Plugin::NAMESPACE . '\schema-self-fields';
+    public final const GLOBAL_ID_FIELD = Plugin::NAMESPACE . '\global-id-field';
 
     private ?GraphQLSchemaConfigurationCustomPostType $graphQLSchemaConfigurationCustomPostType = null;
     private ?MarkdownContentParserInterface $markdownContentParser = null;
@@ -58,6 +59,7 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
             self::NESTED_MUTATIONS,
             self::SCHEMA_EXPOSE_SENSITIVE_DATA,
             self::SCHEMA_SELF_FIELDS,
+            self::GLOBAL_ID_FIELD,
         ];
     }
 
@@ -88,6 +90,7 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
             self::NESTED_MUTATIONS => \__('Nested Mutations', 'graphql-api'),
             self::SCHEMA_EXPOSE_SENSITIVE_DATA => \__('Expose Sensitive Data in the Schema', 'graphql-api'),
             self::SCHEMA_SELF_FIELDS => \__('Self Fields', 'graphql-api'),
+            self::GLOBAL_ID_FIELD => \__('Global ID Field', 'graphql-api'),
             default => $module,
         };
     }
@@ -100,6 +103,7 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
             self::NESTED_MUTATIONS => \__('Execute mutations from any type in the schema, not only from the root', 'graphql-api'),
             self::SCHEMA_EXPOSE_SENSITIVE_DATA => \__('Expose “sensitive” data elements in the schema', 'graphql-api'),
             self::SCHEMA_SELF_FIELDS => \__('Expose "self" fields in the schema', 'graphql-api'),
+            self::GLOBAL_ID_FIELD => \__('Uniquely identify objects via field <code>globalID</code> on all types of the GraphQL schema', 'graphql-api'),
             default => parent::getDescription($module),
         };
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/ModuleResolvers/SchemaConfigurationFunctionalityModuleResolver.php
@@ -108,6 +108,14 @@ class SchemaConfigurationFunctionalityModuleResolver extends AbstractFunctionali
         };
     }
 
+    public function canBeDisabled(string $module): bool
+    {
+        return match ($module) {
+            self::GLOBAL_ID_FIELD => false,
+            default => parent::canBeDisabled($module),
+        };
+    }
+
     /**
      * Default value for an option set by the module
      */

--- a/layers/GraphQLByPoP/packages/graphql-server/src/Helpers/TypeResolverHelper.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/Helpers/TypeResolverHelper.php
@@ -13,6 +13,6 @@ class TypeResolverHelper implements TypeResolverHelperInterface
      */
     public function getObjectTypeResolverMandatoryFields(): array
     {
-        return ['id', 'self', '__typename'];
+        return ['id', 'globalID', 'self', '__typename'];
     }
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/IFTTT/MandatoryDirectivesForFieldsRootTypeEntryDuplicator.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/IFTTT/MandatoryDirectivesForFieldsRootTypeEntryDuplicator.php
@@ -47,7 +47,7 @@ class MandatoryDirectivesForFieldsRootTypeEntryDuplicator implements MandatoryDi
      * For each of the entries assigned to Root (RootObjectTypeResolver::class),
      * add a corresponding additional entry for QueryRoot and/or MutationRoot.
      *
-     * Fields "id", "self" and "__typename" can belong to both types.
+     * Fields "id", "globalID", "self" and "__typename" can belong to both types.
      * Otherwise, the field is added to MutationRoot if it has a MutationResolver,
      * or to QueryRoot otherwise.
      *
@@ -93,7 +93,7 @@ class MandatoryDirectivesForFieldsRootTypeEntryDuplicator implements MandatoryDi
 
         $additionalFieldEntries = [];
 
-        /** Fields "id", "self" and "__typename" belong to both QueryRoot and MutationRoot */
+        /** Fields "id", "globalID", "self" and "__typename" belong to both QueryRoot and MutationRoot */
         $objectTypeResolverMandatoryFields = $this->getTypeResolverHelper()->getObjectTypeResolverMandatoryFields();
 
         $rootObjectTypeResolver = $this->getRootObjectTypeResolver();

--- a/layers/GraphQLByPoP/packages/graphql-server/src/IFTTT/MandatoryDirectivesForFieldsRootTypeEntryDuplicatorInterface.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/IFTTT/MandatoryDirectivesForFieldsRootTypeEntryDuplicatorInterface.php
@@ -13,7 +13,7 @@ interface MandatoryDirectivesForFieldsRootTypeEntryDuplicatorInterface
      * For each of the entries assigned to Root (RootObjectTypeResolver::class),
      * add a corresponding additional entry for QueryRoot and/or MutationRoot.
      *
-     * Fields "id", "self" and "__typename" can belong to both types.
+     * Fields "id", "globalID", "self" and "__typename" can belong to both types.
      * Otherwise, the field is added to MutationRoot if it has a MutationResolver,
      * or to QueryRoot otherwise.
      *


### PR DESCRIPTION
All types in the GraphQL schema offer the `id` field, which returns the ID for the entity in WordPress. This ID makes the object unique only within their types, so that both a user and a post (from types `User` and `Post` respectively) can have ID `1`.

If a unique ID is required for all entities across all types in the GraphQL schema, for instance when using a GraphQL client that caches the response, then we can use the newly-added `globalID` field instead:

```graphql
{
  posts {
    id
    globalID
  }

  users {
    id
    globalID
  }
}
```

...producing

```json
{
  "data": {
    "posts": [
      {
        "id": 1,
        "globalID": "Post:1"
      },
      {
        "id": 2,
        "globalID": "Post:2"
      },
      {
        "id": 3,
        "globalID": "Post:3"
      }
    ],
    "users": [
      {
        "id": 1,
        "globalID": "User:1"
      }
    ]
  }
}
```