### PR TITLE
Normalize settings for specific module

### DIFF
--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
@@ -291,9 +291,24 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
             }
             /** @var string */
             $module = $this->getModuleByID($moduleID);
+            $moduleRegistry = ModuleRegistryFacade::getInstance();
+            $moduleResolver = $moduleRegistry->getModuleResolver($module);
+
+            /**
+             * The provided values only have the input as key.
+             * Convert it to the actual settingsOptionName
+             */
+            $settingsOptionValues = [];
+            foreach ($optionValues as $input => $value) {
+                $optionName = $moduleResolver->getSettingOptionName($module, $input);
+                $settingsOptionValues[$optionName] = $value;
+            }
 
             // Normalize the values
-            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeModuleSettings($module, $optionValues);
+            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeSettingsByModule(
+                $settingsOptionValues,
+                $module,
+            );
 
             // Store in the DB
             $userSettingsManager = UserSettingsManagerFacade::getInstance();

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
@@ -293,7 +293,7 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
             $module = $this->getModuleByID($moduleID);
 
             // Normalize the values
-            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeModuleSettings($module, $optionValues);
+            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeSettingsForRESTAPIController($module, $optionValues);
 
             // Store in the DB
             $userSettingsManager = UserSettingsManagerFacade::getInstance();

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/RESTAPI/Controllers/ModuleSettingsAdminRESTController.php
@@ -291,24 +291,9 @@ class ModuleSettingsAdminRESTController extends AbstractAdminRESTController
             }
             /** @var string */
             $module = $this->getModuleByID($moduleID);
-            $moduleRegistry = ModuleRegistryFacade::getInstance();
-            $moduleResolver = $moduleRegistry->getModuleResolver($module);
-
-            /**
-             * The provided values only have the input as key.
-             * Convert it to the actual settingsOptionName
-             */
-            $settingsOptionValues = [];
-            foreach ($optionValues as $input => $value) {
-                $optionName = $moduleResolver->getSettingOptionName($module, $input);
-                $settingsOptionValues[$optionName] = $value;
-            }
 
             // Normalize the values
-            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeSettingsByModule(
-                $settingsOptionValues,
-                $module,
-            );
+            $normalizedOptionValues = $this->getSettingsNormalizer()->normalizeModuleSettings($module, $optionValues);
 
             // Store in the DB
             $userSettingsManager = UserSettingsManagerFacade::getInstance();

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
@@ -29,7 +29,7 @@ class PluginOptionsFormHandler
      *
      * @return array<string,mixed>
      */
