### PR TITLE
Make the timestamp truly unique

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/AbstractCacheConfigurationManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/AbstractCacheConfigurationManager.php
@@ -120,7 +120,7 @@ abstract class AbstractCacheConfigurationManager implements CacheConfigurationMa
         // (Needed for development) Don't share cache among plugin versions
         $timestampPrefix = '_v' . $this->getMainPluginAndExtensionsTimestamp();
         // The timestamp from when last saving settings/modules to the DB
-        $timestampPrefix .= '_' . $this->getTimestamp();
+        $timestampPrefix .= '_' . $this->getUniqueTimestamp();
         return $timestampPrefix;
     }
 

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/AbstractCacheConfigurationManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/AbstractCacheConfigurationManager.php
@@ -150,7 +150,7 @@ abstract class AbstractCacheConfigurationManager implements CacheConfigurationMa
     /**
      * The timestamp from when last saving settings/modules to the DB
      */
-    abstract protected function getTimestamp(): int;
+    abstract protected function getUniqueTimestamp(): string;
 
     /**
      * Cache under the plugin's cache/ subfolder

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/ContainerCacheConfigurationManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/ContainerCacheConfigurationManager.php
@@ -9,7 +9,7 @@ class ContainerCacheConfigurationManager extends AbstractCacheConfigurationManag
     /**
      * The timestamp from when last saving settings/modules to the DB
      */
-    protected function getTimestamp(): int
+    protected function getUniqueTimestamp(): string
     {
         return $this->getUserSettingsManager()->getContainerTimestamp();
     }

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/ContainerCacheConfigurationManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/ConfigurationCache/ContainerCacheConfigurationManager.php
@@ -11,7 +11,7 @@ class ContainerCacheConfigurationManager extends AbstractCacheConfigurationManag
      */
     protected function getUniqueTimestamp(): string
     {
-        return $this->getUserSettingsManager()->getContainerTimestamp();
+        return $this->getUserSettingsManager()->getContainerUniqueTimestamp();
     }
 
     /**

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Overrides/ConfigurationCache/OperationalCacheConfigurationManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Overrides/ConfigurationCache/OperationalCacheConfigurationManager.php
@@ -13,7 +13,7 @@ class OperationalCacheConfigurationManager extends AbstractCacheConfigurationMan
      */
     protected function getUniqueTimestamp(): string
     {
-        return $this->getUserSettingsManager()->getOperationalTimestamp();
+        return $this->getUserSettingsManager()->getOperationalUniqueTimestamp();
     }
 
     /**

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Overrides/ConfigurationCache/OperationalCacheConfigurationManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Overrides/ConfigurationCache/OperationalCacheConfigurationManager.php
@@ -11,7 +11,7 @@ class OperationalCacheConfigurationManager extends AbstractCacheConfigurationMan
     /**
      * The timestamp from when last saving settings/modules to the DB
      */
-    protected function getTimestamp(): int
+    protected function getUniqueTimestamp(): string
     {
         return $this->getUserSettingsManager()->getOperationalTimestamp();
     }

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
@@ -47,13 +47,13 @@ class UserSettingsManager implements UserSettingsManagerInterface
         return $timestamps[$key];
     }
     /**
-     * Add the PHP process ID to `time()` to make it truly unique,
+     * Add a random number to `time()` to make it truly unique,
      * as to avoid a bug when 2 requests with different schema
      * configuration come in at the same time (i.e. with same `time()`).
      */
     protected function getUniqueTimestamp(): string
     {
-        return (string)\time() . '_' . (string)\getmypid();
+        return (string)\time() . '_' . (string)\rand(1, 999999999);
     }
     /**
      * Static timestamp, reflecting when the service container has been regenerated.

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
@@ -41,10 +41,10 @@ class UserSettingsManager implements UserSettingsManagerInterface
      * a one-time-use before accessing the wp-admin and
      * having a new timestamp generated via `purgeContainer`.
      */
-    protected function getTimestamp(string $key): int
+    protected function getUniqueTimestamp(string $key): string
     {
         $timestamps = \get_option(Options::TIMESTAMPS, [$key => time()]);
-        return (int) $timestamps[$key];
+        return $timestamps[$key];
     }
     /**
      * Static timestamp, reflecting when the service container has been regenerated.
@@ -52,7 +52,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     public function getContainerTimestamp(): int
     {
-        return $this->getTimestamp(self::TIMESTAMP_CONTAINER);
+        return $this->getUniqueTimestamp(self::TIMESTAMP_CONTAINER);
     }
     /**
      * Dynamic timestamp, reflecting when new entities modifying the schema are
@@ -60,7 +60,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     public function getOperationalTimestamp(): int
     {
-        return $this->getTimestamp(self::TIMESTAMP_OPERATIONAL);
+        return $this->getUniqueTimestamp(self::TIMESTAMP_OPERATIONAL);
     }
     /**
      * Store the current time to indicate the latest executed write to DB,

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
@@ -50,7 +50,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      * Static timestamp, reflecting when the service container has been regenerated.
      * Should change not so often
      */
-    public function getContainerTimestamp(): int
+    public function getContainerUniqueTimestamp(): string
     {
         return $this->getUniqueTimestamp(self::TIMESTAMP_CONTAINER);
     }
@@ -58,7 +58,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      * Dynamic timestamp, reflecting when new entities modifying the schema are
      * added to the DB. Can change often
      */
-    public function getOperationalTimestamp(): int
+    public function getOperationalUniqueTimestamp(): string
     {
         return $this->getUniqueTimestamp(self::TIMESTAMP_OPERATIONAL);
     }
