### PR TITLE
Purge the service container when activating/deactivating GraphQL API extension plugins only

### DIFF
--- a/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
+++ b/layers/GraphQLAPIForWP/phpunit-plugins/graphql-api-for-wp-testing/graphql-api-testing.php
@@ -54,9 +54,11 @@ add_action(
         if (!$enablePlugin) {
             \add_action('admin_notices', function () {
                 _e(sprintf(
-                    '<div class="notice notice-error">' .
-                        '<p>%s</p>' .
-                    '</div>',
+                    <<<HTML
+                        <div class="notice notice-error">
+                            <p>%s</p>
+                        </div>
+                    HTML,
                     sprintf(
                         __('Functionality in plugin <strong>%s</strong> can only be enabled during development or testing.', 'graphql-api-testing'),
                         __('GraphQL API - Testing', 'graphql-api-testing')

--- a/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
+++ b/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
@@ -55,9 +55,11 @@ add_action(
         if (!class_exists(Plugin::class)) {
             \add_action('admin_notices', function () use ($extensionName) {
                 _e(sprintf(
-                    '<div class="notice notice-error">' .
-                        '<p>%s</p>' .
-                    '</div>',
+                    <<<HTML
+                        <div class="notice notice-error">
+                            <p>%s</p>
+                        </div>
+                    HTML,
                     sprintf(
                         __('Plugin <strong>%s</strong> is not installed or activated. Without it, plugin <strong>%s</strong> will not be loaded.', 'graphql-api-extension-demo'),
                         __('GraphQL API for WordPress', 'graphql-api-extension-demo'),
@@ -77,7 +79,7 @@ add_action(
         )) {
             return;
         }
-        
+
         /**
          * The commit hash is added to the plugin version 
          * through the CI when merging the PR.

--- a/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
+++ b/layers/GraphQLAPIForWP/plugins/extension-demo/graphql-api-extension-demo.php
@@ -69,37 +69,39 @@ add_action(
         }
 
         $extensionManager = PluginApp::getExtensionManager();
-        if ($extensionManager->assertIsValid(
+        if (!$extensionManager->assertIsValid(
             GraphQLAPIExtension::class,
             $extensionVersion,
             $extensionName,
             $mainPluginVersionConstraint
         )) {
-            /**
-             * The commit hash is added to the plugin version 
-             * through the CI when merging the PR.
-             *
-             * It is required to regenerate the container when
-             * testing a generated .zip plugin without modifying
-             * the plugin version.
-             * (Otherwise, we'd have to @purge-cache.)
-             *
-             * Important: Do not modify this code!
-             * It will be replaced in the CI to append "#{commit hash}"
-             * when generating the plugin. 
-             */
-            $commitHash = null;
-
-            // Load Composer’s autoloader
-            require_once(__DIR__ . '/vendor/autoload.php');
-
-            // Create and set-up the extension instance
-            $extensionManager->register(new GraphQLAPIExtension(
-                __FILE__,
-                $extensionVersion,
-                $extensionName,
-                $commitHash
-            ))->setup();
+            return;
         }
+        
+        /**
+         * The commit hash is added to the plugin version 
+         * through the CI when merging the PR.
+         *
+         * It is required to regenerate the container when
+         * testing a generated .zip plugin without modifying
+         * the plugin version.
+         * (Otherwise, we'd have to @purge-cache.)
+         *
+         * Important: Do not modify this code!
+         * It will be replaced in the CI to append "#{commit hash}"
+         * when generating the plugin. 
+         */
+        $commitHash = null;
+
+        // Load Composer’s autoloader
+        require_once(__DIR__ . '/vendor/autoload.php');
+
+        // Create and set-up the extension instance
+        $extensionManager->register(new GraphQLAPIExtension(
+            __FILE__,
+            $extensionVersion,
+            $extensionName,
+            $commitHash
+        ))->setup();
     }
 );

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/CHANGELOG.md
@@ -19,6 +19,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Configure returning a payload object or the mutated entity for mutations
 - Added "state" column to tables for Custom Endpoints and Persisted Queries
 - Saving the Settings is faster, as it does not regenerate the service container anymore
+- Only activating/deactivating GraphQL API extension plugins will regenerate the service container
 
 ### Fixed
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/1.0/en.md
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/release-notes/1.0/en.md
@@ -266,6 +266,12 @@ The tables for the Custom Endpoint and Persisted Query CPTs now display the "sta
 
 The Plugin Settings has been completely decoupled from the services registered in the container. As such, the container does not need to be regenerated when updating the Settings, leading to a performance boost.
 
+## Only activating/deactivating GraphQL API extension plugins will regenerate the service container
+
+Before, the service container (upon which the GraphQL schema is based) was regenerated whenever any plugin (whether it was related to the GraphQL API plugin or not) was activated or deactivated.
+
+Now, only GraphQL API extension plugins trigger this process.
+
 ## Fixed
 
 - Made field `Comment.type` of type `CommentTypeEnum` (previously was `String`)

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/AbstractPluginManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/AbstractPluginManager.php
@@ -10,9 +10,11 @@ abstract class AbstractPluginManager
     {
         \add_action('admin_notices', function () use ($errorMessage): void {
             _e(sprintf(
-                '<div class="notice notice-error">' .
-                    '<p>%s</p>' .
-                '</div>',
+                <<<HTML
+                    <div class="notice notice-error">
+                        <p>%s</p>
+                    </div>
+                HTML,
                 $errorMessage
             ));
         });

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginManagement/ExtensionManager.php
@@ -11,6 +11,9 @@ use GraphQLAPI\GraphQLAPI\PluginSkeleton\ExtensionInterface;
 
 class ExtensionManager extends AbstractPluginManager
 {
+    /** @var string[] */
+    private array $inactiveExtensionDependedUponPluginFiles = [];
+
     /**
      * Have the extensions organized by their class
      *
@@ -115,5 +118,30 @@ class ExtensionManager extends AbstractPluginManager
         }
 
         return true;
+    }
+
+    /**
+     * Register the depended-upon plugin main file(s), so that
+     * when the plugin is activated, the container is regenerated
+     *
+     * @param string[] $inactiveExtensionDependedUponPluginFiles
+     */
+    public function registerInactiveExtensionDependedUponPluginFiles(array $inactiveExtensionDependedUponPluginFiles): void
+    {
+        $this->inactiveExtensionDependedUponPluginFiles = array_merge(
+            $this->inactiveExtensionDependedUponPluginFiles,
+            $inactiveExtensionDependedUponPluginFiles
+        );
+    }
+
+    /**
+     * Plugin main files that need to be activated in order
+     * for some GraphQL API extension to become active.
+     *
+     * @return string[]
+     */
+    public function getInactiveExtensionsDependedUponPluginFiles(): array
+    {
+        return $this->inactiveExtensionDependedUponPluginFiles;
     }
 }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -130,7 +130,20 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
      */
     public function handleAnyPluginActivatedOrDeactivated(string $pluginFile): void
     {
-        $this->purgeContainer();
+        /**
+         * Check that the activated/deactivated plugin is
+         * a GraphQL API extension
+         */
+        $extensions = PluginApp::getExtensionManager()->getExtensions();
+		foreach ($extensions as $extension) {
+            if ($extension->getPluginFile() !== $pluginFile
+                && !in_array($pluginFile, $extension->getDependedUponPluginFiles())
+            ) {
+                continue;
+            }
+            $this->purgeContainer();
+            return;
+		}
     }
 
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -118,15 +118,19 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
     }
 
     /**
-     * When activating/deactivating an extension plugin for the
-     * GraphQL API, the cached service container and the config
+     * This method dumps the container whenever activating a depended-upon
+     * plugin, or deactivating a GraphQL API extension.
+     *
+     * When activating an extension plugin for the GraphQL API,
+     * the container will be regenerated through method
+     * `handleNewActivations` (in this same class).
+     *
+     * When deactivating an extension, the cached service container
      * must be dumped, so that they can be regenerated.
-     *
-     * This way, extensions depending on 3rd-party plugins
-     * can have their functionality automatically enabled/disabled.
-     *
-     * Do not do it for other plugins as dumping the container is
-     * time intensive.
+     * 
+     * Likewise, when activating/deactivating a depended-upon plugin
+     * (eg: "Events Manager", required by "GraphQL API - Events Manager")
+     * the container must be regenerated.
      */
     public function handlePluginActivatedOrDeactivated(string $pluginFile): void
     {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -118,14 +118,17 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
     }
 
     /**
-     * When activating/deactivating ANY plugin (either from GraphQL API
-     * or 3rd-parties), the cached service container and the config
+     * When activating/deactivating an extension plugin for the
+     * GraphQL API, the cached service container and the config
      * must be dumped, so that they can be regenerated.
      *
      * This way, extensions depending on 3rd-party plugins
      * can have their functionality automatically enabled/disabled.
+     *
+     * Do not do it for other plugins as dumping the container is
+     * time intensive.
      */
-    public function handleAnyPluginActivatedOrDeactivated(): void
+    public function handleAnyPluginActivatedOrDeactivated(string $pluginFile): void
     {
         $this->purgeContainer();
     }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -135,10 +135,13 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
          * a GraphQL API extension, or any plugin depended-upon
          * by any extension.
          */
-        $extensionBaseNameInstances = PluginApp::getExtensionManager()->getExtensions();
+        $extensionManager = PluginApp::getExtensionManager();
+        $inactiveExtensionDependedUponPluginFiles = $extensionManager->getInactiveExtensionsDependedUponPluginFiles();
+        $extensionBaseNameInstances = $extensionManager->getExtensions();
         foreach ($extensionBaseNameInstances as $extensionBaseName => $extensionInstance) {
             if (!($extensionBaseName === $pluginFile
                 || in_array($pluginFile, $extensionInstance->getDependedUponPluginFiles())
+                || in_array($pluginFile, $inactiveExtensionDependedUponPluginFiles)
             )) {
                 continue;
             }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -161,6 +161,12 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
     public function maybeRemoveStoredPluginVersionWhenPluginDeactivated(string $pluginFile): void
     {
         // Check if this is the main plugin
+        if (PluginApp::getMainPlugin()->getPluginFile() === $pluginFile) {
+            $this->removePluginFileFromStoredPluginVersions($pluginFile);
+            return;
+        }
+
+        // Check if this is any extension plugin
         $extensionManager = PluginApp::getExtensionManager();
         $extensionBaseNames = array_keys($extensionManager->getExtensions());
         if (!in_array($pluginFile, $extensionBaseNames)) {

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -136,19 +136,15 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
          * by any extension.
          */
         $extensions = PluginApp::getExtensionManager()->getExtensions();
-        $mustPurgeContainer = false;
-		foreach ($extensions as $extension) {
-            if ($extension->getPluginFile() === $pluginFile
+        foreach ($extensions as $extension) {
+            if (!($extension->getPluginFile() === $pluginFile
                 || in_array($pluginFile, $extension->getDependedUponPluginFiles())
-            ) {
-                $mustPurgeContainer = true;
-                break;
+            )) {
+                continue;
             }
+            $this->purgeContainer();
+            break;
 		}
-        if (!$mustPurgeContainer) {
-            return;
-        }
-        $this->purgeContainer();
     }
 
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -132,18 +132,23 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
     {
         /**
          * Check that the activated/deactivated plugin is
-         * a GraphQL API extension
+         * a GraphQL API extension, or any plugin depended-upon
+         * by any extension.
          */
         $extensions = PluginApp::getExtensionManager()->getExtensions();
+        $mustPurgeContainer = false;
 		foreach ($extensions as $extension) {
-            if ($extension->getPluginFile() !== $pluginFile
-                && !in_array($pluginFile, $extension->getDependedUponPluginFiles())
+            if ($extension->getPluginFile() === $pluginFile
+                || in_array($pluginFile, $extension->getDependedUponPluginFiles())
             ) {
-                continue;
+                $mustPurgeContainer = true;
+                break;
             }
-            $this->purgeContainer();
-            return;
 		}
+        if (!$mustPurgeContainer) {
+            return;
+        }
+        $this->purgeContainer();
     }
 
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -143,12 +143,6 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         $inactiveExtensionDependedUponPluginFiles = $extensionManager->getInactiveExtensionsDependedUponPluginFiles();
         $extensionBaseNameInstances = $extensionManager->getExtensions();
         foreach ($extensionBaseNameInstances as $extensionBaseName => $extensionInstance) {
-            // Only when deactivating an extension this condition will be true
-            if (false) {
-                $storedPluginVersions = get_option(PluginOptions::PLUGIN_VERSIONS, []);
-                unset($storedPluginVersions[$extensionBaseName]);
-                update_option(PluginOptions::PLUGIN_VERSIONS, $storedPluginVersions);
-            }
             if (!($extensionBaseName === $pluginFile
                 || in_array($pluginFile, $extensionInstance->getDependedUponPluginFiles())
                 || in_array($pluginFile, $inactiveExtensionDependedUponPluginFiles)
@@ -166,6 +160,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
      */
     public function maybeRemoveStoredPluginVersionWhenPluginDeactivated(string $pluginFile): void
     {
+        // Check if this is the main plugin
         $extensionManager = PluginApp::getExtensionManager();
         $extensionBaseNames = array_keys($extensionManager->getExtensions());
         if (!in_array($pluginFile, $extensionBaseNames)) {
@@ -351,15 +346,6 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                         $justUpdatedExtensions[$extensionBaseName] = $extensionInstance;
                     }
                 }
-
-                // Check if any extension has been deactivated
-                $justDeactivatedExtensionBaseNames = array_diff(
-                    array_keys($storedPluginVersions),
-                    [
-                        $this->pluginBaseName,
-                    ],
-                    array_keys($registeredExtensionBaseNameInstances)
-                );
 
                 // If there were no changes, nothing to do
                 if (

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -135,10 +135,10 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
          * a GraphQL API extension, or any plugin depended-upon
          * by any extension.
          */
-        $extensions = PluginApp::getExtensionManager()->getExtensions();
-        foreach ($extensions as $extension) {
-            if (!($extension->getPluginFile() === $pluginFile
-                || in_array($pluginFile, $extension->getDependedUponPluginFiles())
+        $extensionBaseNameInstances = PluginApp::getExtensionManager()->getExtensions();
+        foreach ($extensionBaseNameInstances as $extensionBaseName => $extensionInstance) {
+            if (!($extensionBaseName === $pluginFile
+                || in_array($pluginFile, $extensionInstance->getDependedUponPluginFiles())
             )) {
                 continue;
             }

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -160,18 +160,22 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
      */
     public function maybeRemoveStoredPluginVersionWhenPluginDeactivated(string $pluginFile): void
     {
+        $removePluginFileFromStoredPluginVersions = false;
+        
         // Check if this is the main plugin
         if (PluginApp::getMainPlugin()->getPluginFile() === $pluginFile) {
-            $this->removePluginFileFromStoredPluginVersions($pluginFile);
-            return;
+            $removePluginFileFromStoredPluginVersions = true;
+        } else {
+            // Check if this is any extension plugin
+            $extensionManager = PluginApp::getExtensionManager();
+            $extensionBaseNames = array_keys($extensionManager->getExtensions());
+            $removePluginFileFromStoredPluginVersions = in_array($pluginFile, $extensionBaseNames);
         }
 
-        // Check if this is any extension plugin
-        $extensionManager = PluginApp::getExtensionManager();
-        $extensionBaseNames = array_keys($extensionManager->getExtensions());
-        if (!in_array($pluginFile, $extensionBaseNames)) {
+        if (!$removePluginFileFromStoredPluginVersions) {
             return;
         }
+        
         $this->removePluginFileFromStoredPluginVersions($pluginFile);
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -127,7 +127,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
      *
      * When deactivating an extension, the cached service container
      * must be dumped, so that they can be regenerated.
-     * 
+     *
      * Likewise, when activating/deactivating a depended-upon plugin
      * (eg: "Events Manager", required by "GraphQL API - Events Manager")
      * the container must be regenerated.
@@ -143,15 +143,17 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         $inactiveExtensionDependedUponPluginFiles = $extensionManager->getInactiveExtensionsDependedUponPluginFiles();
         $extensionBaseNameInstances = $extensionManager->getExtensions();
         foreach ($extensionBaseNameInstances as $extensionBaseName => $extensionInstance) {
-            if (!($extensionBaseName === $pluginFile
+            if (
+                !($extensionBaseName === $pluginFile
                 || in_array($pluginFile, $extensionInstance->getDependedUponPluginFiles())
                 || in_array($pluginFile, $inactiveExtensionDependedUponPluginFiles)
-            )) {
+                )
+            ) {
                 continue;
             }
             $this->purgeContainer();
             break;
-		}
+        }
     }
 
     /**
@@ -161,7 +163,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
     public function maybeRemoveStoredPluginVersionWhenPluginDeactivated(string $pluginFile): void
     {
         $removePluginFileFromStoredPluginVersions = false;
-        
+
         // Check if this is the main plugin
         if (PluginApp::getMainPlugin()->getPluginFile() === $pluginFile) {
             $removePluginFileFromStoredPluginVersions = true;
@@ -175,7 +177,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         if (!$removePluginFileFromStoredPluginVersions) {
             return;
         }
-        
+
         $this->removePluginFileFromStoredPluginVersions($pluginFile);
     }
 

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractMainPlugin.php
@@ -128,7 +128,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
      * Do not do it for other plugins as dumping the container is
      * time intensive.
      */
-    public function handleAnyPluginActivatedOrDeactivated(string $pluginFile): void
+    public function handlePluginActivatedOrDeactivated(string $pluginFile): void
     {
         /**
          * Check that the activated/deactivated plugin is
@@ -255,8 +255,8 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
          * This way, extensions depending on 3rd-party plugins
          * can have their functionality automatically enabled/disabled.
          */
-        add_action('activate_plugin', $this->handleAnyPluginActivatedOrDeactivated(...));
-        add_action('deactivate_plugin', $this->handleAnyPluginActivatedOrDeactivated(...));
+        add_action('activate_plugin', $this->handlePluginActivatedOrDeactivated(...));
+        add_action('deactivate_plugin', $this->handlePluginActivatedOrDeactivated(...));
 
         /**
          * PoP depends on hook "init" to set-up the endpoint rewrite,

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/AbstractPlugin.php
@@ -56,6 +56,17 @@ abstract class AbstractPlugin implements PluginInterface
     }
 
     /**
+     * Dependencies on other plugins, to regenerate the schema
+     * when these are activated/deactived
+     *
+     * @return string[]
+     */
+    public function getDependedUponPluginFiles(): array
+    {
+        return [];
+    }
+
+    /**
      * Plugin version
      */
     public function getPluginVersion(): string

--- a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginInterface.php
+++ b/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/src/PluginSkeleton/PluginInterface.php
@@ -34,6 +34,14 @@ interface PluginInterface
     public function getPluginFile(): string;
 
     /**
+     * Dependencies on other plugins, to regenerate the schema
+     * when these are activated/deactived
+     *
+     * @return string[]
+     */
+    public function getDependedUponPluginFiles(): array;
+
+    /**
      * Commit hash when merging PR in repo, injected during the CI run
      * when generating the .zip plugin.
      */


### PR DESCRIPTION
Before, the service container (upon which the GraphQL schema is based) was regenerated whenever any plugin (whether it was related to the GraphQL API plugin or not) was activated or deactivated.

Now, only GraphQL API extension plugins trigger this process.