### PR TITLE
Pass async as a param and rename the `_asyncRequest` fields

### DIFF
--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -7,7 +7,7 @@ Addition of fields to execute HTTP requests against a webserver and fetch their 
 - `_requestJSONObjectCollection`
 - `_asyncRequestJSONObjectCollections`
 - `_request`
-- `_asyncRequest`
+- `_multipleRequest`
 - `_requestGraphQL`
 
 ## Description
@@ -53,11 +53,11 @@ It connects to the specified URL and retrieves an `HTTPResponse` object, which c
 
 **Signature:** `_request(input: HTTPRequestInput!): HTTPResponse`.
 
-### `_asyncRequest`
+### `_multipleRequest`
 
 Similar to `_request` but it receives multiple URLs, and connects to them asynchronously, in parallel.
 
-**Signature:** `_asyncRequest(inputs: [HTTPRequestInput!]!): [HTTPResponse]`.
+**Signature:** `_multipleRequest(inputs: [HTTPRequestInput!]!): [HTTPResponse]`.
 
 ### `_requestGraphQL`
 
@@ -319,7 +319,7 @@ Executing the following query:
 }
 ```
 
-### Async fields: `_asyncRequestJSONObjectItems`, `_asyncRequestJSONObjectCollections` and `_asyncRequest`
+### Async fields: `_asyncRequestJSONObjectItems`, `_asyncRequestJSONObjectCollections` and `_multipleRequest`
 
 These fields work similar to their corresponding non-async fields, but they retrieve data from several endpoints at once, asynchronously and in parallel. The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -24,7 +24,7 @@ It retrieves the (REST) response for a single JSON object.
 
 ### `_multipleRequestJSONObjectItems`
 
-It retrieves the (REST) response for a single JSON object from multiple endpoints, executed asynchronously, in parallel.
+It retrieves the (REST) response for a single JSON object from multiple endpoints, executed asynchronously (in parallel) or synchronously (one after the other).
 
 **Signature:** `_multipleRequestJSONObjectItems(inputs: [HTTPRequestInput!]!): [JSONObject]`.
 
@@ -36,7 +36,7 @@ It retrieves the (REST) response for a collection of JSON objects.
 
 ### `_multipleRequestJSONObjectCollections`
 
-It retrieves the (REST) response for a collection of JSON objects from multiple endpoints, executed asynchronously, in parallel.
+It retrieves the (REST) response for a collection of JSON objects from multiple endpoints, executed asynchronously (in parallel) or synchronously (one after the other).
 
 **Signature:** `_multipleRequestJSONObjectCollections(inputs: [HTTPRequestInput!]!): [[JSONObject]]`.
 
@@ -55,7 +55,7 @@ It connects to the specified URL and retrieves an `HTTPResponse` object, which c
 
 ### `_multipleRequest`
 
-Similar to `_request` but it receives multiple URLs, and connects to them asynchronously, in parallel.
+Similar to `_request` but it receives multiple URLs, and allows to connect to them asynchronously (in parallel).
 
 **Signature:** `_multipleRequest(inputs: [HTTPRequestInput!]!): [HTTPResponse]`.
 
@@ -319,9 +319,9 @@ Executing the following query:
 }
 ```
 
-### Async fields: `_multipleRequestJSONObjectItems`, `_multipleRequestJSONObjectCollections` and `_multipleRequest`
+### Multiple-request fields: `_multipleRequestJSONObjectItems`, `_multipleRequestJSONObjectCollections` and `_multipleRequest`
 
-These fields work similar to their corresponding non-async fields, but they retrieve data from several endpoints at once, asynchronously and in parallel. The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
+These fields work similar to their corresponding non-multiple fields, but they retrieve data from several endpoints at once, either asynchronously (in parallel) or synchronously (one after the other). The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
 
 For instance, the following query:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -5,7 +5,7 @@ Addition of fields to execute HTTP requests against a webserver and fetch their 
 - `_requestJSONObjectItem`
 - `_multipleRequestJSONObjectItems`
 - `_requestJSONObjectCollection`
-- `_asyncRequestJSONObjectCollections`
+- `_multipleRequestJSONObjectCollections`
 - `_request`
 - `_multipleRequest`
 - `_requestGraphQL`
@@ -34,11 +34,11 @@ It retrieves the (REST) response for a collection of JSON objects.
 
 **Signature:** `_requestJSONObjectCollection(input: HTTPRequestInput!): [JSONObject]`.
 
