### PR TITLE
Fix XDEBUG_TRIGGER always triggering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -578,7 +578,7 @@
             "Composer\\Config::disableProcessTimeout",
             "INTEGRATION_TESTS_WEBSERVER_DOMAIN=graphql-api-for-prod.lndo.site phpunit --filter='Integration'"
         ],
-        "debug": "XDEBUG_TRIGGER=1 phpunit",
+        "debug": "XDEBUG_TRIGGER=debug phpunit",
         "check-style": "phpcs -n src $(monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests)",
         "fix-style": "php -d memory_limit=512M vendor/bin/phpcbf -n src $(monorepo-builder source-packages --config=config/monorepo-builder/source-packages.php --psr4-only --subfolder=src --subfolder=tests)",
         "analyse": "phpstan analyse --memory-limit 1G --ansi",

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -97,7 +97,7 @@ $ composer enable-caching
 
 ## Debugging
 
-XDebug is enabled by default, but must be triggered for the specific request. To do so, append param `XDEBUG_TRIGGER` to the URL:
+XDebug is enabled by default, but must be triggered for the specific request. To do so, append param `XDEBUG_TRIGGER=debug` to the URL:
 
 - In the `wp-admin`, in the URL to load the GraphiQL or Interactive schema client
 - In the URL of any public client, such as the GraphiQL or Interactive schema client attached to:

--- a/layers/Engine/packages/component-model/src/Configuration/RequestHelpers.php
+++ b/layers/Engine/packages/component-model/src/Configuration/RequestHelpers.php
@@ -12,7 +12,7 @@ use PoP\Root\Environment as RootEnvironment;
 class RequestHelpers
 {
     /**
-     * If XDebug enabled, append param "XDEBUG_TRIGGER" to debug the request
+     * If XDebug enabled, append param "XDEBUG_TRIGGER=debug" to debug the request
      */
     public static function maybeAddParamToDebugRequest(string $url): string
     {

--- a/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ExecutableDocumentTest.php
+++ b/layers/Engine/packages/component-model/tests/Upstream/GraphQLParser/ExtendedSpec/Execution/ExecutableDocumentTest.php
@@ -12,7 +12,7 @@ use PoP\GraphQLParser\Spec\Execution\ExecutableDocumentTest as UpstreamExecutabl
 class ExecutableDocumentTest extends UpstreamExecutableDocumentTest
 {
     use ComponentModelTestCaseTrait;
-    
+
     private ?ParserInterface $parser = null;
 
     protected function getParser(): ParserInterface

--- a/layers/Engine/packages/root/src/App.php
+++ b/layers/Engine/packages/root/src/App.php
@@ -55,7 +55,7 @@ class App implements AppInterface
      *
      * Either inject the desired instance, or have the Root
      * provide the default one.
-     * 
+     *
      * It creates a new AppThread and sets it as the current
      * object hosting all state in the application.
      */

--- a/layers/Engine/packages/root/src/App.php
+++ b/layers/Engine/packages/root/src/App.php
@@ -58,8 +58,6 @@ class App implements AppInterface
      * 
      * It creates a new AppThread and sets it as the current
      * object hosting all state in the application.
-     *
-     * @return AppThreadInterface The newly-created AppThread instance
      */
     public static function initialize(
         ?AppLoaderInterface $appLoader = null,

--- a/layers/Engine/packages/root/src/App/AbstractRootAppProxy.php
+++ b/layers/Engine/packages/root/src/App/AbstractRootAppProxy.php
@@ -41,7 +41,7 @@ abstract class AbstractRootAppProxy implements RootAppInterface
     {
         RootApp::setAppThread($appThread);
     }
-    
+
     /**
      * This function must be invoked at the very beginning,
      * to initialize the instance to run the application.

--- a/layers/Engine/packages/root/src/AppInterface.php
+++ b/layers/Engine/packages/root/src/AppInterface.php
@@ -24,7 +24,7 @@ use PoP\Root\StateManagers\HookManagerInterface;
  * but as static.
  */
 interface AppInterface
-{    
+{
     /**
      * This function must be invoked at the very beginning,
      * to initialize the instance to run the application.
@@ -52,7 +52,7 @@ interface AppInterface
      *
      * Either inject the desired instance, or have the Root
      * provide the default one.
-     * 
+     *
      * It creates a new AppThread and sets it as the current
      * object hosting all state in the application.
      */

--- a/layers/Engine/packages/root/src/AppInterface.php
+++ b/layers/Engine/packages/root/src/AppInterface.php
@@ -55,8 +55,6 @@ interface AppInterface
      * 
      * It creates a new AppThread and sets it as the current
      * object hosting all state in the application.
-     *
-     * @return AppThreadInterface The newly-created AppThread instance
      */
     public static function initialize(
         ?AppLoaderInterface $appLoader = null,

--- a/layers/Engine/packages/root/src/AppThread.php
+++ b/layers/Engine/packages/root/src/AppThread.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Exception\BadRequestException;
  * will be accessed/modified by the whole application.
  * Access the current AppThread via the corresponding
  * methods in the `App` facade class.
- * 
+ *
  * It keeps all state in the application stored and
  * accessible in a single place, so that regenerating
  * this class provides a new state.

--- a/layers/Engine/packages/root/src/AppThreadInterface.php
+++ b/layers/Engine/packages/root/src/AppThreadInterface.php
@@ -22,7 +22,7 @@ use PoP\Root\StateManagers\HookManagerInterface;
  * will be accessed/modified by the whole application.
  * Access the current AppThread via the corresponding
  * methods in the `App` facade class.
- * 
+ *
  * It keeps all state in the application stored and
  * accessible in a single place, so that regenerating
  * this class provides a new state.

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -8,7 +8,6 @@ use Exception;
 use GraphQLAPI\ExternalDependencyWrappers\Symfony\Component\Exception\IOException;
 use GraphQLAPI\ExternalDependencyWrappers\Symfony\Component\Filesystem\FilesystemWrapper;
 use GraphQLAPI\GraphQLAPI\App;
-use GraphQLAPI\GraphQLAPI\AppThread;
 use GraphQLAPI\GraphQLAPI\Facades\UserSettingsManagerFacade;
 use GraphQLAPI\GraphQLAPI\Settings\Options;
 use PoP\RootWP\AppLoader;

--- a/webservers/shared/config/php.ini
+++ b/webservers/shared/config/php.ini
@@ -11,7 +11,7 @@ xdebug.client_host = ${LANDO_HOST_IP}
 xdebug.client_port = 9003
 xdebug.start_with_request = trigger
 # Must pass ?XDEBUG_TRIGGER=debug in URL
-# Keeping the default value will always launch it, evern when ?XDEBUG_TRIGGER=1
+# Keeping the default value will always launch it, even when ?XDEBUG_TRIGGER=1
 # is not passed, because the legacy cookie XDEBUG_SESSION="1" is also passed
 # @see https://xdebug.org/docs/all_settings#start_with_request under "trigger"
 # @see https://xdebug.org/docs/all_settings#trigger_value

--- a/webservers/shared/config/php.ini
+++ b/webservers/shared/config/php.ini
@@ -10,4 +10,10 @@ xdebug.output_dir = /app/tmp/xdebug
 xdebug.client_host = ${LANDO_HOST_IP}
 xdebug.client_port = 9003
 xdebug.start_with_request = trigger
+# Must pass ?XDEBUG_TRIGGER=debug in URL
+# Keeping the default value will always launch it, evern when ?XDEBUG_TRIGGER=1
+# is not passed, because the legacy cookie XDEBUG_SESSION="1" is also passed
+# @see https://xdebug.org/docs/all_settings#start_with_request under "trigger"
+# @see https://xdebug.org/docs/all_settings#trigger_value
+xdebug.trigger_value = debug
 xdebug.log = /tmp/xdebug.log


### PR DESCRIPTION
From now on, must pass `?XDEBUG_TRIGGER=debug` in URL to activate XDebug in VSCode.

Keeping the default value would always launch it, even when `?XDEBUG_TRIGGER=1` is not passed, because the legacy cookie `XDEBUG_SESSION="1"` is also being passed (somehow).

See: https://xdebug.org/docs/all_settings#start_with_request under "trigger"

See: https://xdebug.org/docs/all_settings#trigger_value