### PR TITLE
`@forEach` can now export the key (in addition to the value)

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/DynamicVariableDefinerFieldDirectiveResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/DynamicVariableDefinerFieldDirectiveResolverInterface.php
@@ -26,6 +26,16 @@ interface DynamicVariableDefinerFieldDirectiveResolverInterface extends FieldDir
     public function getExportUnderVariableNameArgumentName(): string;
 
     /**
+     * Names for the directive arg to indicate the name of
+     * additional dynamic variables.
+     *
+     * Eg: @forEach(passKeyOnwardsAs: "variableName")
+     *
+     * @return string[]
+     */
+    public function getAdditionalExportUnderVariableNameArgumentNames(): array;
+
+    /**
      * If `true`, the dynamic variable's scope is the object
      * being currently resolved.
      *

--- a/layers/Engine/packages/component-model/src/ExtendedSpec/Parser/Ast/Document.php
+++ b/layers/Engine/packages/component-model/src/ExtendedSpec/Parser/Ast/Document.php
@@ -57,6 +57,22 @@ class Document extends AbstractDocument
         return $directive->getArgument($exportUnderVariableNameArgumentName);
     }
 
+    /**
+     * @return Argument[]|null
+     */
+    protected function getAdditionalExportUnderVariableNameArguments(Directive $directive): ?array
+    {
+        $dynamicVariableDefinerFieldDirectiveResolver = $this->getDynamicVariableDefinerFieldDirectiveResolver($directive);
+        if ($dynamicVariableDefinerFieldDirectiveResolver === null) {
+            return null;
+        }
+        $additionalExportUnderVariableNameArgumentNames = $dynamicVariableDefinerFieldDirectiveResolver->getAdditionalExportUnderVariableNameArgumentNames();
+        return array_map(
+            fn (string $exportUnderVariableNameArgumentName) => $directive->getArgument($exportUnderVariableNameArgumentName),
+            $additionalExportUnderVariableNameArgumentNames
+        );
+    }
+
     protected function isOperationDependencyDefinerDirective(Directive $directive): bool
     {
         return $this->getOperationDependencyDefinerFieldDirectiveResolver($directive) !== null;

--- a/layers/Engine/packages/component-model/src/ExtendedSpec/Parser/Ast/Document.php
+++ b/layers/Engine/packages/component-model/src/ExtendedSpec/Parser/Ast/Document.php
@@ -68,7 +68,7 @@ class Document extends AbstractDocument
         }
         $additionalExportUnderVariableNameArgumentNames = $dynamicVariableDefinerFieldDirectiveResolver->getAdditionalExportUnderVariableNameArgumentNames();
         return array_map(
-            fn (string $exportUnderVariableNameArgumentName) => $directive->getArgument($exportUnderVariableNameArgumentName),
+            fn (string $additionalExportUnderVariableNameArgumentName) => $directive->getArgument($additionalExportUnderVariableNameArgumentName),
             $additionalExportUnderVariableNameArgumentNames
         );
     }

--- a/layers/Engine/packages/component-model/src/ExtendedSpec/Parser/Ast/Document.php
+++ b/layers/Engine/packages/component-model/src/ExtendedSpec/Parser/Ast/Document.php
@@ -67,10 +67,10 @@ class Document extends AbstractDocument
             return null;
         }
         $additionalExportUnderVariableNameArgumentNames = $dynamicVariableDefinerFieldDirectiveResolver->getAdditionalExportUnderVariableNameArgumentNames();
-        return array_map(
+        return array_values(array_filter(array_map(
             fn (string $additionalExportUnderVariableNameArgumentName) => $directive->getArgument($additionalExportUnderVariableNameArgumentName),
             $additionalExportUnderVariableNameArgumentNames
-        );
+        )));
     }
 
     protected function isOperationDependencyDefinerDirective(Directive $directive): bool

--- a/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
+++ b/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
@@ -129,6 +129,22 @@ class Parser extends AbstractParser
         return $directive->getArgument($exportUnderVariableNameArgumentName);
     }
 
