### PR TITLE
Add custom header when executing tests

### DIFF
--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
@@ -6,5 +6,5 @@ namespace PHPUnitForGraphQLAPI\WebserverRequests\Constants;
 
 class CustomHeaderValues
 {
-    public const REQUEST_SOURCE_VALUE = 'WebserverRequestTest';
+    public const REQUEST_ORIGIN_VALUE = 'WebserverRequestTest';
 }

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\WebserverRequests\Constants;
+
+class CustomHeaderValues
+{
+    public const REQUEST_SOURCE_VALUE = 'WebserverRequestTest';
+}

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace PHPUnitForGraphQLAPI\WebserverRequests\Constants;
 
+/**
+ * Watch out: the constants in this class are referenced from
+ * the GraphQL API Testing plugin, however this class is not
+ * included there, hence its values are hardcoded. Update
+ * with caution!
+ *
+ * @see layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
+ */
 class CustomHeaderValues
 {
     public const REQUEST_ORIGIN_VALUE = 'WebserverRequestTest';

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace PHPUnitForGraphQLAPI\WebserverRequests\Constants;
 
+/**
+ * Watch out: the constants in this class are referenced from
+ * the GraphQL API Testing plugin, however this class is not
+ * included there, hence its values are hardcoded. Update
+ * with caution!
+ *
+ * @see layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
+ */
 class CustomHeaders
 {
     public const REQUEST_ORIGIN = 'X-Request-Origin';

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGraphQLAPI\WebserverRequests\Constants;
+
+class CustomHeaders
+{
+    public const REQUEST_SOURCE = 'X-Request-Source';
+}

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
@@ -6,5 +6,5 @@ namespace PHPUnitForGraphQLAPI\WebserverRequests\Constants;
 
 class CustomHeaders
 {
-    public const REQUEST_SOURCE = 'X-Request-Source';
+    public const REQUEST_ORIGIN = 'X-Request-Origin';
 }

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractWebserverRequestTestCase.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractWebserverRequestTestCase.php
@@ -13,6 +13,8 @@ use PHPUnitForGraphQLAPI\WebserverRequests\Environment;
 use PHPUnitForGraphQLAPI\WebserverRequests\Exception\IntegrationTestApplicationNotAvailableException;
 use PHPUnitForGraphQLAPI\WebserverRequests\Exception\UnauthenticatedUserException;
 use PHPUnit\Framework\TestCase;
+use PHPUnitForGraphQLAPI\WebserverRequests\Constants\CustomHeaders;
+use PHPUnitForGraphQLAPI\WebserverRequests\Constants\CustomHeaderValues;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 
@@ -93,6 +95,18 @@ abstract class AbstractWebserverRequestTestCase extends TestCase
     }
 
     /**
+     * Used to identify the request as originating from these tests.
+     *
+     * @param array<string,mixed> $options
+     * @return array<string,mixed>
+     */
+    protected static function addWebserverRequestTestCustomHeader(array $options): array
+    {
+        $options[RequestOptions::HEADERS][CustomHeaders::REQUEST_SOURCE] = CustomHeaderValues::REQUEST_SOURCE_VALUE;
+        return $options;
+    }
+
+    /**
      * @return array<string,mixed>
      */
     protected static function getRequestBasicOptions(): array
@@ -108,7 +122,7 @@ abstract class AbstractWebserverRequestTestCase extends TestCase
         if (static::useSSL()) {
             $options[RequestOptions::VERIFY] = false;
         }
-        return $options;
+        return static::addWebserverRequestTestCustomHeader($options);
     }
 
     /**
@@ -193,7 +207,8 @@ abstract class AbstractWebserverRequestTestCase extends TestCase
      */
     protected static function getWebserverPingOptions(): array
     {
-        return [];
+        $options = [];
+        return static::addWebserverRequestTestCustomHeader($options);
     }
 
     protected static function getWebserverHomeURL(): string

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractWebserverRequestTestCase.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/AbstractWebserverRequestTestCase.php
@@ -102,7 +102,7 @@ abstract class AbstractWebserverRequestTestCase extends TestCase
      */
     protected static function addWebserverRequestTestCustomHeader(array $options): array
     {
-        $options[RequestOptions::HEADERS][CustomHeaders::REQUEST_SOURCE] = CustomHeaderValues::REQUEST_SOURCE_VALUE;
+        $options[RequestOptions::HEADERS][CustomHeaders::REQUEST_ORIGIN] = CustomHeaderValues::REQUEST_ORIGIN_VALUE;
         return $options;
     }
 

