### PR TITLE
Rename Send HTTP Request fields

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractMetaFieldDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/AbstractMetaFieldDirectiveResolver.php
@@ -224,7 +224,7 @@ abstract class AbstractMetaFieldDirectiveResolver extends AbstractFieldDirective
      * failing, when it's been set to process a certain type only.
      *
      * Eg: `@strUpperCase` has been set to process `String`, but doing
-     * `{ _request(url: ...) @underJSONObjectProperty(...) @strUpperCase }`
+     * `{ _sendHTTPRequest(url: ...) @underJSONObjectProperty(...) @strUpperCase }`
      * must not fail. Then, @underJSONObjectProperty indicates to
      * switch from the original JSONObject to DangerouslyNonScalar.
      */

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
@@ -203,7 +203,7 @@ Transform multiple posts' `"title.rendered"` property into upper case:
 
 ```graphql
 query {
-  postListData: _requestJSONObjectCollection(
+  postListData: _sendJSONObjectCollectionHTTPRequest(
     url: "https://newapi.getpop.org/wp-json/wp/v2/posts/?per_page=3&_fields=id,type,title,date"
   )
     @forEach

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
@@ -191,7 +191,7 @@ Transform a single post's `"title.rendered"` property, obtained through the WP R
 
 ```graphql
 query {
-  postData: _requestJSONObjectItem(
+  postData: _sendJSONObjectItemHTTPRequest(
     url: "https://newapi.getpop.org/wp-json/wp/v2/posts/1/?_fields=id,type,title,date"
   )
     @underJSONObjectProperty(by: { path: "title.rendered" })

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/environment-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/environment-fields/en.md
@@ -107,7 +107,7 @@ For instance, the following query connects to the GitHub REST API using a privat
     @remove
   
   # Use the field from "Send HTTP Request Fields" to connect to GitHub
-  gitHubArtifactData: _requestJSONObjectCollection(
+  gitHubArtifactData: _sendJSONObjectCollectionHTTPRequest(
     url: "https://api.github.com/repos/leoloso/PoP/actions/artifacts",
     headers: [
       "Accept: application/vnd.github+json",

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/field-to-input/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/field-to-input/en.md
@@ -92,7 +92,7 @@ Retrieve data from an external REST endpoint, and manipulate its data to suit yo
 
 ```graphql
 {
-  externalData: _requestJSONObjectItem(input: { url: "https://example.com/rest/some-external-endpoint"} )
+  externalData: _sendJSONObjectItemHTTPRequest(input: { url: "https://example.com/rest/some-external-endpoint"} )
   userName: _objectProperty(object: $__externalData, by: { path: "data.user.name" })
   userLastName: _objectProperty(object: $__externalData, by: { path: "data.user.surname" })
 }
@@ -122,7 +122,7 @@ Using the `@remove` directive on `externalData`, we can also avoid printing the 
 
 ```graphql
 {
-  externalData: _requestJSONObjectItem(input: { url: "https://example.com/rest/some-external-endpoint" } ) @remove
+  externalData: _sendJSONObjectItemHTTPRequest(input: { url: "https://example.com/rest/some-external-endpoint" } ) @remove
   userName: _objectProperty(object: $__externalData, by: { path: "data.user.name" })
   userLastName: _objectProperty(object: $__externalData, by: { path: "data.user.surname" })
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/function-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/function-fields/en.md
@@ -370,7 +370,7 @@ Together with the **Send HTTP Request Fields** module, we can dynamically genera
     ])
     
     # Retrieve the endpoint data
-    endpointData: _requestJSONObjectItem(input: { url: $__endpoint } )
+    endpointData: _sendJSONObjectItemHTTPRequest(input: { url: $__endpoint } )
 
     # Extract specific information
     userAvatar: _objectProperty(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
@@ -12,7 +12,7 @@ These are some examples:
 
 - Those fields from the **Send HTTP Request Fields** module, which connect to external API endpoints and retrieve data from them:
   - `_sendHTTPRequest`
-  - `_requestJSONObjectItem`
+  - `_sendJSONObjectItemHTTPRequest`
   - `_requestJSONObjectCollection`
   - `_requestGraphQL`
 - Those fields from the **Function Fields** module, which expose functionalities commonly found in programming languages (such as PHP):

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
@@ -13,7 +13,7 @@ These are some examples:
 - Those fields from the **Send HTTP Request Fields** module, which connect to external API endpoints and retrieve data from them:
   - `_sendHTTPRequest`
   - `_sendJSONObjectItemHTTPRequest`
-  - `_requestJSONObjectCollection`
+  - `_sendJSONObjectCollectionHTTPRequest`
   - `_requestGraphQL`
 - Those fields from the **Function Fields** module, which expose functionalities commonly found in programming languages (such as PHP):
   - `_not`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
@@ -14,7 +14,7 @@ These are some examples:
   - `_sendHTTPRequest`
   - `_sendJSONObjectItemHTTPRequest`
   - `_sendJSONObjectCollectionHTTPRequest`
-  - `_requestGraphQL`
+  - `_sendGraphQLHTTPRequest`
 - Those fields from the **Function Fields** module, which expose functionalities commonly found in programming languages (such as PHP):
   - `_not`
   - `_if`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/global-fields/en.md
@@ -11,7 +11,7 @@ The GraphQL API PRO, in addition, also offers a different kind of fields: those 
 These are some examples:
 
 - Those fields from the **Send HTTP Request Fields** module, which connect to external API endpoints and retrieve data from them:
-  - `_request`
+  - `_sendHTTPRequest`
   - `_requestJSONObjectItem`
   - `_requestJSONObjectCollection`
   - `_requestGraphQL`

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
@@ -151,13 +151,13 @@ query {
 
 ## @underJSONObjectProperty
 
-`@underJSONObjectProperty` makes the next directive receive an entry from the queried JSON object. This directive is particularly useful to extract and manipulate a desired piece of data after querying an external API, which will quite likely have a generic `JSONObject` type (as when using function field `_requestJSONObjectItem`).
+`@underJSONObjectProperty` makes the next directive receive an entry from the queried JSON object. This directive is particularly useful to extract and manipulate a desired piece of data after querying an external API, which will quite likely have a generic `JSONObject` type (as when using function field `_sendJSONObjectItemHTTPRequest`).
 
 In the query below, we obtain a JSON object coming from the WP REST API, and we use `@underJSONObjectProperty` to manipulate the response's `type` property, transforming it to upper case:
 
 ```graphql
 query {
-  postData: _requestJSONObjectItem(
+  postData: _sendJSONObjectItemHTTPRequest(
     url: "https://newapi.getpop.org/wp-json/wp/v2/posts/1/?_fields=id,type,title,date"
   )
     @underJSONObjectProperty(by: { key: "type" })
@@ -171,7 +171,7 @@ In the query below, the WP REST API endpoint for a post provides property `"titl
 
 ```graphql
 query {
-  postData: _requestJSONObjectItem(
+  postData: _sendJSONObjectItemHTTPRequest(
     url: "https://newapi.getpop.org/wp-json/wp/v2/posts/1/?_fields=id,type,title,date"
   )
     @underJSONObjectProperty(by: { path: "title.rendered" })

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
@@ -185,7 +185,7 @@ In this query, `@forEach` wraps `@underJSONObjectProperty`, which itself wraps `
 
 ```graphql
 query {
-  postListData: _requestJSONObjectCollection(
+  postListData: _sendJSONObjectCollectionHTTPRequest(
     url: "https://newapi.getpop.org/wp-json/wp/v2/posts/?per_page=3&_fields=id,type,title,date"
   )
     @forEach

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/multiple-query-execution/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/multiple-query-execution/en.md
@@ -320,7 +320,7 @@ Import content from an external API endpoint:
 ```graphql
 query FetchDataFromExternalEndpoint
 {
-  _requestJSONObjectItem(input: { url: "https://site.com/wp-json/wp/posts/1" } )
+  _sendJSONObjectItemHTTPRequest(input: { url: "https://site.com/wp-json/wp/posts/1" } )
     @export(as: "externalData")
     @remove
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/remove-directive/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/remove-directive/en.md
@@ -35,7 +35,7 @@ query {
 
 Let's say we want to retrieve some specific data from an external REST API endpoint, and we don't need the rest of the data. We can then use `@remove` to make the response payload smaller, thus boosting performance:
 
-- Use field `_requestJSONObjectItem` (from the **Send HTTP Request Fields** module) to connect to the REST API
+- Use field `_sendJSONObjectItemHTTPRequest` (from the **Send HTTP Request Fields** module) to connect to the REST API
 - Process this data to extract the needed piece of information (via **Field to Input** and the `_objectProperty` field from **Function Fields**)
 - `@remove` the original data from the REST endpoint
 
@@ -43,7 +43,7 @@ This query ties everything together:
 
 ```graphql
 {
-  postData: _requestJSONObjectItem(
+  postData: _sendJSONObjectItemHTTPRequest(
     url: "https://newapi.getpop.org/wp-json/wp/v2/posts/1"
   ) @remove
   renderedTitle: _objectProperty(
@@ -102,7 +102,7 @@ query RetrieveGitHubActionArtifacts(
   )
 
   # Use the field from "Send HTTP Request Fields" to connect to GitHub
-  gitHubArtifactData: _requestJSONObjectItem(
+  gitHubArtifactData: _sendJSONObjectItemHTTPRequest(
     input: {
       url: $__githubAPIEndpoint
       options: { headers: $__githubRequestHeaders }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -3,7 +3,7 @@
 Addition of fields to execute HTTP requests against a webserver and fetch their response:
 
 - `_sendJSONObjectItemHTTPRequest`
-- `_multipleRequestJSONObjectItems`
+- `_sendJSONObjectItemHTTPRequests`
 - `_requestJSONObjectCollection`
 - `_multipleRequestJSONObjectCollections`
 - `_sendHTTPRequest`
@@ -22,11 +22,11 @@ It retrieves the (REST) response for a single JSON object.
 
 **Signature:** `_sendJSONObjectItemHTTPRequest(input: HTTPRequestInput!): JSONObject`.
 
-### `_multipleRequestJSONObjectItems`
+### `_sendJSONObjectItemHTTPRequests`
 
 It retrieves the (REST) response for a single JSON object from multiple endpoints, executed asynchronously (in parallel) or synchronously (one after the other).
 
-**Signature:** `_multipleRequestJSONObjectItems(inputs: [HTTPRequestInput!]!): [JSONObject]`.
+**Signature:** `_sendJSONObjectItemHTTPRequests(inputs: [HTTPRequestInput!]!): [JSONObject]`.
 
 ### `_requestJSONObjectCollection`
 
@@ -319,7 +319,7 @@ Executing the following query:
 }
 ```
 
-### Multiple-request fields: `_multipleRequestJSONObjectItems`, `_multipleRequestJSONObjectCollections` and `_sendHTTPRequests`
+### Multiple-request fields: `_sendJSONObjectItemHTTPRequests`, `_multipleRequestJSONObjectCollections` and `_sendHTTPRequests`
 
 These fields work similar to their corresponding non-multiple fields, but they retrieve data from several endpoints at once, either asynchronously (in parallel) or synchronously (one after the other). The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
 
@@ -327,7 +327,7 @@ For instance, the following query:
 
 ```graphql
 {
-  weatherForecasts: _multipleRequestJSONObjectItems(
+  weatherForecasts: _sendJSONObjectItemHTTPRequests(
     urls: [
       "https://api.weather.gov/gridpoints/TOP/31,80/forecast",
       "https://api.weather.gov/gridpoints/TOP/41,55/forecast"

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -5,7 +5,7 @@ Addition of fields to execute HTTP requests against a webserver and fetch their 
 - `_sendJSONObjectItemHTTPRequest`
 - `_sendJSONObjectItemHTTPRequests`
 - `_sendJSONObjectCollectionHTTPRequest`
-- `_multipleRequestJSONObjectCollections`
+- `_sendJSONObjectCollectionHTTPRequests`
 - `_sendHTTPRequest`
 - `_sendHTTPRequests`
 - `_requestGraphQL`
@@ -34,11 +34,11 @@ It retrieves the (REST) response for a collection of JSON objects.
 
 **Signature:** `_sendJSONObjectCollectionHTTPRequest(input: HTTPRequestInput!): [JSONObject]`.
 
-### `_multipleRequestJSONObjectCollections`
+### `_sendJSONObjectCollectionHTTPRequests`
 
 It retrieves the (REST) response for a collection of JSON objects from multiple endpoints, executed asynchronously (in parallel) or synchronously (one after the other).
 
-**Signature:** `_multipleRequestJSONObjectCollections(inputs: [HTTPRequestInput!]!): [[JSONObject]]`.
+**Signature:** `_sendJSONObjectCollectionHTTPRequests(inputs: [HTTPRequestInput!]!): [[JSONObject]]`.
 
 ### `_sendHTTPRequest`
 
@@ -319,7 +319,7 @@ Executing the following query:
 }
 ```
 
-### Multiple-request fields: `_sendJSONObjectItemHTTPRequests`, `_multipleRequestJSONObjectCollections` and `_sendHTTPRequests`
+### Multiple-request fields: `_sendJSONObjectItemHTTPRequests`, `_sendJSONObjectCollectionHTTPRequests` and `_sendHTTPRequests`
 
 These fields work similar to their corresponding non-multiple fields, but they retrieve data from several endpoints at once, either asynchronously (in parallel) or synchronously (one after the other). The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -2,7 +2,7 @@
 
 Addition of fields to execute HTTP requests against a webserver and fetch their response:
 
-- `_requestJSONObjectItem`
+- `_sendJSONObjectItemHTTPRequest`
 - `_multipleRequestJSONObjectItems`
 - `_requestJSONObjectCollection`
 - `_multipleRequestJSONObjectCollections`
@@ -16,11 +16,11 @@ This module adds global fields to the GraphQL schema to retrieve data from an ex
 
 Due to security reasons, the URLs that can be connected to must be explicitly configured (explained in the next section).
 
-### `_requestJSONObjectItem`
+### `_sendJSONObjectItemHTTPRequest`
 
 It retrieves the (REST) response for a single JSON object.
 
-**Signature:** `_requestJSONObjectItem(input: HTTPRequestInput!): JSONObject`.
+**Signature:** `_sendJSONObjectItemHTTPRequest(input: HTTPRequestInput!): JSONObject`.
 
 ### `_multipleRequestJSONObjectItems`
 
@@ -107,7 +107,7 @@ There are 2 behaviors, "Allow access" and "Deny access":
 
 All fields are similar but different.
 
-### `_requestJSONObjectItem`
+### `_sendJSONObjectItemHTTPRequest`
 
 This field retrieves a JSON object item, which is useful when querying a single item from a REST endpoint, as from the WP REST API endpoint `/wp-json/wp/v2/posts/1/`.
 
@@ -115,7 +115,7 @@ This query:
 
 ```graphql
 {
-  postData: _requestJSONObjectItem(input: { url: "https://newapi.getpop.org/wp-json/wp/v2/posts/1/" } )
+  postData: _sendJSONObjectItemHTTPRequest(input: { url: "https://newapi.getpop.org/wp-json/wp/v2/posts/1/" } )
 }
 ```
 
@@ -170,13 +170,13 @@ This query:
 
 ### `_requestJSONObjectCollection`
 
-This field is similar to `_requestJSONObjectItem`, but it retrieves a collection of JSON objects, as from the WP REST API endpoint `/wp-json/wp/v2/posts/`.
+This field is similar to `_sendJSONObjectItemHTTPRequest`, but it retrieves a collection of JSON objects, as from the WP REST API endpoint `/wp-json/wp/v2/posts/`.
 
 This query:
 
 ```graphql
 {
-  postData: _requestJSONObjectItem(input: { url: "https://newapi.getpop.org/wp-json/wp/v2/posts/?per_page=3&_fields=id,type,title,date" } )
+  postData: _sendJSONObjectItemHTTPRequest(input: { url: "https://newapi.getpop.org/wp-json/wp/v2/posts/?per_page=3&_fields=id,type,title,date" } )
 }
 ```
 
@@ -429,7 +429,7 @@ In this query, we generate the API endpoint using the **Field to Input** feature
       $__id,
       "?_fields=name"
     ])
-    _requestJSONObjectItem(input: { url: $__endpoint } )
+    _sendJSONObjectItemHTTPRequest(input: { url: $__endpoint } )
   }
 }
 ```
@@ -443,7 +443,7 @@ In this query, we generate the API endpoint using the **Field to Input** feature
       {
         "id": 1,
         "endpoint": "https://newapi.getpop.org/wp-json/wp/v2/users/1?_fields=name",
-        "_requestJSONObjectItem": {
+        "_sendJSONObjectItemHTTPRequest": {
           "name": "leo",
           "_links": {
             "self": [
@@ -462,7 +462,7 @@ In this query, we generate the API endpoint using the **Field to Input** feature
       {
         "id": 2,
         "endpoint": "https://newapi.getpop.org/wp-json/wp/v2/users/2?_fields=name",
-        "_requestJSONObjectItem": {
+        "_sendJSONObjectItemHTTPRequest": {
           "name": "themedemos",
           "_links": {
             "self": [

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -4,7 +4,7 @@ Addition of fields to execute HTTP requests against a webserver and fetch their 
 
 - `_sendJSONObjectItemHTTPRequest`
 - `_sendJSONObjectItemHTTPRequests`
-- `_requestJSONObjectCollection`
+- `_sendJSONObjectCollectionHTTPRequest`
 - `_multipleRequestJSONObjectCollections`
 - `_sendHTTPRequest`
 - `_sendHTTPRequests`
@@ -28,11 +28,11 @@ It retrieves the (REST) response for a single JSON object from multiple endpoint
 
 **Signature:** `_sendJSONObjectItemHTTPRequests(inputs: [HTTPRequestInput!]!): [JSONObject]`.
 
-### `_requestJSONObjectCollection`
+### `_sendJSONObjectCollectionHTTPRequest`
 
 It retrieves the (REST) response for a collection of JSON objects.
 
-**Signature:** `_requestJSONObjectCollection(input: HTTPRequestInput!): [JSONObject]`.
+**Signature:** `_sendJSONObjectCollectionHTTPRequest(input: HTTPRequestInput!): [JSONObject]`.
 
 ### `_multipleRequestJSONObjectCollections`
 
@@ -168,7 +168,7 @@ This query:
 }
 ```
 
-### `_requestJSONObjectCollection`
+### `_sendJSONObjectCollectionHTTPRequest`
 
 This field is similar to `_sendJSONObjectItemHTTPRequest`, but it retrieves a collection of JSON objects, as from the WP REST API endpoint `/wp-json/wp/v2/posts/`.
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -6,7 +6,7 @@ Addition of fields to execute HTTP requests against a webserver and fetch their 
 - `_multipleRequestJSONObjectItems`
 - `_requestJSONObjectCollection`
 - `_multipleRequestJSONObjectCollections`
-- `_request`
+- `_sendHTTPRequest`
 - `_multipleRequest`
 - `_requestGraphQL`
 
@@ -40,7 +40,7 @@ It retrieves the (REST) response for a collection of JSON objects from multiple 
 
 **Signature:** `_multipleRequestJSONObjectCollections(inputs: [HTTPRequestInput!]!): [[JSONObject]]`.
 
-### `_request`
+### `_sendHTTPRequest`
 
 It connects to the specified URL and retrieves an `HTTPResponse` object, which contains the following fields:
 
@@ -51,11 +51,11 @@ It connects to the specified URL and retrieves an `HTTPResponse` object, which c
 - `header(name: String!): String`
 - `hasHeader(name: String!): Boolean!`
 
-**Signature:** `_request(input: HTTPRequestInput!): HTTPResponse`.
+**Signature:** `_sendHTTPRequest(input: HTTPRequestInput!): HTTPResponse`.
 
 ### `_multipleRequest`
 
-Similar to `_request` but it receives multiple URLs, and allows to connect to them asynchronously (in parallel).
+Similar to `_sendHTTPRequest` but it receives multiple URLs, and allows to connect to them asynchronously (in parallel).
 
 **Signature:** `_multipleRequest(inputs: [HTTPRequestInput!]!): [HTTPResponse]`.
 
@@ -215,7 +215,7 @@ This query:
 }
 ```
 
-### `_request`
+### `_sendHTTPRequest`
 
 This field retrieves an `HTTPResponse` object with all properties from the response, so we can independently query the body (which is of type `String`, i.e. it is not cast as JSON), the status code, content type and headers.
 
@@ -223,7 +223,7 @@ For instance, the following query:
 
 ```graphql
 {
-  _request(
+  _sendHTTPRequest(
     input: {
       url: "https://newapi.getpop.org/wp-json/wp/v2/comments/11/?_fields=id,date,content"
     }
@@ -243,7 +243,7 @@ For instance, the following query:
 ```json
 {
   "data": {
-    "_request": {
+    "_sendHTTPRequest": {
       "statusCode": 200,
       "contentType": "application\/json; charset=UTF-8",
       "headers": {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -8,7 +8,7 @@ Addition of fields to execute HTTP requests against a webserver and fetch their 
 - `_sendJSONObjectCollectionHTTPRequests`
 - `_sendHTTPRequest`
 - `_sendHTTPRequests`
-- `_requestGraphQL`
+- `_sendGraphQLHTTPRequest`
 
 ## Description
 
@@ -59,13 +59,13 @@ Similar to `_sendHTTPRequest` but it receives multiple URLs, and allows to conne
 
 **Signature:** `_sendHTTPRequests(inputs: [HTTPRequestInput!]!): [HTTPResponse]`.
 
-### `_requestGraphQL`
+### `_sendGraphQLHTTPRequest`
 
 Execute a GraphQL query against the provided endpoint, and retrieve the response as a JSON object.
 
 The input to this field accepts the data expected for GraphQL: the endpoint, GraphQL query, variables and operation name, and already sets the default method (`POST`) and content type (`application/json`).
 
-**Signature:** `_requestGraphQL(input: GraphQLRequestInput!): JSONObject`.
+**Signature:** `_sendGraphQLHTTPRequest(input: GraphQLRequestInput!): JSONObject`.
 
 ## Configuring the allowed URLs
 
@@ -268,13 +268,13 @@ Please notice that the `headers` field retrieves a `JSONObject`, with the keys a
 
 The field `header`, though, retrieves a `String`. Then, a header with multiple entries (such as `Cache-Control`) has all its values joined with `", "`.
 
-### `_requestGraphQL`
+### `_sendGraphQLHTTPRequest`
 
 Executing the following query:
 
 ```graphql
 {
-  graphQLRequest: _requestGraphQL(
+  graphQLRequest: _sendGraphQLHTTPRequest(
     input: {
       endpoint: "https://newapi.getpop.org/api/graphql/"
       query: """

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/send-http-request-fields/en.md
@@ -7,7 +7,7 @@ Addition of fields to execute HTTP requests against a webserver and fetch their 
 - `_requestJSONObjectCollection`
 - `_multipleRequestJSONObjectCollections`
 - `_sendHTTPRequest`
-- `_multipleRequest`
+- `_sendHTTPRequests`
 - `_requestGraphQL`
 
 ## Description
@@ -53,11 +53,11 @@ It connects to the specified URL and retrieves an `HTTPResponse` object, which c
 
 **Signature:** `_sendHTTPRequest(input: HTTPRequestInput!): HTTPResponse`.
 
-### `_multipleRequest`
+### `_sendHTTPRequests`
 
 Similar to `_sendHTTPRequest` but it receives multiple URLs, and allows to connect to them asynchronously (in parallel).
 
-**Signature:** `_multipleRequest(inputs: [HTTPRequestInput!]!): [HTTPResponse]`.
+**Signature:** `_sendHTTPRequests(inputs: [HTTPRequestInput!]!): [HTTPResponse]`.
 
 ### `_requestGraphQL`
 
@@ -319,7 +319,7 @@ Executing the following query:
 }
 ```
 
-### Multiple-request fields: `_multipleRequestJSONObjectItems`, `_multipleRequestJSONObjectCollections` and `_multipleRequest`
+### Multiple-request fields: `_multipleRequestJSONObjectItems`, `_multipleRequestJSONObjectCollections` and `_sendHTTPRequests`
 
 These fields work similar to their corresponding non-multiple fields, but they retrieve data from several endpoints at once, either asynchronously (in parallel) or synchronously (one after the other). The responses are placed in a list, in the same order in which the URLs were defined in the `urls` parameter.
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/bulk-editing-content/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/bulk-editing-content/en.md
@@ -171,7 +171,7 @@ query CalculateURLInputs
 query ExecuteURLs
   @depends(on:"CalculateURLInputs")
 {
-  _multipleRequest(inputs: $urlInputs) {
+  _sendHTTPRequests(inputs: $urlInputs) {
     statusCode
     body
   }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/combining-user-data-from-different-systems/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/combining-user-data-from-different-systems/en.md
@@ -6,7 +6,7 @@ combine-user-data.gql
 
 ```graphql
 query ProvideNewsletterUserData {
-  userList: _requestJSONObjectCollection(
+  userList: _sendJSONObjectCollectionHTTPRequest(
     input: {
       url: "https://newapi.getpop.org/wp-json/newsletter/v1/subscriptions"
     }
@@ -43,7 +43,7 @@ query CombineUserDataFromDisparateSources
     append: $__joinedUserEmails
   ) # @remove
 
-  userEndpointDataItems: _requestJSONObjectCollection(
+  userEndpointDataItems: _sendJSONObjectCollectionHTTPRequest(
     input: {
       url: $__userEndpoint
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/filtering-data-from-an-external-api/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/filtering-data-from-an-external-api/en.md
@@ -45,7 +45,7 @@ fail-if-external-api-has-errors.gql <= Check if to place it on this Recipe, or e
 
 ```graphql
 query ConnectToAPI($endpoint: String!) {
-  externalData: _requestJSONObjectItem(
+  externalData: _sendJSONObjectItemHTTPRequest(
     input: {
       url: $endpoint
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/filtering-data-from-an-external-api/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/filtering-data-from-an-external-api/en.md
@@ -4,7 +4,7 @@ api-filtering.gql:
 
 ```graphql
 query FilterExternalAPIData {
-  userList: _requestJSONObjectCollection(
+  userList: _sendJSONObjectCollectionHTTPRequest(
     input: {
       url: "https://newapi.getpop.org/wp-json/wp/v2/users/?_fields=id,name,url"
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-a-post-from-another-site/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-a-post-from-another-site/en.md
@@ -6,7 +6,7 @@ Modify this query! (it's for multiple entries)
 
 ```graphql
 query CreatePostInputs {
-  githubPullRequestEntries: _requestJSONObjectCollection(
+  githubPullRequestEntries: _sendJSONObjectCollectionHTTPRequest(
     input: {
       url: "https://api.github.com/repos/leoloso/PoP/pulls?state=closed&per_page=2&page=75"
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-multiple-posts-at-once-from-another-site/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-multiple-posts-at-once-from-another-site/en.md
@@ -12,7 +12,7 @@ Mention we will need some new Custom Endpoint just to enable this
 
 ```graphql
 query CreatePostInputs {
-  githubPullRequestEntries: _requestJSONObjectCollection(
+  githubPullRequestEntries: _sendJSONObjectCollectionHTTPRequest(
     input: {
       url: "https://api.github.com/repos/leoloso/PoP/pulls?state=closed&per_page=2&page=75"
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
@@ -63,7 +63,7 @@ query RetrieveProxyArtifactDownloadURLs
     @export(as: "githubRequestHeaders")
   
   # Use the field from "Send HTTP Request Fields" to connect to GitHub
-  gitHubArtifactData: _requestJSONObjectItem(
+  gitHubArtifactData: _sendJSONObjectItemHTTPRequest(
     input: {
       url: "https://api.github.com/repos/leoloso/PoP/actions/artifacts?per_page=2",
       options: {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
@@ -122,7 +122,7 @@ query CreateHTTPRequestInputs
 query RetrieveActualArtifactDownloadURLs
   @depends(on: "CreateHTTPRequestInputs")
 {
-  _multipleRequest(
+  _sendHTTPRequests(
     inputs: $httpRequestInputs
   ) {
     artifactDownloadURL: header(name: "Location")

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/transforming-data-from-an-external-api/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/transforming-data-from-an-external-api/en.md
@@ -4,7 +4,7 @@ api-transformation.gql:
 
 ```graphql
 query AdaptExternalAPIData {
-  userList: _requestJSONObjectCollection(
+  userList: _sendJSONObjectCollectionHTTPRequest(
     input: {
       url: "https://newapi.getpop.org/wp-json/wp/v2/users/?_fields=id,name,url"
     }
@@ -77,7 +77,7 @@ conditional-data-manipulation-in-array.gql
 query ExtractEmailsFromAPIAndUpperCaseSpecialOnes
 {
   # Retrieve data from a REST API endpoint
-  userEntries: _requestJSONObjectCollection(
+  userEntries: _sendJSONObjectCollectionHTTPRequest(
     input: {
       url: "https://newapi.getpop.org/wp-json/newsletter/v1/subscriptions"
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/using-the-graphql-server-without-wordpress/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/using-the-graphql-server-without-wordpress/en.md
@@ -112,7 +112,7 @@ query RetrieveProxyArtifactDownloadURLs(
   )
 
   # Use the field from "Send HTTP Request Fields" to connect to GitHub
-  gitHubArtifactData: _requestJSONObjectItem(
+  gitHubArtifactData: _sendJSONObjectItemHTTPRequest(
     input: {
       url: $__githubAPIEndpoint
       options: { headers: $__githubRequestHeaders }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/using-the-graphql-server-without-wordpress/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/using-the-graphql-server-without-wordpress/en.md
@@ -158,7 +158,7 @@ query CreateHTTPRequestInputs
 query RetrieveActualArtifactDownloadURLs
   @depends(on: "CreateHTTPRequestInputs")
 {
-  _multipleRequest(inputs: $httpRequestInputs) {
+  _sendHTTPRequests(inputs: $httpRequestInputs) {
     artifactDownloadURL: header(name: "Location")
       @export(as: "artifactDownloadURLs")
   }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/modules/schema-mutations/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/modules/schema-mutations/en.md
@@ -183,7 +183,7 @@ In case of errors, these will appear under the `errors` entry of the response. F
 }
 ```
 
-We must notice that, as a result, the top-level `errors` entry will contain not only syntax, schema validation and logic errors (eg: not passing a field argument's name, requesting a non-existing field, or calling `_request` and the network is down respectively), but also "content validation" errors (eg: "you're not authorized to modify this post").
+We must notice that, as a result, the top-level `errors` entry will contain not only syntax, schema validation and logic errors (eg: not passing a field argument's name, requesting a non-existing field, or calling `_sendHTTPRequest` and the network is down respectively), but also "content validation" errors (eg: "you're not authorized to modify this post").
 
 Because there are no additional types added, the GraphQL schema will look leaner:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/1.0/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/1.0/en.md
@@ -250,7 +250,7 @@ In case of errors, these will appear under the `errors` entry of the response. F
 }
 ```
 
-We must notice that, as a result, the top-level `errors` entry will contain not only syntax, schema validation and logic errors (eg: not passing a field argument's name, requesting a non-existing field, or calling `_request` and the network is down respectively), but also "content validation" errors (eg: "you're not authorized to modify this post").
+We must notice that, as a result, the top-level `errors` entry will contain not only syntax, schema validation and logic errors (eg: not passing a field argument's name, requesting a non-existing field, or calling `_sendHTTPRequest` and the network is down respectively), but also "content validation" errors (eg: "you're not authorized to modify this post").
 
 Because there are no additional types added, the GraphQL schema will look leaner:
 


### PR DESCRIPTION
Renamed:

- `_request` => `_sendHTTPRequest`
- `_multipleRequest` => `_sendHTTPRequests`
- `_requestJSONObjectItem` => `_sendJSONObjectItemHTTPRequest`
- `_multipleRequestJSONObjectItems` => `_sendJSONObjectItemHTTPRequests`
- `_requestJSONObjectCollection` => `_sendJSONObjectCollectionHTTPRequest`
- `_multipleRequestJSONObjectCollections` => `_sendJSONObjectCollectionHTTPRequests`
- `_requestGraphQL` => `_sendGraphQLHTTPRequest`