+    /**
+     * @return Argument[]|null
+     */
+    protected function getAdditionalExportUnderVariableNameArguments(Directive $directive): array
+    {
+        $dynamicVariableDefinerFieldDirectiveResolver = $this->getDynamicVariableDefinerFieldDirectiveResolver($directive);
+        if ($dynamicVariableDefinerFieldDirectiveResolver === null) {
+            return null;
+        }
+        $additionalExportUnderVariableNameArgumentNames = $dynamicVariableDefinerFieldDirectiveResolver->getAdditionalExportUnderVariableNameArgumentNames();
+        return array_map(
+            fn (string $exportUnderVariableNameArgumentName) => $directive->getArgument($exportUnderVariableNameArgumentName),
+            $additionalExportUnderVariableNameArgumentNames
+        );
+    }
+
     protected function getAffectAdditionalFieldsUnderPosArgumentName(Directive $directive): ?string
     {
         $directiveResolver = $this->getFieldDirectiveResolver($directive->getName());

--- a/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
+++ b/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
@@ -132,7 +132,7 @@ class Parser extends AbstractParser
     /**
      * @return Argument[]|null
      */
-    protected function getAdditionalExportUnderVariableNameArguments(Directive $directive): array
+    protected function getAdditionalExportUnderVariableNameArguments(Directive $directive): ?array
     {
         $dynamicVariableDefinerFieldDirectiveResolver = $this->getDynamicVariableDefinerFieldDirectiveResolver($directive);
         if ($dynamicVariableDefinerFieldDirectiveResolver === null) {

--- a/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
+++ b/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
@@ -140,7 +140,7 @@ class Parser extends AbstractParser
         }
         $additionalExportUnderVariableNameArgumentNames = $dynamicVariableDefinerFieldDirectiveResolver->getAdditionalExportUnderVariableNameArgumentNames();
         return array_map(
-            fn (string $exportUnderVariableNameArgumentName) => $directive->getArgument($exportUnderVariableNameArgumentName),
+            fn (string $additionalExportUnderVariableNameArgumentName) => $directive->getArgument($additionalExportUnderVariableNameArgumentName),
             $additionalExportUnderVariableNameArgumentNames
         );
     }

--- a/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
+++ b/layers/Engine/packages/component-model/src/GraphQLParser/ExtendedSpec/Parser/Parser.php
@@ -139,10 +139,10 @@ class Parser extends AbstractParser
             return null;
         }
         $additionalExportUnderVariableNameArgumentNames = $dynamicVariableDefinerFieldDirectiveResolver->getAdditionalExportUnderVariableNameArgumentNames();
-        return array_map(
+        return array_values(array_filter(array_map(
             fn (string $additionalExportUnderVariableNameArgumentName) => $directive->getArgument($additionalExportUnderVariableNameArgumentName),
             $additionalExportUnderVariableNameArgumentNames
-        );
+        )));
     }
 
     protected function getAffectAdditionalFieldsUnderPosArgumentName(Directive $directive): ?string

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -978,6 +978,10 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
 
     abstract protected function isDynamicVariableDefinerDirective(Directive $directive): bool;
     abstract protected function getExportUnderVariableNameArgument(Directive $directive): ?Argument;
+    /**
+     * @return Argument[]|null
+     */
+    abstract protected function getAdditionalExportUnderVariableNameArguments(Directive $directive): ?array;
     abstract protected function getAffectAdditionalFieldsUnderPosArgumentName(Directive $directive): ?string;
     abstract protected function mustResolveDynamicVariableOnObject(Directive $directive): ?bool;
 }

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -302,6 +302,14 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
         }
 
         /**
+         * The DirectiveResolver will indicate if the dynamic variable's scope
+         * is the "document" or "resolved in the object"
+         */
+        $mustResolveDynamicVariableOnObject = $this->mustResolveDynamicVariableOnObject($directive);
+        if ($mustResolveDynamicVariableOnObject === null) {
+            return;
+        }
+        /**
          * Obtain the name under which to export the value,
          * and stored in the the "parsed" list.
          *
@@ -311,24 +319,24 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
          * @see layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/Document.php
          */
         $exportUnderVariableNameArgument = $this->getExportUnderVariableNameArgument($directive);