--- a/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/WordPressAuthenticatedUserWebserverRequestTestCaseTrait.php
+++ b/layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/tests/WordPressAuthenticatedUserWebserverRequestTestCaseTrait.php
@@ -31,12 +31,15 @@ trait WordPressAuthenticatedUserWebserverRequestTestCaseTrait
      */
     protected static function getWebserverPingOptions(): array
     {
-        return [
-            'form_params' => [
-                'log' => static::getLoginUsername(),
-                'pwd' => static::getLoginPassword(),
-            ],
-        ];
+        return array_merge(
+            parent::getWebserverPingOptions(),
+            [
+                'form_params' => [
+                    'log' => static::getLoginUsername(),
+                    'pwd' => static::getLoginPassword(),
+                ],
+            ]
+        );
     }
 
     protected static function getLoginUsername(): string

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
@@ -10,8 +10,6 @@ use PHPUnitForGraphQLAPI\GraphQLAPITesting\Hooks\AddDummyCustomAdminEndpointHook
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\RESTAPI\Endpoints\AdminRESTAPIEndpointManager;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\Settings\Options;
 use PHPUnitForGraphQLAPI\GraphQLAPITesting\Utilities\CustomHeaderAppender;
-use PHPUnitForGraphQLAPI\WebserverRequests\Constants\CustomHeaders;
-use PHPUnitForGraphQLAPI\WebserverRequests\Constants\CustomHeaderValues;
 use WP_REST_Response;
 
 use function add_action;
@@ -65,8 +63,19 @@ class Plugin
      */
     protected function maybeAdaptRESTAPIResponse(): void
     {
-        // Make sure the origin of the request is some test
-        if (($_SERVER[CustomHeaders::REQUEST_ORIGIN] ?? null) !== CustomHeaderValues::REQUEST_ORIGIN_VALUE) {
+        /**
+         * Make sure the origin of the request is some test.
+         * 
+         * Watch out: the classes containing these constants are not
+         * included in this plugin, hence the values are hardcoded.
+         * Update with caution!
+         *
+         * @see layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
+         * @see layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
+         */
+        $header = 'X-Request-Origin'; // CustomHeaders::REQUEST_ORIGIN;
+        $headerValue = 'WebserverRequestTest'; // CustomHeaderValues::REQUEST_ORIGIN_VALUE
+        if (($_SERVER[$header] ?? null) !== $headerValue) {
             return;
         }
 

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
@@ -73,8 +73,13 @@ class Plugin
          * @see layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaders.php
          * @see layers/GraphQLAPIForWP/phpunit-packages/webserver-requests/src/Constants/CustomHeaderValues.php
          */
-        $header = 'X-Request-Origin'; // CustomHeaders::REQUEST_ORIGIN;
+        $headerName = 'X-Request-Origin'; // CustomHeaders::REQUEST_ORIGIN;
         $headerValue = 'WebserverRequestTest'; // CustomHeaderValues::REQUEST_ORIGIN_VALUE
+        /**
+         * The custom header somehow arrives prepended with "HTTP_",
+         * replacing all "-" with "_", and in uppercase
+         */
+        $header = strtoupper('HTTP_' . str_replace('-', '_', $headerName));
         if (($_SERVER[$header] ?? null) !== $headerValue) {
             return;
         }

--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/src/Plugin.php
@@ -66,7 +66,7 @@ class Plugin
     protected function maybeAdaptRESTAPIResponse(): void
     {
         // Make sure the origin of the request is some test
-        if (($_SERVER[CustomHeaders::REQUEST_SOURCE] ?? null) !== CustomHeaderValues::REQUEST_SOURCE_VALUE) {
+        if (($_SERVER[CustomHeaders::REQUEST_ORIGIN] ?? null) !== CustomHeaderValues::REQUEST_ORIGIN_VALUE) {
             return;
         }
 


### PR DESCRIPTION
And only adapt the REST API response when executing tests, so that the WordPress editor is not affected (eg: creating a new post would not show the tags/categories)