@@ -86,7 +86,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
     public function storeOperationalTimestamp(): void
     {
         $timestamps = [
-            self::TIMESTAMP_CONTAINER => $this->getContainerTimestamp(),
+            self::TIMESTAMP_CONTAINER => $this->getContainerUniqueTimestamp(),
             self::TIMESTAMP_OPERATIONAL => time(),
         ];
         \update_option(Options::TIMESTAMPS, $timestamps);

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
@@ -53,7 +53,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     protected function getUniqueTimestamp(): string
     {
-        return (string)\time() . '_' . (string)\rand(1, 999999999);
+        return \uniqid();
     }
     /**
      * Static timestamp, reflecting when the service container has been regenerated.

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
@@ -43,7 +43,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     protected function getOptionUniqueTimestamp(string $key): string
     {
-        $timestamps = \get_option(Options::TIMESTAMPS, [$key => $this->getUniqueTimestamp()]);
+        $timestamps = \get_option(Options::TIMESTAMPS, [$key => $this->getUniqueIdentifier()]);
         return $timestamps[$key];
     }
     /**
@@ -51,7 +51,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      * as to avoid a bug when 2 requests with different schema
      * configuration come in at the same time (i.e. with same `time()`).
      */
-    protected function getUniqueTimestamp(): string
+    protected function getUniqueIdentifier(): string
     {
         return \uniqid();
     }
@@ -80,7 +80,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     public function storeContainerTimestamp(): void
     {
-        $time = $this->getUniqueTimestamp();
+        $time = $this->getUniqueIdentifier();
         $timestamps = [
             self::TIMESTAMP_CONTAINER => $time,
             self::TIMESTAMP_OPERATIONAL => $time,
@@ -96,7 +96,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
     {
         $timestamps = [
             self::TIMESTAMP_CONTAINER => $this->getContainerUniqueTimestamp(),
-            self::TIMESTAMP_OPERATIONAL => $this->getUniqueTimestamp(),
+            self::TIMESTAMP_OPERATIONAL => $this->getUniqueIdentifier(),
         ];
         \update_option(Options::TIMESTAMPS, $timestamps);
     }

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
@@ -41,7 +41,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      * a one-time-use before accessing the wp-admin and
      * having a new timestamp generated via `purgeContainer`.
      */
-    protected function getUniqueTimestamp(string $key): string
+    protected function getOptionUniqueTimestamp(string $key): string
     {
         $timestamps = \get_option(Options::TIMESTAMPS, [$key => time()]);
         return $timestamps[$key];
@@ -52,7 +52,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     public function getContainerUniqueTimestamp(): string
     {
-        return $this->getUniqueTimestamp(self::TIMESTAMP_CONTAINER);
+        return $this->getOptionUniqueTimestamp(self::TIMESTAMP_CONTAINER);
     }
     /**
      * Dynamic timestamp, reflecting when new entities modifying the schema are
@@ -60,7 +60,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     public function getOperationalUniqueTimestamp(): string
     {
-        return $this->getUniqueTimestamp(self::TIMESTAMP_OPERATIONAL);
+        return $this->getOptionUniqueTimestamp(self::TIMESTAMP_OPERATIONAL);
     }
     /**
      * Store the current time to indicate the latest executed write to DB,

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManager.php
@@ -43,8 +43,17 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     protected function getOptionUniqueTimestamp(string $key): string
     {
-        $timestamps = \get_option(Options::TIMESTAMPS, [$key => time()]);
+        $timestamps = \get_option(Options::TIMESTAMPS, [$key => $this->getUniqueTimestamp()]);
         return $timestamps[$key];
+    }
+    /**
+     * Add the PHP process ID to `time()` to make it truly unique,
+     * as to avoid a bug when 2 requests with different schema
+     * configuration come in at the same time (i.e. with same `time()`).
+     */
+    protected function getUniqueTimestamp(): string
+    {
+        return (string)\time() . '_' . (string)\getmypid();
     }
     /**
      * Static timestamp, reflecting when the service container has been regenerated.
@@ -71,7 +80,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
      */
     public function storeContainerTimestamp(): void
     {
-        $time = time();
+        $time = $this->getUniqueTimestamp();
         $timestamps = [
             self::TIMESTAMP_CONTAINER => $time,
             self::TIMESTAMP_OPERATIONAL => $time,
@@ -87,7 +96,7 @@ class UserSettingsManager implements UserSettingsManagerInterface
     {
         $timestamps = [
             self::TIMESTAMP_CONTAINER => $this->getContainerUniqueTimestamp(),
-            self::TIMESTAMP_OPERATIONAL => time(),
+            self::TIMESTAMP_OPERATIONAL => $this->getUniqueTimestamp(),
         ];
         \update_option(Options::TIMESTAMPS, $timestamps);
     }

--- a/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManagerInterface.php
+++ b/layers/GatoGraphQLForWP/plugins/gato-graphql/src/Settings/UserSettingsManagerInterface.php
@@ -11,13 +11,13 @@ interface UserSettingsManagerInterface
      * module enabled/disabled, user settings updated, to refresh the Service
      * Container
      */
-    public function getContainerTimestamp(): int;
+    public function getContainerUniqueTimestamp(): string;
     /**
      * Timestamp of latest executed write to DB, concerning CPT entity created
      * or modified (such as Schema Configuration, ACL, etc), to refresh
      * the GraphQL schema
      */
-    public function getOperationalTimestamp(): int;
+    public function getOperationalUniqueTimestamp(): string;
     /**
      * Store the current time to indicate the latest executed write to DB,
      * concerning plugin activation, module enabled/disabled, user settings updated,


### PR DESCRIPTION
When caching the service container, add a random number to `time()` to make it truly unique, as to avoid a bug when 2 requests with different schema configuration come in at the same time (i.e. with same `time()`).

To simplify, use `uniqid()`.