-        if ($exportUnderVariableNameArgument === null) {
-            return;
+        if ($exportUnderVariableNameArgument !== null) {
+            $exportUnderVariableName = (string)$exportUnderVariableNameArgument->getValue();
+            if ($mustResolveDynamicVariableOnObject) {
+                $this->parsedFieldDefinedObjectResolvedDynamicVariableNames[0][] = $exportUnderVariableName;
+            } else {
+                $this->parsedDefinedDocumentDynamicVariableNames[] = $exportUnderVariableName;
+            }
         }
-        $exportUnderVariableName = (string)$exportUnderVariableNameArgument->getValue();
 
-        /**
-         * The DirectiveResolver will indicate if the dynamic variable's scope
-         * is the "document" or "resolved in the object"
-         */
-        $mustResolveDynamicVariableOnObject = $this->mustResolveDynamicVariableOnObject($directive);
-        if ($mustResolveDynamicVariableOnObject === null) {
-            return;
+        $additionalExportUnderVariableNameArguments = $this->getAdditionalExportUnderVariableNameArguments($directive);
+        foreach (($additionalExportUnderVariableNameArguments ?? []) as $additionalExportUnderVariableNameArgument) {
+            $additionalExportUnderVariableName = (string)$additionalExportUnderVariableNameArgument->getValue();
+            if ($mustResolveDynamicVariableOnObject) {
+                $this->parsedFieldDefinedObjectResolvedDynamicVariableNames[0][] = $additionalExportUnderVariableName;
+            } else {
+                $this->parsedDefinedDocumentDynamicVariableNames[] = $additionalExportUnderVariableName;
+            }
         }
-        if ($mustResolveDynamicVariableOnObject) {
-            $this->parsedFieldDefinedObjectResolvedDynamicVariableNames[0][] = $exportUnderVariableName;
-            return;
-        }
-        $this->parsedDefinedDocumentDynamicVariableNames[] = $exportUnderVariableName;
     }
 
     /**

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -312,7 +312,7 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
         /**
          * Obtain the name under which to export the value,
          * and stored in the the "parsed" list.
-         * 
+         *
          * Every directive can pass the value being modified under
          * `getExportUnderVariableNameArgument`, and potentially
          * additional values under `getAdditionalExportUnderVariableNameArguments`.

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -319,22 +319,17 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
          * @see layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/Document.php
          */
         $exportUnderVariableNameArgument = $this->getExportUnderVariableNameArgument($directive);
-        if ($exportUnderVariableNameArgument !== null) {
+        $additionalExportUnderVariableNameArguments = $this->getAdditionalExportUnderVariableNameArguments($directive);
+        $exportUnderVariableNameArguments = array_merge(
+            $exportUnderVariableNameArgument !== null ? [$exportUnderVariableNameArgument] : [],
+            $additionalExportUnderVariableNameArguments !== null ? $additionalExportUnderVariableNameArguments : []
+        );
+        foreach ($exportUnderVariableNameArguments as $exportUnderVariableNameArgument) {
             $exportUnderVariableName = (string)$exportUnderVariableNameArgument->getValue();
             if ($mustResolveDynamicVariableOnObject) {
                 $this->parsedFieldDefinedObjectResolvedDynamicVariableNames[0][] = $exportUnderVariableName;
             } else {
                 $this->parsedDefinedDocumentDynamicVariableNames[] = $exportUnderVariableName;
-            }
-        }
-
-        $additionalExportUnderVariableNameArguments = $this->getAdditionalExportUnderVariableNameArguments($directive);
-        foreach (($additionalExportUnderVariableNameArguments ?? []) as $additionalExportUnderVariableNameArgument) {
-            $additionalExportUnderVariableName = (string)$additionalExportUnderVariableNameArgument->getValue();
-            if ($mustResolveDynamicVariableOnObject) {
-                $this->parsedFieldDefinedObjectResolvedDynamicVariableNames[0][] = $additionalExportUnderVariableName;
-            } else {
-                $this->parsedDefinedDocumentDynamicVariableNames[] = $additionalExportUnderVariableName;
             }
         }
     }

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php
@@ -312,6 +312,15 @@ abstract class AbstractParser extends UpstreamParser implements ParserInterface
         /**
          * Obtain the name under which to export the value,
          * and stored in the the "parsed" list.
+         * 
+         * Every directive can pass the value being modified under
+         * `getExportUnderVariableNameArgument`, and potentially
+         * additional values under `getAdditionalExportUnderVariableNameArguments`.
+         *
+         * Eg: @forEach(
+         *   passValueOnwardsAs: "value" <= getExportUnderVariableNameArgument
+         *   passKeyOnwardsAs: "key" <= getAdditionalExportUnderVariableNameArguments
+         * )
          *
          * There is no need to check if there's a (static) Variable with
          * the same name, as that validation will happen in the Document.

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
@@ -298,13 +298,13 @@ abstract class AbstractDocument extends UpstreamDocument
              * Get the Argument under which the Dynamic Variable is defined
              */
             $exportUnderVariableNameArgument = $this->getExportUnderVariableNameArgument($directive);
-            if ($exportUnderVariableNameArgument === null) {
-                continue;
+            if ($exportUnderVariableNameArgument !== null) {
+                $dynamicVariableDefinitionArguments[] = $exportUnderVariableNameArgument;
             }
-            /**
-             * All success!
-             */
-            $dynamicVariableDefinitionArguments[] = $exportUnderVariableNameArgument;
+            $additionalExportUnderVariableNameArguments = $this->getAdditionalExportUnderVariableNameArguments($directive);
+            foreach ($additionalExportUnderVariableNameArguments ?? [] as $additionalExportUnderVariableNameArgument) {
+                $dynamicVariableDefinitionArguments[] = $additionalExportUnderVariableNameArgument;
+            }
         }
         return $dynamicVariableDefinitionArguments;
     }

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
@@ -311,6 +311,10 @@ abstract class AbstractDocument extends UpstreamDocument
 
     abstract protected function isDynamicVariableDefinerDirective(Directive $directive): bool;
     abstract protected function getExportUnderVariableNameArgument(Directive $directive): ?Argument;