-### `_asyncRequestJSONObjectCollections`
+### `_multipleRequestJSONObjectCollections`
 
 It retrieves the (REST) response for a collection of JSON objects from multiple endpoints, executed asynchronously, in parallel.
 
-**Signature:** `_asyncRequestJSONObjectCollections(inputs: [HTTPRequestInput!]!): [[JSONObject]]`.
+**Signature:** `_multipleRequestJSONObjectCollections(inputs: [HTTPRequestInput!]!): [[JSONObject]]`.
 
 ### `_request`
 
@@ -319,7 +319,7 @@ Executing the following query:
 }
 ```
 
-### Async fields: `_multipleRequestJSONObjectItems`, `_asyncRequestJSONObjectCollections` and `_multipleRequest`
+### Async fields: `_multipleRequestJSONObjectItems`, `_multipleRequestJSONObjectCollections` and `_multipleRequest`
 
 These fields work similar to their corresponding non-async fields, but they retrieve data from several endpoints at once, asynchronously and in parallel. The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -3,7 +3,7 @@
 Addition of fields to execute HTTP requests against a webserver and fetch their response:
 
 - `_requestJSONObjectItem`
-- `_asyncRequestJSONObjectItems`
+- `_multipleRequestJSONObjectItems`
 - `_requestJSONObjectCollection`
 - `_asyncRequestJSONObjectCollections`
 - `_request`
@@ -22,11 +22,11 @@ It retrieves the (REST) response for a single JSON object.
 
 **Signature:** `_requestJSONObjectItem(input: HTTPRequestInput!): JSONObject`.
 
-### `_asyncRequestJSONObjectItems`
+### `_multipleRequestJSONObjectItems`
 
 It retrieves the (REST) response for a single JSON object from multiple endpoints, executed asynchronously, in parallel.
 
-**Signature:** `_asyncRequestJSONObjectItems(inputs: [HTTPRequestInput!]!): [JSONObject]`.
+**Signature:** `_multipleRequestJSONObjectItems(inputs: [HTTPRequestInput!]!): [JSONObject]`.
 
 ### `_requestJSONObjectCollection`
 
@@ -319,7 +319,7 @@ Executing the following query:
 }
 ```
 
-### Async fields: `_asyncRequestJSONObjectItems`, `_asyncRequestJSONObjectCollections` and `_multipleRequest`
+### Async fields: `_multipleRequestJSONObjectItems`, `_asyncRequestJSONObjectCollections` and `_multipleRequest`
 
 These fields work similar to their corresponding non-async fields, but they retrieve data from several endpoints at once, asynchronously and in parallel. The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
 
@@ -327,7 +327,7 @@ For instance, the following query:
 
 ```graphql
 {
-  weatherForecasts: _asyncRequestJSONObjectItems(
+  weatherForecasts: _multipleRequestJSONObjectItems(
     urls: [
       "https://api.weather.gov/gridpoints/TOP/31,80/forecast",
       "https://api.weather.gov/gridpoints/TOP/41,55/forecast"

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/bulk-editing-content/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/bulk-editing-content/en.md
@@ -171,7 +171,7 @@ query CalculateURLInputs
 query ExecuteURLs
   @depends(on:"CalculateURLInputs")
 {
-  _asyncRequest(inputs: $urlInputs) {
+  _multipleRequest(inputs: $urlInputs) {
     statusCode
     body
   }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
@@ -122,7 +122,7 @@ query CreateHTTPRequestInputs
 query RetrieveActualArtifactDownloadURLs
   @depends(on: "CreateHTTPRequestInputs")
 {
-  _asyncRequest(
+  _multipleRequest(
     inputs: $httpRequestInputs
   ) {
     artifactDownloadURL: header(name: "Location")

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/using-the-graphql-server-without-wordpress/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/using-the-graphql-server-without-wordpress/en.md
@@ -158,7 +158,7 @@ query CreateHTTPRequestInputs
 query RetrieveActualArtifactDownloadURLs
   @depends(on: "CreateHTTPRequestInputs")
 {
-  _asyncRequest(inputs: $httpRequestInputs) {
+  _multipleRequest(inputs: $httpRequestInputs) {
     artifactDownloadURL: header(name: "Location")
       @export(as: "artifactDownloadURLs")
   }


### PR DESCRIPTION
Converted fields:

- `_asyncRequest` => `_multipleRequest(async: Boolean = true)`
- `_asyncRequestJSONObjectItems` => `_multipleRequestJSONObjectItems(async: Boolean = true)`
- `_asyncRequestJSONObjectCollections` => `_multipleRequestJSONObjectCollections(async: Boolean = true)`