-    public function getNormalizedModuleOptionValues(
+    protected function getNormalizedModuleOptionValues(
         string $settingsCategory,
         string $module,
     ): array {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
@@ -52,6 +52,10 @@ class PluginOptionsFormHandler
              * If calling normalizeSettingsByCategory, this other module would
              * also be normalized, attempting to initialize these services,
              * and throwing an error.
+             *
+             * But just normalizing the modules that use `getURLPathSettingValue` and
+             * `getCPTPermalinkBasePathSettingValue` (eg: GraphiQL client path, etc),
+             * these ones currently have no other dependencies, and they do not fail.
              */
             $this->normalizedModuleOptionValuesCache[$settingsCategory][$module] = $settingsNormalizer->normalizeSettingsByModule($value, $module);
         }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
@@ -37,9 +37,22 @@ class PluginOptionsFormHandler
             $instanceManager = SystemInstanceManagerFacade::getInstance();
             /** @var SettingsNormalizerInterface */
             $settingsNormalizer = $instanceManager->getInstance(SettingsNormalizerInterface::class);
-            
+
             // Obtain the values from the POST and normalize them
             $value = $this->getSubmittedFormOptionValues($settingsCategory);
+
+            /**
+             * Important: call normalizeSettingsByModule instead of normalizeSettingsByCategory,
+             * because there are settings that depend on other services, which are not initialized
+             * in the system service.
+             *
+             * For instance, module SCHEMA_CONFIGURATION requires service
+             * GraphQLSchemaConfigurationCustomPostType.
+             *
+             * If calling normalizeSettingsByCategory, this other module would
+             * also be normalized, attempting to initialize these services,
+             * and throwing an error.
+             */
             $this->normalizedModuleOptionValuesCache[$settingsCategory][$module] = $settingsNormalizer->normalizeSettingsByModule($value, $module);
         }
         return $this->normalizedModuleOptionValuesCache[$settingsCategory][$module];

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
@@ -35,17 +35,28 @@ class PluginOptionsFormHandler
     ): array {
         if (($this->normalizedModuleOptionValuesCache[$settingsCategory][$module] ?? null) === null) {
             $instanceManager = SystemInstanceManagerFacade::getInstance();
-            $settingsCategoryRegistry = SystemSettingsCategoryRegistryFacade::getInstance();
-            $settingsCategoryResolver = $settingsCategoryRegistry->getSettingsCategoryResolver($settingsCategory);
-            $optionsFormName = $settingsCategoryResolver->getOptionsFormName($settingsCategory);
-
             /** @var SettingsNormalizerInterface */
             $settingsNormalizer = $instanceManager->getInstance(SettingsNormalizerInterface::class);
+            
             // Obtain the values from the POST and normalize them
-            $value = App::getRequest()->request->all()[$optionsFormName] ?? [];
+            $value = $this->getSubmittedFormOptionValues($settingsCategory);
             $this->normalizedModuleOptionValuesCache[$settingsCategory][$module] = $settingsNormalizer->normalizeSettings($value, $settingsCategory);
         }
         return $this->normalizedModuleOptionValuesCache[$settingsCategory][$module];
+    }
+
+    /**
+     * Obtain the values from the POST
+     *
+     * @return array<string,mixed>
+     */
+    protected function getSubmittedFormOptionValues(
+        string $settingsCategory,
+    ): array {
+        $settingsCategoryRegistry = SystemSettingsCategoryRegistryFacade::getInstance();
+        $settingsCategoryResolver = $settingsCategoryRegistry->getSettingsCategoryResolver($settingsCategory);
+        $optionsFormName = $settingsCategoryResolver->getOptionsFormName($settingsCategory);
+        return App::getRequest()->request->all()[$optionsFormName] ?? [];
     }
 
     /**

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
@@ -40,7 +40,7 @@ class PluginOptionsFormHandler
             
             // Obtain the values from the POST and normalize them
             $value = $this->getSubmittedFormOptionValues($settingsCategory);
-            $this->normalizedModuleOptionValuesCache[$settingsCategory][$module] = $settingsNormalizer->normalizeModuleSettings($module, $value);
+            $this->normalizedModuleOptionValuesCache[$settingsCategory][$module] = $settingsNormalizer->normalizeSettingsByModule($value, $module);
         }
         return $this->normalizedModuleOptionValuesCache[$settingsCategory][$module];
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/PluginOptionsFormHandler.php
@@ -40,7 +40,7 @@ class PluginOptionsFormHandler
             
             // Obtain the values from the POST and normalize them
             $value = $this->getSubmittedFormOptionValues($settingsCategory);
-            $this->normalizedModuleOptionValuesCache[$settingsCategory][$module] = $settingsNormalizer->normalizeSettings($value, $settingsCategory);
+            $this->normalizedModuleOptionValuesCache[$settingsCategory][$module] = $settingsNormalizer->normalizeModuleSettings($module, $value);
         }
         return $this->normalizedModuleOptionValuesCache[$settingsCategory][$module];
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistry.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Registries/ModuleRegistry.php
@@ -85,7 +85,7 @@ class ModuleRegistry implements ModuleRegistryInterface
          *   `BehaviorHelpers::areUnsafeDefaultsEnabled()` in
          *   `isEnabledByDefault`
          * - `BehaviorHelpers::areUnsafeDefaultsEnabled()` calls
-         *   `->normalizeSettings` which loads all modules with
+         *   `->normalizeSettingsByCategory` which loads all modules with
          *   `->getAllModules(`, and SINGLE_ENDPOINT is one of them,
          *   but it would call again `areUnsafeDefaultsEnabled`
          *   to decide if it's enabled or not...

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Services/MenuPages/SettingsMenuPage.php
@@ -226,7 +226,7 @@ class SettingsMenuPage extends AbstractPluginMenuPage
         array $values,
         string $settingsCategory,
     ): array {
-        return $this->getSettingsNormalizer()->normalizeSettings($values, $settingsCategory);
+        return $this->getSettingsNormalizer()->normalizeSettingsByCategory($values, $settingsCategory);
     }
 
     protected function flushContainer(): void

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
@@ -138,37 +138,6 @@ class SettingsNormalizer implements SettingsNormalizerInterface
     }
 
     /**
-     * Normalize the form values:
-     *
-     * - If the input is empty, replace with the default
-     * - Convert from string to int/bool
-     *
-     * @param array<string,string> $values All values submitted, each under its optionName as key
-     * @return array<string,mixed> Normalized values
-     */
-    public function normalizeModuleSettings(string $module, array $values): array
-    {
-        $moduleResolver = $this->getModuleRegistry()->getModuleResolver($module);
-
-        // Obtain the settingsOptionName for each option
-        $normalizedOptionValues = [];
-        foreach ($values as $option => $value) {
-            $settingsOptionName = $moduleResolver->getSettingOptionName($module, $option);
-            $normalizedOptionValues[$settingsOptionName] = $value;
-        }
-        // Normalize it
-        $normalizedOptionValues = $this->normalizeSettingsByModule($values, $module);
-
-        // Transform back
-        foreach ($values as $option => $value) {
-            $settingsOptionName = $moduleResolver->getSettingOptionName($module, $option);
-            $values[$option] = $normalizedOptionValues[$settingsOptionName];
-        }
-
-        return $values;
-    }
-
-    /**
      * Return all the modules with settings
      *
      * @return array<array<string,mixed>> Each item is an array of prop => value

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
@@ -138,10 +138,12 @@ class SettingsNormalizer implements SettingsNormalizerInterface
     }
 
     /**
-     * Normalize the form values:
+     * Normalize the form values for a specific module.
      *
-     * - If the input is empty, replace with the default
-     * - Convert from string to int/bool
+     * This method sets the previous values properly when
+     * called from the REST API (eg: when executing Integration Tests)
+     * as the previousValue for some Settings option could be non-existent,
+     * and it must be overriden/removed.
      *
      * @param array<string,string> $values All values submitted, each under its optionName as key
      * @return array<string,mixed> Normalized values

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
@@ -37,8 +37,25 @@ class SettingsNormalizer implements SettingsNormalizerInterface
         array $values,
         string $settingsCategory,
     ): array {
-        $moduleRegistry = $this->getModuleRegistry();
         $settingsItems = $this->getAllSettingsItems($settingsCategory);
+        return $this->normalizeSettings($values, $settingsItems);
+    }
+
+    /**
+     * Normalize the form values:
+     *
+     * - If the input is empty, replace with the default
+     * - Convert from string to int/bool
+     *
+     * @param array<string,string> $values All values submitted, each under its optionName as key
+     * @param array<array<string, mixed>> $settingsItems Each item is an array of prop => value
+     * @return array<string,mixed> Normalized values
+     */
+    protected function normalizeSettings(
+        array $values,
+        array $settingsItems,
+    ): array {
+        $moduleRegistry = $this->getModuleRegistry();
         foreach ($settingsItems as $item) {
             $module = $item['module'];
             $moduleResolver = $moduleRegistry->getModuleResolver($module);

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
@@ -146,7 +146,7 @@ class SettingsNormalizer implements SettingsNormalizerInterface
      * @param array<string,string> $values All values submitted, each under its optionName as key
      * @return array<string,mixed> Normalized values
      */
-    public function normalizeModuleSettings(string $module, array $values): array
+    public function normalizeSettingsForRESTAPIController(string $module, array $values): array
     {
         $moduleResolver = $this->getModuleRegistry()->getModuleResolver($module);
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
@@ -33,7 +33,7 @@ class SettingsNormalizer implements SettingsNormalizerInterface
      * @param array<string,string> $values All values submitted, each under its optionName as key
      * @return array<string,mixed> Normalized values
      */
-    public function normalizeSettings(
+    public function normalizeSettingsByCategory(
         array $values,
         string $settingsCategory,
     ): array {
@@ -123,7 +123,7 @@ class SettingsNormalizer implements SettingsNormalizerInterface
             $normalizedOptionValues[$settingsOptionName] = $value;
         }
         // Normalize it
-        $normalizedOptionValues = $this->normalizeSettings(
+        $normalizedOptionValues = $this->normalizeSettingsByCategory(
             $normalizedOptionValues,
             $moduleResolver->getSettingsCategory($module)
         );

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizer.php
@@ -138,6 +138,40 @@ class SettingsNormalizer implements SettingsNormalizerInterface
     }
 
     /**
+     * Normalize the form values:
+     *
+     * - If the input is empty, replace with the default
+     * - Convert from string to int/bool
+     *
+     * @param array<string,string> $values All values submitted, each under its optionName as key
+     * @return array<string,mixed> Normalized values
+     */
+    public function normalizeModuleSettings(string $module, array $values): array
+    {
+        $moduleResolver = $this->getModuleRegistry()->getModuleResolver($module);
+
+        // Obtain the settingsOptionName for each option
+        $normalizedOptionValues = [];
+        foreach ($values as $option => $value) {
+            $settingsOptionName = $moduleResolver->getSettingOptionName($module, $option);
+            $normalizedOptionValues[$settingsOptionName] = $value;
+        }
+        // Normalize it
+        $normalizedOptionValues = $this->normalizeSettingsByCategory(
+            $normalizedOptionValues,
+            $moduleResolver->getSettingsCategory($module)
+        );
+
+        // Transform back
+        foreach ($values as $option => $value) {
+            $settingsOptionName = $moduleResolver->getSettingOptionName($module, $option);
+            $values[$option] = $normalizedOptionValues[$settingsOptionName];
+        }
+
+        return $values;
+    }
+
+    /**
      * Return all the modules with settings
      *
      * @return array<array<string,mixed>> Each item is an array of prop => value

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
@@ -33,6 +33,13 @@ interface SettingsNormalizerInterface
         string $module,
     ): array;
     /**
+     * Normalize the form values for a specific module
+     *
+     * @param array<string,string> $values All values submitted, each under its optionName as key
+     * @return array<string,mixed> Normalized values
+     */
+    public function normalizeModuleSettings(string $module, array $values): array;
+    /**
      * Return all the modules with settings
      *
      * @return array<array<string,mixed>> Each item is an array of prop => value

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
@@ -33,13 +33,6 @@ interface SettingsNormalizerInterface
         string $module,
     ): array;
     /**
-     * Normalize the form values for a specific module
-     *
-     * @param array<string,string> $values All values submitted, each under its optionName as key
-     * @return array<string,mixed> Normalized values
-     */
-    public function normalizeModuleSettings(string $module, array $values): array;
-    /**
      * Return all the modules with settings
      *
      * @return array<array<string,mixed>> Each item is an array of prop => value

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
@@ -33,7 +33,12 @@ interface SettingsNormalizerInterface
         string $module,
     ): array;
     /**
-     * Normalize the form values for a specific module
+     * Normalize the form values for a specific module.
+     *
+     * This method sets the previous values properly when
+     * called from the REST API (eg: when executing Integration Tests)
+     * as the previousValue for some Settings option could be non-existent,
+     * and it must be overriden/removed.
      *
      * @param array<string,string> $values All values submitted, each under its optionName as key
      * @return array<string,mixed> Normalized values

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
@@ -38,7 +38,7 @@ interface SettingsNormalizerInterface
      * @param array<string,string> $values All values submitted, each under its optionName as key
      * @return array<string,mixed> Normalized values
      */
-    public function normalizeModuleSettings(string $module, array $values): array;
+    public function normalizeSettingsForRESTAPIController(string $module, array $values): array;
     /**
      * Return all the modules with settings
      *

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
@@ -20,6 +20,19 @@ interface SettingsNormalizerInterface
         string $settingsCategory,
     ): array;
     /**
+     * Normalize the form values:
+     *
+     * - If the input is empty, replace with the default
+     * - Convert from string to int/bool
+     *
+     * @param array<string,string> $values All values submitted, each under its optionName as key
+     * @return array<string,mixed> Normalized values
+     */
+    public function normalizeSettingsByModule(
+        array $values,
+        string $module,
+    ): array;
+    /**
      * Normalize the form values for a specific module
      *
      * @param array<string,string> $values All values submitted, each under its optionName as key

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/SettingsNormalizerInterface.php
@@ -15,7 +15,7 @@ interface SettingsNormalizerInterface
      * @param array<string,string> $values All values submitted, each under its optionName as key
      * @return array<string,mixed> Normalized values
      */
-    public function normalizeSettings(
+    public function normalizeSettingsByCategory(
         array $values,
         string $settingsCategory,
     ): array;

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
@@ -154,7 +154,13 @@ class UserSettingsManager implements UserSettingsManagerInterface
         $settingsCategory = $moduleResolver->getSettingsCategory($module);
         $optionName = $settingsCategoryRegistry->getSettingsCategoryResolver($settingsCategory)->getDBOptionName($settingsCategory);
 
-        $this->setOptionItems($optionName, $optionValues);
+        $itemValues = [];
+        foreach ($optionValues as $option => $value) {
+            $item = $moduleResolver->getSettingOptionName($module, $option);
+            $itemValues[$item] = $value;
+        }
+
+        $this->setOptionItems($optionName, $itemValues);
     }
 
     public function hasSetModuleEnabled(string $moduleID): bool

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/Settings/UserSettingsManager.php
@@ -154,13 +154,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
         $settingsCategory = $moduleResolver->getSettingsCategory($module);
         $optionName = $settingsCategoryRegistry->getSettingsCategoryResolver($settingsCategory)->getDBOptionName($settingsCategory);
 
-        $itemValues = [];
-        foreach ($optionValues as $option => $value) {
-            $item = $moduleResolver->getSettingOptionName($module, $option);
-            $itemValues[$item] = $value;
-        }
-
-        $this->setOptionItems($optionName, $itemValues);
+        $this->setOptionItems($optionName, $optionValues);
     }
 
     public function hasSetModuleEnabled(string $moduleID): bool


### PR DESCRIPTION
To avoid bug produced when storing the Settings:

```
PHP Fatal error:  Uncaught Symfony\\Component\\DependencyInjection\\Exception\\ServiceNotFoundException: You have requested a non-existent service "GraphQLAPI\\GraphQLAPI\\Registries\\CustomPostTypeRegistryInterface". in /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php:935
Stack trace:
#0 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php(550): Symfony\\Component\\DependencyInjection\\ContainerBuilder->getDefinition('GraphQLAPI\\\\Grap...')
#1 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php(513): Symfony\\Component\\DependencyInjection\\ContainerBuilder->doGet('GraphQLAPI\\\\Grap...', 1)
#2 /app/wordpress/Engine/packages/root/src/Instances/SystemInstanceManager.php(15): Symfony\\Component\\DependencyInjection\\ContainerBuilder->get('GraphQLAPI\\\\Grap...')
#3 /app/wordpress/wp-content/plugins/graphql-api/src/WPDataModel/WPDataModelProvider.php(38): PoP\\Root\\Instances\\SystemInstanceManager->getInstance('GraphQLAPI\\\\Grap...')
#4 /app/wordpress/wp-content/plugins/graphql-api/src/WPDataModel/WPDataModelProvider.php(63): GraphQLAPI\\GraphQLAPI\\WPDataModel\\WPDataModelProvider->getCustomPostTypeRegistry()
#5 /app/wordpress/wp-content/plugins/graphql-api/src/ModuleResolvers/SchemaTypeModuleResolver.php(651): GraphQLAPI\\GraphQLAPI\\WPDataModel\\WPDataModelProvider->getFilteredNonGraphQLAPIPluginCustomPostTypes()
#6 /app/wordpress/wp-content/plugins/graphql-api/src/ModuleResolvers/AbstractModuleResolver.php(106): GraphQLAPI\\GraphQLAPI\\ModuleResolvers\\SchemaTypeModuleResolver->getSettings('GraphQLAPI\\\\Grap...')
#7 /app/wordpress/wp-content/plugins/graphql-api/src/Registries/ModuleRegistry.php(114): GraphQLAPI\\GraphQLAPI\\ModuleResolvers\\AbstractModuleResolver->hasSettings('GraphQLAPI\\\\Grap...')
#8 [internal function]: GraphQLAPI\\GraphQLAPI\\Registries\\ModuleRegistry->GraphQLAPI\\GraphQLAPI\\Registries\\{closure}('GraphQLAPI\\\\Grap...')
#9 /app/wordpress/wp-content/plugins/graphql-api/src/Registries/ModuleRegistry.php(115): array_filter(Array, Object(Closure))
#10 /app/wordpress/wp-content/plugins/graphql-api/src/Settings/SettingsNormalizer.php(149): GraphQLAPI\\GraphQLAPI\\Registries\\ModuleRegistry->getAllModules(true, true, false, true, 'GraphQLAPI\\\\Grap...')
#11 /app/wordpress/wp-content/plugins/graphql-api/src/Settings/SettingsNormalizer.php(41): GraphQLAPI\\GraphQLAPI\\Settings\\SettingsNormalizer->getAllSettingsItems('GraphQLAPI\\\\Grap...')
#12 /app/wordpress/wp-content/plugins/graphql-api/src/PluginManagement/PluginOptionsFormHandler.php(44): GraphQLAPI\\GraphQLAPI\\Settings\\SettingsNormalizer->normalizeSettingsByCategory(Array, 'GraphQLAPI\\\\Grap...')
#13 /app/wordpress/wp-content/plugins/graphql-api/src/PluginManagement/PluginOptionsFormHandler.php(75): GraphQLAPI\\GraphQLAPI\\PluginManagement\\PluginOptionsFormHandler->getNormalizedOptionValues('GraphQLAPI\\\\Grap...')
#14 /app/wordpress/wp-content/plugins/graphql-api/src/PluginManagement/PluginOptionsFormHandler.php(107): GraphQLAPI\\GraphQLAPI\\PluginManagement\\PluginOptionsFormHandler->maybeOverrideValueFromForm('graphql', 'GraphQLAPI\\\\Grap...', 'path')
#15 /app/wordpress/wp-content/plugins/graphql-api/src/PluginInitializationConfiguration.php(124): GraphQLAPI\\GraphQLAPI\\PluginManagement\\PluginOptionsFormHandler->getCPTPermalinkBasePathSettingValue('graphql', 'GraphQLAPI\\\\Grap...', 'path')
#16 /app/wordpress/wp-content/plugins/graphql-api/src/PluginSkeleton/AbstractPluginInitializationConfiguration.php(140): GraphQLAPI\\GraphQLAPI\\PluginInitializationConfiguration->GraphQLAPI\\GraphQLAPI\\{closure}('graphql')
#17 /app/wordpress/wp-includes/class-wp-hook.php(310): GraphQLAPI\\GraphQLAPI\\PluginSkeleton\\AbstractPluginInitializationConfiguration->GraphQLAPI\\GraphQLAPI\\PluginSkeleton\\{closure}('graphql')
#18 /app/wordpress/wp-includes/plugin.php(205): WP_Hook->apply_filters('graphql', Array)
#19 /app/wordpress/Engine/packages/root-wp/src/StateManagers/HookManager.php(24): apply_filters('GraphQLAPI\\\\Grap...', 'graphql', 'GraphQLAPI\\\\Grap...', 'ENDPOINT_SLUG_B...')
#20 /app/wordpress/Engine/packages/root/src/App.php(268): PoP\\RootWP\\StateManagers\\HookManager->applyFilters('GraphQLAPI\\\\Grap...', 'graphql', 'GraphQLAPI\\\\Grap...', 'ENDPOINT_SLUG_B...')
#21 /app/wordpress/Engine/packages/root/src/Module/AbstractModuleConfiguration.php(70): PoP\\Root\\App::applyFilters('GraphQLAPI\\\\Grap...', 'graphql', 'GraphQLAPI\\\\Grap...', 'ENDPOINT_SLUG_B...')
#22 /app/wordpress/wp-content/plugins/graphql-api/src/ModuleConfiguration.php(81): PoP\\Root\\Module\\AbstractModuleConfiguration->retrieveConfigurationValueOrUseDefault('ENDPOINT_SLUG_B...', 'graphql')
#23 /app/wordpress/wp-content/plugins/graphql-api/src/Services/CustomPostTypes/GraphQLCustomEndpointCustomPostType.php(97): GraphQLAPI\\GraphQLAPI\\ModuleConfiguration->getCustomEndpointSlugBase()
#24 /app/wordpress/wp-content/plugins/graphql-api/src/Services/CustomPostTypes/AbstractCustomPostType.php(606): GraphQLAPI\\GraphQLAPI\\Services\\CustomPostTypes\\GraphQLCustomEndpointCustomPostType->getSlugBase()
#25 /app/wordpress/wp-content/plugins/graphql-api/src/Services/CustomPostTypes/AbstractCustomPostType.php(671): GraphQLAPI\\GraphQLAPI\\Services\\CustomPostTypes\\AbstractCustomPostType->getCustomPostTypeArgs()
#26 /app/wordpress/wp-content/plugins/graphql-api/src/Services/CustomPostTypes/AbstractCustomPostType.php(663): GraphQLAPI\\GraphQLAPI\\Services\\CustomPostTypes\\AbstractCustomPostType->registerCustomPostType()
#27 /app/wordpress/wp-includes/class-wp-hook.php(308): GraphQLAPI\\GraphQLAPI\\Services\\CustomPostTypes\\AbstractCustomPostType->initCustomPostType('')
#28 /app/wordpress/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array)
#29 /app/wordpress/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#30 /app/wordpress/wp-settings.php(617): do_action('init')
#31 /app/wordpress/wp-config.php(104): require_once('/app/wordpress/...')
#32 /app/wordpress/wp-load.php(50): require_once('/app/wordpress/...')
#33 /app/wordpress/wp-admin/admin.php(34): require_once('/app/wordpress/...')
#34 /app/wordpress/wp-admin/options.php(19): require_once('/app/wordpress/...')
#35 {main}
  thrown in /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php on line 935, referer: https://graphql-api-pro.lndo.site/wp-admin/admin.php?page=graphql_api_settings
```

## PR explanation

Call `normalizeSettingsByModule` instead of `normalizeSettingsByCategory`, because there are settings that depend on other services, which are not initialized in the system service.

For instance, module `SCHEMA_CONFIGURATION` requires service `GraphQLSchemaConfigurationCustomPostType`.

If calling `normalizeSettingsByCategory`, this other module would also be normalized, attempting to initialize these services, and throwing an error.

But just normalizing the modules that use `getURLPathSettingValue` and `getCPTPermalinkBasePathSettingValue` (eg: GraphiQL client path, etc), these ones currently have no other dependencies, and they do not fail.