+    /**
+     * @return Argument[]|null
+     */
+    abstract protected function getAdditionalExportUnderVariableNameArguments(Directive $directive): ?array;
 
     /**
      * Validate that all Resolved Field Value References

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
@@ -295,7 +295,7 @@ abstract class AbstractDocument extends UpstreamDocument
                 continue;
             }
             /**
-             * Get the Argument under which the Dynamic Variable is defined
+             * Get the Argument(s) under which the Dynamic Variable(s) is defined
              */
             $exportUnderVariableNameArgument = $this->getExportUnderVariableNameArgument($directive);
             $additionalExportUnderVariableNameArguments = $this->getAdditionalExportUnderVariableNameArguments($directive);

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
@@ -302,7 +302,7 @@ abstract class AbstractDocument extends UpstreamDocument
                 $dynamicVariableDefinitionArguments[] = $exportUnderVariableNameArgument;
             }
             $additionalExportUnderVariableNameArguments = $this->getAdditionalExportUnderVariableNameArguments($directive);
-            foreach ($additionalExportUnderVariableNameArguments ?? [] as $additionalExportUnderVariableNameArgument) {
+            foreach (($additionalExportUnderVariableNameArguments ?? []) as $additionalExportUnderVariableNameArgument) {
                 $dynamicVariableDefinitionArguments[] = $additionalExportUnderVariableNameArgument;
             }
         }

--- a/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
+++ b/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/AbstractDocument.php
@@ -298,13 +298,12 @@ abstract class AbstractDocument extends UpstreamDocument
              * Get the Argument under which the Dynamic Variable is defined
              */
             $exportUnderVariableNameArgument = $this->getExportUnderVariableNameArgument($directive);
-            if ($exportUnderVariableNameArgument !== null) {
-                $dynamicVariableDefinitionArguments[] = $exportUnderVariableNameArgument;
-            }
             $additionalExportUnderVariableNameArguments = $this->getAdditionalExportUnderVariableNameArguments($directive);
-            foreach (($additionalExportUnderVariableNameArguments ?? []) as $additionalExportUnderVariableNameArgument) {
-                $dynamicVariableDefinitionArguments[] = $additionalExportUnderVariableNameArgument;
-            }
+            $dynamicVariableDefinitionArguments = array_merge(
+                $dynamicVariableDefinitionArguments,
+                $exportUnderVariableNameArgument !== null ? [$exportUnderVariableNameArgument] : [],
+                $additionalExportUnderVariableNameArguments !== null ? $additionalExportUnderVariableNameArguments : []
+            );
         }
         return $dynamicVariableDefinitionArguments;
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/apply-field-directive/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/apply-field-directive/en.md
@@ -173,7 +173,7 @@ Manipulate all items in an array, shortening to no more than 20 chars long:
 {
   posts {
     categoryNames
-      @forEach(passOnwardsAs: "categoryName")
+      @forEach(passValueOnwardsAs: "categoryName")
         @applyField(
           name: "_strSubstr"
           arguments: {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
@@ -137,14 +137,14 @@ The response is:
 
 ### Exporting dynamic variables
 
-A meta directive can pass the value it contains as a "dynamic variable" to its nested directives, via directive argument `passOnwardsAs`.
+A meta directive can pass the value it contains as a "dynamic variable" to its nested directives, via a directive argument (sometimes via `passValueOnwardsAs`, some others via `passOnwardsAs`).
 
-In the query below, the array `["Hello everyone", "How are you?"]` is iterated upon using `@forEach`, and by defining argument `passOnwardsAs: "text"` each value in the array is made available to the nested directive `@applyField` under the dynamic variable `$text`:
+In the query below, the array `["Hello everyone", "How are you?"]` is iterated upon using `@forEach`, and by defining argument `passValueOnwardsAs: "text"` each value in the array is made available to the nested directive `@applyField` under the dynamic variable `$text`:
 
 ```graphql
 query {
   _echo(value: ["Hello everyone", "How are you?"])
-    @forEach(passOnwardsAs: "text")
+    @forEach(passValueOnwardsAs: "text")
       @applyField(
         name: "_strReplace"
         arguments: {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/composable-directives/en.md
@@ -137,7 +137,7 @@ The response is:
 
 ### Exporting dynamic variables
 
-A meta directive can pass the value it contains as a "dynamic variable" to its nested directives, via a directive argument (sometimes via `passValueOnwardsAs`, some others via `passOnwardsAs`).
+A meta directive can pass the value it contains as a "dynamic variable" to its nested directives, via a directive argument (`passValueOnwardsAs` for `@forEach`, or `passOnwardsAs` otherwise).
 
 In the query below, the array `["Hello everyone", "How are you?"]` is iterated upon using `@forEach`, and by defining argument `passValueOnwardsAs: "text"` each value in the array is made available to the nested directive `@applyField` under the dynamic variable `$text`:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
@@ -118,7 +118,7 @@ query {
 }
 ```
 
-`@forEach` can pass both the key and the value it is iterating on as a dynamic variable to its nested directive(s), via directive args `passKeyOnwardsAs` and `passValueOnwardsAs`. It works both when iterating arrays and `JSON` objects.
+Used with the **Dynamic Variables** feature, `@forEach` can pass both the key and the value it is iterating on as a dynamic variable to its nested directive(s), via directive args `passKeyOnwardsAs` and `passValueOnwardsAs`. It works both when iterating arrays and `JSON` objects.
 
 This query demonstrates this feature:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
@@ -118,6 +118,87 @@ query {
 }
 ```
 
+`@forEach` can pass both the key and the value it is iterating on as a dynamic variable to its nested directive(s), via directive args `passKeyOnwardsAs` and `passValueOnwardsAs`. It works both when iterating arrays and `JSON` objects.
+
+This query demonstrates this feature:
+
+```graphql
+{
+  withArray: _echo(value: ["first", "second", "third"])
+    @forEach(
+      passKeyOnwardsAs: "key"
+      passValueOnwardsAs: "value"
+    )
+      @applyField(
+        name: "_echo"
+        arguments: {
+          value: {
+            key: $key,
+            value: $value
+          }
+        },
+        setResultInResponse: true
+      )
+
+  withObject: _echo(value: {
+    uno: "first",
+    dos: "second",
+    tres: "third"
+  })
+    @forEach(
+      passKeyOnwardsAs: "key"
+      passValueOnwardsAs: "value"
+    )
+      @applyField(
+        name: "_echo"
+        arguments: {
+          value: {
+            key: $key,
+            value: $value
+          }
+        },
+        setResultInResponse: true
+      )
+}
+```
+
+The result is:
+
+```json
+{
+  "data": {
+    "withArray": [
+      {
+        "key": 0,
+        "value": "first"
+      },
+      {
+        "key": 1,
+        "value": "second"
+      },
+      {
+        "key": 2,
+        "value": "third"
+      }
+    ],
+    "withObject": {
+      "uno": {
+        "key": "uno",
+        "value": "first"
+      },
+      "dos": {
+        "key": "dos",
+        "value": "second"
+      },
+      "tres": {
+        "key": "tres",
+        "value": "third"
+      }
+    }
+  }
+}
+```
+
 ## @underArrayItem
 
 `@underArrayItem` makes the next directive be applied on a specific item from the array.

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
@@ -67,7 +67,7 @@ Similar to `@if`, but it executes the nested directives when the condition is `f
 
 ## @forEach
 
-`@forEach` iterates over a list of elements from the queried entity, and passes a reference to the iterated element to the next directive.
+`@forEach` iterates over a list of elements from the queried entity, and passes a reference to the iterated element to the nested directive(s).
 
 For instance, field `Post.categoryNames` is of type `[String]`. Using `@forEach`, we can iterate each of the category names, each of type `String`, and apply an operation to it via some nested directive.
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/modules/meta-directives/en.md
@@ -69,7 +69,7 @@ Similar to `@if`, but it executes the nested directives when the condition is `f
 
 `@forEach` iterates over a list of elements from the queried entity, and passes a reference to the iterated element to the nested directive(s).
 
-For instance, field `Post.categoryNames` is of type `[String]`. Using `@forEach`, we can iterate each of the category names, each of type `String`, and apply an operation to it via some nested directive.
+For instance, field `Post.categoryNames` is of type `[String]`. Using `@forEach`, we can iterate the category names and apply an operation to each of them via some nested directive.
 
 In this query, the post categories are translated from English to French:
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/_using-the-graphql-server-without-wordpress/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/_using-the-graphql-server-without-wordpress/en.md
@@ -126,7 +126,7 @@ query RetrieveProxyArtifactDownloadURLs(
     object: $__gitHubArtifactData
     by: { key: "artifacts" }
   )
-    @forEach(passOnwardsAs: "artifactItem")
+    @forEach(passValueOnwardsAs: "artifactItem")
       @applyField(
         name: "_objectProperty"
         arguments: { object: $artifactItem, by: { key: "archive_download_url" } }
@@ -139,7 +139,7 @@ query CreateHTTPRequestInputs
   @depends(on: "RetrieveProxyArtifactDownloadURLs")
 {
   httpRequestInputs: _echo(value: $gitHubProxyArtifactDownloadURLs)
-    @forEach(passOnwardsAs: "url")
+    @forEach(passValueOnwardsAs: "url")
       @applyField(
         name: "_objectAddEntry"
         arguments: {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/bulk-editing-content/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/bulk-editing-content/en.md
@@ -129,7 +129,7 @@ query CalculateVars($limit:Int! = 10) {
   arrayPositions: _arrayKeys(array: $__placeholderArray)
     @remove
   arrayOffsets: _echo(value: $__arrayPositions)
-    @forEach(passOnwardsAs: "position")
+    @forEach(passValueOnwardsAs: "position")
       @intMultiply(with:$limit)
     @export(as:"offsets")
     @remove
@@ -139,7 +139,7 @@ query CalculateURLs($limit:Int! = 10)
   @depends(on:"CalculateVars")
 {
   urls: _echo(value: $offsets)
-    @forEach(passOnwardsAs: "offset")
+    @forEach(passValueOnwardsAs: "offset")
       @applyField(
         name: "_sprintf",
         arguments: {
@@ -155,7 +155,7 @@ query CalculateURLInputs
   @depends(on:"CalculateURLs")
 {
   urlInputs: _echo(value: $urls)
-    @forEach(passOnwardsAs: "url")
+    @forEach(passValueOnwardsAs: "url")
       @applyField(
         name: "_objectAddEntry",
         arguments: {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/combining-user-data-from-different-systems/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/combining-user-data-from-different-systems/en.md
@@ -15,7 +15,7 @@ query ProvideNewsletterUserData {
     # @remove
 
   userEmails: _echo(value: $__userList)
-    @forEach(passOnwardsAs: "userListItemForEmail")
+    @forEach(passValueOnwardsAs: "userListItemForEmail")
       @applyField(
         name: "_objectProperty",
         arguments: {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/filtering-data-from-an-external-api/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/filtering-data-from-an-external-api/en.md
@@ -13,7 +13,7 @@ query FilterExternalAPIData {
   usersWithWebsiteURL: _echo(value: $__userList)
     # Remove users without a website URL
     @forEach(
-      passOnwardsAs: "userDataEntry"
+      passValueOnwardsAs: "userDataEntry"
       affectDirectivesUnderPos: [1, 2, 3]
     )
       @applyField(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-a-post-from-another-site/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-a-post-from-another-site/en.md
@@ -16,7 +16,7 @@ query CreatePostInputs {
     # For each entry: Extract the title and body
     @forEach(
       affectDirectivesUnderPos: [1, 2, 3],
-      passOnwardsAs: "item"
+      passValueOnwardsAs: "item"
     )
       @applyField(
         name: "_objectProperty",
@@ -73,7 +73,7 @@ mutation ImportContentAsNewPosts
   createdPostIDs: _echo(value: $postInputs)
     # For each entry: Create a new post
     @forEach(
-      passOnwardsAs: "postInput"
+      passValueOnwardsAs: "postInput"
     )
       # The result is the list of IDs of the created posts
       @applyField(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-multiple-posts-at-once-from-another-site/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/importing-multiple-posts-at-once-from-another-site/en.md
@@ -22,7 +22,7 @@ query CreatePostInputs {
     # For each entry: Extract the title and body
     @forEach(
       affectDirectivesUnderPos: [1, 2, 3],
-      passOnwardsAs: "item"
+      passValueOnwardsAs: "item"
     )
       @applyField(
         name: "_objectProperty",
@@ -79,7 +79,7 @@ mutation ImportContentAsNewPosts
   createdPostIDs: _echo(value: $postInputs)
     # For each entry: Create a new post
     @forEach(
-      passOnwardsAs: "postInput"
+      passValueOnwardsAs: "postInput"
     )
       # The result is the list of IDs of the created posts
       @applyField(

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/removing-a-gutenberg-block-from-all-posts/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/removing-a-gutenberg-block-from-all-posts/en.md
@@ -47,7 +47,7 @@ mutation RestorePosts
   @depends(on: "CreateVars")
 {
   restorePosts: _echo(value: $originalInputs)
-    @forEach(passOnwardsAs: "input")
+    @forEach(passValueOnwardsAs: "input")
       @applyField(
         name: "updatePost"
         arguments: { input: $input }
@@ -129,7 +129,7 @@ mutation RestorePosts
   @depends(on: "CreateVars")
 {
   restorePosts: _echo(value: $originalInputs)
-    @forEach(passOnwardsAs: "input")
+    @forEach(passValueOnwardsAs: "input")
       @applyField(
         name: "updatePost"
         arguments: { input: $input }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/retrieving-and-downloading-github-artifacts/en.md
@@ -81,7 +81,7 @@ query RetrieveProxyArtifactDownloadURLs
       key: "artifacts"
     }
   )
-    @forEach(passOnwardsAs: "artifactItem")
+    @forEach(passValueOnwardsAs: "artifactItem")
       @applyField(
         name: "_objectProperty",
         arguments: {
@@ -100,7 +100,7 @@ query CreateHTTPRequestInputs
 {
 
   httpRequestInputs: _echo(value: $gitHubProxyArtifactDownloadURLs)
-    @forEach(passOnwardsAs: "url")
+    @forEach(passValueOnwardsAs: "url")
       @applyField(
         name: "_objectAddEntry",
         arguments: {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/reverting-mutations-in-case-of-error/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/reverting-mutations-in-case-of-error/en.md
@@ -51,7 +51,7 @@ mutation RestorePosts
   @depends(on: "CreateVars")
 {
   restorePosts: _echo(value: $originalInputs)
-    @forEach(passOnwardsAs: "input")
+    @forEach(passValueOnwardsAs: "input")
       @applyField(
         name: "updatePost"
         arguments: { input: $input }
@@ -133,7 +133,7 @@ mutation RestorePosts
   @depends(on: "CreateVars")
 {
   restorePosts: _echo(value: $originalInputs)
-    @forEach(passOnwardsAs: "input")
+    @forEach(passValueOnwardsAs: "input")
       @applyField(
         name: "updatePost"
         arguments: { input: $input }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/transforming-data-from-an-external-api/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs-pro/recipes/transforming-data-from-an-external-api/en.md
@@ -25,7 +25,7 @@ query AdaptExternalAPIData {
     # Add a new "link" entry on the JSON object
     @forEach(
       affectDirectivesUnderPos: [1, 2, 3, 4],
-      passOnwardsAs: "userListItem"
+      passValueOnwardsAs: "userListItem"
     )
       @applyField(
         name: "_objectProperty",
@@ -89,7 +89,7 @@ query ExtractEmailsFromAPIAndUpperCaseSpecialOnes
     # (under the dynamic variable $userEntry)
     # to each of the next 4 directives
     @forEach(
-      passOnwardsAs: "userEntry"
+      passValueOnwardsAs: "userEntry"
       affectDirectivesUnderPos: [1, 2, 3, 4]
     )
 


### PR DESCRIPTION
Used with the **Dynamic Variables** feature, `@forEach` can now pass both the key and the value it is iterating on as a dynamic variable to its nested directive(s), via directive args `passKeyOnwardsAs` and `passValueOnwardsAs`. It works both when iterating arrays and `JSON` objects.

This query demonstrates this feature:

```graphql
{
  withArray: _echo(value: ["first", "second", "third"])
    @forEach(
      passKeyOnwardsAs: "key"
      passValueOnwardsAs: "value"
    )
      @applyField(
        name: "_echo"
        arguments: {
          value: {
            key: $key,
            value: $value
          }
        },
        setResultInResponse: true
      )

  withObject: _echo(value: {
    uno: "first",
    dos: "second",
    tres: "third"
  })
    @forEach(
      passKeyOnwardsAs: "key"
      passValueOnwardsAs: "value"
    )
      @applyField(
        name: "_echo"
        arguments: {
          value: {
            key: $key,
            value: $value
          }
        },
        setResultInResponse: true
      )
}
```

The result is:

```json
{
  "data": {
    "withArray": [
      {
        "key": 0,
        "value": "first"
      },
      {
        "key": 1,
        "value": "second"
      },
      {
        "key": 2,
        "value": "third"
      }
    ],
    "withObject": {
      "uno": {
        "key": "uno",
        "value": "first"
      },
      "dos": {
        "key": "dos",
        "value": "second"
      },
      "tres": {
        "key": "tres",
        "value": "third"
      }
    }
  }
}
```
